### PR TITLE
Add sliceParameters

### DIFF
--- a/MSAL/src/MSALPublicClientApplication+Internal.h
+++ b/MSAL/src/MSALPublicClientApplication+Internal.h
@@ -27,10 +27,15 @@
 
 #import "MSALPublicClientApplication.h"
 
+// TODO: Remove these defaults once uid/client info is in prod
+#define DEFAULT_SLICE_PARAMS @"slice" : @"testslice", @"uid" : @"true"
+
 @class MSALTokenCache;
 
 @interface MSALPublicClientApplication (Internal)
 
 @property (nullable) MSALTokenCache *tokenCache;
+
++ (nullable NSDictionary<NSString *, NSString *> *)defaultSliceParameters;
 
 @end

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -109,6 +109,8 @@
     
     _validateAuthority = YES;
     
+    _sliceParameters = [MSALPublicClientApplication defaultSliceParameters];
+    
     return self;
 }
 
@@ -402,6 +404,7 @@
     params.apiId = apiId;
     params.user = user;
     params.validateAuthority = _validateAuthority;
+    params.sliceParameters = _sliceParameters;
     
     LOG_INFO(params,
              @"-[MSALPublicClientApplication acquireTokenForScopes:%@\n"
@@ -480,6 +483,7 @@
     params.user = user;
     params.apiId = apiId;
     params.validateAuthority = _validateAuthority;
+    params.sliceParameters = _sliceParameters;
     
     [params setScopesFromArray:scopes];
     
@@ -558,6 +562,11 @@
 - (void)setTokenCache:(MSALTokenCache *)tokenCache
 {
     _tokenCache = tokenCache;
+}
+
++ (NSDictionary *)defaultSliceParameters
+{
+    return @{ DEFAULT_SLICE_PARAMS };
 }
 
 @end

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -50,6 +50,12 @@
 /*! The redirect URI of the application */
 @property (readonly) NSURL *redirectUri;
 
+/*!
+    Used to specify query parameters that must be passed to both the authorize and token endpoints
+    to target MSAL at a specific test slice & flight. These apply to all requests made by an application.
+ */
+@property NSDictionary<NSString *, NSString *> *sliceParameters;
+
 /*! Used in logging callbacks to identify what component in the application
     called MSAL. */
 @property NSString *component;

--- a/MSAL/src/requests/MSALBaseRequest.m
+++ b/MSAL/src/requests/MSALBaseRequest.m
@@ -152,8 +152,11 @@ static MSALScopes *s_reservedScopes = nil;
     NSURLComponents *tokenEndpoint = [NSURLComponents componentsWithURL:_authority.tokenEndpoint resolvingAgainstBaseURL:NO];
     
     NSMutableDictionary *endpointQPs = [[NSDictionary msalURLFormDecode:tokenEndpoint.percentEncodedQuery] mutableCopy];
-    endpointQPs[@"slice"] = @"testslice";
-    endpointQPs[@"uid"] = @"true";
+    
+    if (_parameters.sliceParameters)
+    {
+        [endpointQPs addEntriesFromDictionary:_parameters.sliceParameters];
+    }
     
     tokenEndpoint.query = [endpointQPs msalURLFormEncode];
     

--- a/MSAL/src/requests/MSALInteractiveRequest.m
+++ b/MSAL/src/requests/MSALInteractiveRequest.m
@@ -122,9 +122,10 @@ static MSALInteractiveRequest *s_currentRequest = nil;
         }
     }
     
-    // TODO: Remove once uid+utid is in prod
-    parameters[@"slice"] = @"testslice";
-    parameters[@"uid"] = @"true";
+    if (_parameters.sliceParameters)
+    {
+        [parameters addEntriesFromDictionary:_parameters.sliceParameters];
+    }
     
     MSALUser *user = _parameters.user;
     if (user)

--- a/MSAL/src/requests/MSALRequestParameters.h
+++ b/MSAL/src/requests/MSALRequestParameters.h
@@ -46,6 +46,7 @@
 @property NSString *prompt;
 @property MSALUser *user;
 @property MSALTelemetryApiId apiId;
