### PR TITLE
Revise validated authorities cache lookup

### DIFF
--- a/MSAL/src/instance/MSALAuthority.h
+++ b/MSAL/src/instance/MSALAuthority.h
@@ -104,6 +104,7 @@ typedef void(^MSALAuthorityCompletion)(MSALAuthority *authority, NSError *error)
               userPrincipalName:(NSString *)userPrincipalName;
 
 + (MSALAuthority *)authorityFromCache:(NSURL *)authority
+                        authorityType:(MSALAuthorityType)authorityType
                     userPrincipalName:(NSString *)userPrincipalName;
 
 @end

--- a/MSAL/src/instance/MSALAuthority.m
+++ b/MSAL/src/instance/MSALAuthority.m
@@ -157,7 +157,9 @@ static NSMutableDictionary *s_validatedUsersForAuthority;
         tenant = firstPathComponent;
     }
     
-    MSALAuthority *authorityInCache = [MSALAuthority authorityFromCache:updatedAuthority userPrincipalName:userPrincipalName];
+    MSALAuthority *authorityInCache = [MSALAuthority authorityFromCache:updatedAuthority
+                                                          authorityType:authorityType
+                                                      userPrincipalName:userPrincipalName];
     
     if (authorityInCache)
     {
@@ -235,7 +237,6 @@ static NSMutableDictionary *s_validatedUsersForAuthority;
             s_validatedUsersForAuthority[authorityKey] = usersInDomain;
         }
         [usersInDomain addObject:userPrincipalName];
-        
     }
     s_validatedAuthorities[authorityKey] = authority;
 
@@ -243,6 +244,7 @@ static NSMutableDictionary *s_validatedUsersForAuthority;
 }
 
 + (MSALAuthority *)authorityFromCache:(NSURL *)authority
+                        authorityType:(MSALAuthorityType)authorityType
                     userPrincipalName:(NSString *)userPrincipalName
 {
     if (!authority)
@@ -251,16 +253,22 @@ static NSMutableDictionary *s_validatedUsersForAuthority;
     }
     
     NSString *authorityKey = authority.absoluteString;
-
-    if (userPrincipalName)
+    
+    if (authorityType == ADFSAuthority)
     {
+        if (!userPrincipalName)
+        {
+            return nil;
+        }
+        
         NSSet *validatedUsers = s_validatedUsersForAuthority[authorityKey];
+
         if (![validatedUsers containsObject:userPrincipalName])
         {
             return nil;
         }
     }
-    
+
     return s_validatedAuthorities[authorityKey];
 }
 

--- a/MSAL/test/unit/MSALAuthorityTests.m
+++ b/MSAL/test/unit/MSALAuthorityTests.m
@@ -183,44 +183,73 @@
     XCTAssertTrue([MSALAuthority isKnownHost:[NSURL URLWithString:@"https://login-us.microsoftonline.com"]]);
 }
 
-- (void)testAuthorityFromCache_whenNilAuthority_shouldFail
+- (void)testAuthorityAddToValidatedAuthority_whenNilAuthority_shouldFail
 {
     XCTAssertFalse([MSALAuthority addToValidatedAuthority:nil userPrincipalName:nil]);
 }
 
-- (void)testAuthorityFromCache_whenAdfsWithNilUpn_shouldFail
+- (void)testAuthorityAddToValidatedAuthority_whenAdfsAuthorityNilUpn_shouldFail
 {
     MSALAuthority *adfsAuthority = [MSALTestAuthority ADFSAuthority:[NSURL URLWithString:@"https://fs.contoso.com/adfs/"]];
     XCTAssertFalse([MSALAuthority addToValidatedAuthority:adfsAuthority userPrincipalName:nil]);
 }
 
