### PR TITLE
ClientId should not be removed from scopes in Active Directory B2C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 xcuserdata
 MSAL.xcscmblueprint
+DerivedData
+.DS_Store

--- a/MSAL/src/requests/MSALBaseRequest.m
+++ b/MSAL/src/requests/MSALBaseRequest.m
@@ -114,7 +114,6 @@ static MSALScopes *s_reservedScopes = nil;
         [requestScopes unionOrderedSet:extraScopes];
     }
     [requestScopes unionOrderedSet:s_reservedScopes];
-    [requestScopes removeObject:_parameters.clientId];
     return requestScopes;
 }
 


### PR DESCRIPTION
I have spent the last few days attempting to make this library work with Active Directory B2C. No matter what I tried, there was no way to make it authenticate successfully: I kept getting an error that told me that the `accessToken` was missing from the response.

After some debugging, I have identified the core issue to this function, in `MSALBaseRequest`:

```objective-c
- (MSALScopes *)requestScopes:(MSALScopes *)extraScopes
{
    NSMutableOrderedSet *requestScopes = [_parameters.scopes mutableCopy];
    if (extraScopes)
    {
        [requestScopes unionOrderedSet:extraScopes];
    }
    [requestScopes unionOrderedSet:s_reservedScopes];
    [requestScopes removeObject:_parameters.clientId]; // <-- Why?
    return requestScopes;
}
```

This function removes the ClientID from the request scopes, making impossible to use it with Active Directory B2C. This is because, as clearly stated in the [Azure Active Directory B2C documentation](https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-oidc#get-a-token):

> The convention for requesting a token to yourself is to use your app's client ID as the scope

By removing that line, I am now able to successfully get a token and use it to authenticate my app to my services.

_I have also edited the .gitignore file to automatically ignore DerivedData and .DS_Store files._