+@property NSDictionary<NSString *, NSString *> *sliceParameters;
 
 #pragma mark MSALRequestContext properties
 @property NSUUID *correlationId;

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -98,8 +98,7 @@
            @"code_challenge": [MSALTestSentinel sentinel],
            @"code_challenge_method" : @"S256",
            @"p" : @"b2c_1_policy",
-           @"uid" : @"true",
-           @"slice" : @"testslice"
+           UT_SLICE_PARAMS_DICT
            } mutableCopy];
          [expectedQPs addEntriesFromDictionary:[MSALLogger msalId]];
          NSDictionary *QPs = [NSDictionary msalURLFormDecode:url.query];

--- a/MSAL/test/unit/MSALInteractiveRequestTests.m
+++ b/MSAL/test/unit/MSALInteractiveRequestTests.m
@@ -97,6 +97,7 @@
     parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
+    parameters.sliceParameters = @{ UT_SLICE_PARAMS_DICT };
     
     [MSALTestSwizzle classMethod:@selector(randomUrlSafeStringOfSize:)
                               class:[NSString class]
@@ -150,8 +151,7 @@
       @"response_type" : @"code",
       @"code_challenge": pkce.codeChallenge,
       @"code_challenge_method" : @"S256",
-      @"uid" : @"true",
-      @"slice" : @"testslice"
+      UT_SLICE_PARAMS_DICT
       };
     NSDictionary *QPs = [NSDictionary msalURLFormDecode:authorizationUrl.query];
     XCTAssertTrue([expectedQPs compareToActual:QPs]);
@@ -230,8 +230,6 @@
       @"response_type" : @"code",
       @"code_challenge": pkce.codeChallenge,
       @"code_challenge_method" : @"S256",
-      @"uid" : @"true",
-      @"slice" : @"testslice"
       };
     NSDictionary *QPs = [NSDictionary msalURLFormDecode:authorizationUrl.query];
     XCTAssertTrue([expectedQPs compareToActual:QPs]);
@@ -314,8 +312,6 @@
            @"response_type" : @"code",
            @"code_challenge": pkce.codeChallenge,
            @"code_challenge_method" : @"S256",
-           @"uid" : @"true",
-           @"slice" : @"testslice"
            };
          NSDictionary *QPs = [NSDictionary msalURLFormDecode:url.query];
          XCTAssertTrue([expectedQPs compareToActual:QPs]);
@@ -344,7 +340,7 @@
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
     
     MSALTestURLResponse *response =
-    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=testslice&uid=true"
+    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token"
                            requestHeaders:reqHeaders
                         requestParamsBody:@{ @"code" : @"iamafakecode",
                                              @"client_id" : UNIT_TEST_CLIENT_ID,
@@ -476,8 +472,6 @@
            @"response_type" : @"code",
            @"code_challenge": pkce.codeChallenge,
            @"code_challenge_method" : @"S256",
-           @"uid" : @"true",
-           @"slice" : @"testslice"
            };
          NSDictionary *QPs = [NSDictionary msalURLFormDecode:url.query];
          XCTAssertTrue([expectedQPs compareToActual:QPs]);
@@ -506,7 +500,7 @@
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
     
     MSALTestURLResponse *response =
-    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=testslice&uid=true"
+    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token"
                            requestHeaders:reqHeaders
                         requestParamsBody:@{ @"code" : @"iamafakecode",
                                              @"client_id" : UNIT_TEST_CLIENT_ID,
@@ -638,8 +632,6 @@
            @"response_type" : @"code",
            @"code_challenge": pkce.codeChallenge,
            @"code_challenge_method" : @"S256",
-           @"uid" : @"true",
-           @"slice" : @"testslice"
            };
          NSDictionary *QPs = [NSDictionary msalURLFormDecode:url.query];
          XCTAssertTrue([expectedQPs compareToActual:QPs]);
@@ -668,7 +660,7 @@
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
     
     MSALTestURLResponse *response =
