### PR TITLE
Fix form urlencoded in MSALHttpRequest

### DIFF
--- a/MSAL/src/http/MSALHttpRequest.h
+++ b/MSAL/src/http/MSALHttpRequest.h
@@ -48,11 +48,13 @@ typedef void(^MSALHttpRequestCallback)(MSALHttpResponse *response, NSError  *err
 
 @property (readonly) BOOL isGetRequest;
 
-// Key/value pairs that is included as a request header
+/*! Key/value pairs that are included in the HTTP headers of the request */
 @property (copy) NSDictionary<NSString *, NSString *> *headers;
-// Key/value pairs that is included in the body as a JSON for POST request
+
+/*! Key/value pairs that are url encoded and included in the body of a POST request */
 @property (copy) NSDictionary<NSString *, NSString *> *bodyParameters;
-// Key/value pairs that is included in GET request
+
+/*! Key/value pairs that are included in a GET request */
 @property (copy) NSDictionary<NSString *, NSString *> *queryParameters;
 
 - (id)initWithURL:(NSURL *)endpoint context:(id<MSALRequestContext>)context;
@@ -81,9 +83,6 @@ typedef void(^MSALHttpRequestCallback)(MSALHttpResponse *response, NSError  *err
 
 // Sets Accept:Application/json to the header.
 - (void)setAcceptJSON;
-
-// Sets ContentType:application/x-www-form-urlencoded to the header.
-- (void)setContentTypeFormURLEncoded;
 
 @end
 

--- a/MSAL/src/http/MSALHttpRequest.m
+++ b/MSAL/src/http/MSALHttpRequest.m
@@ -155,11 +155,8 @@ static NSString *const s_kHttpHeaderDelimeter = @",";
     NSData *bodyData = nil;
     if (!_isGetRequest && _bodyParameters)
     {
-        bodyData = [NSJSONSerialization dataWithJSONObject:_bodyParameters options:0 error:nil];
-        if (bodyData)
-        {
-            [_headers setValue:[NSString stringWithFormat:@"%ld", (unsigned long)bodyData.length] forKey:@"Content-Length"];
-        }
+        bodyData = [[_bodyParameters msalURLFormEncode] dataUsingEncoding:NSUTF8StringEncoding];
+        [self setContentTypeFormURLEncoded];
     }
     
     // TODO: Add client version to URL
@@ -220,7 +217,7 @@ static NSString *const s_kHttpHeaderDelimeter = @",";
 
 - (void)setAcceptJSON;
 {
-        [_headers setValue:MSALHttpHeaderApplicationJSON forKey:MSALHttpHeaderAccept];
+    [_headers setValue:MSALHttpHeaderApplicationJSON forKey:MSALHttpHeaderAccept];
 }
 
 - (void)setContentTypeFormURLEncoded;

--- a/MSAL/src/requests/MSALWebAuthRequest.m
+++ b/MSAL/src/requests/MSALWebAuthRequest.m
@@ -44,7 +44,6 @@
 #endif
     
     [self setAcceptJSON];
-    [self setContentTypeFormURLEncoded];
     
     _retryIfServerError = YES;
     

--- a/MSAL/test/unit/MSALHttpRequestTests.m
+++ b/MSAL/test/unit/MSALHttpRequestTests.m
@@ -91,10 +91,15 @@
     
     NSString *testURLString = @"https://somehttprequest.com";
     
+    NSMutableDictionary *reqHeaders = [[MSALLogger msalId] mutableCopy];
+    [reqHeaders setObject:@"true" forKey:@"return-client-request-id"];
+    
     MSALTestURLResponse *response = [MSALTestURLResponse requestURLString:testURLString
+                                                           requestHeaders:reqHeaders
+                                                        requestParamsBody:nil
                                                         responseURLString:@"https://someresponsestring.com"
                                                              responseCode:200
-                                                         httpHeaderFields:@{}
+                                                         httpHeaderFields:nil
                                                          dictionaryAsJSON:@{@"endpoint" : @"valid"}];
     
     [MSALTestURLSession addResponse:response];

--- a/MSAL/test/unit/MSALInteractiveRequestTests.m
+++ b/MSAL/test/unit/MSALInteractiveRequestTests.m
@@ -208,9 +208,16 @@
          completionBlock([NSURL URLWithString:responseString], nil);
      }];
     
