### PR TITLE
Fix issues @jak was running into with inconsistency in MSALWebUITests

### DIFF
--- a/MSAL/src/ui/MSALWebUI.h
+++ b/MSAL/src/ui/MSALWebUI.h
@@ -37,6 +37,6 @@ typedef void (^MSALWebUICompletionBlock)(NSURL *response, NSError *error);
 
 + (BOOL)handleResponse:(NSURL *)url;
 
-+ (void)cancelCurrentWebAuthSession;
++ (BOOL)cancelCurrentWebAuthSession;
 
 @end

--- a/MSAL/src/ui/mac/MSALWebUI.m
+++ b/MSAL/src/ui/mac/MSALWebUI.m
@@ -46,9 +46,9 @@
     @throw @"MSAL is not supported on macOS at this time.";
 }
 
-+ (void)cancelCurrentWebAuthSession
++ (BOOL)cancelCurrentWebAuthSession
 {
-    @throw @"MSAL is not supported on macOS at this time.";
+    return NO;
 }
 
 @end

--- a/MSAL/test/unit/ios/MSALWebUITestsiOS.m
+++ b/MSAL/test/unit/ios/MSALWebUITestsiOS.m
@@ -170,8 +170,6 @@
      }];
     
     // A delegate should be set on the Safari View Controller
-    
-    
     dispatch_async(dispatch_get_main_queue(), ^{
         id<SFSafariViewControllerDelegate> delegate = fakeSvc.delegate;
         XCTAssertNotNil(delegate);

--- a/MSAL/test/unit/utils/MSALTestCase.m
+++ b/MSAL/test/unit/utils/MSALTestCase.m
@@ -29,6 +29,7 @@
 #import "MSALTestLogger.h"
 #import "MSALTestBundle.h"
 #import "MSALTestSwizzle.h"
+#import "MSALWebUI.h"
 
 #if TARGET_OS_IPHONE
 #import "SFSafariViewController+TestOverrides.h"
@@ -37,7 +38,8 @@
 
 @implementation MSALTestCase
 
-- (void)setUp {
+- (void)setUp
+{
     [super setUp];
     [[MSALTestLogger sharedLogger] reset];
     [MSALTestBundle reset];
@@ -48,8 +50,10 @@
 #endif
 }
 
-- (void)tearDown {
+- (void)tearDown
+{
     // Put teardown code here. This method is called after the invocation of each test method in the class.
+    XCTAssertFalse([MSALWebUI cancelCurrentWebAuthSession]);
     [super tearDown];
 }
 


### PR DESCRIPTION
- Clear out the web session in the safariViewControllerDidFinish code path
- Add checking in `-[MSALTestCase tearDown]` to make sure that there are no lingering web auth sessions laying around that can break subsequent tests
- Change mac stub to not throw on the cancel codepath.
- Rename `currentWebSession` to `getAndClearCurrentWebSession` to make it clearer what that call does.