-    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=testslice&uid=true"
+    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token"
                            requestHeaders:reqHeaders
                         requestParamsBody:@{ @"code" : @"iamafakecode",
                                              @"client_id" : UNIT_TEST_CLIENT_ID,

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -161,6 +161,7 @@
     [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
                                                 authority:@"https://login.microsoftonline.com/common"
                                                     error:&error];
+    application.sliceParameters = @{ @"slice" : @"myslice" };
     
     XCTAssertNotNil(application);
     XCTAssertNil(error);
@@ -180,6 +181,7 @@
          XCTAssertEqualObjects(params.scopes, [NSOrderedSet orderedSetWithObject:@"fakescope"]);
          XCTAssertEqualObjects(params.clientId, UNIT_TEST_CLIENT_ID);
          XCTAssertEqualObjects(params.redirectUri, [NSURL URLWithString:UNIT_TEST_DEFAULT_REDIRECT_URI]);
+         XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          XCTAssertNil(params.extraQueryParameters);
          XCTAssertNil(params.loginHint);
          XCTAssertNil(params.component);
@@ -216,6 +218,7 @@
                                                 authority:@"https://login.microsoftonline.com/common"
                                                     error:&error];
     application.component = @"unittests";
+    application.sliceParameters = @{ @"slice" : @"myslice" };
     
     XCTAssertNotNil(application);
     XCTAssertNil(error);
@@ -237,6 +240,7 @@
          XCTAssertEqualObjects(params.scopes, ([NSOrderedSet orderedSetWithObjects:@"fakescope1", @"fakescope2", nil]));
          XCTAssertEqualObjects(params.clientId, UNIT_TEST_CLIENT_ID);
          XCTAssertEqualObjects(params.redirectUri.absoluteString, UNIT_TEST_DEFAULT_REDIRECT_URI);
+         XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          XCTAssertNotNil(params.correlationId);
          XCTAssertNil(params.extraQueryParameters);
          XCTAssertEqualObjects(params.loginHint, @"fakeuser@contoso.com");
@@ -265,6 +269,7 @@
                                                 authority:@"https://login.microsoftonline.com/common"
                                                     error:&error];
     application.component = @"unittests";
+    application.sliceParameters = @{ @"slice" : @"myslice" };
     
     XCTAssertNotNil(application);
     XCTAssertNil(error);
@@ -286,6 +291,7 @@
          XCTAssertEqualObjects(params.scopes, ([NSOrderedSet orderedSetWithObjects:@"fakescope1", @"fakescope2", nil]));
          XCTAssertEqualObjects(params.clientId, UNIT_TEST_CLIENT_ID);
          XCTAssertEqualObjects(params.redirectUri.absoluteString, UNIT_TEST_DEFAULT_REDIRECT_URI);
+         XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          XCTAssertNotNil(params.correlationId);
          XCTAssertEqualObjects(params.extraQueryParameters, (@{ @"eqp1" : @"val1", @"eqp2" : @"val2" }));
          XCTAssertEqualObjects(params.loginHint, @"fakeuser@contoso.com");
@@ -318,6 +324,7 @@
                                                 authority:@"https://login.microsoftonline.com/common"
                                                     error:&error];
     application.component = @"unittests";
+    application.sliceParameters = @{ @"slice" : @"myslice" };
     
     XCTAssertNotNil(application);
     XCTAssertNil(error);
@@ -341,6 +348,7 @@
          XCTAssertEqualObjects(params.scopes, ([NSOrderedSet orderedSetWithObjects:@"fakescope1", @"fakescope2", nil]));
          XCTAssertEqualObjects(params.clientId, UNIT_TEST_CLIENT_ID);
          XCTAssertEqualObjects(params.redirectUri.absoluteString, UNIT_TEST_DEFAULT_REDIRECT_URI);
+         XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          XCTAssertEqualObjects(params.correlationId, correlationId);
          XCTAssertEqualObjects(params.extraQueryParameters, (@{ @"eqp1" : @"val1", @"eqp2" : @"val2" }));
          XCTAssertEqualObjects(params.loginHint, @"fakeuser@contoso.com");
@@ -377,6 +385,7 @@
                                                 authority:@"https://login.microsoftonline.com/common"
                                                     error:&error];
     application.component = @"unittests";
