### PR TITLE
Refactor MSALTokenCache

### DIFF
--- a/MSAL/src/cache/MSALTokenCache.h
+++ b/MSAL/src/cache/MSALTokenCache.h
@@ -33,19 +33,31 @@
 
 - (id<MSALTokenCacheAccessor>)dataSource;
 
-- (MSALAccessTokenCacheItem *)saveAccessAndRefreshToken:(MSALRequestParameters *)requestParam
-                                               response:(MSALTokenResponse *)response
-                                                context:(id<MSALRequestContext>)ctx
-                                                  error:(NSError * __autoreleasing *)error;
+- (MSALAccessTokenCacheItem *)saveAccessTokenWithAuthority:(NSURL *)authority
+                                                  clientId:(NSString *)clientId
+                                                  response:(MSALTokenResponse *)response
+                                                   context:(id<MSALRequestContext>)context
+                                                     error:(NSError * __autoreleasing *)error;
 
-- (MSALAccessTokenCacheItem *)findAccessToken:(MSALRequestParameters *)requestParam
-                                      context:(id<MSALRequestContext>)ctx
-                               authorityFound:(NSString * __autoreleasing *)authorityFound
-                                        error:(NSError * __autoreleasing *)error;
+- (MSALRefreshTokenCacheItem *)saveRefreshTokenWithEnvironment:(NSString *)environment
+                                                      clientId:(NSString *)clientId
+                                                      response:(MSALTokenResponse *)response
+                                                       context:(id<MSALRequestContext>)context
+                                                         error:(NSError * __autoreleasing *)error;
 
-- (MSALRefreshTokenCacheItem *)findRefreshToken:(MSALRequestParameters *)requestParam
-                                        context:(id<MSALRequestContext>)ctx
-                                          error:(NSError * __autoreleasing *)error;
+- (MSALAccessTokenCacheItem *)findAccessTokenWithAuthority:(NSURL *)authority
+                                                  clientId:(NSString *)clientId
+                                                    scopes:(MSALScopes *)scopes
+                                                      user:(MSALUser *)user
+                                                   context:(id<MSALRequestContext>)ctx
+                                            authorityFound:(NSString * __autoreleasing *)authorityFound
+                                                     error:(NSError * __autoreleasing *)error;
+
+- (MSALRefreshTokenCacheItem *)findRefreshTokenWithEnvironment:(NSString *)environment
+                                                      clientId:(NSString *)clientId
+                                                userIdentifier:(NSString *)userIdentifier
+                                                       context:(id<MSALRequestContext>)ctx
+                                                         error:(NSError * __autoreleasing *)error;
 
 - (BOOL)deleteAllTokensForUser:(MSALUser *)user
                       clientId:(NSString *)clientId

--- a/MSAL/src/cache/MSALTokenCache.m
+++ b/MSAL/src/cache/MSALTokenCache.m
@@ -157,12 +157,6 @@
                                                                            context:ctx];
     [event setTokenType:MSAL_TELEMETRY_VALUE_ACCESS_TOKEN];
     
