### PR TITLE
Minor updates

### DIFF
--- a/MSAL/src/MSALLogger.m
+++ b/MSAL/src/MSALLogger.m
@@ -152,7 +152,7 @@ static NSDateFormatter *s_dateFormatter = nil;
         UIDevice* device = [UIDevice currentDevice];
         NSMutableDictionary* result = [NSMutableDictionary dictionaryWithDictionary:
                                        @{
-                                         MSAL_ID_PLATFORM:@"iOS",
+                                         MSAL_ID_PLATFORM:@"MSAL.iOS",
                                          MSAL_ID_VERSION:@MSAL_VERSION_STRING,
                                          MSAL_ID_OS_VER:device.systemVersion,
                                          MSAL_ID_DEVICE_MODEL:device.model,//Prints out only "iPhone" or "iPad".
@@ -161,7 +161,7 @@ static NSDateFormatter *s_dateFormatter = nil;
         NSOperatingSystemVersion osVersion = [[NSProcessInfo processInfo] operatingSystemVersion];
         NSMutableDictionary* result = [NSMutableDictionary dictionaryWithDictionary:
                                        @{
-                                         MSAL_ID_PLATFORM:@"OSX",
+                                         MSAL_ID_PLATFORM:@"MSAL.OSX",
                                          MSAL_ID_VERSION:@MSAL_VERSION_STRING,
                                          MSAL_ID_OS_VER:[NSString stringWithFormat:@"%ld.%ld.%ld", (long)osVersion.majorVersion, (long)osVersion.minorVersion, (long)osVersion.patchVersion],
                                          }];

--- a/MSAL/src/http/MSALHttpRequest.m
+++ b/MSAL/src/http/MSALHttpRequest.m
@@ -49,7 +49,6 @@ NSString *const MSALHttpHeaderFormURLEncoded = @"application/x-www-form-urlencod
     NSMutableDictionary<NSString *, NSString *> *_headers;
     NSMutableDictionary *_queryParameters;
     
-    //TODO: move to seperate settings? - MSALAuthenticationSettings.h
     NSTimeInterval _timeOutInterval;
     NSURLRequestCachePolicy _cachePolicy;
 }
@@ -165,8 +164,6 @@ static NSString *const s_kHttpHeaderDelimeter = @",";
         bodyData = [[_bodyParameters msalURLFormEncode] dataUsingEncoding:NSUTF8StringEncoding];
         [self setContentTypeFormURLEncoded];
     }
-    
-    // TODO: Add client version to URL
     
     newURL = newURL? newURL : _endpointURL;
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:newURL

--- a/MSAL/src/instance/MSALAdfsAuthorityResolver.m
+++ b/MSAL/src/instance/MSALAdfsAuthorityResolver.m
@@ -40,8 +40,9 @@
     (void)validate;
     (void)context;
     (void)completionBlock;
-    @throw @"TODO";
-
+    
+    NSError *error = CREATE_LOG_ERROR(context, MSALErrorInvalidRequest, @"AD FS as authority is not supported for preview");
+    completionBlock(nil, error);
 }
 
 - (NSString *)defaultOpenIdConfigurationEndpointForAuthority:(NSURL *)authority

--- a/MSAL/test/unit/MSALAuthorityTests.m
+++ b/MSAL/test/unit/MSALAuthorityTests.m
@@ -213,7 +213,7 @@
     XCTAssertNil([MSALAuthority authorityFromCache:[NSURL URLWithString:@"https://somehost.com/"] userPrincipalName:nil]);
 }
 
-- (void)testResolveEndpointsSuccess
+- (void)testResolveEndpointsForAuthority_whenNormalAad_shouldPass
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Expectation"];
 
@@ -283,7 +283,7 @@
      }];
 }
 
-- (void)testResolveEndpointsOpenIDConfigError
+- (void)testResolveEndpointsForAuthority_whenOpenIDConfigError_shouldFail
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Expectation"];
     
@@ -325,7 +325,7 @@
      }];
 }
 
-- (void)testResolveEndpointWithTenantEndpointError
+- (void)testResolveEndpointsForAuthority_whenTenantEndpointError_shouldFail
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Expectation"];
     
@@ -381,6 +381,32 @@
      {
          (void)error;
      }];
