### PR TITLE
[Memory leak] invalidate url session

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -415,7 +415,7 @@
     params.redirectUri = _redirectUri;
     params.clientId = _clientId;
     params.tokenCache = _tokenCache;
-    params.urlSession = [MSALURLSession createMSALSesssion:params];
+    params.urlSession = [MSALURLSession createMSALSession:params];
     
     MSALInteractiveRequest *request =
     [[MSALInteractiveRequest alloc] initWithParameters:params
@@ -472,7 +472,7 @@
     params.redirectUri = _redirectUri;
     params.clientId = _clientId;
     params.tokenCache = _tokenCache;
-    params.urlSession = [MSALURLSession createMSALSesssion:params];
+    params.urlSession = [MSALURLSession createMSALSession:params];
 
     MSALSilentRequest *request =
     [[MSALSilentRequest alloc] initWithParameters:params forceRefresh:forceRefresh error:&error];

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -373,7 +373,6 @@
               completionBlock:(MSALCompletionBlock)completionBlock
 {
     MSALRequestParameters* params = [MSALRequestParameters new];
-    params.urlSession = [MSALURLSession createMSALSesssion:params];
     params.correlationId = correlationId ? correlationId : [NSUUID new];
     params.component = _component;
     params.apiId = apiId;
@@ -416,6 +415,7 @@
     params.redirectUri = _redirectUri;
     params.clientId = _clientId;
     params.tokenCache = _tokenCache;
+    params.urlSession = [MSALURLSession createMSALSesssion:params];
     
     MSALInteractiveRequest *request =
     [[MSALInteractiveRequest alloc] initWithParameters:params
@@ -424,11 +424,15 @@
                                                  error:&error];
     if (!request)
     {
+        [params.urlSession invalidateAndCancel];
         completionBlock(nil, error);
         return;
     }
     
-    [request run:completionBlock];
+    [request run:^(MSALResult *result, NSError *error) {
+        [params.urlSession invalidateAndCancel];
+        completionBlock(result, error);
+    }];
 }
 
 - (void)acquireTokenSilentForScopes:(NSArray<NSString *> *)scopes
@@ -440,7 +444,6 @@
                     completionBlock:(MSALCompletionBlock)completionBlock
 {
     MSALRequestParameters* params = [MSALRequestParameters new];
-    params.urlSession = [MSALURLSession createMSALSesssion:params];
     params.correlationId = correlationId ? correlationId : [NSUUID new];
     params.user = user;
     params.apiId = apiId;
@@ -469,17 +472,22 @@
     params.redirectUri = _redirectUri;
     params.clientId = _clientId;
     params.tokenCache = _tokenCache;
-    
+    params.urlSession = [MSALURLSession createMSALSesssion:params];
+
     MSALSilentRequest *request =
     [[MSALSilentRequest alloc] initWithParameters:params forceRefresh:forceRefresh error:&error];
     
     if (!request)
     {
+        [params.urlSession invalidateAndCancel];
         completionBlock(nil, error);
         return;
     }
     
-    [request run:completionBlock];
+    [request run:^(MSALResult *result, NSError *error) {
+        [params.urlSession invalidateAndCancel];
+        completionBlock(result, error);
+    }];
 }
 
 #pragma mark -

--- a/MSAL/src/http/MSALURLSession.h
+++ b/MSAL/src/http/MSALURLSession.h
@@ -29,6 +29,6 @@
 
 @interface MSALURLSession : NSObject
 
-+ (NSURLSession *)createMSALSesssion:(id<MSALRequestContext>)context;
++ (NSURLSession *)createMSALSession:(id<MSALRequestContext>)context;
 
 @end

--- a/MSAL/src/http/MSALURLSession.m
+++ b/MSAL/src/http/MSALURLSession.m
@@ -30,7 +30,7 @@
 
 @implementation MSALURLSession
 
-+ (NSURLSession *)createMSALSesssion:(id<MSALRequestContext>)context
++ (NSURLSession *)createMSALSession:(id<MSALRequestContext>)context
 {
     MSALURLSessionDelegate *delegate = [[MSALURLSessionDelegate alloc] initWithContext:context];
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];

--- a/MSAL/test/unit/utils/MSALTestURLSession.m
+++ b/MSAL/test/unit/utils/MSALTestURLSession.m
@@ -373,7 +373,10 @@ static NSMutableArray *s_responses = nil;
 #pragma mark - NSURLSession
 
 // Invalidate
-- (void)invalidateAndCancel{}
+- (void)invalidateAndCancel
+{
+    // No need to invalidate anything here.
+}
 
 
 // Runtime methods for NSURLSession, needs to declare since this is a NSObject, not :NSURLSession

--- a/MSAL/test/unit/utils/MSALTestURLSession.m
+++ b/MSAL/test/unit/utils/MSALTestURLSession.m
@@ -371,6 +371,11 @@ static NSMutableArray *s_responses = nil;
 
 
 #pragma mark - NSURLSession
+
+// Invalidate
+- (void)invalidateAndCancel{}
+
+
 // Runtime methods for NSURLSession, needs to declare since this is a NSObject, not :NSURLSession
 // For now though, of no real usage
 - (void)set_isSharedSession:(BOOL)shared


### PR DESCRIPTION
(#103) Addresses memory leak with the url session:
- Move creation of a session after authority checking, 
- invalidate after acquire token has been complete.

*The session object keeps a strong reference to the delegate until your app exits or explicitly invalidates the session. If you do not invalidate the session, your app leaks memory until it exits.*
