### PR TITLE
Reverting the invalid scope fix

### DIFF
--- a/MSAL/src/MSALError_Internal.m
+++ b/MSAL/src/MSALError_Internal.m
@@ -72,10 +72,6 @@ MSALErrorCode MSALErrorCodeForOAuthError(NSString *oauthError, MSALErrorCode def
     {
         return MSALErrorInvalidClient;
     }
-    if ([oauthError isEqualToString:@"invalid_scope"])
-    {
-        return MSALErrorInvalidParameter;
-    }
     
     return defaultCode;
 }


### PR DESCRIPTION
Since this fix was accidentally pulled in together with #173 and github didn’t warn about it (just automatically closed another pull request too without ability to revert only that one), then I’m reopening this pull request for review (first one to revert change and then second one to apply change)