+}
+
+// For preview, AD FS as authority is not supported
+- (void)testResolveEndpointsForAuthority_whenAdfsAuthority_shouldFail
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Expectation"];
+    
+    NSURL *adfsAuthority = [NSURL URLWithString:@"https://somehost.com/adfs/"];
+    
+    [MSALAuthority resolveEndpointsForAuthority:adfsAuthority
+                              userPrincipalName:nil
+                                       validate:YES
+                                        context:nil
+                                completionBlock:^(MSALAuthority *authority, NSError *error)
+     {
+         XCTAssertNil(authority);
+         XCTAssertNotNil(error);
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectationsWithTimeout:1.0
+                                 handler:^(NSError * _Nullable error)
+     {
+         (void)error;
+     }];
+
 }
 
 @end

--- a/MSAL/test/unit/MSALInteractiveRequestTests.m
+++ b/MSAL/test/unit/MSALInteractiveRequestTests.m
@@ -130,10 +130,10 @@
     @{
       @"x-client-Ver" : MSAL_VERSION_NSSTRING,
 #if TARGET_OS_IPHONE
-      @"x-client-SKU" : @"iOS",
+      @"x-client-SKU" : @"MSAL.iOS",
       @"x-client-DM" : msalId[@"x-client-DM"],
 #else
-      @"x-client-SKU" : @"OSX",
+      @"x-client-SKU" : @"MSAL.OSX",
 #endif
       @"x-client-OS" : msalId[@"x-client-OS"],
       @"x-client-CPU" : msalId[@"x-client-CPU"],
@@ -208,10 +208,10 @@
     @{
       @"x-client-Ver" : MSAL_VERSION_NSSTRING,
 #if TARGET_OS_IPHONE
-      @"x-client-SKU" : @"iOS",
+      @"x-client-SKU" : @"MSAL.iOS",
       @"x-client-DM" : msalId[@"x-client-DM"],
 #else
-      @"x-client-SKU" : @"OSX",
+      @"x-client-SKU" : @"MSAL.OSX",
 #endif
       @"x-client-OS" : msalId[@"x-client-OS"],
       @"x-client-CPU" : msalId[@"x-client-CPU"],
@@ -294,10 +294,10 @@
          @{
            @"x-client-Ver" : MSAL_VERSION_NSSTRING,
 #if TARGET_OS_IPHONE
-           @"x-client-SKU" : @"iOS",
+           @"x-client-SKU" : @"MSAL.iOS",
            @"x-client-DM" : msalId[@"x-client-DM"],
 #else
-           @"x-client-SKU" : @"OSX",
+           @"x-client-SKU" : @"MSAL.OSX",
 #endif
            @"x-client-OS" : msalId[@"x-client-OS"],
            @"x-client-CPU" : msalId[@"x-client-CPU"],
@@ -454,10 +454,10 @@
          @{
            @"x-client-Ver" : MSAL_VERSION_NSSTRING,
 #if TARGET_OS_IPHONE
-           @"x-client-SKU" : @"iOS",
+           @"x-client-SKU" : @"MSAL.iOS",
            @"x-client-DM" : msalId[@"x-client-DM"],
 #else
-           @"x-client-SKU" : @"OSX",
+           @"x-client-SKU" : @"MSAL.OSX",
 #endif
            @"x-client-OS" : msalId[@"x-client-OS"],
            @"x-client-CPU" : msalId[@"x-client-CPU"],
@@ -616,10 +616,10 @@
          @{
            @"x-client-Ver" : MSAL_VERSION_NSSTRING,
 #if TARGET_OS_IPHONE
-           @"x-client-SKU" : @"iOS",
+           @"x-client-SKU" : @"MSAL.iOS",
            @"x-client-DM" : msalId[@"x-client-DM"],
 #else
-           @"x-client-SKU" : @"OSX",
+           @"x-client-SKU" : @"MSAL.OSX",
 #endif
            @"x-client-OS" : msalId[@"x-client-OS"],
            @"x-client-CPU" : msalId[@"x-client-CPU"],


### PR DESCRIPTION
- update x-client-sky value to "MSAL.iOS" and "MSAL.OSX"
- add error for AD FS authority instead of leaving it as "todo"