### PR TITLE
Rename MSALErrorMultipleMatchesNoAuthoritySpecified 

### DIFF
--- a/MSAL/src/MSALError_Internal.m
+++ b/MSAL/src/MSALError_Internal.m
@@ -42,7 +42,7 @@ NSString *MSALStringForErrorCode(MSALErrorCode code)
         STRING_CASE(MSALErrorKeychainFailure);
         STRING_CASE(MSALErrorTokenCacheItemFailure);
         STRING_CASE(MSALErrorWrapperCacheFailure);
-        STRING_CASE(MSALErrorMultipleMatchesNoAuthoritySpecified);
+        STRING_CASE(MSALErrorAmbiguousAuthority);
         STRING_CASE(MSALErrorInteractionRequired);
         STRING_CASE(MSALErrorInvalidResponse);
         STRING_CASE(MSALErrorBadAuthorizationResponse);

--- a/MSAL/src/cache/MSALTokenCache.m
+++ b/MSAL/src/cache/MSALTokenCache.m
@@ -200,7 +200,7 @@
     
     if (matchedTokens.count > 1)
     {
-        MSAL_ERROR_PARAM(ctx, MSALErrorMultipleMatchesNoAuthoritySpecified, @"Found multiple access tokens, which token to return is ambiguous! Please pass in authority if not provided.");
+        MSAL_ERROR_PARAM(ctx, MSALErrorAmbiguousAuthority, @"Found multiple access tokens. Please specify an authority.");
         
         [[MSALTelemetry sharedInstance] stopEvent:[ctx telemetryRequestId] event:event];
         

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -106,7 +106,7 @@ typedef NS_ENUM(NSInteger, MSALErrorCode)
         documented in Apple's <Security/SecBase.h> header file
      */
     MSALErrorTokenCacheItemFailure = -42200,
-    MSALErrorMultipleMatchesNoAuthoritySpecified = -42201,
+    MSALErrorAmbiguousAuthority = -42201,
     MSALErrorUserNotFound = -42202,
     MSALErrorKeychainFailure = -42240,
     MSALErrorWrapperCacheFailure = -42270,

--- a/MSAL/test/unit/MSALTokenCacheTests.m
+++ b/MSAL/test/unit/MSALTokenCacheTests.m
@@ -559,7 +559,7 @@
                                               context:nil
                                        authorityFound:nil
                                                 error:&error]);
-    XCTAssertEqual(error.code, MSALErrorMultipleMatchesNoAuthoritySpecified);
+    XCTAssertEqual(error.code, MSALErrorAmbiguousAuthority);
 }
 
 - (void)testFindAccessToken_whenTokenExpired_shouldReturnNil
@@ -686,7 +686,7 @@
                                                                              error:&error];
     XCTAssertNil(atItemInCache);
     XCTAssertNil(authorityFound);
-    XCTAssertEqual(error.code, MSALErrorMultipleMatchesNoAuthoritySpecified);
+    XCTAssertEqual(error.code, MSALErrorAmbiguousAuthority);
 }
 
 - (void)testFindAccessTokenWithoutAuthority_whenNoMatchButFoundUniqueAuthority_shouldReturnAuthority


### PR DESCRIPTION
#132 
Rename MSALErrorMultipleMatchesNoAuthoritySpecified to MSALErrorAmbiguousAuthority