### PR TITLE
Change nullability specifier on return types in MSALTelemetry

### DIFF
--- a/MSAL/src/public/MSALTelemetry.h
+++ b/MSAL/src/public/MSALTelemetry.h
@@ -47,8 +47,8 @@
  */
 @interface MSALTelemetry : NSObject
 
-+ (nullable instancetype)new __attribute__((unavailable("new is unavailable, use sharedInstance instead.")));
-- (nullable instancetype)init __attribute__((unavailable("init is unavailable, use sharedInstance instead.")));
++ (nonnull instancetype)new __attribute__((unavailable("new is unavailable, use sharedInstance instead.")));
+- (nonnull instancetype)init __attribute__((unavailable("init is unavailable, use sharedInstance instead.")));
 
 /*!
  Get a singleton instance of MSALTelemetry.


### PR DESCRIPTION
#207 

return type should be nonnull, 

https://developer.apple.com/reference/objectivec/nsobject/1418641-init

The init() method defined in the NSObject class does no initialization; it simply returns self. In terms of nullability, callers can assume that the NSObject implemetation of init() does not return nil.
