### PR TITLE
Synchronizing validatedAuthorities dictionary

### DIFF
--- a/MSAL/src/instance/MSALAuthority.m
+++ b/MSAL/src/instance/MSALAuthority.m
@@ -239,7 +239,6 @@ static NSMutableDictionary *s_validatedUsersForAuthority;
                 s_validatedUsersForAuthority[authorityKey] = usersInDomain;
             }
             [usersInDomain addObject:userPrincipalName];
-            
         }
         
         s_validatedAuthorities[authorityKey] = authority;
@@ -261,9 +260,15 @@ static NSMutableDictionary *s_validatedUsersForAuthority;
     
     @synchronized ([MSALAuthority class])
     {
-        if (userPrincipalName)
+        if (authorityType == ADFSAuthority)
         {
+            if (!userPrincipalName)
+            {
+                return nil;
+            }
+            
             NSSet *validatedUsers = s_validatedUsersForAuthority[authorityKey];
+            
             if (![validatedUsers containsObject:userPrincipalName])
             {
                 return nil;


### PR DESCRIPTION
This pull request is for general discussion and every opinion is welcome! 
The problem: Validated authorities dictionary is modified from multiple threads, which leads to a crash. In combination with a bug #119 it leads to a crash pretty fast. However, once #119 is fixed/merged I hardly see a real-app scenario, where different authorities will need to be resolved from multiple threads at the same time. But there’s still a theoretical possibility for that :) We should decide together if we should address it or not. 