### PR TITLE
udpate trusted hosts list and fix unit testing

### DIFF
--- a/MSAL/src/instance/MSALAuthority.m
+++ b/MSAL/src/instance/MSALAuthority.m
@@ -60,7 +60,8 @@ BOOL isTenantless(NSURL *authority)
 + (void)initialize
 {
     s_trustedHostList = [NSSet setWithObjects: @"login.windows.net",
-                         @"loginchinacloudapi.cn",
+                         @"login.chinacloudapi.cn",
+                         @"login-us.microsoftonline.com",
                          @"login.cloudgovapi.us",
                          @"login.microsoftonline.com",
                          @"login.microsoftonline.de", nil];

--- a/MSAL/test/unit/MSALAuthorityTests.m
+++ b/MSAL/test/unit/MSALAuthorityTests.m
@@ -100,9 +100,10 @@
 {
     XCTAssertFalse([MSALAuthority isKnownHost:[NSURL URLWithString:@"https://www.noknownhost.com"]]);
     XCTAssertTrue([MSALAuthority isKnownHost:[NSURL URLWithString:@"https://login.windows.net"]]);
-    XCTAssertTrue([MSALAuthority isKnownHost:[NSURL URLWithString:@"https://loginchinacloudapi.cn"]]);
+    XCTAssertTrue([MSALAuthority isKnownHost:[NSURL URLWithString:@"https://login.chinacloudapi.cn"]]);
     XCTAssertTrue([MSALAuthority isKnownHost:[NSURL URLWithString:@"https://login.microsoftonline.com"]]);
     XCTAssertTrue([MSALAuthority isKnownHost:[NSURL URLWithString:@"https://login.microsoftonline.de"]]);
+    XCTAssertTrue([MSALAuthority isKnownHost:[NSURL URLWithString:@"https://login-us.microsoftonline.com"]]);
 }
 
 - (void)testResolveEndpointsSuccess


### PR DESCRIPTION
- Update trusted hosts
both login-us.microsoftonline.com and login.cloudgovapi.us should be trusted.
(should check with other platforms to ensure the same)

- Fix the test case for the hosts check.