### PR TITLE
Fixed tests when updating to latest MSID common core dev

### DIFF
--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -62,6 +62,7 @@ static NSDictionary *s_userInfoKeyMapping;
                                    @(MSIDErrorInteractiveSessionStartFailure) : @(MSALErrorInternal),
                                    @(MSIDErrorInteractiveSessionAlreadyRunning) : @(MSALErrorInteractiveSessionAlreadyRunning),
                                    @(MSIDErrorNoMainViewController) : @(MSALErrorNoViewController),
+                                   @(MSIDErrorServerUnhandledResponse): @(MSALErrorUnhandledResponse)
                                    },
                            MSIDOAuthErrorDomain:@{
                                    @(MSIDErrorInteractionRequired) : @(MSALErrorInteractionRequired),

--- a/MSAL/src/instance/MSALAadAuthorityResolver.m
+++ b/MSAL/src/instance/MSALAadAuthorityResolver.m
@@ -77,8 +77,6 @@
                                                                                                 context:context];
     [request sendWithBlock:^(id response, NSError *error) {
         
-        [request finishAndInvalidate];
-
          if (error)
          {
              completionBlock(nil, error);

--- a/MSAL/src/instance/MSALAdfsAuthorityResolver.m
+++ b/MSAL/src/instance/MSALAdfsAuthorityResolver.m
@@ -138,9 +138,7 @@ static NSString *const s_kWebFingerError    = @"WebFinger request was invalid or
     MSIDAADAuthorityValidationRequest *request = [[MSIDAADAuthorityValidationRequest alloc] initWithUrl:url
                                                                                                 context:context];
     [request sendWithBlock:^(id response, NSError *error) {
-        
-        [request finishAndInvalidate];
-        
+
         CHECK_COMPLETION(!error);
         
         if(response && ![response isKindOfClass:[NSDictionary class]])
@@ -223,9 +221,7 @@ static NSString *const s_kWebFingerError    = @"WebFinger request was invalid or
     MSIDAADAuthorityValidationRequest *request = [[MSIDAADAuthorityValidationRequest alloc] initWithUrl:webfingerUrl
                                                                                                 context:context];
     [request sendWithBlock:^(id response, NSError *error) {
-        
-        [request finishAndInvalidate];
-        
+                
         CHECK_COMPLETION(!error);
         
         if(response && ![response isKindOfClass:[NSDictionary class]])

--- a/MSAL/src/instance/MSALAuthorityBaseResolver.m
+++ b/MSAL/src/instance/MSALAuthorityBaseResolver.m
@@ -42,9 +42,7 @@
     MSIDAADAuthorityValidationRequest *request = [[MSIDAADAuthorityValidationRequest alloc] initWithUrl:url
                                                                                                 context:context];
     [request sendWithBlock:^(id response, NSError *error) {
-        
-        [request finishAndInvalidate];
-        
+                
         CHECK_COMPLETION(!error);
         
         if(response && ![response isKindOfClass:[NSDictionary class]])

--- a/MSAL/src/requests/MSALBaseRequest.m
+++ b/MSAL/src/requests/MSALBaseRequest.m
@@ -170,9 +170,7 @@ static MSALScopes *s_reservedScopes = nil;
     MSIDTokenRequest *authRequest = [self tokenRequest];
     
     [authRequest sendWithBlock:^(id response, NSError *error) {
-        
-        [authRequest finishAndInvalidate];
-        
+                
         if (error)
         {
             if(completionBlock) completionBlock(nil, error);

--- a/MSAL/src/requests/MSALSilentRequest.m
+++ b/MSAL/src/requests/MSALSilentRequest.m
@@ -90,7 +90,7 @@
             MSALTelemetryAPIEvent *event = [self getTelemetryAPIEvent];
             [self stopTelemetryEvent:event error:error];
 
-            completionBlock(nil, error);
+            completionBlock(nil, [MSALErrorConverter MSALErrorFromMSIDError:error]);
             return;
         }
         
@@ -166,7 +166,7 @@
                  error = nil;
              }
              
-             completionBlock(result, error);
+             completionBlock(result, [MSALErrorConverter MSALErrorFromMSIDError:error]);
          }];
     }];
 }

--- a/MSAL/test/unit/MSALAadAuthorityResolverTests.m
+++ b/MSAL/test/unit/MSALAadAuthorityResolverTests.m
@@ -91,7 +91,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:UNIT_TEST_CORRELATION_ID forKey:@"client-request-id"];
     
-    NSString *requestURLString = [NSString stringWithFormat:@"%@?api-version=1.0&authorization_endpoint=%@&%@", AAD_INSTANCE_DISCOVERY_ENDPOINT, authorizationEndpoint, MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *requestURLString = [NSString stringWithFormat:@"%@?api-version=1.0&authorization_endpoint=%@", AAD_INSTANCE_DISCOVERY_ENDPOINT, authorizationEndpoint];
     
     MSIDTestURLResponse *response = [MSIDTestURLResponse requestURLString:requestURLString
                                                            requestHeaders:reqHeaders
@@ -170,7 +170,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:UNIT_TEST_CORRELATION_ID forKey:@"client-request-id"];
     
-    NSString *requestURLString = [NSString stringWithFormat:@"%@?api-version=1.0&authorization_endpoint=%@&%@", AAD_INSTANCE_DISCOVERY_ENDPOINT, authorizationEndpoint, MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *requestURLString = [NSString stringWithFormat:@"%@?api-version=1.0&authorization_endpoint=%@", AAD_INSTANCE_DISCOVERY_ENDPOINT, authorizationEndpoint];
     
     MSIDTestURLResponse *response = [MSIDTestURLResponse requestURLString:requestURLString
                                                            requestHeaders:reqHeaders
@@ -214,7 +214,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:UNIT_TEST_CORRELATION_ID forKey:@"client-request-id"];
     
-    NSString *requestURLString = [NSString stringWithFormat:@"%@?api-version=1.0&authorization_endpoint=%@&%@", AAD_INSTANCE_DISCOVERY_ENDPOINT, authorizationEndpoint, MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *requestURLString = [NSString stringWithFormat:@"%@?api-version=1.0&authorization_endpoint=%@", AAD_INSTANCE_DISCOVERY_ENDPOINT, authorizationEndpoint];
     
     MSIDTestURLResponse *response = [MSIDTestURLResponse request:[NSURL URLWithString:requestURLString]
                                                respondWithError:[NSError errorWithDomain:NSURLErrorDomain

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -673,7 +673,7 @@
          // Ensure error is returned
          XCTAssertNil(result);
          XCTAssertNotNil(error);
-         XCTAssertEqualObjects(error.domain, MSIDHttpErrorCodeDomain);
+         XCTAssertEqualObjects(error.domain, MSALErrorDomain);
          XCTAssertEqual(error.code, MSIDErrorServerUnhandledResponse);
          
          [expectation fulfill];

--- a/MSAL/test/unit/MSALAdfsAuthorityResolverTests.m
+++ b/MSAL/test/unit/MSALAdfsAuthorityResolverTests.m
@@ -86,11 +86,9 @@ typedef void (^MSALWebFingerCompletionBlock)(MSALWebFingerResponse *response, NS
     NSDictionary *resultJson = customResponse? customResponse :
     @{ @"IdentityProviderService" : @{ @"PassiveAuthEndpoint" : @"https://fs.fabrikam.com/adfs/ls" }};
     
-    NSString *urlFormat = onPrems?
-    @"https://enterpriseregistration.contoso.com/enrollmentserver/contract?api-version=1.0&%@" :
-    @"https://enterpriseregistration.windows.net/contoso.com/enrollmentserver/contract?api-version=1.0&%@";
-    
-    NSString *url = [NSString stringWithFormat:urlFormat, MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = onPrems?
+    @"https://enterpriseregistration.contoso.com/enrollmentserver/contract?api-version=1.0" :
+    @"https://enterpriseregistration.windows.net/contoso.com/enrollmentserver/contract?api-version=1.0";
     
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url
@@ -110,7 +108,7 @@ typedef void (^MSALWebFingerCompletionBlock)(MSALWebFingerResponse *response, NS
     [reqHeaders setObject:UNIT_TEST_CORRELATION_ID forKey:@"client-request-id"];
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     
-    NSString *url = [NSString stringWithFormat:@"https://enterpriseregistration.contoso.com/enrollmentserver/contract?api-version=1.0&%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://enterpriseregistration.contoso.com/enrollmentserver/contract?api-version=1.0";
     [MSIDTestURLSession addResponse:
      [MSIDTestURLResponse serverNotFoundResponseForURLString:url
                                               requestHeaders:reqHeaders
@@ -125,7 +123,7 @@ typedef void (^MSALWebFingerCompletionBlock)(MSALWebFingerResponse *response, NS
     [reqHeaders setObject:UNIT_TEST_CORRELATION_ID forKey:@"client-request-id"];
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     
-    NSString *url = [NSString stringWithFormat:@"https://enterpriseregistration.windows.net/contoso.com/enrollmentserver/contract?api-version=1.0&%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://enterpriseregistration.windows.net/contoso.com/enrollmentserver/contract?api-version=1.0";
     [MSIDTestURLSession addResponse:
      [MSIDTestURLResponse serverNotFoundResponseForURLString:url
                                               requestHeaders:reqHeaders
@@ -142,7 +140,7 @@ typedef void (^MSALWebFingerCompletionBlock)(MSALWebFingerResponse *response, NS
     NSDictionary *resultJson = customResponse? customResponse :
     @{ @"links" : @[@{ @"rel" : TRUSTED_REALM, @"href" : @"https://fs.fabrikam.com/adfs/"}]};
     
-    NSString *url = [NSString stringWithFormat:@"https://fs.fabrikam.com/.well-known/webfinger?resource=https://fs.fabrikam.com/adfs/&%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://fs.fabrikam.com/.well-known/webfinger?resource=https://fs.fabrikam.com/adfs/";
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url
                            requestHeaders:reqHeaders

--- a/MSAL/test/unit/MSALAuthorityBaseResolverTests.m
+++ b/MSAL/test/unit/MSALAuthorityBaseResolverTests.m
@@ -74,7 +74,7 @@
     [reqHeaders setObject:UNIT_TEST_CORRELATION_ID forKey:@"client-request-id"];
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     
-    MSIDTestURLResponse *response = [MSIDTestURLResponse requestURLString:[NSString stringWithFormat:@"%@?%@", tenantDiscoveryEndpoint, MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode]
+    MSIDTestURLResponse *response = [MSIDTestURLResponse requestURLString:[NSString stringWithFormat:@"%@", tenantDiscoveryEndpoint]
                                                            requestHeaders:reqHeaders
                                                         requestParamsBody:nil
                                                         responseURLString:@"https://someresponseurl.com"
@@ -125,7 +125,7 @@
     [reqHeaders setObject:UNIT_TEST_CORRELATION_ID forKey:@"client-request-id"];
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     
-    MSIDTestURLResponse *response = [MSIDTestURLResponse requestURLString:[NSString stringWithFormat:@"%@?%@", tenantDiscoveryEndpoint, MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode]
+    MSIDTestURLResponse *response = [MSIDTestURLResponse requestURLString:[NSString stringWithFormat:@"%@", tenantDiscoveryEndpoint]
                                                            requestHeaders:reqHeaders
                                                         requestParamsBody:nil
                                                         responseURLString:@"https://someresponseurl.com"

--- a/MSAL/test/unit/MSALInteractiveRequestTests.m
+++ b/MSAL/test/unit/MSALInteractiveRequestTests.m
@@ -145,7 +145,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
     
-    NSString *url = [NSString stringWithFormat:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://login.microsoftonline.com/common/oauth2/v2.0/token";
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url
                            requestHeaders:reqHeaders
@@ -387,7 +387,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
 
-    NSString *url = [NSString stringWithFormat:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://login.microsoftonline.com/common/oauth2/v2.0/token";
 
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url
@@ -531,7 +531,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
 
-    NSString *url = [NSString stringWithFormat:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://login.microsoftonline.com/common/oauth2/v2.0/token";
 
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url
@@ -640,7 +640,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
    
-    NSString *url = [NSString stringWithFormat:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://login.microsoftonline.com/common/oauth2/v2.0/token";
 
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url

--- a/MSAL/test/unit/MSALSilentRequestTests.m
+++ b/MSAL/test/unit/MSALSilentRequestTests.m
@@ -275,7 +275,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
 
-    NSString *url = [NSString stringWithFormat:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=myslice&%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=myslice";
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url
                            requestHeaders:reqHeaders
@@ -378,7 +378,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
 
-    NSString *url = [NSString stringWithFormat:@"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token?%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://login.microsoftonline.com/1234-5678-90abcdefg/oauth2/v2.0/token";
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url UT_SLICE_PARAMS_QUERY
                            requestHeaders:reqHeaders
@@ -560,7 +560,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
 
-    NSString *url = [NSString stringWithFormat:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://login.microsoftonline.com/common/oauth2/v2.0/token";
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url
                            requestHeaders:reqHeaders
@@ -717,7 +717,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
 
-    NSString *url = [NSString stringWithFormat:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://login.microsoftonline.com/common/oauth2/v2.0/token";
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url
                            requestHeaders:reqHeaders
@@ -828,7 +828,7 @@
     [reqHeaders setObject:@"application/json" forKey:@"Accept"];
     [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
 
-    NSString *url = [NSString stringWithFormat:@"https://login.microsoftonline.com/common/oauth2/v2.0/token?%@", MSIDTestURLResponse.defaultQueryParameters.msidURLFormEncode];
+    NSString *url = @"https://login.microsoftonline.com/common/oauth2/v2.0/token";
     MSIDTestURLResponse *response =
     [MSIDTestURLResponse requestURLString:url
                            requestHeaders:reqHeaders

--- a/MSAL/test/unit/utils/MSIDTestURLResponse+MSAL.m
+++ b/MSAL/test/unit/utils/MSIDTestURLResponse+MSAL.m
@@ -50,7 +50,7 @@
        };
     
     MSIDTestURLResponse *oidcResponse =
-    [MSIDTestURLResponse requestURLString:[NSString stringWithFormat:@"%@/v2.0/.well-known/openid-configuration?%@", authority, self.defaultQueryParameters.msidURLFormEncode]
+    [MSIDTestURLResponse requestURLString:[NSString stringWithFormat:@"%@/v2.0/.well-known/openid-configuration", authority]
                            requestHeaders:oidcReqHeaders
                         requestParamsBody:nil
                         responseURLString:@"https://someresponseurl.com"
@@ -69,22 +69,24 @@
     [oidcReqHeaders setObject:@"true" forKey:@"return-client-request-id"];
     [oidcReqHeaders setObject:[MSIDTestRequireValueSentinel new] forKey:@"client-request-id"];
     [oidcReqHeaders setObject:@"application/json" forKey:@"Accept"];
-    
+
+    NSString *queryString = query ? [NSString stringWithFormat:@"?%@", query] : @"";
+
     NSDictionary *oidcJson =
-    @{ @"token_endpoint" : [NSString stringWithFormat:@"%@/v2.0/oauth/token?%@", responseAuthority, query],
-       @"authorization_endpoint" : [NSString stringWithFormat:@"%@/v2.0/oauth/authorize?%@", responseAuthority, query],
+    @{ @"token_endpoint" : [NSString stringWithFormat:@"%@/v2.0/oauth/token%@", responseAuthority, queryString],
+       @"authorization_endpoint" : [NSString stringWithFormat:@"%@/v2.0/oauth/authorize%@", responseAuthority, queryString],
        @"issuer" : @"issuer"
        };
-    
+
     MSIDTestURLResponse *oidcResponse =
-    [MSIDTestURLResponse requestURLString:[NSString stringWithFormat:@"%@/v2.0/.well-known/openid-configuration?%@", authority, self.defaultQueryParameters.msidURLFormEncode]
+    [MSIDTestURLResponse requestURLString:[NSString stringWithFormat:@"%@/v2.0/.well-known/openid-configuration", authority]
                            requestHeaders:oidcReqHeaders
                         requestParamsBody:nil
                         responseURLString:@"https://someresponseurl.com"
                              responseCode:200
                          httpHeaderFields:nil
                          dictionaryAsJSON:oidcJson];
-    
+
     return oidcResponse;
 }
 
@@ -100,7 +102,7 @@
     [tokenReqHeaders setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
     
     MSIDTestURLResponse *tokenResponse =
-    [MSIDTestURLResponse requestURLString:[NSString stringWithFormat:@"%@/v2.0/oauth/token?%@", authority, self.defaultQueryParameters.msidURLFormEncode]
+    [MSIDTestURLResponse requestURLString:[NSString stringWithFormat:@"%@/v2.0/oauth/token", authority]
                            requestHeaders:tokenReqHeaders
                         requestParamsBody:@{ MSID_OAUTH2_CLIENT_ID : UNIT_TEST_CLIENT_ID,
                                              MSID_OAUTH2_SCOPE : [scopes msalToString],
@@ -149,7 +151,6 @@
     [tokenReqHeaders setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
     
     NSMutableDictionary *tokenQPs = [NSMutableDictionary new];
-    [tokenQPs addEntriesFromDictionary:self.defaultQueryParameters];
     if (query)
     {
         [tokenQPs addEntriesFromDictionary:[NSDictionary msidURLFormDecode:query]];


### PR DESCRIPTION
PR in common core: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/219
Common core doesn't send x-client-Ver in query parameters anymore, because it's being sent in headers anyway.
