### PR TITLE
MSALTestURLResponse update

### DIFF
--- a/MSAL/test/unit/utils/MSALTestURLSession.h
+++ b/MSAL/test/unit/utils/MSALTestURLSession.h
@@ -33,7 +33,6 @@ typedef void (^MSALTestHttpCompletionBlock)(NSData *data, NSURLResponse *respons
 {
     @public
     NSURL *_requestURL;
-    id _requestJSONBody;
     id _requestParamsBody;
     NSDictionary *_requestHeaders;
     NSData *_requestBody;

--- a/MSAL/test/unit/utils/MSALTestURLSession.m
+++ b/MSAL/test/unit/utils/MSALTestURLSession.m
@@ -179,17 +179,6 @@
 
 - (BOOL)matchesBody:(NSData *)body
 {
-    if (_requestJSONBody)    {
-        NSError* error = nil;
-        id obj = [NSJSONSerialization JSONObjectWithData:body options:NSJSONReadingAllowFragments error:&error];
-        if ([obj isKindOfClass:[NSDictionary class]] && [_requestJSONBody isKindOfClass:[NSDictionary class]])
-        {
-            return [(NSDictionary *)_requestJSONBody compareDictionary:obj];
-        }
-        BOOL match = [obj isEqual:_requestJSONBody];
-        return match;
-    }
-    
     if (_requestParamsBody)
     {
         NSString * string = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
- Remove _requestJSONBody from the response. 
   (There is already a _requestParamsBody and HTTPRequest does www-url-form-encoded for POST)

- Remove unused convenience response creation methods

- Add request header/paramsBody to existing response creation methods.