### PR TITLE
B2C authority validation - check against known host

### DIFF
--- a/MSAL/src/instance/MSALB2CAuthorityResolver.m
+++ b/MSAL/src/instance/MSALB2CAuthorityResolver.m
@@ -39,7 +39,7 @@
 {
     (void)userPrincipalName;
     
-    if (validate) // And check for !IsInTrustedHostList(authority.Host)
+    if (validate && ![MSALAuthority isKnownHost:authority])
     {
         NSError *error = CREATE_LOG_ERROR(context, MSALErrorInvalidRequest, UNSUPPORTED_AUTHORITY_VALIDATION);
         completionBlock(nil, error);


### PR DESCRIPTION
If the authority passed in is included in the list of known hosts, proceed instead of failing.