### PR TITLE
Fixed MSAL error converter for userinfo

### DIFF
--- a/MSAL/MSAL Test App.entitlements
+++ b/MSAL/MSAL Test App.entitlements
@@ -6,6 +6,7 @@
 	<array>
 		<string>$(AppIdentifierPrefix)com.microsoft.MSALTestApp</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
+		<string>$(AppIdentifierPrefix)com.microsoft.workplacejoin</string>
 	</array>
 </dict>
 </plist>

--- a/MSAL/src/MSALError.m
+++ b/MSAL/src/MSALError.m
@@ -33,3 +33,4 @@ NSString *MSALOAuthSubErrorKey = @"MSALOAuthSubErrorKey";
 NSString *MSALErrorDescriptionKey = @"MSALErrorDescriptionKey";
 NSString *MSALHTTPHeadersKey = @"MSALHTTPHeadersKey";
 NSString *MSALHTTPResponseCodeKey = @"MSALHTTPResponseCodeKey";
+NSString *MSALCorrelationIDKey = @"MSALCorrelationIDKey";

--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -80,7 +80,11 @@ static NSDictionary *s_userInfoKeyMapping;
     
     s_userInfoKeyMapping = @{
                              MSIDHTTPHeadersKey : MSALHTTPHeadersKey,
-                             MSIDHTTPResponseCodeKey : MSALHTTPResponseCodeKey
+                             MSIDHTTPResponseCodeKey : MSALHTTPResponseCodeKey,
+                             MSIDCorrelationIdKey : MSALCorrelationIDKey,
+                             MSIDErrorDescriptionKey : MSALErrorDescriptionKey,
+                             MSIDOAuthErrorKey: MSALOAuthErrorKey,
+                             MSIDOAuthSubErrorKey: MSALOAuthSubErrorKey
                              };
 }
 
@@ -124,10 +128,10 @@ static NSDictionary *s_userInfoKeyMapping;
     
     return MSALCreateError(domain,
                            errorCode,
-                           msidError.userInfo[MSIDErrorDescriptionKey],
-                           msidError.userInfo[MSIDOAuthErrorKey],
-                           msidError.userInfo[MSIDOAuthSubErrorKey],
-                           msidError.userInfo[NSUnderlyingErrorKey],
+                           nil,
+                           nil,
+                           nil,
+                           nil,
                            userInfo);
     
 }

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -51,6 +51,11 @@ extern NSString *MSALErrorDescriptionKey;
 extern NSString *MSALHTTPHeadersKey;
 
 /*!
+ Correlation ID used for the request
+ */
+extern NSString *MSALCorrelationIDKey;
+
+/*!
  Specifies http response code for error cases
  */
 extern NSString *MSALHTTPResponseCodeKey;

--- a/MSAL/test/automation/ios/MSALAutomation.entitlements
+++ b/MSAL/test/automation/ios/MSALAutomation.entitlements
@@ -6,6 +6,7 @@
 	<array>
 		<string>$(AppIdentifierPrefix)com.microsoft.MSALAutomationApp</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
+		<string>$(AppIdentifierPrefix)com.microsoft.workplacejoin</string>
 	</array>
 </dict>
 </plist>

--- a/MSAL/test/unit/MSALErrorConverterTests.m
+++ b/MSAL/test/unit/MSALErrorConverterTests.m
@@ -66,7 +66,8 @@
                                          underlyingError,
                                          correlationId,
                                          @{MSIDHTTPHeadersKey : httpHeaders,
-                                           MSIDHTTPResponseCodeKey : httpResponseCode
+                                           MSIDHTTPResponseCodeKey : httpResponseCode,
+                                           @"additional_user_info": @"unmapped_userinfo"
                                            });
     NSError *msalError = [MSALErrorConverter MSALErrorFromMSIDError:msidError];
     
@@ -75,11 +76,17 @@
     XCTAssertEqualObjects(msalError.domain, expectedErrorDomain);
     XCTAssertEqual(msalError.code, errorCode);
     XCTAssertEqualObjects(msalError.userInfo[MSALErrorDescriptionKey], errorDescription);
+    XCTAssertNil(msalError.userInfo[MSIDErrorDescriptionKey]);
     XCTAssertEqualObjects(msalError.userInfo[MSALOAuthErrorKey], oauthError);
+    XCTAssertNil(msalError.userInfo[MSIDOAuthErrorKey]);
     XCTAssertEqualObjects(msalError.userInfo[MSALOAuthSubErrorKey], subError);
+    XCTAssertNil(msalError.userInfo[MSIDOAuthSubErrorKey]);
     XCTAssertEqualObjects(msalError.userInfo[NSUnderlyingErrorKey], underlyingError);
     XCTAssertEqualObjects(msalError.userInfo[MSALHTTPHeadersKey], httpHeaders);
+    XCTAssertNil(msalError.userInfo[MSIDHTTPHeadersKey]);
     XCTAssertEqualObjects(msalError.userInfo[MSALHTTPResponseCodeKey], httpResponseCode);
+    XCTAssertNil(msalError.userInfo[MSIDHTTPResponseCodeKey]);
+    XCTAssertEqualObjects(msalError.userInfo[@"additional_user_info"], @"unmapped_userinfo");
 }
 
 - (void)testErrorConversion_whenBothErrorDomainAndCodeAreMapped_shouldMapBoth {
@@ -100,7 +107,8 @@
                                          underlyingError,
                                          correlationId,
                                          @{MSIDHTTPHeadersKey : httpHeaders,
-                                           MSIDHTTPResponseCodeKey : httpResponseCode
+                                           MSIDHTTPResponseCodeKey : httpResponseCode,
+                                           @"additional_user_info": @"unmapped_userinfo"
                                            });
     NSError *msalError = [MSALErrorConverter MSALErrorFromMSIDError:msidError];
     
@@ -110,11 +118,17 @@
     XCTAssertEqualObjects(msalError.domain, expectedErrorDomain);
     XCTAssertEqual(msalError.code, expectedErrorCode);
     XCTAssertEqualObjects(msalError.userInfo[MSALErrorDescriptionKey], errorDescription);
+    XCTAssertNil(msalError.userInfo[MSIDErrorDescriptionKey]);
     XCTAssertEqualObjects(msalError.userInfo[MSALOAuthErrorKey], oauthError);
+    XCTAssertNil(msalError.userInfo[MSIDOAuthErrorKey]);
     XCTAssertEqualObjects(msalError.userInfo[MSALOAuthSubErrorKey], subError);
+    XCTAssertNil(msalError.userInfo[MSIDOAuthSubErrorKey]);
     XCTAssertEqualObjects(msalError.userInfo[NSUnderlyingErrorKey], underlyingError);
     XCTAssertEqualObjects(msalError.userInfo[MSALHTTPHeadersKey], httpHeaders);
+    XCTAssertNil(msalError.userInfo[MSIDHTTPHeadersKey]);
     XCTAssertEqualObjects(msalError.userInfo[MSALHTTPResponseCodeKey], httpResponseCode);
+    XCTAssertNil(msalError.userInfo[MSIDHTTPResponseCodeKey]);
+    XCTAssertEqualObjects(msalError.userInfo[@"additional_user_info"], @"unmapped_userinfo");
 }
 
 /*!


### PR DESCRIPTION
Previous implementation was copying MSALErrorDescription, OauthError and suberror keys, but also leaving MSID keys in user info. Also, correlation ID wasn't mapped. 

I changed it to use the same mapping mechanism for all user info items.
Also, updated identity core submodule to point to the latest commit with JK's fixes.