### PR TITLE
Fix B2C authority parsing (#154)

### DIFF
--- a/MSAL/src/instance/MSALAuthority.m
+++ b/MSAL/src/instance/MSALAuthority.m
@@ -100,20 +100,21 @@ static NSMutableDictionary *s_resolvedUsersForAuthority;
     REQUIRED_STRING_PARAMETER(authority, nil);
     
     NSURL *authorityUrl = [NSURL URLWithString:authority];
+    NSArray *pathComponents = [authorityUrl pathComponents];
     CHECK_ERROR_RETURN_NIL(authorityUrl, nil, MSALErrorInvalidParameter, @"\"authority\" must be a valid URI");
     CHECK_ERROR_RETURN_NIL([authorityUrl.scheme isEqualToString:@"https"], nil, MSALErrorInvalidParameter, @"authority must use HTTPS");
-    CHECK_ERROR_RETURN_NIL((authorityUrl.pathComponents.count > 1), nil, MSALErrorInvalidParameter, @"authority must specify a tenant or common");
+    CHECK_ERROR_RETURN_NIL((pathComponents.count > 1), nil, MSALErrorInvalidParameter, @"authority must specify a tenant or common");
     
     CHECK_ERROR_RETURN_NIL(![authorityUrl.host.lowercaseString isEqualToString:@"login.windows.net"], nil, MSALErrorInvalidParameter, @"login.windows.net has been deprecated. Use login.microsoftonline.com instead.");
     
     
     // B2C
-    if ([[authorityUrl.pathComponents[1] lowercaseString] isEqualToString:@"tfp"])
+    if ([pathComponents[1] caseInsensitiveCompare:@"tfp"] == NSOrderedSame)
     {
-        CHECK_ERROR_RETURN_NIL((authorityUrl.pathComponents.count > 3), nil, MSALErrorInvalidParameter,
+        CHECK_ERROR_RETURN_NIL((pathComponents.count > 3), nil, MSALErrorInvalidParameter,
                                @"B2C authority should have at least 3 segments in the path (i.e. https://<host>/tfp/<tenant>/<policy>/...)");
         
-        NSString *updatedAuthorityString = [NSString stringWithFormat:@"https://%@/%@/%@/%@", [authorityUrl msalHostWithPort], authorityUrl.pathComponents[0], authorityUrl.pathComponents[1], authorityUrl.pathComponents[2]];
+        NSString *updatedAuthorityString = [NSString stringWithFormat:@"https://%@/%@/%@/%@", [authorityUrl msalHostWithPort], authorityUrl.pathComponents[1], authorityUrl.pathComponents[2], authorityUrl.pathComponents[3]];
         return [NSURL URLWithString:updatedAuthorityString];
     }
     

--- a/MSAL/test/unit/MSALAuthorityTests.m
+++ b/MSAL/test/unit/MSALAuthorityTests.m
@@ -59,6 +59,17 @@
     XCTAssertEqualObjects(url, [NSURL URLWithString:@"https://login.microsoftonline.com/common"]);
 }
 
+- (void)testCheckAuthorityString_whenB2C_shouldPass
+{
+    NSError *error = nil;
+    NSURL *url = nil;
+    
+    url = [MSALAuthority checkAuthorityString:@"https://login.microsoftonline.com/tfp/contoso.onmicrosoft.com/B2C_1_contosify" error:&error];
+    XCTAssertNotNil(url);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(url, [NSURL URLWithString:@"https://login.microsoftonline.com/tfp/contoso.onmicrosoft.com/B2C_1_contosify"]);
+}
+
 - (void)testCheckAuthorityString_whenNil_shouldFail
 {
     NSError *error = nil;


### PR DESCRIPTION
The first path component in -[NSURL pathComponents] is a slash ending up in URLs that look like "l.mso.c///tfp/"