### PR TITLE
disabling console logger by default

### DIFF
--- a/MSAL/src/MSALLogger.m
+++ b/MSAL/src/MSALLogger.m
@@ -58,7 +58,7 @@
     // and we'll probably not have enough diagnostic information, however verbose
     // will most likely be too noisy for most usage.
     self.level = MSALLogLevelInfo;
-    self.consoleLogging = YES;
+    self.consoleLogging = NO;
     
     return self;
 }

--- a/MSAL/src/MSALLogger.m
+++ b/MSAL/src/MSALLogger.m
@@ -58,7 +58,6 @@
     // and we'll probably not have enough diagnostic information, however verbose
     // will most likely be too noisy for most usage.
     self.level = MSALLogLevelInfo;
-    self.consoleLogging = NO;
     
     return self;
 }
@@ -221,12 +220,6 @@ static NSDateFormatter *s_dateFormatter = nil;
     
     
     NSString* log = [NSString stringWithFormat:@"MSAL " MSAL_VERSION_STRING " %@ [%@%@]%@ %@", s_OSString, dateString, correlationIdStr, component, message];
-    
-    // Don't log PII out to console.
-    if (_consoleLogging && !isPii)
-    {
-        NSLog(@"%@", log);
-    }
     
     if (_callback)
     {

--- a/MSAL/src/public/MSALLogger.h
+++ b/MSAL/src/public/MSALLogger.h
@@ -59,8 +59,6 @@ typedef void (^MSALLogCallback)(MSALLogLevel level, NSString *message, BOOL cont
  */
 @property (readwrite) MSALLogLevel level;
 
-@property (readwrite) BOOL consoleLogging;
-
 /*!
     Sets the callback block to send MSAL log messages to.
  


### PR DESCRIPTION
no need to rip it out entirely, we should just default to off