### PR TITLE
Fixed MSID error handling and login hint passing

### DIFF
--- a/MSAL/src/requests/MSALInteractiveRequest.m
+++ b/MSAL/src/requests/MSALInteractiveRequest.m
@@ -187,8 +187,6 @@
             completionBlock(nil, error);
             return;
         }
-        
-        completionBlock(nil, error);
     };
 
 #if TARGET_OS_IPHONE


### PR DESCRIPTION
Fixing two issues:
1. MSID webview errors weren't converted to MSAL errors (long term we should improve it, see here https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/issues/194)
2. if dev provided account, login hint wasn't passed