### PR TITLE
Add more information on redirect URI scheme error.

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -63,7 +63,7 @@
         }
     }
     
-    MSAL_ERROR_PARAM(nil, MSALErrorRedirectSchemeNotRegistered, @"The required app scheme (%@) is not registered in the app's info.plist file. Make sure the URI scheme matches exactly \"%@<clientID>\" format without any whitespaces.", scheme, scheme);
+    MSAL_ERROR_PARAM(nil, MSALErrorRedirectSchemeNotRegistered, @"The required app scheme (%@) is not registered in the app's info.plist file. Make sure the URI scheme matches exactly \"msal<clientID>\" format without any whitespaces.", scheme);
     
     return NO;
 }

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -63,7 +63,7 @@
         }
     }
     
-    MSAL_ERROR_PARAM(nil, MSALErrorRedirectSchemeNotRegistered, @"The required app scheme (%@) is not registered in the app's info.plist file.", scheme);
+    MSAL_ERROR_PARAM(nil, MSALErrorRedirectSchemeNotRegistered, @"The required app scheme (%@) is not registered in the app's info.plist file. Make sure the URI scheme matches exactly \"%@<clientID>\" format without any whitespaces.", scheme, scheme);
     
     return NO;
 }


### PR DESCRIPTION
Addresses #145 

"The required app scheme (msal) is not registered in the app's info.plist file." to
"The required app scheme (msal) is not registered in the app's info.plist file. Make sure the URI scheme matches exactly \"msal\<clientID\>\" format without any whitespaces."