+    NSMutableDictionary *reqHeaders = [[MSALLogger msalId] mutableCopy];
+    [reqHeaders setObject:@"true" forKey:@"return-client-request-id"];
+    [reqHeaders setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
+    [reqHeaders setObject:@"application/json" forKey:@"Accept"];
+    [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
+    
     MSALTestURLResponse *response =
     [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token"
-                          requestJSONBody:@{ @"code" : @"iamafakecode",
+                           requestHeaders:reqHeaders
+                        requestParamsBody:@{ @"code" : @"iamafakecode",
                                              @"client_id" : @"b92e0ba5-f86e-4411-8e18-6b5f928d968a",
                                              @"scope" : @"fakescope1 fakescope2 openid profile offline_access",
                                              @"redirect_uri" : @"x-msauth-com-microsoft-unittests://com.microsoft.unittests/msal",

--- a/MSAL/test/unit/utils/MSALTestURLSession.h
+++ b/MSAL/test/unit/utils/MSALTestURLSession.h
@@ -44,18 +44,57 @@ typedef void (^MSALTestHttpCompletionBlock)(NSData *data, NSURLResponse *respons
     NSError *_error;
 }
 
-+ (MSALTestURLResponse *)requestURLString:(NSString *)requestUrlString
-                        responseURLString:(NSString *)responseUrlString
-                             responseCode:(NSInteger)responseCode
-                         httpHeaderFields:(NSDictionary *)headerFields
-                         dictionaryAsJSON:(NSDictionary *)data;
++ (MSALTestURLResponse*)requestURLString:(NSString *)requestUrlString
+                     responseURLString:(NSString *)responseUrlString
+                          responseCode:(NSInteger)responseCode
+                      httpHeaderFields:(NSDictionary *)headerFields
+                      dictionaryAsJSON:(NSDictionary *)data;
 
 + (MSALTestURLResponse*)requestURLString:(NSString *)requestUrlString
-                         requestJSONBody:(id)requestJSONBody
-                       responseURLString:(NSString *)responseUrlString
-                            responseCode:(NSInteger)responseCode
-                        httpHeaderFields:(NSDictionary *)headerFields
-                        dictionaryAsJSON:(NSDictionary *)data;
+                       requestJSONBody:(id)requestJSONBody
+                     responseURLString:(NSString *)responseUrlString
+                          responseCode:(NSInteger)responseCode
+                      httpHeaderFields:(NSDictionary *)headerFields
+                      dictionaryAsJSON:(NSDictionary *)data;
+
++ (MSALTestURLResponse*)requestURLString:(NSString *)requestUrlString
+                        requestHeaders:(NSDictionary *)requestHeaders
+                     requestParamsBody:(id)requestParams
+                     responseURLString:(NSString *)responseUrlString
+                          responseCode:(NSInteger)responseCode
+                      httpHeaderFields:(NSDictionary *)headerFields
+                      dictionaryAsJSON:(NSDictionary *)data;
+
++ (MSALTestURLResponse*)request:(NSURL *)request
+                     response:(NSURLResponse *)response
+                  reponseData:(NSData *)data;
+
++ (MSALTestURLResponse*)request:(NSURL *)request
+                      reponse:(NSURLResponse *)response;
+
++ (MSALTestURLResponse*)request:(NSURL *)request
+             respondWithError:(NSError *)error;
+
++ (MSALTestURLResponse*)serverNotFoundResponseForURLString:(NSString *)requestURLString;
+
++ (MSALTestURLResponse*)responseValidAuthority:(NSString *)authority;
++ (MSALTestURLResponse*)responseInvalidAuthority:(NSString *)authority;
+
++ (MSALTestURLResponse*)responseValidDrsPayload:(NSString *)domain
+                                      onPrems:(BOOL)onPrems
+                passiveAuthenticationEndpoint:(NSString *)passiveAuthEndpoint;
++ (MSALTestURLResponse*)responseInvalidDrsPayload:(NSString *)domain
+                                        onPrems:(BOOL)onPrems;
++ (MSALTestURLResponse*)responseUnreachableDrsService:(NSString *)domain
+                                            onPrems:(BOOL)onPrems;
++ (MSALTestURLResponse*)responseValidWebFinger:(NSString *)passiveEndpoint
+                                   authority:(NSString *)authority;
++ (MSALTestURLResponse*)responseInvalidWebFinger:(NSString *)passiveEndpoint
+                                     authority:(NSString *)authority;
++ (MSALTestURLResponse*)responseInvalidWebFingerNotTrusted:(NSString *)passiveEndpoint
+                                               authority:(NSString *)authority;
++ (MSALTestURLResponse*)responseUnreachableWebFinger:(NSString *)passiveEndpoint
+                                         authority:(NSString *)authority;
 
 @end
 

--- a/MSAL/test/unit/utils/MSALTestURLSession.m
+++ b/MSAL/test/unit/utils/MSALTestURLSession.m
@@ -33,13 +33,211 @@
 
 @implementation MSALTestURLResponse
 
-+ (MSALTestURLResponse *)requestURLString:(NSString *)requestUrlString
-                        responseURLString:(NSString *)responseUrlString
-                             responseCode:(NSInteger)responseCode
-                         httpHeaderFields:(NSDictionary *)headerFields
-                         dictionaryAsJSON:(NSDictionary *)data
++ (MSALTestURLResponse *)request:(NSURL *)request
+               requestJSONBody:(NSDictionary *)requestBody
+                      response:(NSURLResponse *)urlResponse
+                   reponseData:(NSData *)data
 {
+    MSALTestURLResponse * response = [MSALTestURLResponse new];
+    [response setRequestURL:request];
+    response->_requestJSONBody = requestBody;
+    response->_response = urlResponse;
+    response->_responseData = data;
     
+    return response;
+}
+
++ (MSALTestURLResponse *)request:(NSURL *)request
+                      response:(NSURLResponse *)urlResponse
+                   reponseData:(NSData *)data
+{
+    MSALTestURLResponse * response = [MSALTestURLResponse new];
+    
+    [response setRequestURL:request];
+    response->_response = urlResponse;
+    response->_responseData = data;
+    
+    return response;
+}
+
++ (MSALTestURLResponse *)request:(NSURL *)request
+                       reponse:(NSURLResponse *)urlResponse
+{
+    MSALTestURLResponse * response = [MSALTestURLResponse new];
+    
+    [response setRequestURL:request];
+    response->_response = urlResponse;
+    
+    return response;
+}
+
++ (MSALTestURLResponse *)request:(NSURL *)request
+              respondWithError:(NSError *)error
+{
+    MSALTestURLResponse * response = [MSALTestURLResponse new];
+    
+    [response setRequestURL:request];
+    response->_error = error;
+    
+    return response;
+}
+
++ (MSALTestURLResponse *)serverNotFoundResponseForURLString:(NSString *)requestURLString
+{
+    NSURL *requestURL = [NSURL URLWithString:requestURLString];
+    MSALTestURLResponse *response = [MSALTestURLResponse request:requestURL
+                                            respondWithError:[NSError errorWithDomain:NSURLErrorDomain
+                                                                                 code:NSURLErrorCannotFindHost
+                                                                             userInfo:nil]];
+    return response;
+}
+
++ (MSALTestURLResponse *)responseValidAuthority:(NSString *)authority
+{
+    NSString* authorityValidationURL = [NSString stringWithFormat:@"https://login.windows.net/common/discovery/instance?api-version=1.0&authorization_endpoint=%@/oauth2/authorize", [authority lowercaseString]];
+    MSALTestURLResponse *response = [MSALTestURLResponse requestURLString:authorityValidationURL
+                                                    responseURLString:@"https://idontmatter.com"
+                                                         responseCode:200
+                                                     httpHeaderFields:@{}
+                                                     dictionaryAsJSON:@{@"tenant_discovery_endpoint" : @"totally valid!"}];
+    
+    return response;
+}
+
++ (MSALTestURLResponse *)responseInvalidAuthority:(NSString *)authority
+{
+    NSString* authorityValidationURL = [NSString stringWithFormat:@"https://login.windows.net/common/discovery/instance?api-version=1.0&authorization_endpoint=%@/oauth2/authorize", [authority lowercaseString]];
+    MSALTestURLResponse *response = [MSALTestURLResponse requestURLString:authorityValidationURL
+                                                    responseURLString:@"https://idontmatter.com"
+                                                         responseCode:400
+                                                     httpHeaderFields:@{}
+                                                     dictionaryAsJSON:@{OAUTH2_ERROR : @"I'm an OAUTH server error!",
+                                                                        OAUTH2_ERROR_DESCRIPTION : @" I'm an OAUTH error description!"}];
+    
+    return response;
+}
+
++ (MSALTestURLResponse *)responseValidDrsPayload:(NSString *)domain
+                                       onPrems:(BOOL)onPrems
+                 passiveAuthenticationEndpoint:(NSString *)passiveAuthEndpoint
+{
+    NSString* validationPayloadURL = [NSString stringWithFormat:@"%@%@/enrollmentserver/contract?api-version=1.0",
+                                      onPrems ? @"https://enterpriseregistration." : @"https://enterpriseregistration.windows.net/", domain];
+    
+    MSALTestURLResponse *response = [MSALTestURLResponse requestURLString:validationPayloadURL
+                                                    responseURLString:@"https://idontmatter.com"
+                                                         responseCode:200
+                                                     httpHeaderFields:@{}
+                                                     dictionaryAsJSON:@{@"DeviceRegistrationService" :
+                                                                            @{@"RegistrationEndpoint" : @"https://idontmatter.com/EnrollmentServer/DeviceEnrollmentWebService.svc",
+                                                                              @"RegistrationResourceId" : @"urn:ms-drs:UUID"
+                                                                              },
+                                                                        @"AuthenticationService" :
+                                                                            @{@"AuthCodeEndpoint" : @"https://idontmatter.com/adfs/oauth2/authorize",
+                                                                              @"TokenEndpoint" : @"https://idontmatter.com/adfs/oauth2/token"
+                                                                              },
+                                                                        @"IdentityProviderService" :
+                                                                            @{@"PassiveAuthEndpoint" : passiveAuthEndpoint}
+                                                                        }];
+    return response;
+}
+
+
++ (MSALTestURLResponse *)responseInvalidDrsPayload:(NSString *)domain
+                                         onPrems:(BOOL)onPrems
+{
+    NSString* validationPayloadURL = [NSString stringWithFormat:@"%@%@/enrollmentserver/contract?api-version=1.0",
+                                      onPrems ? @"https://enterpriseregistration." : @"https://enterpriseregistration.windows.net/", domain];
+    
+    MSALTestURLResponse *response = [MSALTestURLResponse requestURLString:validationPayloadURL
+                                                    responseURLString:@"https://idontmatter.com"
+                                                         responseCode:400
+                                                     httpHeaderFields:@{}
+                                                     dictionaryAsJSON:@{}];
+    return response;
+}
+
+
++ (MSALTestURLResponse *)responseUnreachableDrsService:(NSString *)domain
+                                             onPrems:(BOOL)onPrems
+{
+    NSString *drsURL = [NSString stringWithFormat:@"%@%@/enrollmentserver/contract?api-version=1.0",
+                        onPrems ? @"https://enterpriseregistration." : @"https://enterpriseregistration.windows.net/", domain];
+    
+    return [self serverNotFoundResponseForURLString:drsURL];
+}
+
+
++ (MSALTestURLResponse *)responseValidWebFinger:(NSString *)passiveEndpoint
+                                    authority:(NSString *)authority
+{
+    NSURL *endpointFullUrl = [NSURL URLWithString:passiveEndpoint.lowercaseString];
+    NSString *url = [NSString stringWithFormat:@"https://%@/.well-known/webfinger?resource=%@", endpointFullUrl.host, authority];
+    
+    MSALTestURLResponse *response = [MSALTestURLResponse requestURLString:url
+                                                    responseURLString:@"https://idontmatter.com"
+                                                         responseCode:200
+                                                     httpHeaderFields:@{}
+                                                     dictionaryAsJSON:@{@"subject" : authority,
+                                                                        @"links" : @[@{
+                                                                                         @"rel" : @"http://schemas.microsoft.com/rel/trusted-realm",
+                                                                                         @"href" : authority
+                                                                                         }]
+                                                                        }];
+    return response;
+}
+
++ (MSALTestURLResponse *)responseInvalidWebFinger:(NSString *)passiveEndpoint
+                                      authority:(NSString *)authority
+{
+    NSURL *endpointFullUrl = [NSURL URLWithString:passiveEndpoint.lowercaseString];
+    NSString *url = [NSString stringWithFormat:@"https://%@/.well-known/webfinger?resource=%@", endpointFullUrl.host, authority];
+    
+    MSALTestURLResponse *response = [MSALTestURLResponse requestURLString:url
+                                                    responseURLString:@"https://idontmatter.com"
+                                                         responseCode:400
+                                                     httpHeaderFields:@{}
+                                                     dictionaryAsJSON:@{}];
+    return response;
+}
+
++ (MSALTestURLResponse *)responseInvalidWebFingerNotTrusted:(NSString *)passiveEndpoint
+                                                authority:(NSString *)authority
+{
+    NSURL *endpointFullUrl = [NSURL URLWithString:passiveEndpoint.lowercaseString];
+    NSString *url = [NSString stringWithFormat:@"https://%@/.well-known/webfinger?resource=%@", endpointFullUrl.host, authority];
+    
+    MSALTestURLResponse *response = [MSALTestURLResponse requestURLString:url
+                                                    responseURLString:@"https://idontmatter.com"
+                                                         responseCode:200
+                                                     httpHeaderFields:@{}
+                                                     dictionaryAsJSON:@{@"subject" : authority,
+                                                                        @"links" : @[@{
+                                                                                         @"rel" : @"http://schemas.microsoft.com/rel/trusted-realm",
+                                                                                         @"href" : @"idontmatch.com"
+                                                                                         }]
+                                                                        }];
+    return response;
+}
+
++ (MSALTestURLResponse *)responseUnreachableWebFinger:(NSString *)passiveEndpoint
+                                          authority:(NSString *)authority
+
+{
+    (void)authority;
+    NSURL *endpointFullUrl = [NSURL URLWithString:passiveEndpoint.lowercaseString];
+    NSString *url = [NSString stringWithFormat:@"https://%@/.well-known/webfinger?resource=%@", endpointFullUrl.host, authority];
+    
+    return [self serverNotFoundResponseForURLString:url];
+}
+
+
++ (MSALTestURLResponse *)requestURLString:(NSString*)requestUrlString
+                      responseURLString:(NSString*)responseUrlString
+                           responseCode:(NSInteger)responseCode
+                       httpHeaderFields:(NSDictionary *)headerFields
+                       dictionaryAsJSON:(NSDictionary *)data
+{
     MSALTestURLResponse *response = [MSALTestURLResponse new];
     [response setRequestURL:[NSURL URLWithString:requestUrlString]];
     [response setResponseURL:responseUrlString code:responseCode headerFields:headerFields];
@@ -49,11 +247,11 @@
 }
 
 + (MSALTestURLResponse *)requestURLString:(NSString*)requestUrlString
-                          requestJSONBody:(id)requestJSONBody
-                        responseURLString:(NSString*)responseUrlString
-                             responseCode:(NSInteger)responseCode
-                         httpHeaderFields:(NSDictionary *)headerFields
-                         dictionaryAsJSON:(NSDictionary *)data
+                        requestJSONBody:(id)requestJSONBody
+                      responseURLString:(NSString*)responseUrlString
+                           responseCode:(NSInteger)responseCode
+                       httpHeaderFields:(NSDictionary *)headerFields
+                       dictionaryAsJSON:(NSDictionary *)data
 {
     MSALTestURLResponse *response = [MSALTestURLResponse new];
     [response setRequestURL:[NSURL URLWithString:requestUrlString]];
@@ -64,11 +262,29 @@
     return response;
 }
 
++ (MSALTestURLResponse *)requestURLString:(NSString*)requestUrlString
+                         requestHeaders:(NSDictionary *)requestHeaders
+                      requestParamsBody:(id)requestParams
+                      responseURLString:(NSString*)responseUrlString
+                           responseCode:(NSInteger)responseCode
+                       httpHeaderFields:(NSDictionary *)headerFields
+                       dictionaryAsJSON:(NSDictionary *)data
+{
+    MSALTestURLResponse *response = [MSALTestURLResponse new];
+    [response setRequestURL:[NSURL URLWithString:requestUrlString]];
+    [response setResponseURL:responseUrlString code:responseCode headerFields:headerFields];
+    response->_requestHeaders = requestHeaders;
+    response->_requestParamsBody = requestParams;
+    [response setJSONResponse:data];
+    
+    return response;
+}
+
 - (void)setResponseURL:(NSString *)urlString
                   code:(NSInteger)code
           headerFields:(NSDictionary *)headerFields
 {
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:urlString]
+    NSHTTPURLResponse * response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:urlString]
                                                                statusCode:code
                                                               HTTPVersion:@"1.1"
                                                              headerFields:headerFields];
@@ -91,7 +307,6 @@
     NSAssert(_responseData, @"Invalid JSON object set for test response! %@", error);
 }
 
-
 - (void)setRequestURL:(NSURL *)requestURL
 {
     
@@ -99,7 +314,6 @@
     NSString *query = [requestURL query];
     _QPs = [NSString msalIsStringNilOrBlank:query] ? nil : [NSDictionary msalURLFormDecode:query];
 }
-
 
 - (BOOL)matchesURL:(NSURL *)url
 {
@@ -171,30 +385,16 @@
 {
     if (!_requestHeaders)
     {
-        return YES;
+        if (!headers || headers.count == 0)
+        {
+            return YES;
+        }
+        // This wiil spit out to console the extra stuff that we weren't expecting
+        [@{} compareDictionary:headers];
+        return NO;
     }
     
-    BOOL matches = YES;
-    
-    for (id key in _requestHeaders)
-    {
-        id header = [_requestHeaders objectForKey:key];
-        id matchHeader = [headers objectForKey:key];
-        if (!matchHeader)
-        {
-            // TODO: Add logging
-            // AD_LOG_ERROR_F(@"Request is missing header", AD_FAILED, nil, @"%@", key);
-            matches = NO;
-        }
-        else if (![header isEqual:matchHeader])
-        {
-            // TODO: Add logging
-            // AD_LOG_ERROR_F(@"Request headers do not match", AD_FAILED, nil, @"expected: \"%@\" actual: \"%@\"", header, matchHeader);
-            matches = NO;
-        }
-    }
-    
-    return matches;
+    return [_requestHeaders compareDictionary:headers];
 }
 
 @end
@@ -289,6 +489,29 @@ static NSMutableArray *s_responses = nil;
             }
         }
     }
