### PR TITLE
Just link update for Quick Start.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Microsoft Authentication Library Preview for iOS
 =====================================
 
-| [Get Started](https://apps.dev.microsoft.com/portal/register-app)| [Sample Code](https://github.com/Azure-Samples/active-directory-ios-swift-native-v2) | [API Reference](https://azuread.github.io/docs/objc/) | [Support](README.md#community-help-and-support)
+| [Get Started](https://apps.dev.microsoft.com/)| [Sample Code](https://github.com/Azure-Samples/active-directory-ios-swift-native-v2) | [API Reference](https://azuread.github.io/docs/objc/) | [Support](README.md#community-help-and-support)
 | --- | --- | --- | --- |
 
 


### PR DESCRIPTION
Since we don't have the iOS Quick Start portal from Portal Team ready for iOS yet, we are moving back to linking to the https://apps.dev.microsoft.com/ again.