-- (void)testAuthorityFromCache_whenCached_shoulRetrieve
+- (void)testAuthorityFromCache_whenAadAuthorityCachedNilUpn_shouldRetrieveAuthority
 {
     MSALAuthority *aadAuthority = [MSALTestAuthority AADAuthority:[NSURL URLWithString:@"https://login.microsoftonline.in/common"]];
-    MSALAuthority *b2cAuthority = [MSALTestAuthority B2CAuthority:[NSURL URLWithString:@"https://login.microsoftonline.in/tfp"]];
-    MSALAuthority *adfsAuthority = [MSALTestAuthority ADFSAuthority:[NSURL URLWithString:@"https://fs.contoso.com/adfs/"]];
-    
+   
     // Add valid authority
     XCTAssertTrue([MSALAuthority addToValidatedAuthority:aadAuthority userPrincipalName:nil]);
-    XCTAssertTrue([MSALAuthority addToValidatedAuthority:b2cAuthority userPrincipalName:nil]);
-    XCTAssertTrue([MSALAuthority addToValidatedAuthority:adfsAuthority userPrincipalName:@"user@contoso.com"]);
-
+   
     // Check if valid authority returned
     MSALAuthority *retrivedAuthority = [MSALAuthority authorityFromCache:aadAuthority.canonicalAuthority
                                                            authorityType:AADAuthority
                                                        userPrincipalName:nil];
     XCTAssertNotNil(retrivedAuthority);
     XCTAssertTrue([retrivedAuthority.canonicalAuthority isEqual:aadAuthority.canonicalAuthority]);
-    
+}
+
+- (void)testAuthorityFromCache_whenAadAuthorityCachedNonNilUpn_shouldRetrieveAuthority
+{
+    MSALAuthority *aadAuthority = [MSALTestAuthority AADAuthority:[NSURL URLWithString:@"https://login.microsoftonline.in/common"]];
+   
+    // Add valid authority
+    XCTAssertTrue([MSALAuthority addToValidatedAuthority:aadAuthority userPrincipalName:nil]);
+   
+    // Check if valid authority returned
+    MSALAuthority *retrivedAuthority = [MSALAuthority authorityFromCache:aadAuthority.canonicalAuthority
+                                                           authorityType:AADAuthority
+                                                       userPrincipalName:@"user@contoso.com"];
+    XCTAssertNotNil(retrivedAuthority);
+    XCTAssertTrue([retrivedAuthority.canonicalAuthority isEqual:aadAuthority.canonicalAuthority]);
+}
+
+- (void)testAuthorityFromCache_whenAdfsAuthorityCachedNonNilUpn_shouldRetrieveAuthority
+{
+    MSALAuthority *adfsAuthority = [MSALTestAuthority ADFSAuthority:[NSURL URLWithString:@"https://fs.contoso.com/adfs/"]];
+
+    // Add valid authority
+    XCTAssertTrue([MSALAuthority addToValidatedAuthority:adfsAuthority userPrincipalName:@"user@contoso.com"]);
+
+    // Check if valid authority returned
     MSALAuthority *retrivedAdfsAuthority = [MSALAuthority authorityFromCache:adfsAuthority.canonicalAuthority
                                                                authorityType:ADFSAuthority
                                                            userPrincipalName:@"user@contoso.com"];
     XCTAssertNotNil(retrivedAdfsAuthority);
     XCTAssertTrue([retrivedAdfsAuthority.canonicalAuthority isEqual:adfsAuthority.canonicalAuthority]);
+}
+
+- (void)testAuthorityFromCache_whenAdfsWithNilUpn_shouldFail
+{
+    MSALAuthority *adfsAuthority = [MSALTestAuthority ADFSAuthority:[NSURL URLWithString:@"https://fs.contoso.com/adfs/"]];
+    XCTAssertTrue([MSALAuthority addToValidatedAuthority:adfsAuthority userPrincipalName:@"user@contoso.com"]);
     
-    
-    // Check if non valid authority was not returned
-    XCTAssertNil([MSALAuthority authorityFromCache:[NSURL URLWithString:@"https://somehost.com/"] authorityType:AADAuthority userPrincipalName:nil]);
+    // Check if valid authority returned
+    MSALAuthority *retrivedAdfsAuthority = [MSALAuthority authorityFromCache:adfsAuthority.canonicalAuthority
+                                                               authorityType:ADFSAuthority
+                                                           userPrincipalName:nil];
+   
+    XCTAssertNil(retrivedAdfsAuthority);
 }
 
 - (void)testResolveEndpointsForAuthority_whenNormalAad_shouldPass


### PR DESCRIPTION
#119 

Validated authority look up by UPN doesn't work for ATS with user. 
Changing this to be more direct with an additional parameter that we readily derive before calling the look up.

Also, revise some of the existing unit testing with the naming and the above changes.