+    
+    // This class is used in the test target only. If you're seeing this outside the test target that means you linked in the file wrong
+    // take it out!
+    //
+    // No unit tests are allowed to hit network. This is done to ensure reliability of the test code. Tests should run quickly and
+    // deterministically. If you're hitting this assert that means you need to add an expected request and response to ADTestURLConnection
+    // using the ADTestRequestReponse class and add it using -[ADTestURLConnection addExpectedRequestResponse:] if you have a single
+    // request/response or -[ADTestURLConnection addExpectedRequestsAndResponses:] if you have a series of network requests that you need
+    // to ensure happen in the proper order.
+    //
+    // Example:
+    //
+    // MSALTestRequestResponse *response = [MSALTestRequestResponse requestURLString:@"https://requestURL"
+    //                                                             responseURLString:@"https://idontknowwhatthisshouldbe.com"
+    //                                                                  responseCode:400
+    //                                                              httpHeaderFields:@{}
+    //                                                              dictionaryAsJSON:@{@"tenant_discovery_endpoint" : @"totally valid!"}];
+    //
+    //  [MSALTestURLSession addResponse:response];
+    
+    NSAssert(nil, @"did not find a matching response for %@", requestURL.absoluteString);
+    
+    LOG_ERROR(nil, @"No matching response found, request url = %@", request.URL);
     
     return nil;
 }

