### PR TITLE
Change Public APIs that took NSURL to take in NSString for consistency

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -40,8 +40,6 @@
 #import "MSALTelemetryApiId.h"
 #import "MSALTelemetry.h"
 
-#define DEFAULT_AUTHORITY @"https://login.microsoftonline.com/common"
-
 @implementation MSALPublicClientApplication
 {
     MSALTokenCacheAccessor *_tokenCache;
@@ -87,8 +85,16 @@
     REQUIRED_PARAMETER(clientId, nil);
     _clientId = clientId;
     
-    _authority = [MSALAuthority checkAuthorityString:authority ? authority : DEFAULT_AUTHORITY error:error];
-    CHECK_RETURN_NIL(_authority);
+    if (authority)
+    {
+        _authority = [MSALAuthority checkAuthorityString:authority error:error];
+        CHECK_RETURN_NIL(_authority);
+    }
+    else
+    {
+        // TODO: Rationalize our default authority behavior (#93)
+        _authority = [MSALAuthority defaultAuthority];
+    }
     
     CHECK_RETURN_NIL([self generateRedirectUri:error]);
     
@@ -263,7 +269,7 @@
                          user:(MSALUser *)user
                    uiBehavior:(MSALUIBehavior)uiBehavior
          extraQueryParameters:(NSDictionary <NSString *, NSString *> *)extraQueryParameters
-                    authority:(NSURL *)authority
+                    authority:(NSString *)authority
                 correlationId:(NSUUID *)correlationId
               completionBlock:(MSALCompletionBlock)completionBlock
 {
@@ -296,7 +302,7 @@
 
 - (void)acquireTokenSilentForScopes:(NSArray<NSString *> *)scopes
                                user:(MSALUser *)user
-                          authority:(NSURL *)authority
+                          authority:(NSString *)authority
                     completionBlock:(MSALCompletionBlock)completionBlock
 {
     [self acquireTokenSilentForScopes:scopes
@@ -310,7 +316,7 @@
 
 - (void)acquireTokenSilentForScopes:(NSArray<NSString *> *)scopes
                                user:(MSALUser *)user
-                          authority:(NSURL *)authority
+                          authority:(NSString *)authority
                        forceRefresh:(BOOL)forceRefresh
                       correlationId:(NSUUID *)correlationId
                     completionBlock:(MSALCompletionBlock)completionBlock
@@ -363,26 +369,22 @@
     [params setScopesFromArray:scopes];
     params.loginHint = loginHint;
     params.extraQueryParameters = extraQueryParameters;
-    if (authority)
+    NSError *error = nil;
+    if (!authority)
     {
-        NSError *error = nil;
-        NSURL *authorityUrl = [MSALAuthority checkAuthorityString:authority error:&error];
-        if (!authorityUrl)
-        {
-            completionBlock(nil, error);
-            return;
-        }
-        params.unvalidatedAuthority = authorityUrl;
+        // TODO: Rationalize default authority behavior (#93)
+        params.unvalidatedAuthority = [MSALAuthority defaultAuthority];
     }
-    else
+    else if (![params setAuthorityFromString:authority error:&error])
     {
-        params.unvalidatedAuthority = _authority;
+        completionBlock(nil, error);
+        return;
     }
+    
     params.redirectUri = _redirectUri;
     params.clientId = _clientId;
     params.tokenCache = _tokenCache;
     
-    NSError *error = nil;
     MSALInteractiveRequest *request =
     [[MSALInteractiveRequest alloc] initWithParameters:params
                                       additionalScopes:additionalScopes
@@ -399,7 +401,7 @@
 
 - (void)acquireTokenSilentForScopes:(NSArray<NSString *> *)scopes
                                user:(MSALUser *)user
-                          authority:(NSURL *)authority
+                          authority:(NSString *)authority
                        forceRefresh:(BOOL)forceRefresh
                       correlationId:(NSUUID *)correlationId
                               apiId:(MSALTelemetryApiId)apiId
@@ -426,12 +428,15 @@
                  "                                            correlationId:%@\n]",
                  scopes, user, forceRefresh ? @"Yes" : @"No", correlationId);
 
-    params.unvalidatedAuthority = authority;
+    NSError *error = nil;
+    if (![params setAuthorityFromString:authority error:&error])
+    {
+        completionBlock(nil, error);
+        return;
+    }
     params.redirectUri = _redirectUri;
     params.clientId = _clientId;
     params.tokenCache = _tokenCache;
-
-    NSError *error = nil;
     
     MSALSilentRequest *request =
     [[MSALSilentRequest alloc] initWithParameters:params forceRefresh:forceRefresh error:&error];

--- a/MSAL/src/instance/MSALAuthority.h
+++ b/MSAL/src/instance/MSALAuthority.h
@@ -89,6 +89,8 @@ typedef void(^MSALAuthorityCompletion)(MSALAuthority *authority, NSError *error)
  */
 + (BOOL)isTenantless:(NSURL *)authority;
 
++ (NSURL *)defaultAuthority;
+
 /*!
     Returns the URL to use in the cache key for a given authority input string
     and tenant ID returned with the token response.

--- a/MSAL/src/instance/MSALAuthority.m
+++ b/MSAL/src/instance/MSALAuthority.m
@@ -89,6 +89,10 @@ static NSMutableDictionary *s_validatedUsersForAuthority;
     return s_trustedHostList;
 }
 
++ (NSURL *)defaultAuthority
+{
+    return [NSURL URLWithString:@"https://login.microsoftonline.com/common"];
+}
 
 + (NSURL *)checkAuthorityString:(NSString *)authority
                           error:(NSError * __autoreleasing *)error

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -101,7 +101,7 @@
                          user:(MSALUser *)user
                    uiBehavior:(MSALUIBehavior)uiBehavior
          extraQueryParameters:(NSDictionary <NSString *, NSString *> *)extraQueryParameters
-                    authority:(NSURL *)authority
+                    authority:(NSString *)authority
                 correlationId:(NSUUID *)correlationId
               completionBlock:(MSALCompletionBlock)completionBlock;
 
@@ -114,12 +114,12 @@
 
 - (void)acquireTokenSilentForScopes:(NSArray<NSString *> *)scopes
                                user:(MSALUser *)user
-                          authority:(NSURL *)authority
+                          authority:(NSString *)authority
                     completionBlock:(MSALCompletionBlock)completionBlock;
 
 - (void)acquireTokenSilentForScopes:(NSArray<NSString *> *)scopes
                                user:(MSALUser *)user
-                          authority:(NSURL *)authority
+                          authority:(NSString *)authority
                        forceRefresh:(BOOL)forceRefresh
                       correlationId:(NSUUID *)correlationId
                     completionBlock:(MSALCompletionBlock)completionBlock;

--- a/MSAL/src/requests/MSALRequestParameters.h
+++ b/MSAL/src/requests/MSALRequestParameters.h
@@ -55,5 +55,6 @@
 
 #pragma mark Methods
 - (void)setScopesFromArray:(NSArray<NSString *> *)array;
-
+- (BOOL)setAuthorityFromString:(NSString *)authority
+                         error:(NSError * __autoreleasing *)error;
 @end

--- a/MSAL/src/requests/MSALRequestParameters.m
+++ b/MSAL/src/requests/MSALRequestParameters.m
@@ -28,6 +28,7 @@
 #import "MSALRequestParameters.h"
 #import "MSALUIBehavior.h"
 #import "MSALError_Internal.h"
+#import "MSALAuthority.h"
 
 @implementation MSALRequestParameters
 
@@ -39,6 +40,25 @@
         [scopesLowercase addObject:scope.lowercaseString];
     }
     self.scopes = [[NSOrderedSet alloc] initWithArray:scopesLowercase copyItems:YES];
+}
+
+- (BOOL)setAuthorityFromString:(NSString *)authority
+                         error:(NSError * __autoreleasing *)error
+{
+    if (!authority)
+    {
+        return YES;
+    }
+    
+    NSURL *authorityUrl = [MSALAuthority checkAuthorityString:authority error:error];
+    if (!authorityUrl)
+    {
+        return NO;
+    }
+    
+    self.unvalidatedAuthority = authorityUrl;
+    
+    return YES;
 }
 
 @end

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -382,12 +382,12 @@
          XCTAssertNotNil(params);
 
          XCTAssertEqual(params.apiId, MSALTelemetryApiIdAcquireSilentWithUser);
-         XCTAssertEqual(params.user.displayableId, @"displayableId");
-         XCTAssertEqual(params.user.name, @"user@contoso.com");
-         XCTAssertEqual(params.user.identityProvider, @"identifyProvider");
-         XCTAssertEqual(params.user.uid, @"1");
-         XCTAssertEqual(params.user.utid, @"1234-5678-90abcdefg");
-         XCTAssertEqual(params.user.environment, @"https://login.microsoftonline.com");
+         XCTAssertEqualObjects(params.user.displayableId, @"displayableId");
+         XCTAssertEqualObjects(params.user.name, @"user@contoso.com");
+         XCTAssertEqualObjects(params.user.identityProvider, @"identifyProvider");
+         XCTAssertEqualObjects(params.user.uid, @"1");
+         XCTAssertEqualObjects(params.user.utid, @"1234-5678-90abcdefg");
+         XCTAssertEqualObjects(params.user.environment, @"https://login.microsoftonline.com");
          
          XCTAssertNil(params.unvalidatedAuthority);
          
@@ -445,14 +445,14 @@
          XCTAssertNotNil(params);
          
          XCTAssertEqual(params.apiId, MSALTelemetryApiIdAcquireSilentWithUserAndAuthority);
-         XCTAssertEqual(params.user.displayableId, @"displayableId");
-         XCTAssertEqual(params.user.name, @"user@contoso.com");
-         XCTAssertEqual(params.user.identityProvider, @"identifyProvider");
-         XCTAssertEqual(params.user.uid, @"1");
-         XCTAssertEqual(params.user.utid, @"1234-5678-90abcdefg");
-         XCTAssertEqual(params.user.environment, @"https://login.microsoftonline.com");
+         XCTAssertEqualObjects(params.user.displayableId, @"displayableId");
+         XCTAssertEqualObjects(params.user.name, @"user@contoso.com");
+         XCTAssertEqualObjects(params.user.identityProvider, @"identifyProvider");
+         XCTAssertEqualObjects(params.user.uid, @"1");
+         XCTAssertEqualObjects(params.user.utid, @"1234-5678-90abcdefg");
+         XCTAssertEqualObjects(params.user.environment, @"https://login.microsoftonline.com");
          
-         XCTAssertEqual(params.unvalidatedAuthority.absoluteString, @"https://login.microsoft.com/common");
+         XCTAssertEqualObjects(params.unvalidatedAuthority.absoluteString, @"https://login.microsoft.com/common");
          
          XCTAssertFalse(obj.forceRefresh);
          
@@ -473,7 +473,7 @@
     
     [application acquireTokenSilentForScopes:@[@"fakescope1", @"fakescope2"]
                                         user:user
-                                   authority:[NSURL URLWithString:@"https://login.microsoft.com/common"]
+                                   authority:@"https://login.microsoft.com/common"
                              completionBlock:^(MSALResult *result, NSError *error)
      {
          XCTAssertNil(result);
@@ -512,18 +512,18 @@
          XCTAssertNotNil(params);
          
          XCTAssertEqual(params.apiId, MSALTelemetryApiIdAcquireSilentWithUserAuthorityForceRefreshAndCorrelationId);
-         XCTAssertEqual(params.user.displayableId, @"displayableId");
-         XCTAssertEqual(params.user.name, @"user@contoso.com");
-         XCTAssertEqual(params.user.identityProvider, @"identifyProvider");
-         XCTAssertEqual(params.user.uid, @"1");
-         XCTAssertEqual(params.user.utid, @"1234-5678-90abcdefg");
-         XCTAssertEqual(params.user.environment, @"https://login.microsoftonline.com");
+         XCTAssertEqualObjects(params.user.displayableId, @"displayableId");
+         XCTAssertEqualObjects(params.user.name, @"user@contoso.com");
+         XCTAssertEqualObjects(params.user.identityProvider, @"identifyProvider");
+         XCTAssertEqualObjects(params.user.uid, @"1");
+         XCTAssertEqualObjects(params.user.utid, @"1234-5678-90abcdefg");
+         XCTAssertEqualObjects(params.user.environment, @"https://login.microsoftonline.com");
          
-         XCTAssertEqual(params.unvalidatedAuthority.absoluteString, @"https://login.microsoft.com/common");
+         XCTAssertEqualObjects(params.unvalidatedAuthority.absoluteString, @"https://login.microsoft.com/common");
          
          XCTAssertTrue(obj.forceRefresh);
          
-         XCTAssertEqual(params.correlationId, correlationId);
+         XCTAssertEqualObjects(params.correlationId, correlationId);
          XCTAssertEqualObjects(params.scopes, ([NSOrderedSet orderedSetWithObjects:@"fakescope1", @"fakescope2", nil]));
          XCTAssertEqualObjects(params.clientId, @"b92e0ba5-f86e-4411-8e18-6b5f928d968a");
          
@@ -541,7 +541,7 @@
     
     [application acquireTokenSilentForScopes:@[@"fakescope1", @"fakescope2"]
                                         user:user
-                                   authority:[NSURL URLWithString:@"https://login.microsoft.com/common"]
+                                   authority:@"https://login.microsoft.com/common"
                                 forceRefresh:YES
                                correlationId:correlationId
                              completionBlock:^(MSALResult *result, NSError *error)


### PR DESCRIPTION
- Change the parameter type of authority on the cople methods that added it from NSURL to NSString for API consistency
- Add `-setAuthorityFromString:error:` method to MSALRequestParameters to centralize authority setting behavior
- Move `DEFAULT_AUTHORITY` to MSALAuthority
- Fix a bunch of XCTAssertEqual(s) that should have been XCTAssertEqualObjects