### PR TITLE
Add expiration buffer check for access tokens

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -237,6 +237,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
     
     _sliceParameters = [MSALPublicClientApplication defaultSliceParameters];
     
+    _expirationBuffer = 300;  //in seconds, ensures catching of clock differences between the server and the device
     
     return self;
 }
@@ -701,6 +702,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
     MSALSilentRequest *request = [[MSALSilentRequest alloc] initWithParameters:params
                                                                   forceRefresh:forceRefresh
                                                                     tokenCache:self.tokenCache
+                                                              expirationBuffer:self.expirationBuffer
                                                                          error:&error];
     
     if (!request)

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -59,7 +59,7 @@
  is less than this value (in seconds) before making the request. The goal is to
  refresh the token ahead of its expiration and also not to return a token that is
  about to expire. */
-@property uint expirationBuffer;
+@property NSUInteger expirationBuffer;
 
 /*!
     Used to specify query parameters that must be passed to both the authorize and token endpoints

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -55,6 +55,12 @@
 /*! The redirect URI of the application */
 @property (readonly) NSString *redirectUri;
 
+/*! When checking an access token for expiration we check if time to expiration
+ is less than this value (in seconds) before making the request. The goal is to
+ refresh the token ahead of its expiration and also not to return a token that is
+ about to expire. */
+@property uint expirationBuffer;
+
 /*!
     Used to specify query parameters that must be passed to both the authorize and token endpoints
     to target MSAL at a specific test slice & flight. These apply to all requests made by an application.

--- a/MSAL/src/requests/MSALSilentRequest.h
+++ b/MSAL/src/requests/MSALSilentRequest.h
@@ -30,7 +30,7 @@
 @interface MSALSilentRequest : MSALBaseRequest
 {
     BOOL _forceRefresh;
-    uint _expirationBuffer;
+    NSUInteger _expirationBuffer;
 }
 
 @property NSString *state;
@@ -38,7 +38,7 @@
 - (id)initWithParameters:(MSALRequestParameters *)parameters
             forceRefresh:(BOOL)forceRefresh
               tokenCache:(MSIDDefaultTokenCacheAccessor *)tokenCache
-        expirationBuffer:(uint)expirationBuffer
+        expirationBuffer:(NSUInteger)expirationBuffer
                    error:(NSError *__autoreleasing *)error;
 
 @end

--- a/MSAL/src/requests/MSALSilentRequest.h
+++ b/MSAL/src/requests/MSALSilentRequest.h
@@ -30,6 +30,7 @@
 @interface MSALSilentRequest : MSALBaseRequest
 {
     BOOL _forceRefresh;
+    uint _expirationBuffer;
 }
 
 @property NSString *state;
@@ -37,6 +38,7 @@
 - (id)initWithParameters:(MSALRequestParameters *)parameters
             forceRefresh:(BOOL)forceRefresh
               tokenCache:(MSIDDefaultTokenCacheAccessor *)tokenCache
+        expirationBuffer:(uint)expirationBuffer
                    error:(NSError *__autoreleasing *)error;
 
 @end

--- a/MSAL/src/requests/MSALSilentRequest.m
+++ b/MSAL/src/requests/MSALSilentRequest.m
@@ -56,6 +56,7 @@
 - (id)initWithParameters:(MSALRequestParameters *)parameters
             forceRefresh:(BOOL)forceRefresh
               tokenCache:(MSIDDefaultTokenCacheAccessor *)tokenCache
+        expirationBuffer:(uint)expirationBuffer
                    error:(NSError *__autoreleasing  _Nullable *)error;
 {
     if (!(self = [super initWithParameters:parameters
@@ -67,7 +68,7 @@
     
     _forceRefresh = forceRefresh;
     _refreshToken = nil;
-    
+    _expirationBuffer = expirationBuffer;
     return self;
 }
 
@@ -108,7 +109,7 @@
             return;
         }
 
-        if (accessToken && !accessToken.isExpired)
+        if (accessToken && ![accessToken isExpiredWithExpiryBuffer:_expirationBuffer])
         {
             MSIDIdToken *idToken = [self.tokenCache getIDTokenForAccount:_parameters.account.lookupAccountIdentifier
                                                            configuration:msidConfiguration

--- a/MSAL/src/requests/MSALSilentRequest.m
+++ b/MSAL/src/requests/MSALSilentRequest.m
@@ -56,7 +56,7 @@
 - (id)initWithParameters:(MSALRequestParameters *)parameters
             forceRefresh:(BOOL)forceRefresh
               tokenCache:(MSIDDefaultTokenCacheAccessor *)tokenCache
-        expirationBuffer:(uint)expirationBuffer
+        expirationBuffer:(NSUInteger)expirationBuffer
                    error:(NSError *__autoreleasing  _Nullable *)error;
 {
     if (!(self = [super initWithParameters:parameters

--- a/MSAL/test/unit/MSALSilentRequestTests.m
+++ b/MSAL/test/unit/MSALSilentRequestTests.m
@@ -107,7 +107,7 @@
     parameters.correlationId = correlationId;
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);
@@ -127,7 +127,7 @@
     parameters.correlationId = correlationId;
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);
@@ -192,7 +192,7 @@
     XCTAssertTrue(result);
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);
@@ -297,7 +297,7 @@
     [MSIDTestURLSession addResponse:response];
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);
@@ -404,7 +404,7 @@
     parameters.unvalidatedAuthority = [@"https://login.microsoftonline.com/1234-5678-90abcdefg" authority];
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);
@@ -478,7 +478,7 @@
     XCTAssertTrue(result);
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);
@@ -589,7 +589,7 @@
     [MSIDTestURLSession addResponse:response];
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:YES tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:YES tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);
@@ -639,7 +639,7 @@
     parameters.account = account;
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:YES tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:YES tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);
@@ -749,7 +749,7 @@
     [MSIDTestURLSession addResponse:response];
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:YES tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:YES tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);
@@ -860,7 +860,7 @@
     [MSIDTestURLSession addResponse:response];
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:YES tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:YES tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);
@@ -992,7 +992,7 @@
     [MSIDTestURLSession addResponse:successfulResponse];
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);
@@ -1100,7 +1100,7 @@
     [MSIDTestURLSession addResponse:response];
 
     MSALSilentRequest *request =
-    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor error:&error];
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
 
     XCTAssertNotNil(request);
     XCTAssertNil(error);

--- a/MSAL/test/unit/MSALSilentRequestTests.m
+++ b/MSAL/test/unit/MSALSilentRequestTests.m
@@ -320,6 +320,111 @@
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
 }
 
+- (void)testAtsAuthority_whenATExpiresIn50WithinExpirationBuffer100_shouldReAcquireToken
+{
+    NSError *error = nil;
+    NSUUID *correlationId = [NSUUID new];
+    
+    MSALRequestParameters *parameters = [MSALRequestParameters new];
+    parameters.scopes = [NSOrderedSet orderedSetWithArray:@[@"fakescope1", @"fakescope2"]];
+    parameters.unvalidatedAuthority = [@"https://login.microsoftonline.com/common" authority];
+    parameters.redirectUri = UNIT_TEST_DEFAULT_REDIRECT_URI;
+    parameters.clientId = UNIT_TEST_CLIENT_ID;
+    parameters.loginHint = @"fakeuser@contoso.com";
+    parameters.correlationId = correlationId;
+    parameters.urlSession = [MSIDTestURLSession createMockSession];
+    parameters.sliceParameters = @{ @"slice" : @"myslice" };
+    NSDictionary* clientInfoClaims = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
+    MSIDClientInfo *clientInfo = [[MSIDClientInfo alloc] initWithJSONDictionary:clientInfoClaims error:nil];
+    
+    MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"preferredUserName"
+                                                            name:@"user@contoso.com"
+                                                   homeAccountId:@"1.1234-5678-90abcdefg"
+                                                  localAccountId:@"1"
+                                                     environment:@"login.microsoftonline.com"
+                                                        tenantId:@"1234-5678-90abcdefg"
+                                                      clientInfo:clientInfo];
+    
+    parameters.account = account;
+    
+    NSDictionary* idTokenClaims = @{ @"home_oid" : @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97", @"preferred_username": @"fakeuser@contoso.com"};
+    //store at & rt in cache
+    NSString *rawIdToken = [NSString stringWithFormat:@"fakeheader.%@.fakesignature",
+                            [NSString msidBase64UrlEncodedStringFromData:[NSJSONSerialization dataWithJSONObject:idTokenClaims options:0 error:nil]]];
+    NSString *rawClientInfo = [NSString msidBase64UrlEncodedStringFromData:[NSJSONSerialization dataWithJSONObject:clientInfoClaims options:0 error:nil]];
+    
+    MSIDAADV2TokenResponse *msidResponse =
+    [[MSIDAADV2TokenResponse alloc] initWithJSONDictionary:@{
+                                                             @"access_token": @"access_token",
+                                                             @"refresh_token": @"fakeRefreshToken",
+                                                             @"authority" : @"https://login.microsoftonline.com/common",
+                                                             @"scope": @"fakescope1 fakescope2",
+                                                             @"client_id": UNIT_TEST_CLIENT_ID,
+                                                             @"id_token": rawIdToken,
+                                                             @"client_info": rawClientInfo,
+                                                             @"expires_on" : [NSString stringWithFormat:@"%qu", (uint64_t)[[NSDate dateWithTimeIntervalSinceNow:50] timeIntervalSince1970]]
+                                                             }
+                                                     error:nil];
+    
+    BOOL result = [self.tokenCacheAccessor saveTokensWithConfiguration:parameters.msidConfiguration
+                                                              response:msidResponse
+                                                               context:nil
+                                                                 error:nil];
+    XCTAssertTrue(result);
+    
+    NSMutableDictionary *reqHeaders = [[MSIDDeviceId deviceId] mutableCopy];
+    [reqHeaders setObject:@"true" forKey:@"return-client-request-id"];
+    [reqHeaders setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
+    [reqHeaders setObject:@"application/json" forKey:@"Accept"];
+    [reqHeaders setObject:correlationId.UUIDString forKey:@"client-request-id"];
+    
+    NSString *url = @"https://login.microsoftonline.com/common/oauth2/v2.0/token?slice=myslice";
+    MSIDTestURLResponse *response =
+    [MSIDTestURLResponse requestURLString:url
+                           requestHeaders:reqHeaders
+                        requestParamsBody:@{ @"client_id" : UNIT_TEST_CLIENT_ID,
+                                             @"scope" : @"fakescope1 fakescope2 openid profile offline_access",
+                                             @"grant_type" : @"refresh_token",
+                                             @"refresh_token" : @"fakeRefreshToken",
+                                             @"client_info" : @"1"}
+                        responseURLString:@"https://login.microsoftonline.com/common/oauth2/v2.0/token"
+                             responseCode:200
+                         httpHeaderFields:nil
+                         dictionaryAsJSON:@{ @"access_token" : @"i am a access token!",
+                                             @"expires_in" : @"600",
+                                             @"refresh_token" : @"i am a refresh token",
+                                             @"id_token_expires_in" : @"1200",
+                                             @"id_token": rawIdToken,
+                                             @"client_info" : [@{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"} msidBase64UrlJson]}];
+    
+    [response->_requestHeaders removeObjectForKey:@"Content-Length"];
+    
+    [MSIDTestURLSession addResponse:response];
+    
+    MSALSilentRequest *request =
+    [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor expirationBuffer:100 error:&error];
+    
+    XCTAssertNotNil(request);
+    XCTAssertNil(error);
+    
+    NSString *authority = @"https://login.microsoftonline.com/common";
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
+    MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:authority];
+    [MSIDTestURLSession addResponses:@[discoveryResponse, oidcResponse]];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Expectation"];
+    
+    [request run:^(MSALResult *result, NSError *error)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertNil(error);
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
 - (void)testAtsHomeAuthorityATExpired
 {
     NSError *error = nil;


### PR DESCRIPTION
By default, set to 300 like ADAL.