+    application.sliceParameters = @{ @"slice" : @"myslice" };
     
     XCTAssertNotNil(application);
     XCTAssertNil(error);
@@ -404,6 +413,7 @@
          XCTAssertEqualObjects(params.scopes, ([NSOrderedSet orderedSetWithObjects:@"fakescope1", @"fakescope2", nil]));
          XCTAssertEqualObjects(params.clientId, UNIT_TEST_CLIENT_ID);
          XCTAssertEqualObjects(params.redirectUri.absoluteString, UNIT_TEST_DEFAULT_REDIRECT_URI);
+         XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          XCTAssertNotNil(params.correlationId);
          XCTAssertNil(params.extraQueryParameters);
          XCTAssertNil(params.loginHint);
@@ -434,6 +444,7 @@
                                                 authority:@"https://login.microsoftonline.com/common"
                                                     error:&error];
     application.component = @"unittests";
+    application.sliceParameters = @{ @"slice" : @"myslice" };
     
     XCTAssertNotNil(application);
     XCTAssertNil(error);
@@ -461,6 +472,7 @@
          XCTAssertEqualObjects(params.scopes, ([NSOrderedSet orderedSetWithObjects:@"fakescope1", @"fakescope2", nil]));
          XCTAssertEqualObjects(params.clientId, UNIT_TEST_CLIENT_ID);
          XCTAssertEqualObjects(params.redirectUri.absoluteString, UNIT_TEST_DEFAULT_REDIRECT_URI);
+         XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          XCTAssertNotNil(params.correlationId);
          XCTAssertEqualObjects(params.extraQueryParameters, (@{ @"eqp1" : @"val1", @"eqp2" : @"val2" }));
          XCTAssertNil(params.loginHint);
@@ -492,6 +504,7 @@
                                                 authority:@"https://login.microsoftonline.com/common"
                                                     error:&error];
     application.component = @"unittests";
+    application.sliceParameters = @{ @"slice" : @"myslice" };
     
     XCTAssertNotNil(application);
     XCTAssertNil(error);
@@ -522,6 +535,7 @@
          XCTAssertEqualObjects(params.scopes, ([NSOrderedSet orderedSetWithObjects:@"fakescope1", @"fakescope2", nil]));
          XCTAssertEqualObjects(params.clientId, UNIT_TEST_CLIENT_ID);
          XCTAssertEqualObjects(params.redirectUri.absoluteString, UNIT_TEST_DEFAULT_REDIRECT_URI);
+         XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          XCTAssertEqualObjects(params.correlationId, correlationId);
          XCTAssertEqualObjects(params.extraQueryParameters, (@{ @"eqp1" : @"val1", @"eqp2" : @"val2" }));
          XCTAssertNil(params.loginHint);
@@ -560,6 +574,7 @@
                                                 authority:@"https://login.microsoftonline.com/common"
                                                     error:&error];
     application.component = @"unittests";
+    application.sliceParameters = @{ @"slice" : @"myslice" };
     
     XCTAssertNotNil(application);
     XCTAssertNil(error);
@@ -580,6 +595,7 @@
          XCTAssertEqualObjects(params.user.uid, @"1");
          XCTAssertEqualObjects(params.user.utid, @"1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.user.environment, @"https://login.microsoftonline.com");
+         XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          
          XCTAssertNil(params.unvalidatedAuthority);
          
@@ -621,6 +637,7 @@
                                                 authority:@"https://login.microsoftonline.com/common"
                                                     error:&error];
     application.component = @"unittests";
+    application.sliceParameters = @{ @"slice" : @"myslice" };
     
     XCTAssertNotNil(application);
     XCTAssertNil(error);
@@ -641,6 +658,7 @@
          XCTAssertEqualObjects(params.user.uid, @"1");
          XCTAssertEqualObjects(params.user.utid, @"1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.user.environment, @"https://login.microsoftonline.com");
+         XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          
          XCTAssertEqualObjects(params.unvalidatedAuthority.absoluteString, @"https://login.microsoft.com/common");
          
@@ -684,6 +702,7 @@
                                                 authority:@"https://login.microsoftonline.com/common"
                                                     error:&error];
     application.component = @"unittests";