--- a/MSAL/test/unit/utils/MSALTestURLSessionDataTask.m
+++ b/MSAL/test/unit/utils/MSALTestURLSessionDataTask.m
@@ -61,30 +61,6 @@
     
     if (!response)
     {
-        // This class is used in the test target only. If you're seeing this outside the test target that means you linked in the file wrong
-        // take it out!
-        //
-        // No unit tests are allowed to hit network. This is done to ensure reliability of the test code. Tests should run quickly and
-        // deterministically. If you're hitting this assert that means you need to add an expected request and response to ADTestURLConnection
-        // using the ADTestRequestReponse class and add it using -[ADTestURLConnection addExpectedRequestResponse:] if you have a single
-        // request/response or -[ADTestURLConnection addExpectedRequestsAndResponses:] if you have a series of network requests that you need
-        // to ensure happen in the proper order.
-        //
-        // Example:
-        //
-        // MSALTestRequestResponse *response = [MSALTestRequestResponse requestURLString:@"https://requestURL"
-        //                                                             responseURLString:@"https://idontknowwhatthisshouldbe.com"
-        //                                                                  responseCode:400
-        //                                                              httpHeaderFields:@{}
-        //                                                              dictionaryAsJSON:@{@"tenant_discovery_endpoint" : @"totally valid!"}];
-        //
-        //  [MSALTestURLSession addResponse:response];
-        
-        NSString *requestURLString = self.request.URL.absoluteString;
-        NSAssert(response, @"did not find a matching response for %@", requestURLString);
-        
-        LOG_ERROR(nil, @"No matching response found, request url = %@", self.request.URL);
-        
         [self.session dispatchIfNeed:^{
             NSError* error = [NSError errorWithDomain:NSURLErrorDomain
                                                  code:NSURLErrorNotConnectedToInternet


### PR DESCRIPTION
* Body parameters are default url encoded:
  - automatically set that header if body parameters are provided
  - remove the  (void)setContentTypeFormURLEncoded
* Copy over remaining helper methods for MSALTestURLResponse from ADAL
* Have MSALTestURLSession strongly check HTTP headers in the request
  - Fixed some tests to pass in expected HTTP headers