### PR TITLE
Telemetry cache cleanup

### DIFF
--- a/MSAL/src/telemetry/MSALTelemetry.m
+++ b/MSAL/src/telemetry/MSALTelemetry.m
@@ -171,6 +171,8 @@ setTelemetryOnFailure:(BOOL)setTelemetryOnFailure
         {
             [_errorEvents addObject:requestId];
         }
+        
+        [_eventTracking removeObjectForKey:key];
     }
 }
 


### PR DESCRIPTION
Remove cached event time from the tracking dictionary, when it's not necessary anymore to avoid memory overhead