-    MSALAccessTokenCacheKey *key = [[MSALAccessTokenCacheKey alloc] initWithAuthority:authority.absoluteString
-                                                                             clientId:clientId
-                                                                                scope:scopes
-                                                                       userIdentifier:user.userIdentifier
-                                                                          environment:user.environment];
-    
     NSArray<MSALAccessTokenCacheItem *> *allAccessTokens = [self allAccessTokensForUser:user
                                                                                clientId:clientId
                                                                                 context:ctx
@@ -178,13 +172,14 @@
     
     for (MSALAccessTokenCacheItem *tokenItem in allAccessTokens)
     {
-        if (authority && [key matches:[tokenItem tokenCacheKey:nil]])
+        if ([scopes isSubsetOfOrderedSet:tokenItem.scope])
         {
-            [matchedTokens addObject:tokenItem];
-        }
-        else if (!authority && [scopes isSubsetOfOrderedSet:tokenItem.scope])
-        {
-            [matchedTokens addObject:tokenItem];
+            if ((!authority) ||
+                (authority && [authority.absoluteString isEqual:tokenItem.authority]))
+                
+            {
+                [matchedTokens addObject:tokenItem];
+            }
         }
     }
     

--- a/MSAL/src/requests/MSALBaseRequest.m
+++ b/MSAL/src/requests/MSALBaseRequest.m
@@ -38,6 +38,7 @@
 #import "NSString+MSALHelperMethods.h"
 #import "MSALTelemetryApiId.h"
 #import "MSALClientInfo.h"
+#import "NSURL+MSALExtensions.h"
 
 static MSALScopes *s_reservedScopes = nil;
 
@@ -237,11 +238,12 @@ static MSALScopes *s_reservedScopes = nil;
          
          NSError *cacheError = nil;
          MSALTokenCache *cache = self.parameters.tokenCache;
-         MSALAccessTokenCacheItem *atItem =
-         [cache saveAccessAndRefreshToken:self.parameters
-                                 response:tokenResponse
-                                  context:_parameters
-                                    error:&cacheError];
+         
+         MSALAccessTokenCacheItem *atItem = [cache saveAccessTokenWithAuthority:_parameters.unvalidatedAuthority
+                                                                       clientId:_parameters.clientId
+                                                                       response:tokenResponse
+                                                                        context:_parameters
+                                                                          error:&cacheError];
          
          if (!atItem)
          {
@@ -249,6 +251,17 @@ static MSALScopes *s_reservedScopes = nil;
              return;
          }
 
+         MSALRefreshTokenCacheItem *rtItem =  [cache saveRefreshTokenWithEnvironment:_parameters.unvalidatedAuthority.msalHostWithPort
+                                                                            clientId:_parameters.clientId
+                                                                            response:tokenResponse
+                                                                             context:_parameters
+                                                                               error:&cacheError];
+         if (!rtItem && cacheError)
+         {
+             completionBlock(nil, cacheError);
+             return;
+         }
+         
          MSALResult *result =
          [MSALResult resultWithAccessToken:atItem.accessToken
                                  expiresOn:atItem.expiresOn

--- a/MSAL/src/requests/MSALSilentRequest.m
+++ b/MSAL/src/requests/MSALSilentRequest.m
@@ -35,6 +35,8 @@
 #import "MSALTelemetry+Internal.h"
 #import "MSALTelemetryEventStrings.h"
 
+#import "NSURL+MSALExtensions.h"
+
 @interface MSALSilentRequest()
 {
     MSALRefreshTokenCacheItem *_refreshToken;
@@ -70,10 +72,13 @@
     {
         NSString *updatedAuthority = nil;
         NSError *error = nil;
-        MSALAccessTokenCacheItem *accessToken = [cache findAccessToken:_parameters
-                                                               context:_parameters
-                                                        authorityFound:&updatedAuthority
-                                                                 error:&error];
+        MSALAccessTokenCacheItem *accessToken = [cache findAccessTokenWithAuthority:_parameters.unvalidatedAuthority
+                                                                           clientId:_parameters.clientId
+                                                                             scopes:_parameters.scopes
+                                                                               user:_parameters.user
+                                                                            context:_parameters
+                                                                     authorityFound:&updatedAuthority
+                                                                              error:&error];
         
         if (accessToken)
         {
@@ -99,7 +104,12 @@
         _parameters.unvalidatedAuthority = [NSURL URLWithString:updatedAuthority];
     }
     
-    _refreshToken = [cache findRefreshToken:_parameters context:_parameters error:nil];
+    _refreshToken = [cache findRefreshTokenWithEnvironment:_parameters.unvalidatedAuthority.msalHostWithPort
+                                                  clientId:_parameters.clientId
+                                            userIdentifier:_parameters.user.userIdentifier
+                                                   context:_parameters
+                                                     error:nil];
+    
     CHECK_ERROR_COMPLETION(_refreshToken, _parameters, MSALErrorAuthorizationFailed, @"No token matching arguments found in the cache")
     
     [super resolveEndpoints:^(MSALAuthority *authority, NSError *error) {

--- a/MSAL/test/unit/MSALTokenCacheTests.m
+++ b/MSAL/test/unit/MSALTokenCacheTests.m
@@ -136,18 +136,29 @@
     [super tearDown];
 }
 
-- (void)testSaveAndRetrieveAccessToken_whenExists_shouldFind
+- (void)testSaveAccessTokenWithAuthority_whenExists_shouldFindAT
 {
     //prepare token response and save AT/RT
     MSALAccessTokenCacheItem *atItem = [[MSALAccessTokenCacheItem alloc] initWithAuthority:_testAuthority
                                                                                   clientId:_testClientId
                                                                                   response:_testTokenResponse];
-    [_cache saveAccessAndRefreshToken:_requestParam1 response:_testTokenResponse context:nil error:nil];
+    [_cache saveAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                clientId:_requestParam1.clientId
+                                response:_testTokenResponse
+                                 context:nil error:nil];
+    
     
     //retrieve AT
     NSString *authorityFound;
     NSError *error = nil;
-    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessToken:_requestParam1 context:nil authorityFound:&authorityFound error:&error];
+    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                                                          clientId:_requestParam1.clientId
+                                                                            scopes:_requestParam1.scopes
+                                                                              user:_requestParam1.user
+                                                                           context:nil
+                                                                    authorityFound:&authorityFound
+                                                                             error:&error];
+                                               
     XCTAssertNil(error);
     
     //compare AT with the AT retrieved from cache
@@ -155,40 +166,73 @@
     XCTAssertEqualObjects(atItem, atItemInCache);
 }
 
-- (void)testSaveSameTokenTwice
+- (void)testSaveAccessTokenWithAuthority_whenSameTokenTwice_shouldSaveOne
 {
-    //save AT/RT twice
+    //save AT twice
     NSError *error = nil;
-    [_cache saveAccessAndRefreshToken:_requestParam1 response:_testTokenResponse context:nil error:&error];
+    [_cache saveAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                clientId:_requestParam1.clientId
+                                response:_testTokenResponse
+                                 context:nil error:nil];
     XCTAssertNil(error);
     
     error = nil;
-    [_cache saveAccessAndRefreshToken:_requestParam1 response:_testTokenResponse context:nil error:&error];
+    [_cache saveAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                clientId:_requestParam1.clientId
+                                response:_testTokenResponse
+                                 context:nil error:nil];
+    
     XCTAssertNil(error);
     
-    //there should be still one AT and one RT in cache
+    //there should be still one AT in cache
     NSArray <MSALAccessTokenCacheItem *> *atsInCache = [_cache.dataSource getAccessTokenItemsWithKey:nil context:nil error:nil];
     XCTAssertEqual(atsInCache.count, 1);
+}
+
+- (void)testSaveRefreshTokenWithEnvironment_whenSameTokenTwice_shouldSaveOne
+{
+    //save RT twice
+    NSError *error = nil;
+    [_cache saveRefreshTokenWithEnvironment:_requestParam1.unvalidatedAuthority.msalHostWithPort
+                                   clientId:_requestParam1.clientId
+                                   response:_testTokenResponse
+                                    context:nil error:nil];
+    XCTAssertNil(error);
+    
+    error = nil;
+    [_cache saveRefreshTokenWithEnvironment:_requestParam1.unvalidatedAuthority.msalHostWithPort
+                                   clientId:_requestParam1.clientId
+                                   response:_testTokenResponse
+                                    context:nil error:nil];
+    
+    XCTAssertNil(error);
+    
+    //there should be still one RT in cache
     NSArray <MSALRefreshTokenCacheItem *> *rtsInCache = [_cache.dataSource allRefreshTokens:nil context:nil error:nil];
     XCTAssertEqual(rtsInCache.count, 1);
 }
 
-- (void)testSaveMultipleTokens
+- (void)testSaveAccessTokenWithAuthority_whenMultipleTokens_shouldSaveMultipleTokens
 {
-    //save first and second AT/RT
+    //save first and second AT
     NSError *error = nil;
-    [_cache saveAccessAndRefreshToken:_requestParam1 response:_testTokenResponse context:nil error:&error];
+    [_cache saveAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                clientId:_requestParam1.clientId
+                                response:_testTokenResponse
+                                 context:nil error:nil];
     XCTAssertNil(error);
     
     error = nil;
-    [_cache saveAccessAndRefreshToken:_requestParam2 response:_testTokenResponse2 context:nil error:&error];
+    [_cache saveAccessTokenWithAuthority:_requestParam2.unvalidatedAuthority
+                                clientId:_requestParam2.clientId
+                                response:_testTokenResponse2
+                                 context:nil error:nil];
+    
     XCTAssertNil(error);
     
-    //there should be two ATs and RTs in cache
+    //there should be two ATs in cache
     NSArray <MSALAccessTokenCacheItem *> *atsInCache = [_cache.dataSource getAccessTokenItemsWithKey:nil context:nil error:nil];
-    NSArray <MSALRefreshTokenCacheItem *> *rtsInCache = [_cache.dataSource allRefreshTokens:nil context:nil error:nil];
     XCTAssertEqual(atsInCache.count, 2);
-    XCTAssertEqual(rtsInCache.count, 2);
     
     //compare ATs with the ATs retrieved from cache
     MSALAccessTokenCacheItem *atItem = [[MSALAccessTokenCacheItem alloc] initWithAuthority:_testAuthority
@@ -200,6 +244,31 @@
     NSSet *atsSet = [[NSSet alloc] initWithObjects:atItem, atItem2, nil];
     NSSet *atsInCacheSet = [[NSSet alloc] initWithArray:atsInCache];
     XCTAssertEqualObjects(atsInCacheSet, atsSet);
+}
+
+
+- (void)testSaveRefreshTokenWithEnvironment_whenMultipleTokens_shouldSaveMultipleTokens
+{
+    //save first and second RT
+    NSError *error = nil;
+    [_cache saveRefreshTokenWithEnvironment:_requestParam1.unvalidatedAuthority.msalHostWithPort
+                                   clientId:_requestParam1.clientId
+                                   response:_testTokenResponse
+                                    context:nil error:nil];
+    
+    XCTAssertNil(error);
+    
+    error = nil;
+    [_cache saveRefreshTokenWithEnvironment:_requestParam2.unvalidatedAuthority.msalHostWithPort
+                                   clientId:_requestParam2.clientId
+                                   response:_testTokenResponse2
+                                    context:nil error:nil];
+    
+    XCTAssertNil(error);
+    
+    //there should be two RTs in cache
+    NSArray <MSALRefreshTokenCacheItem *> *rtsInCache = [_cache.dataSource allRefreshTokens:nil context:nil error:nil];
+    XCTAssertEqual(rtsInCache.count, 2);
     
     //compare RTs with the RTs retrieved from cache
     MSALRefreshTokenCacheItem *rtItem = [[MSALRefreshTokenCacheItem alloc] initWithEnvironment:_testAuthority.msalHostWithPort
@@ -237,30 +306,43 @@
     requestParam.user = _user1;
     [requestParam setScopesFromArray:@[@"User.Read", @"scope.notexist"]];
     NSError *error = nil;
-    XCTAssertNil([_cache findAccessToken:requestParam context:nil authorityFound:nil error:&error]);
+    XCTAssertNil([_cache findAccessTokenWithAuthority:requestParam.unvalidatedAuthority
+                                             clientId:requestParam.clientId
+                                               scopes:requestParam.scopes
+                                                 user:requestParam.user
+                                              context:nil
+                                       authorityFound:nil
+                                                error:&error]);
     XCTAssertNil(error);
 }
 
-- (void)testSaveAndRetrieveRefreshToken
+- (void)testFindRefreshTokenWithEnvironment_whenOneSaved_shouldFindRT
 {
-    //prepare token response and save AT/RT
+    //prepare token response and save RT
     MSALRefreshTokenCacheItem *rtItem = [[MSALRefreshTokenCacheItem alloc] initWithEnvironment:_testAuthority.msalHostWithPort
                                                                                       clientId:_testClientId
                                                                                       response:_testTokenResponse];
     NSError *error = nil;
-    [_cache saveAccessAndRefreshToken:_requestParam1 response:_testTokenResponse context:nil error:&error];
+    [_cache saveRefreshTokenWithEnvironment:_requestParam1.unvalidatedAuthority.msalHostWithPort
+                                   clientId:_requestParam1.clientId
+                                   response:_testTokenResponse
+                                    context:nil error:nil];
+    
     XCTAssertNil(error);
     
     //retrieve RT
     error = nil;
-    MSALRefreshTokenCacheItem *rtItemInCache = [_cache findRefreshToken:_requestParam1 context:nil error:&error];
+    MSALRefreshTokenCacheItem *rtItemInCache = [_cache findRefreshTokenWithEnvironment:_requestParam1.unvalidatedAuthority.msalHostWithPort
+                                                                              clientId:_requestParam1.clientId
+                                                                        userIdentifier:_requestParam1.user.userIdentifier
+                                                                               context:nil error:&error];
     XCTAssertNil(error);
     
     //compare RT with the RT retrieved from cache
     XCTAssertEqualObjects(rtItem, rtItemInCache);
 }
 
-- (void)testDeleteAllTokensForUser
+- (void)testDeleteAllTokensForUser_whenMultipleUsersAndTokens_shouldDeleteTokensForOneUser
 {
     //store AT/RT for user 1
     NSDictionary *clientInfo1 = @{ @"uid" : _user1.uid, @"utid" : _user1.utid };
@@ -321,11 +403,20 @@
     
     //Both RT and AT are deleted, both should return nil
     NSError *error = nil;
-    XCTAssertNil([_cache findAccessToken:_requestParam1 context:nil authorityFound:nil error:&error]);
+    XCTAssertNil([_cache findAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                             clientId:_requestParam1.clientId
+                                               scopes:_requestParam1.scopes
+                                                 user:_requestParam1.user
+                                              context:nil
+                                       authorityFound:nil
+                                                error:&error]);
     XCTAssertNil(error);
     
     error = nil;
-    XCTAssertNil([_cache findRefreshToken:_requestParam1 context:nil error:&error]);
+    XCTAssertNil([_cache findRefreshTokenWithEnvironment:_requestParam1.unvalidatedAuthority.msalHostWithPort
+                                                clientId:_requestParam1.clientId
+                                          userIdentifier:_requestParam1.user.userIdentifier
+                                                 context:nil error:&error]);
     XCTAssertNil(error);
     
     //there should be one AT and one RT left in cache, both are for user 2
@@ -333,10 +424,19 @@
     XCTAssertEqual([_cache.dataSource allRefreshTokens:nil context:nil error:nil].count, 1);
     
     error = nil;
-    MSALAccessTokenCacheItem *atItemInCache2 = [_cache findAccessToken:_requestParam2 context:nil authorityFound:nil error:&error];
+    MSALAccessTokenCacheItem *atItemInCache2 = [_cache findAccessTokenWithAuthority:_requestParam2.unvalidatedAuthority
+                                                                           clientId:_requestParam2.clientId
+                                                                             scopes:_requestParam2.scopes
+                                                                               user:_requestParam2.user
+                                                                            context:nil
+                                                                     authorityFound:nil
+                                                                              error:&error];;
     XCTAssertNil(error);
     error = nil;
-    MSALRefreshTokenCacheItem *rtItemInCache2 = [_cache findRefreshToken:_requestParam2 context:nil error:&error];
+    MSALRefreshTokenCacheItem *rtItemInCache2 = [_cache findRefreshTokenWithEnvironment:_requestParam2.unvalidatedAuthority.msalHostWithPort
+                                                                               clientId:_requestParam2.clientId
+                                                                         userIdentifier:_requestParam2.user.userIdentifier
+                                                                                context:nil error:&error];
     XCTAssertNil(error);
     XCTAssertEqualObjects(atItem2, atItemInCache2);
     XCTAssertEqualObjects(rtItem2, rtItemInCache2);
@@ -429,11 +529,19 @@
 {
     //store 2 tokens
     NSError *error = nil;
-    [_cache saveAccessAndRefreshToken:_requestParam1 response:_testTokenResponse context:nil error:&error];
+    [_cache saveAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                clientId:_requestParam1.clientId
+                                response:_testTokenResponse
+                                 context:nil error:nil];
+    
     XCTAssertNil(error);
     
     error = nil;
-    [_cache saveAccessAndRefreshToken:_requestParam2 response:_testTokenResponse2 context:nil error:&error];
+    [_cache saveAccessTokenWithAuthority:_requestParam2.unvalidatedAuthority
+                                clientId:_requestParam2.clientId
+                                response:_testTokenResponse2
+                                 context:nil error:nil];
+    
     XCTAssertNil(error);
     
     //remove user specifier to make an ambigious query
@@ -444,7 +552,13 @@
     requestParam.user = nil;
     
     error = nil;
-    XCTAssertNil([_cache findAccessToken:requestParam context:nil authorityFound:nil error:&error]);
+    XCTAssertNil([_cache findAccessTokenWithAuthority:requestParam.unvalidatedAuthority
+                                             clientId:requestParam.clientId
+                                               scopes:requestParam.scopes
+                                                 user:requestParam.user
+                                              context:nil
+                                       authorityFound:nil
+                                                error:&error]);
     XCTAssertEqual(error.code, MSALErrorMultipleMatchesNoAuthoritySpecified);
 }
 
@@ -467,7 +581,13 @@
     
     //token is expired so it is not returned
     NSError *error = nil;
-    XCTAssertNil([_cache findAccessToken:_requestParam1 context:nil authorityFound:nil error:&error]);
+    XCTAssertNil([_cache findAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                                     clientId:_requestParam1.clientId
+                                                       scopes:_requestParam1.scopes
+                                                         user:_requestParam1.user
+                                                      context:nil
+                                               authorityFound:nil
+                                                        error:&error]);
     XCTAssertNil(error);
 }
 
@@ -492,7 +612,13 @@
     NSString *authorityFound = nil;
     _requestParam1.unvalidatedAuthority = nil;
     NSError *error = nil;
-    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessToken:_requestParam1 context:nil authorityFound:&authorityFound error:&error];
+    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                                                          clientId:_requestParam1.clientId
+                                                                            scopes:_requestParam1.scopes
+                                                                              user:_requestParam1.user
+                                                                           context:nil
+                                                                    authorityFound:&authorityFound
+                                                                             error:&error];
     XCTAssertNil(error);
     XCTAssertNotNil(atItemInCache);
     XCTAssertNil(authorityFound);
@@ -503,7 +629,13 @@
     _requestParam1.unvalidatedAuthority = nil;
     NSString *authorityFound;
     NSError *error = nil;
-    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessToken:_requestParam1 context:nil authorityFound:&authorityFound error:&error];
+    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                                                          clientId:_requestParam1.clientId
+                                                                            scopes:_requestParam1.scopes
+                                                                              user:_requestParam1.user
+                                                                           context:nil
+                                                                    authorityFound:&authorityFound
+                                                                             error:&error];
     XCTAssertNil(error);
     XCTAssertNil(atItemInCache);
     XCTAssertNil(authorityFound);
@@ -545,7 +677,13 @@
     _requestParam1.unvalidatedAuthority = nil;
     NSString *authorityFound = nil;
     NSError *error = nil;
-    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessToken:_requestParam1 context:nil authorityFound:&authorityFound error:&error];
+    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                                                          clientId:_requestParam1.clientId
+                                                                            scopes:_requestParam1.scopes
+                                                                              user:_requestParam1.user
+                                                                           context:nil
+                                                                    authorityFound:&authorityFound
+                                                                             error:&error];
     XCTAssertNil(atItemInCache);
     XCTAssertNil(authorityFound);
     XCTAssertEqual(error.code, MSALErrorMultipleMatchesNoAuthoritySpecified);
