### PR TITLE
Telemetry fix for MSAL

### DIFF
--- a/MSAL/src/telemetry/MSALDefaultDispatcher.m
+++ b/MSAL/src/telemetry/MSALDefaultDispatcher.m
@@ -87,7 +87,7 @@
     if ([events count])
     {
         NSArray* eventsToBeDispatched = @[[_defaultEvent getProperties]];
-        [_dispatcher dispatchEvent:[eventsToBeDispatched arrayByAddingObjectsFromArray:events]];
+        [self dispatchEvents:[eventsToBeDispatched arrayByAddingObjectsFromArray:events]];
     }
 }
 
@@ -116,6 +116,30 @@
     }
     
     [_dispatchLock unlock];
+}
+
+- (void)dispatchEvents:(NSArray<NSDictionary<NSString *, NSString *> *> *)rawEvents;
+{
+    NSMutableArray *eventsToBeDispatched = [NSMutableArray new];
+    
+    for (NSDictionary *event in rawEvents)
+    {
+        [eventsToBeDispatched addObject:[self appendPrefixForEvent:event]];
+    }
+    
+    [_dispatcher dispatchEvent:eventsToBeDispatched];
+}
+
+- (NSDictionary *)appendPrefixForEvent:(NSDictionary *)event
+{
+    NSMutableDictionary *eventWithPrefix = [NSMutableDictionary new];
+    
+    for (NSString *propertyName in [event allKeys])
+    {
+        [eventWithPrefix setValue:event[propertyName] forKey:TELEMETRY_KEY(propertyName)];
+    }
+    
+    return eventWithPrefix;
 }
 
 @end

--- a/MSAL/src/telemetry/MSALTelemetry.m
+++ b/MSAL/src/telemetry/MSALTelemetry.m
@@ -65,5 +65,15 @@ setTelemetryOnFailure:(BOOL)setTelemetryOnFailure
     [[MSIDTelemetry sharedInstance] removeAllDispatchers];
 }
 
+- (BOOL)piiEnabled
+{
+    return [[MSIDTelemetry sharedInstance] piiEnabled];
+}
+
+- (void)setPiiEnabled:(BOOL)piiEnabled
+{
+    [[MSIDTelemetry sharedInstance] setPiiEnabled:piiEnabled];
+}
+
 @end
 


### PR DESCRIPTION
- Use the latest commit of common core dev;
- If `piiEnabled` of `MSALTelemetry` is set, change `piiEnabled` of `MSIDTelemetry` accordingly;
- Append telemetry prefix `msal.` to all events being dispatched.