### PR TITLE
Adds parameter to specify keychain share group

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -78,6 +78,14 @@
              authority:(NSString *)authority
                  error:(NSError * __autoreleasing *)error
 {
+    return [self initWithClientId:clientId authority:authority group:nil error:error];
+}
+
+- (id)initWithClientId:(NSString *)clientId
+             authority:(NSString *)authority
+                 group:(NSString *)sharedGroup
+                 error:(NSError * __autoreleasing *)error
+{
     if (!(self = [super init]))
     {
         return nil;
@@ -101,7 +109,7 @@
     
     id<MSALTokenCacheAccessor> dataSource;
 #if TARGET_OS_IPHONE
-    dataSource = [MSALKeychainTokenCache defaultKeychainCache];
+    dataSource = [MSALKeychainTokenCache sharedKeychainCacheWithGroup:sharedGroup];
 #else
     dataSource = [MSALWrapperTokenCache defaultCache];
 #endif

--- a/MSAL/src/cache/ios/MSALKeychainTokenCache.h
+++ b/MSAL/src/cache/ios/MSALKeychainTokenCache.h
@@ -31,6 +31,8 @@
 
 + (nonnull MSALKeychainTokenCache *)defaultKeychainCache;
 
++ (nonnull MSALKeychainTokenCache *)sharedKeychainCacheWithGroup:(NSString *)group;
+
 @end
 
 @interface MSALKeychainTokenCache (Internal) <MSALTokenCacheAccessor>

--- a/MSAL/src/cache/ios/MSALKeychainTokenCache.m
+++ b/MSAL/src/cache/ios/MSALKeychainTokenCache.m
@@ -49,12 +49,17 @@ typedef NS_ENUM(uint32_t, MSALTokenType)
 
 + (MSALKeychainTokenCache *)defaultKeychainCache
 {
+    return [self.class sharedKeychainCacheWithGroup:nil];
+}
+
++ (MSALKeychainTokenCache *)sharedKeychainCacheWithGroup:(NSString *)group
+{
     static dispatch_once_t s_once;
-    
+
     dispatch_once(&s_once, ^{
-        s_defaultCache = [[MSALKeychainTokenCache alloc] initWithGroup:nil];
+        s_defaultCache = [[MSALKeychainTokenCache alloc] initWithGroup:group];
     });
-    
+
     return s_defaultCache;
 }
 

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -87,6 +87,25 @@
                  error:(NSError * __autoreleasing *)error;
 
 /*!
+    Initialize a MSALPublicClientApplication with a given clientID and authority
+
+    @param  clientId    The clientID of your application, you should get this from the app portal.
+    @param  authority   A URL indicating a directory that MSAL can use to obtain tokens. In Azure AD
+                        it is of the form https://<instance/<tenant>, where <instance> is the
+                        directory host (e.g. https://login.microsoftonline.com) and <tenant> is a
+                        identifier within the directory itself (e.g. a domain associated to the
+                        tenant, such as contoso.onmicrosoft.com, or the GUID representing the
+                        TenantID property of the directory)
+    @param  sharedGroup The keychain to use to store the token cache. Pass in nil to use the default group.
+    @param  error       The error that occurred creating the application object, if any, if you're
+                        not interested in the specific error pass in nil.
+ */
+- (id)initWithClientId:(NSString *)clientId
+             authority:(NSString *)authority
+                 group:(NSString *)sharedGroup
+                 error:(NSError * __autoreleasing *)error;
+
+/*!
     Returns an array of users visible to this application
  
     @param  error   The error that occured trying to retrieve users, if any, if you're


### PR DESCRIPTION
After switching from ADAL to MSAL I noticed that sharing tokens via a common keychain sharing group is no longer possible as by default MSAL uses a keychain group based on the bundle identifier and this cannot be overwritten. This PR allows to override the keychain group by providing it to a new initializer for MSALPublicClientApplication and so allowing apps and their extensions to share tokens via a common keychain cache.