### PR TITLE
Rename compareDictionary: to compareToActual:

### DIFF
--- a/MSAL/test/unit/MSALInteractiveRequestTests.m
+++ b/MSAL/test/unit/MSALInteractiveRequestTests.m
@@ -154,7 +154,7 @@
       @"slice" : @"testslice"
       };
     NSDictionary *QPs = [NSDictionary msalURLFormDecode:authorizationUrl.query];
-    XCTAssertTrue([expectedQPs compareDictionary:QPs]);
+    XCTAssertTrue([expectedQPs compareToActual:QPs]);
 }
 
 - (void)testAuthorizationUriWithUser
@@ -234,7 +234,7 @@
       @"slice" : @"testslice"
       };
     NSDictionary *QPs = [NSDictionary msalURLFormDecode:authorizationUrl.query];
-    XCTAssertTrue([expectedQPs compareDictionary:QPs]);
+    XCTAssertTrue([expectedQPs compareToActual:QPs]);
 }
 
 - (void)testInteractiveRequestFlow
@@ -318,7 +318,7 @@
            @"slice" : @"testslice"
            };
          NSDictionary *QPs = [NSDictionary msalURLFormDecode:url.query];
-         XCTAssertTrue([expectedQPs compareDictionary:QPs]);
+         XCTAssertTrue([expectedQPs compareToActual:QPs]);
          
          NSString *responseString = [NSString stringWithFormat:UNIT_TEST_DEFAULT_REDIRECT_URI"?code=%@&state=%@", @"iamafakecode", request.state];
          completionBlock([NSURL URLWithString:responseString], nil);
@@ -480,7 +480,7 @@
            @"slice" : @"testslice"
            };
          NSDictionary *QPs = [NSDictionary msalURLFormDecode:url.query];
-         XCTAssertTrue([expectedQPs compareDictionary:QPs]);
+         XCTAssertTrue([expectedQPs compareToActual:QPs]);
          
          NSString *responseString = [NSString stringWithFormat:UNIT_TEST_DEFAULT_REDIRECT_URI"?code=%@&state=%@", @"iamafakecode", request.state];
          completionBlock([NSURL URLWithString:responseString], nil);
@@ -642,7 +642,7 @@
            @"slice" : @"testslice"
            };
          NSDictionary *QPs = [NSDictionary msalURLFormDecode:url.query];
-         XCTAssertTrue([expectedQPs compareDictionary:QPs]);
+         XCTAssertTrue([expectedQPs compareToActual:QPs]);
          
          NSString *responseString = [NSString stringWithFormat:UNIT_TEST_DEFAULT_REDIRECT_URI"?code=%@&state=%@", @"iamafakecode", request.state];
          completionBlock([NSURL URLWithString:responseString], nil);

--- a/MSAL/test/unit/utils/MSALTestURLSession.m
+++ b/MSAL/test/unit/utils/MSALTestURLSession.m
@@ -229,7 +229,7 @@
     if (![NSString msalIsStringNilOrBlank:query])
     {
         NSDictionary *QPs = [NSDictionary msalURLFormDecode:query];
-        if (![QPs isEqualToDictionary:_QPs])
+        if (![_QPs compareToActual:QPs])
         {
             return NO;
         }
@@ -247,8 +247,8 @@
     if (_requestParamsBody)
     {
         NSString * string = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
-        id obj = [NSDictionary msalURLFormDecode:string];
-        return [obj isEqual:_requestParamsBody];
+        NSDictionary *obj = [NSDictionary msalURLFormDecode:string];
+        return [_requestParamsBody compareToActual:obj];
     }
     
     if (_requestBody)
@@ -268,11 +268,11 @@
             return YES;
         }
         // This wiil spit out to console the extra stuff that we weren't expecting
-        [@{} compareDictionary:headers];
+        [@{} compareToActual:headers];
         return NO;
     }
     
-    return [_requestHeaders compareDictionary:headers];
+    return [_requestHeaders compareToActual:headers];
 }
 
 @end

--- a/MSAL/test/unit/utils/NSDictionary+MSALTestUtil.h
+++ b/MSAL/test/unit/utils/NSDictionary+MSALTestUtil.h
@@ -29,7 +29,7 @@
 
 @interface NSDictionary (MSALTestUtil)
 
-- (BOOL)compareDictionary:(NSDictionary *)dictionary;
+- (BOOL)compareToActual:(NSDictionary *)dictionary;
 
 - (NSString *)base64UrlJson;
 

--- a/MSAL/test/unit/utils/NSDictionary+MSALTestUtil.m
+++ b/MSAL/test/unit/utils/NSDictionary+MSALTestUtil.m
@@ -29,7 +29,7 @@
 
 @implementation NSDictionary (MSALTestUtil)
 
-- (BOOL)compareDictionary:(NSDictionary *)dictionary
+- (BOOL)compareToActual:(NSDictionary *)dictionary
 {
     BOOL fSame = YES;
     


### PR DESCRIPTION
This better reflects the logging that comes out of the method and hopefully results in more coherent diagnostic logging in the console when trying to figure out why something isn’t matching.