### PR TITLE
pass redirect uri from settings in test app

### DIFF
--- a/MSAL/test/app/MSALTestAppSettings.m
+++ b/MSAL/test/app/MSALTestAppSettings.m
@@ -142,12 +142,15 @@ static NSDictionary *s_profiles = nil;
         return nil;
     }
     
+    NSDictionary *currentProfile = _profile;
+    NSString *clientId = [currentProfile objectForKey:MSAL_APP_CLIENT_ID];
+    NSString *redirectUri = [currentProfile objectForKey:MSAL_APP_REDIRECT_URI];
+    
     NSError *error = nil;
-    NSString *clientId = [_profile objectForKey:MSAL_APP_CLIENT_ID];
-    MSALPublicClientApplication *application =
-    [[MSALPublicClientApplication alloc] initWithClientId:clientId
-                                                authority:self.authority
-                                                    error:&error];
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:clientId
+                                                                                           authority:_authority
+                                                                                         redirectUri:redirectUri
+                                                                                               error:&error];
     if (application == nil)
     {
         MSID_LOG_ERROR(nil, @"failed to create application to get user: %@", error);

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -481,8 +481,11 @@
     NSDictionary *extraQueryParameters = [NSDictionary msidDictionaryFromWWWFormURLEncodedString:_extraQueryParamsField.text];
 
     NSError *error = nil;
-    MSALPublicClientApplication *application =
-    [[MSALPublicClientApplication alloc] initWithClientId:clientId authority:authority redirectUri:redirectUri error:&error];
+    
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:clientId
+                                                                                           authority:authority
+                                                                                         redirectUri:redirectUri
+                                                                                               error:&error];
     if (!application)
     {
         NSString *resultText = [NSString stringWithFormat:@"Failed to create PublicClientApplication:\n%@", error];
@@ -587,8 +590,10 @@
     
     NSError *error = nil;
     
-    MSALPublicClientApplication *application =
-    [[MSALPublicClientApplication alloc] initWithClientId:clientId authority:authority redirectUri:redirectUri error:&error];
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:clientId
+                                                                                           authority:authority
+                                                                                         redirectUri:redirectUri
+                                                                                               error:&error];
     if (!application)
     {
         NSString *resultText = [NSString stringWithFormat:@"Failed to create PublicClientApplication:\n%@", error];
@@ -647,8 +652,10 @@
     __auto_type authority = [settings authority];
     
     NSError *error = nil;
-    MSALPublicClientApplication *application =
-    [[MSALPublicClientApplication alloc] initWithClientId:clientId authority:authority redirectUri:redirectUri error:&error];
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:clientId
+                                                                                           authority:authority
+                                                                                         redirectUri:redirectUri
+                                                                                               error:&error];
     
     BOOL result = [application.tokenCache clearWithContext:nil error:&error];
     
@@ -773,7 +780,10 @@
     
     NSError *error = nil;
     
-    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:clientId authority:authority redirectUri:redirectUri error:&error];
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:clientId
+                                                                                           authority:authority
+                                                                                         redirectUri:redirectUri
+                                                                                               error:&error];
     
     if (!application)
     {

--- a/MSAL/test/app/ios/MSALTestAppUserViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppUserViewController.m
@@ -68,11 +68,15 @@
     MSALTestAppSettings *settings = [MSALTestAppSettings settings];
     NSDictionary *currentProfile = [settings profile];
     NSString *clientId = [currentProfile objectForKey:MSAL_APP_CLIENT_ID];
+    NSString *redirectUri = [currentProfile objectForKey:MSAL_APP_REDIRECT_URI];
+    MSALAuthority *authority = [settings authority];
     NSError *error = nil;
-    MSALPublicClientApplication *application =
-    [[MSALPublicClientApplication alloc] initWithClientId:clientId
-                                                authority:settings.authority
-                                                    error:&error];
+    
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:clientId
+                                                                                           authority:authority
+                                                                                         redirectUri:redirectUri
+                                                                                               error:&error];
+    
     
     if (!application)
     {


### PR DESCRIPTION
*Minor fix for test app to pass redirectUri and clientId from settings
*Use MSALPublicClientApplication constructor which takes clientId, authority and redirectUri instead of the one which takes just clientId and redirectUri as parameters.