### PR TITLE
[Memory leak] Use CFBridgingRelease in keychain token cache

### DIFF
--- a/MSAL/src/cache/ios/MSALKeychainTokenCache.m
+++ b/MSAL/src/cache/ios/MSALKeychainTokenCache.m
@@ -222,7 +222,7 @@ typedef NS_ENUM(uint32_t, MSALTokenType)
         return nil;
     }
     
-    return [MSALKeychainTokenCache refreshTokenItemFromKeychainAttributes:(__bridge NSDictionary *)item context:ctx error:error];;
+    return [MSALKeychainTokenCache refreshTokenItemFromKeychainAttributes:CFBridgingRelease(item) context:ctx error:error];;
 }
 
 - (nullable NSArray<MSALRefreshTokenCacheItem *> *)allRefreshTokens:(nullable NSString *)clientId


### PR DESCRIPTION
(#105)
Use CFBridgingRelease for getRefreshTokenItemForKey:context:error