@@ -587,7 +725,13 @@
     [_requestParam1 setScopesFromArray:@[@"nonexist"]];
     NSString *authorityFound = nil;
     NSError *error = nil;
-    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessToken:_requestParam1 context:nil authorityFound:&authorityFound error:&error];
+    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                                                          clientId:_requestParam1.clientId
+                                                                            scopes:_requestParam1.scopes
+                                                                              user:_requestParam1.user
+                                                                           context:nil
+                                                                    authorityFound:&authorityFound
+                                                                             error:&error];
     XCTAssertNil(error);
     XCTAssertNil(atItemInCache);
     XCTAssertEqualObjects(authorityFound, _testAuthority.absoluteString);
@@ -628,7 +772,13 @@
     [_requestParam1 setScopesFromArray:@[@"nonexist"]];
     NSString *authorityFound = nil;
     NSError *error = nil;
-    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessToken:_requestParam1 context:nil authorityFound:&authorityFound error:&error];
+    MSALAccessTokenCacheItem *atItemInCache = [_cache findAccessTokenWithAuthority:_requestParam1.unvalidatedAuthority
+                                                                          clientId:_requestParam1.clientId
+                                                                            scopes:_requestParam1.scopes
+                                                                              user:_requestParam1.user
+                                                                           context:nil
+                                                                    authorityFound:&authorityFound
+                                                                             error:&error];;
     XCTAssertNil(error);
     XCTAssertNil(atItemInCache);
     XCTAssertNil(authorityFound);


### PR DESCRIPTION
- Remove MSALRequestParameter from MSALTokenCache methods
- Split saveAccessAndRefreshToken into 2 methods

Addresses #76 and #77