### PR TITLE
Bump travis to Xcode 8.3, remove simulator hack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.2
+osx_image: xcode8.3
 
 # Set up our rubygems (slather and xcpretty, namely)
 install: 
@@ -8,10 +8,6 @@ install:
 before_script:
 # Start by nuking any lingering codecov files. These can cause issues when the xcode version changes
   - find . -name "*.gcda" -print0 | xargs -0 rm
-  
-# This is to work around travis-ci/travis-ci#7031. There are duplicate iOS Simulator devices
-# on iOS 10.2 for every device type, which causes the build script to fail.
-  - xcrun simctl delete 1FD54EA7-5A25-4D6F-8599-D6F7687DA4EE
 
 # Tell the shell to echo failure codes up the pipe so that Travis will properly fail the
 # build when the xcodebuild command fails


### PR DESCRIPTION
Our hack to remove an ios simulator from the xcode image to keep things passing appears to be making things fail, so remove that. While we're at it bump up to the xcode8.3 image