### PR TITLE
Add “PiiLoggingEnabled” flag to MSALLogger

### DIFF
--- a/MSAL/src/MSALLogger.m
+++ b/MSAL/src/MSALLogger.m
@@ -59,6 +59,7 @@
     // will most likely be too noisy for most usage.
     self.level = MSALLogLevelInfo;
     self.consoleLogging = YES;
+    self.PiiLoggingEnabled = NO;
     
     return self;
 }
@@ -191,6 +192,11 @@ static NSDateFormatter *s_dateFormatter = nil;
     }
     
     if (level > _level)
+    {
+        return;
+    }
+    
+    if (isPii && !_PiiLoggingEnabled)
     {
         return;
     }

--- a/MSAL/src/public/MSALLogger.h
+++ b/MSAL/src/public/MSALLogger.h
@@ -44,8 +44,11 @@ typedef NS_ENUM(NSInteger, MSALLogLevel)
  
     @param  level           The level of the log message
     @param  message         The message being logged
-    @param  containsPII     Whether the message contains personally identifiable
-                            information (PII)
+    @param  containsPII     If the message might contain Personally Identifiable Information (PII)
+                            this will be true. Log messages possibly containing PII will not be
+                            sent to the callback unless PIllLoggingEnabled is set to YES on the
+                            logger.
+
  */
 typedef void (^MSALLogCallback)(MSALLogLevel level, NSString *message, BOOL containsPII);
 
@@ -60,6 +63,12 @@ typedef void (^MSALLogCallback)(MSALLogLevel level, NSString *message, BOOL cont
 @property (readwrite) MSALLogLevel level;
 
 @property (readwrite) BOOL consoleLogging;
+
+/*!
+    Set to YES to allow messages possibly containing Personally Identifiable Information (PII) to be
+    sent to the logging callback.
+ */
+@property (readwrite) BOOL PiiLoggingEnabled;
 
 /*!
     Sets the callback block to send MSAL log messages to.

--- a/MSAL/test/app/ios/MSALTestAppLogViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppLogViewController.m
@@ -59,6 +59,7 @@ static NSAttributedString* s_attrNewLine = nil;
     
     [self setEdgesForExtendedLayout:UIRectEdgeNone];
     
+    [[MSALLogger sharedLogger] setPiiLoggingEnabled:YES];
     [[MSALLogger sharedLogger] setCallback:^(MSALLogLevel level, NSString *message, BOOL containsPII)
     {
         (void)level;

--- a/MSAL/test/automation/ios/MSALAutoMainViewController.m
+++ b/MSAL/test/automation/ios/MSALAutoMainViewController.m
@@ -47,6 +47,7 @@
     [super viewDidLoad];
     // Do any additional setup after loading the view.
     
+    [MSALLogger sharedLogger].PiiLoggingEnabled = YES;
     [[MSALLogger sharedLogger] setCallback:^(MSALLogLevel level, NSString *message, BOOL containsPII) {
         (void)level;
         if (!containsPII)

--- a/MSAL/test/unit/MSALLoggerTests.m
+++ b/MSAL/test/unit/MSALLoggerTests.m
@@ -78,6 +78,7 @@
     XCTAssertEqual(logger.lastLevel, MSALLogLevelVerbose);
     
     [logger reset];
+    [[MSALLogger sharedLogger] setPiiLoggingEnabled:YES];
     LOG_ERROR_PII(nil, @"userId: %@ failed to sign in", @"user@contoso.com");
     XCTAssertNotNil(logger.lastMessage);
     XCTAssertTrue(logger.containsPII);
@@ -85,6 +86,7 @@
     XCTAssertEqual(logger.lastLevel, MSALLogLevelError);
     
     [logger reset];
+    [[MSALLogger sharedLogger] setPiiLoggingEnabled:YES];
     LOG_WARN_PII(nil, @"%@ pressed the cancel button", @"user@contoso.com");
     XCTAssertNotNil(logger.lastMessage);
     XCTAssertTrue(logger.containsPII);
@@ -92,6 +94,7 @@
     XCTAssertEqual(logger.lastLevel, MSALLogLevelWarning);
     
     [logger reset];
+    [[MSALLogger sharedLogger] setPiiLoggingEnabled:YES];
     LOG_INFO_PII(nil, @"%@ is trying to log in", @"user@contoso.com");
     XCTAssertNotNil(logger.lastMessage);
     XCTAssertTrue(logger.containsPII);
@@ -99,6 +102,23 @@
     XCTAssertEqual(logger.lastLevel, MSALLogLevelInfo);
      
     [logger reset];
+    [[MSALLogger sharedLogger] setPiiLoggingEnabled:YES];
+    LOG_VERBSOE_PII(nil, @"waiting on response from %@", @"contoso.com");
+    XCTAssertNotNil(logger.lastMessage);
+    XCTAssertTrue(logger.containsPII);
+    XCTAssertTrue([logger.lastMessage containsString:@"waiting on response from contoso.com"]);
+    XCTAssertEqual(logger.lastLevel, MSALLogLevelVerbose);
+}
+
+- (void)testIsPiiEnabled
+{
+    [[MSALLogger sharedLogger] setLevel:MSALLogLevelLast];
+    MSALTestLogger* logger = [MSALTestLogger sharedLogger];
+    [[MSALLogger sharedLogger] setPiiLoggingEnabled:NO];
+    LOG_VERBSOE_PII(nil, @"waiting on response from %@", @"contoso.com");
+    XCTAssertNil(logger.lastMessage);
+    
+    [[MSALLogger sharedLogger] setPiiLoggingEnabled:YES];
     LOG_VERBSOE_PII(nil, @"waiting on response from %@", @"contoso.com");
     XCTAssertNotNil(logger.lastMessage);
     XCTAssertTrue(logger.containsPII);

--- a/MSAL/test/unit/utils/MSALTestLogger.m
+++ b/MSAL/test/unit/utils/MSALTestLogger.m
@@ -68,6 +68,7 @@
     _lastLevel = -1;
     _containsPII = NO;
     [[MSALLogger sharedLogger] setLevel:level];
+    [[MSALLogger sharedLogger] setPiiLoggingEnabled:NO];
 }
 
 @end


### PR DESCRIPTION
This flag matches the one in MSAL.NET and should make it less likely an app developer inadvertantly logs PII due to ignorance.

Fixes #190