### PR TITLE
Set a minimum TLS version of 1.2 for MSAL’s NSURLSessions

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -35,6 +35,7 @@
 #import "MSALSilentRequest.h"
 #import "MSALRequestParameters.h"
 #import "MSALUIBehavior_Internal.h"
+#import "MSALURLSession.h"
 #import "MSALWebUI.h"
 
 #define DEFAULT_AUTHORITY @"https://login.microsoftonline.com/common"
@@ -208,7 +209,7 @@
               completionBlock:(MSALCompletionBlock)completionBlock
 {
     MSALRequestParameters* params = [MSALRequestParameters new];
-    params.urlSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    params.urlSession = [MSALURLSession createMSALSesssion:params];
     params.correlationId = correlationId ? correlationId : [NSUUID new];
     params.component = _component;
     LOG_INFO(params, @"-[MSALPublicClientApplication acquireTokenForScopes:%@\n"
@@ -321,7 +322,7 @@
                     completionBlock:(MSALCompletionBlock)completionBlock
 {
     MSALRequestParameters* params = [MSALRequestParameters new];
-    params.urlSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    params.urlSession = [MSALURLSession createMSALSesssion:params];
     params.correlationId = correlationId ? correlationId : [NSUUID new];
     params.user = user;
     

--- a/MSAL/src/http/MSALURLSession.h
+++ b/MSAL/src/http/MSALURLSession.h
@@ -29,7 +29,6 @@
 
 @interface MSALURLSession : NSObject
 
-+ (NSURLSession *)createSesssionWithConfiguration:(NSURLSessionConfiguration *)config
-                                          context:(id<MSALRequestContext>)context;
++ (NSURLSession *)createMSALSesssion:(id<MSALRequestContext>)context;
 
 @end

--- a/MSAL/src/http/MSALURLSession.m
+++ b/MSAL/src/http/MSALURLSession.m
@@ -30,10 +30,12 @@
 
 @implementation MSALURLSession
 
-+ (NSURLSession *)createSesssionWithConfiguration:(NSURLSessionConfiguration *)config
-                                          context:(id<MSALRequestContext>)context
++ (NSURLSession *)createMSALSesssion:(id<MSALRequestContext>)context
 {
     MSALURLSessionDelegate *delegate = [[MSALURLSessionDelegate alloc] initWithContext:context];
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    config.TLSMinimumSupportedProtocol = kTLSProtocol12;
+    
     NSURLSession *session = [NSURLSession sessionWithConfiguration:config
                                                           delegate:delegate
                                                      delegateQueue:nil];

--- a/MSAL/test/unit/MSALAadAuthorityResolverTests.m
+++ b/MSAL/test/unit/MSALAadAuthorityResolverTests.m
@@ -70,7 +70,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Expectation"];
     
     MSALRequestParameters *params = [MSALRequestParameters new];
-    params.urlSession = [NSURLSession new];
+    params.urlSession = [MSALTestURLSession createMockSession];
     
     NSString *authorityString = @"https://login.microsoftonline.in/mytenant.com";
     NSString *responseEndpoint = @"https://login.microsoftonline.in/mytenant.com/v2.0/.well-known/openid-configuration";
@@ -146,7 +146,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Expectation"];
     
     MSALRequestParameters *params = [MSALRequestParameters new];
-    params.urlSession = [NSURLSession new];
+    params.urlSession = [MSALTestURLSession createMockSession];
     
     NSString *authorityString = @"https://somehost.com/sometenant.com";
     
@@ -187,7 +187,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Expectation"];
     
     MSALRequestParameters *params = [MSALRequestParameters new];
-    params.urlSession = [NSURLSession new];
+    params.urlSession = [MSALTestURLSession createMockSession];
     
     NSMutableDictionary *reqHeaders = [[MSALLogger msalId] mutableCopy];
     [reqHeaders setObject:@"1.0" forKey:@"api-version"];

--- a/MSAL/test/unit/MSALAuthorityBaseResolverTests.m
+++ b/MSAL/test/unit/MSALAuthorityBaseResolverTests.m
@@ -59,7 +59,7 @@
     NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
 
     MSALRequestParameters *params = [MSALRequestParameters new];
-    params.urlSession = [NSURLSession new];
+    params.urlSession = [MSALTestURLSession createMockSession];
     
     NSString *tenantDiscoveryEndpoint = @"https://login.windows.net/common/v2.0/.well-known/openid-configuration";
     
@@ -107,7 +107,7 @@
     NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
 
     MSALRequestParameters *params = [MSALRequestParameters new];
-    params.urlSession = [NSURLSession new];
+    params.urlSession = [MSALTestURLSession createMockSession];
     
     NSString *tenantDiscoveryEndpoint = @"https://login.windows.net/common/v2.0/.well-known/openid-configuration";
     

--- a/MSAL/test/unit/MSALHttpRequestTests.m
+++ b/MSAL/test/unit/MSALHttpRequestTests.m
@@ -87,7 +87,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Expectation"];
 
     MSALRequestParameters *params = [MSALRequestParameters new];
-    params.urlSession = [NSURLSession new];
+    params.urlSession = [MSALTestURLSession createMockSession];
     
     NSString *testURLString = @"https://somehttprequest.com";
     

--- a/MSAL/test/unit/MSALInteractiveRequestTests.m
+++ b/MSAL/test/unit/MSALInteractiveRequestTests.m
@@ -157,7 +157,7 @@
     __block NSUUID *correlationId = [NSUUID new];
     
     MSALRequestParameters *parameters = [MSALRequestParameters new];
-    parameters.urlSession = [NSURLSession new];
+    parameters.urlSession = [MSALTestURLSession createMockSession];
     parameters.scopes = [NSOrderedSet orderedSetWithArray:@[@"fakescope1", @"fakescope2"]];
     parameters.unvalidatedAuthority = [NSURL URLWithString:@"https://login.microsoftonline.com/common"];
     parameters.redirectUri = [NSURL URLWithString:@"x-msauth-com-microsoft-unittests://com.microsoft.unittests/msal"];

--- a/MSAL/test/unit/MSALSilentRequestTests.m
+++ b/MSAL/test/unit/MSALSilentRequestTests.m
@@ -194,7 +194,7 @@
     NSUUID *correlationId = [NSUUID new];
     
     MSALRequestParameters *parameters = [MSALRequestParameters new];
-    parameters.urlSession = [NSURLSession new];
+    parameters.urlSession = [MSALTestURLSession createMockSession];
     parameters.scopes = [NSOrderedSet orderedSetWithArray:@[@"fakescope1", @"fakescope2"]];
     parameters.unvalidatedAuthority = [NSURL URLWithString:@"https://login.microsoftonline.com/common"];
     parameters.redirectUri = [NSURL URLWithString:@"x-msauth-com-microsoft-unittests://com.microsoft.unittests/msal"];

--- a/MSAL/test/unit/utils/MSALTestURLSession.h
+++ b/MSAL/test/unit/utils/MSALTestURLSession.h
@@ -75,6 +75,8 @@ typedef void (^MSALTestHttpCompletionBlock)(NSData *data, NSURLResponse *respons
 @property id delegate;
 @property NSOperationQueue* delegateQueue;
 
++ (NSURLSession *)createMockSession;
+
 - (id)initWithDelegate:(id)delegate delegateQueue:(NSOperationQueue *)delegateQueue;
 
 // This adds an expected request, and response to it.

--- a/MSAL/test/unit/utils/MSALTestURLSession.m
+++ b/MSAL/test/unit/utils/MSALTestURLSession.m
@@ -219,13 +219,22 @@
 
 - (id)init
 {
-    return (NSURLSession *)[[MSALTestURLSession alloc] initWithDelegate:nil delegateQueue:nil];
+    @throw @"This constructor should not be used. If you're in test code use +[MSALTestURLSession createMockSession] if you're in product code use +[MSALURLSession createMSALSession:]";
 }
 
 + (NSURLSession *)sessionWithConfiguration:(NSURLSessionConfiguration *)configuration
                                   delegate:(id<NSURLSessionDelegate>)delegate
                              delegateQueue:(NSOperationQueue *)queue
 {
+    // We're not in the context of a test class here, so XCTAssert can't be used,
+    // however I still want to make sure we're not inadvertantly creating any
+    // NSURLSessions without the proper security settings.
+    
+    // If you're hitting this fix whatever code path is creating NSURLSessions
+    // directly instad of using +[MSALURLSession createMSALSession:]
+    assert(configuration != nil);
+    assert(configuration.TLSMinimumSupportedProtocol == kTLSProtocol12);
+    
     (void)configuration;
     return (NSURLSession *)[[MSALTestURLSession alloc] initWithDelegate:delegate delegateQueue:queue];
 }
@@ -236,6 +245,11 @@
 
 
 @implementation MSALTestURLSession
+
++ (NSURLSession *)createMockSession
+{
+    return (NSURLSession *)[[MSALTestURLSession alloc] initWithDelegate:nil delegateQueue:nil];
+}
 
 static NSMutableArray *s_responses = nil;
 


### PR DESCRIPTION
* Use convenience constructor in MSALURLSession to have a single spot for setting configuration values on NSURLSession
* Add checking in MSALTestURLSession to make sure we’re not inadvertantly creating NSURLSessions without the right configuration settings
* Add +[MSALTestURLSession createMockSession] to replace alll the uses of [NSURLSession new] in test code so we can check and fail if [NSURLSession new] is used in product code.