### PR TITLE
implement -[MSALTestURLResponse description]

### DIFF
--- a/MSAL/test/unit/utils/MSALTestURLSession.m
+++ b/MSAL/test/unit/utils/MSALTestURLSession.m
@@ -275,6 +275,11 @@
     return [_requestHeaders compareDictionary:headers];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %@>", NSStringFromClass(self.class), _requestURL];
+}
+
 @end
 
 


### PR DESCRIPTION
This makes it a little easier in the debugger to see what responses are in the response queue when you do a `po s_responses` now you’ll see the URLs of the expected responses!