### PR TITLE
Collapse handleMSALResponse and isMSALResponse to a single method

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -166,9 +166,14 @@
     return YES;
 }
 
-+ (void)handleMSALResponse:(NSURL *)response
++ (BOOL)handleMSALResponse:(NSURL *)response
 {
-    [MSALWebUI handleResponse:response];
+    if (![self.class isMSALResponse:response])
+    {
+        return NO;
+    }
+    
+    return [MSALWebUI handleResponse:response];
 }
 
 + (void)cancelCurrentWebAuthSession

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -126,7 +126,7 @@
 
 #pragma SafariViewController Support
 
-+ (BOOL)isMSALResponse:(NSURL *)response
++ (BOOL)handleMSALResponse:(NSURL *)response
 {
     if (!response)
     {
@@ -160,16 +160,6 @@
     {
         LOG_ERROR(request.parameters, @"State in response \"%@\" does not match request \"%@\"", state, request.state);
         LOG_ERROR_PII(request.parameters, @"State in response \"%@\" does not match request \"%@\"", state, request.state);
-        return NO;
-    }
-    
-    return YES;
-}
-
-+ (BOOL)handleMSALResponse:(NSURL *)response
-{
-    if (![self.class isMSALResponse:response])
-    {
         return NO;
     }
     

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -104,7 +104,7 @@
     Ask MSAL to handle a URL response.
     
     @param   response   URL response from your application delegate's openURL handler into
-                        MSAL for web authnetication sessions
+                        MSAL for web authentication sessions
     @return  YES if URL is a response to a MSAL web authentication session and handled,
              NO otherwise.
  */

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -101,11 +101,12 @@
 #pragma SafariViewController Support
 
 /*!
-    Pass a URL response from your application delegate's openURL handler into
-    MSAL for web authnetication sessions.
- 
-    Returns whether or not the URL is a response to a MSAL web authentication
-    session
+    Ask MSAL to handle a URL response.
+    
+    @param   response   URL response from your application delegate's openURL handler into
+                        MSAL for web authnetication sessions
+    @return  YES if URL is a response to a MSAL web authentication session and handled,
+             NO otherwise.
  */
 + (BOOL)handleMSALResponse:(NSURL *)response;
 

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -101,16 +101,13 @@
 #pragma SafariViewController Support
 
 /*!
-    Returns whether or not the URL is a response to a MSAL web authentication
-    session. Call this before passing the URL into -handleMSALResponse:
- */
-+ (BOOL)isMSALResponse:(NSURL *)response;
-
-/*!
     Pass a URL response from your application delegate's openURL handler into
     MSAL for web authnetication sessions.
+ 
+    Returns whether or not the URL is a response to a MSAL web authentication
+    session
  */
-+ (void)handleMSALResponse:(NSURL *)response;
++ (BOOL)handleMSALResponse:(NSURL *)response;
 
 /*!
     Cancels any currently running interactive web authentication session, resulting

--- a/MSAL/test/app/ios/MSALTestAppDelegate.m
+++ b/MSAL/test/app/ios/MSALTestAppDelegate.m
@@ -142,10 +142,7 @@
     (void)options;
     NSLog(@"iOS 9 OpenURL Method!");
     
-    if ([MSALPublicClientApplication isMSALResponse:url])
-    {
-        [MSALPublicClientApplication handleMSALResponse:url];
-    }
+    [MSALPublicClientApplication handleMSALResponse:url];
     
     return YES;
 }

--- a/MSAL/test/automation/ios/MSALAutoAppDelegate.m
+++ b/MSAL/test/automation/ios/MSALAutoAppDelegate.m
@@ -91,11 +91,8 @@
     (void)options;
     NSLog(@"iOS 9 OpenURL Method!");
     
-    if ([MSALPublicClientApplication isMSALResponse:url])
-    {
-        [MSALPublicClientApplication handleMSALResponse:url];
-    }
-    
+    [MSALPublicClientApplication handleMSALResponse:url];
+
     return YES;
 }
 

--- a/Samples/ios/SampleApp/SampleAppiOS/SampleAppDelegate.m
+++ b/Samples/ios/SampleApp/SampleAppiOS/SampleAppDelegate.m
@@ -73,12 +73,10 @@
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
-    if ([MSALPublicClientApplication isMSALResponse:url])
+    if ([MSALPublicClientApplication handleMSALResponse:url])
     {
-        [MSALPublicClientApplication handleMSALResponse:url];
-        return YES;
+        NSLog(@"This URL is a response to a MSAL web authentication");
     }
-    
     return YES;
 }
 

--- a/Samples/ios/SampleApp/SampleAppiOS/SampleAppDelegate.m
+++ b/Samples/ios/SampleApp/SampleAppiOS/SampleAppDelegate.m
@@ -75,7 +75,7 @@
 {
     if ([MSALPublicClientApplication handleMSALResponse:url])
     {
-        NSLog(@"This URL is a response to a MSAL web authentication");
+        NSLog(@"This URL is handled by MSAL");
     }
     return YES;
 }


### PR DESCRIPTION
#122 

Collapse handleMSALResponse and isMSALResponse.
Reflect changes to the header file, unit testing, and sample.