+    application.sliceParameters = @{ @"slice" : @"myslice" };
     
     XCTAssertNotNil(application);
     XCTAssertNil(error);
@@ -706,6 +725,7 @@
          XCTAssertEqualObjects(params.user.uid, @"1");
          XCTAssertEqualObjects(params.user.utid, @"1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.user.environment, @"https://login.microsoftonline.com");
+         XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          
          XCTAssertEqualObjects(params.unvalidatedAuthority.absoluteString, @"https://login.microsoft.com/common");
          

--- a/MSAL/test/unit/MSALSilentRequestTests.m
+++ b/MSAL/test/unit/MSALSilentRequestTests.m
@@ -202,6 +202,7 @@
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.urlSession = [MSALTestURLSession createMockSession];
+    parameters.sliceParameters = @{ @"slice" : @"myslice" };
     
     NSDictionary* idTokenClaims = @{ @"home_oid" : @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97"};
     MSALIdToken *idToken = [[MSALIdToken alloc] initWithJson:idTokenClaims error:nil];
@@ -246,7 +247,7 @@
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
     
     MSALTestURLResponse *response =
-    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=testslice&uid=true"
+    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=myslice"
                            requestHeaders:reqHeaders
                         requestParamsBody:@{ @"client_id" : UNIT_TEST_CLIENT_ID,
                                              @"scope" : @"fakescope1 fakescope2 openid profile offline_access",
@@ -298,6 +299,7 @@
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.urlSession = [MSALTestURLSession createMockSession];
+    parameters.sliceParameters = @{ UT_SLICE_PARAMS_DICT };
     
     NSDictionary* idTokenClaims = @{ @"home_oid" : @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97"};
     MSALIdToken *idToken = [[MSALIdToken alloc] initWithJson:idTokenClaims error:nil];
@@ -342,7 +344,7 @@
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
     
     MSALTestURLResponse *response =
-    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=testslice&uid=true"
+    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token" UT_SLICE_PARAMS_QUERY
                            requestHeaders:reqHeaders
                         requestParamsBody:@{ @"client_id" : UNIT_TEST_CLIENT_ID,
                                              @"scope" : @"fakescope1 fakescope2 openid profile offline_access",
@@ -487,7 +489,7 @@
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
     
     MSALTestURLResponse *response =
-    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=testslice&uid=true"
+    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token"
                            requestHeaders:reqHeaders
                         requestParamsBody:@{ @"client_id" : UNIT_TEST_CLIENT_ID,
                                              @"scope" : @"fakescope1 fakescope2 openid profile offline_access",
@@ -616,7 +618,7 @@
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
     
     MSALTestURLResponse *response =
-    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=testslice&uid=true"
+    [MSALTestURLResponse requestURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token"
                            requestHeaders:reqHeaders
                         requestParamsBody:@{ @"client_id" : UNIT_TEST_CLIENT_ID,
                                              @"scope" : @"fakescope1 fakescope2 openid profile offline_access",

--- a/MSAL/test/unit/utils/MSALTestConstants.h
+++ b/MSAL/test/unit/utils/MSALTestConstants.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include "MSALPublicClientApplication+Internal.h"
+
 // Unit test client ID
 #define UNIT_TEST_CLIENT_ID                 @"b92e0ba5-f86e-4411-8e18-6b5f928d968a"
 
@@ -36,4 +38,5 @@
 // Unit test redirect uri : msal<clientId>://auth
 #define UNIT_TEST_DEFAULT_REDIRECT_URI      UNIT_TEST_DEFAULT_REDIRECT_SCHEME"://auth"
 
-
+#define UT_SLICE_PARAMS_DICT DEFAULT_SLICE_PARAMS
+#define UT_SLICE_PARAMS_QUERY "?slice=testslice&uid=true"


### PR DESCRIPTION
- Public API way to set parameters to target specific slices and flights that get added to the QPs on all token and authorize requests
- Unit test changes for slice parameters to use #defines as much as possible when pulling default slice parameters
- More unit test changes due to differences in how testslice is handled now