### PR TITLE
Adding README and CHANGELOG to Xcode workspace

### DIFF
--- a/MSAL.xcworkspace/.xcodesamplecode.plist
+++ b/MSAL.xcworkspace/.xcodesamplecode.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>

--- a/MSAL.xcworkspace/contents.xcworkspacedata
+++ b/MSAL.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,12 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:README.md">
+   </FileRef>
+   <FileRef
+      location = "group:CHANGELOG.md">
+   </FileRef>
+   <FileRef
       location = "group:MSAL/MSAL.xcodeproj">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
## PROBLEM:
- It is not really a problem but a  convenient way to get access to the ReadME and Changelog.

## SUGGESTED SOLUTION IN THIS PULL REQUEST:

- Added the 2 files at the Top of the Xcode workspace
- Added the magic .xcodesamplecode.plist to the Xcode workspace (telling Xcode to render MD files)