### PR TITLE
Separate B2C logic and fixed access token lookups

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -107,6 +107,8 @@
 		B221CEEC20C0AF0B002F5E94 /* MSALAccountId+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B221CEEA20C0AF0B002F5E94 /* MSALAccountId+Internal.h */; };
 		B2341A2A21507CA1008E93FC /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 963C89A6214BA1760051AFEE /* AuthenticationServices.framework */; };
 		B2341A2B21507CA7008E93FC /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 963C89A6214BA1760051AFEE /* AuthenticationServices.framework */; };
+		B256121B217EA44900999876 /* MSALOauth2FactoryProducerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B256121A217EA44900999876 /* MSALOauth2FactoryProducerTests.m */; };
+		B256121C217EA44900999876 /* MSALOauth2FactoryProducerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B256121A217EA44900999876 /* MSALOauth2FactoryProducerTests.m */; };
 		B25F1BBB1EC3DB3200474D1B /* MSIDTokenCacheItem+Automation.m in Sources */ = {isa = PBXBuildFile; fileRef = B25F1BBA1EC3DB3200474D1B /* MSIDTokenCacheItem+Automation.m */; };
 		B25F1BC11EC3DD3200474D1B /* MSALUser+Automation.m in Sources */ = {isa = PBXBuildFile; fileRef = B25F1BC01EC3DD3200474D1B /* MSALUser+Automation.m */; };
 		B25F1BC41EC3E44500474D1B /* MSALResult+Automation.m in Sources */ = {isa = PBXBuildFile; fileRef = B25F1BC31EC3E44500474D1B /* MSALResult+Automation.m */; };
@@ -115,6 +117,10 @@
 		B2734C1C21253AD300DAB1CD /* MSALMultiAppCacheCoexistenceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2734C1B21253AD300DAB1CD /* MSALMultiAppCacheCoexistenceTests.m */; };
 		B2734C1E21253B1B00DAB1CD /* MSALDotNetCacheCoexistenceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2734C1D21253B1B00DAB1CD /* MSALDotNetCacheCoexistenceTests.m */; };
 		B277241E1EAE97D700375C53 /* MSALStressTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B277241D1EAE97D700375C53 /* MSALStressTestHelper.m */; };
+		B28BDA8E217E9EAB003E5670 /* MSALOauth2FactoryProducer.h in Headers */ = {isa = PBXBuildFile; fileRef = B28BDA8C217E9EAB003E5670 /* MSALOauth2FactoryProducer.h */; };
+		B28BDA8F217E9EAB003E5670 /* MSALOauth2FactoryProducer.h in Headers */ = {isa = PBXBuildFile; fileRef = B28BDA8C217E9EAB003E5670 /* MSALOauth2FactoryProducer.h */; };
+		B28BDA90217E9EAB003E5670 /* MSALOauth2FactoryProducer.m in Sources */ = {isa = PBXBuildFile; fileRef = B28BDA8D217E9EAB003E5670 /* MSALOauth2FactoryProducer.m */; };
+		B28BDA91217E9EAB003E5670 /* MSALOauth2FactoryProducer.m in Sources */ = {isa = PBXBuildFile; fileRef = B28BDA8D217E9EAB003E5670 /* MSALOauth2FactoryProducer.m */; };
 		B29E2AC221238DCD00B170ED /* libIdentityCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A206231FC50A4D00755A51 /* libIdentityCore.a */; };
 		B29E2AC321238DFC00B170ED /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96902DEC20E1574F00200E6F /* WebKit.framework */; };
 		B29E2AC521238E0000B170ED /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B29E2AC421238E0000B170ED /* SafariServices.framework */; };
@@ -556,6 +562,7 @@
 		B221CED920C0AC60002F5E94 /* MSALAccountId.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALAccountId.h; sourceTree = "<group>"; };
 		B221CEDA20C0AC60002F5E94 /* MSALAccountId.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAccountId.m; sourceTree = "<group>"; };
 		B221CEEA20C0AF0B002F5E94 /* MSALAccountId+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSALAccountId+Internal.h"; sourceTree = "<group>"; };
+		B256121A217EA44900999876 /* MSALOauth2FactoryProducerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALOauth2FactoryProducerTests.m; sourceTree = "<group>"; };
 		B25F1BB21EC257F900474D1B /* MSALB2CPolicyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSALB2CPolicyTests.m; sourceTree = "<group>"; };
 		B25F1BB91EC3DB3200474D1B /* MSIDTokenCacheItem+Automation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSIDTokenCacheItem+Automation.h"; sourceTree = "<group>"; };
 		B25F1BBA1EC3DB3200474D1B /* MSIDTokenCacheItem+Automation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MSIDTokenCacheItem+Automation.m"; sourceTree = "<group>"; };
@@ -571,6 +578,8 @@
 		B2734C1D21253B1B00DAB1CD /* MSALDotNetCacheCoexistenceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALDotNetCacheCoexistenceTests.m; sourceTree = "<group>"; };
 		B277241C1EAE97D700375C53 /* MSALStressTestHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSALStressTestHelper.h; sourceTree = "<group>"; };
 		B277241D1EAE97D700375C53 /* MSALStressTestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSALStressTestHelper.m; sourceTree = "<group>"; };
+		B28BDA8C217E9EAB003E5670 /* MSALOauth2FactoryProducer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALOauth2FactoryProducer.h; sourceTree = "<group>"; };
+		B28BDA8D217E9EAB003E5670 /* MSALOauth2FactoryProducer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALOauth2FactoryProducer.m; sourceTree = "<group>"; };
 		B29E2AC421238E0000B170ED /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.4.sdk/System/Library/Frameworks/SafariServices.framework; sourceTree = DEVELOPER_DIR; };
 		B29E2AC821238F2200B170ED /* MSALNonUnifiedADALCoexistenceCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALNonUnifiedADALCoexistenceCacheTests.m; sourceTree = "<group>"; };
 		B29E2ACE21238F5200B170ED /* MultiAppiOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MultiAppiOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -861,6 +870,8 @@
 				23A68A7F20F538DE0071E435 /* MSALADFSAuthority.m */,
 				23A68A8B20F57A440071E435 /* MSALAuthorityFactory.h */,
 				23A68A8C20F57A440071E435 /* MSALAuthorityFactory.m */,
+				B28BDA8C217E9EAB003E5670 /* MSALOauth2FactoryProducer.h */,
+				B28BDA8D217E9EAB003E5670 /* MSALOauth2FactoryProducer.m */,
 			);
 			path = instance;
 			sourceTree = "<group>";
@@ -1260,6 +1271,7 @@
 				B25F1BB21EC257F900474D1B /* MSALB2CPolicyTests.m */,
 				04D32CCF1FD8AFF3000B123E /* MSALErrorConverterTests.m */,
 				B210E3E21FC23D4700E7A325 /* MSALErrorTests.m */,
+				B256121A217EA44900999876 /* MSALOauth2FactoryProducerTests.m */,
 			);
 			path = unit;
 			sourceTree = "<group>";
@@ -1467,6 +1479,7 @@
 				23F32F071FF4787600B2905E /* MSIDTestURLResponse+MSAL.h in Headers */,
 				D65A6FB21E3FF41D00C69FBA /* MSALError.h in Headers */,
 				9682624C20E304F30080694D /* MSALWebviewType.h in Headers */,
+				B28BDA8E217E9EAB003E5670 /* MSALOauth2FactoryProducer.h in Headers */,
 				D65A6FB41E3FF41D00C69FBA /* MSALPublicClientApplication.h in Headers */,
 				B2A3C29621460D290082525C /* MSALAuthority.h in Headers */,
 				B21E07B1210E542C007E3A3C /* MSALRedirectUriVerifier.h in Headers */,
@@ -1496,6 +1509,7 @@
 				B2B5F08C1FCA61EB00F6AFAD /* MSALTelemetryDefaultEvent.h in Headers */,
 				D673F0791E4A633B0018BA91 /* MSALError_Internal.h in Headers */,
 				B21E07B2210E542C007E3A3C /* MSALRedirectUriVerifier.h in Headers */,
+				B28BDA8F217E9EAB003E5670 /* MSALOauth2FactoryProducer.h in Headers */,
 				94E876DF1E495F2700FB96ED /* MSALUIBehavior.h in Headers */,
 				D65A6FA91E3FF3D900C69FBA /* MSALError.h in Headers */,
 				96D9A5451E4AB1DC00674A85 /* MSALTelemetry.h in Headers */,
@@ -2107,6 +2121,7 @@
 				D61BD2AF1EBD09F90007E484 /* MSALLogger.m in Sources */,
 				D61BD2BF1EBD0A010007E484 /* MSALDefaultDispatcher.m in Sources */,
 				D61BD2B81EBD0A010007E484 /* MSALTelemetryAPIEvent.m in Sources */,
+				B28BDA90217E9EAB003E5670 /* MSALOauth2FactoryProducer.m in Sources */,
 				D61BD2B01EBD09F90007E484 /* MSALPublicClientApplication.m in Sources */,
 				D61BD2AD1EBD09F90007E484 /* MSALError.m in Sources */,
 				963377C1211E14C600943EE0 /* MSALWebviewType.m in Sources */,
@@ -2141,6 +2156,7 @@
 				D673F08F1E4CE6D70018BA91 /* MSALError.m in Sources */,
 				23A68A8320F538DE0071E435 /* MSALADFSAuthority.m in Sources */,
 				23A68A7720F5386A0071E435 /* MSALAADAuthority.m in Sources */,
+				B28BDA91217E9EAB003E5670 /* MSALOauth2FactoryProducer.m in Sources */,
 				D673F0951E4CE6DB0018BA91 /* MSALRequestParameters.m in Sources */,
 				D673F0981E4CE6DB0018BA91 /* MSALInteractiveRequest.m in Sources */,
 				D673F0911E4CE6D70018BA91 /* MSALLogger.m in Sources */,
@@ -2170,6 +2186,7 @@
 				D61F5BC01E5913BE00912CB8 /* SFSafariViewController+TestOverrides.m in Sources */,
 				D69ADB351E516F9B00952049 /* MSALTestBundle.m in Sources */,
 				D69ADB3F1E516F9B00952049 /* MSALTestURLSessionDataTask.m in Sources */,
+				B256121B217EA44900999876 /* MSALOauth2FactoryProducerTests.m in Sources */,
 				D62746D91E9B5F1E00EFCE99 /* MSALUserTests.m in Sources */,
 				D69ADB3D1E516F9B00952049 /* MSIDTestURLSession+MSAL.m in Sources */,
 				2364C74B1FB3E5CB00835428 /* XCTestCase+HelperMethods.m in Sources */,
@@ -2201,6 +2218,7 @@
 				B21E07C3210E5C3C007E3A3C /* MSALRedirectUriVerifierTests.m in Sources */,
 				D69ADB401E516F9B00952049 /* MSALTestURLSessionDataTask.m in Sources */,
 				D62746DA1E9B5F1E00EFCE99 /* MSALUserTests.m in Sources */,
+				B256121C217EA44900999876 /* MSALOauth2FactoryProducerTests.m in Sources */,
 				D69ADB3C1E516F9B00952049 /* MSALTestSwizzle.m in Sources */,
 				D69ADB381E516F9B00952049 /* MSALTestCase.m in Sources */,
 				04D32CD11FD8AFF3000B123E /* MSALErrorConverterTests.m in Sources */,

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -54,6 +54,7 @@
 #import "MSIDAADAuthority.h"
 #import "MSIDAuthorityFactory.h"
 #import "MSALAADAuthority.h"
+#import "MSALOauth2FactoryProducer.h"
 
 static NSString *const s_defaultAuthorityUrlString = @"https://login.microsoftonline.com/common";
 
@@ -71,6 +72,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
 {
     WKWebView *_customWebview;
     NSString *_defaultKeychainGroup;
+    MSIDOauth2Factory *_oauth2Factory;
 }
 
 @property (nonatomic) MSIDDefaultTokenCacheAccessor *tokenCache;
@@ -205,6 +207,14 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         _authority = [[MSALAADAuthority alloc] initWithURL:authorityURL context:nil error:error];
     }
 
+    _oauth2Factory = [MSALOauth2FactoryProducer msidOauth2FactoryForAuthority:_authority.url context:nil error:error];
+
+    if (!_oauth2Factory)
+    {
+        MSID_LOG_ERROR(nil, @"Couldn't create Oauth2 factory");
+        return nil;
+    }
+
     BOOL redirectUriValid = [self verifyRedirectUri:redirectUri clientId:clientId error:error];
 
     if (!redirectUriValid) return nil;
@@ -220,11 +230,9 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
     }
     
     dataSource = [[MSIDKeychainTokenCache alloc] initWithGroup:_keychainGroup];
-    
-    MSIDOauth2Factory *factory = [MSIDAADV2Oauth2Factory new];
-    
-    MSIDLegacyTokenCacheAccessor *legacyAccessor = [[MSIDLegacyTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:nil factory:factory];
-    MSIDDefaultTokenCacheAccessor *defaultAccessor = [[MSIDDefaultTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:@[legacyAccessor] factory:factory];
+
+    MSIDLegacyTokenCacheAccessor *legacyAccessor = [[MSIDLegacyTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:nil factory:_oauth2Factory];
+    MSIDDefaultTokenCacheAccessor *defaultAccessor = [[MSIDDefaultTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:@[legacyAccessor] factory:_oauth2Factory];
     
     self.tokenCache = defaultAccessor;
     
@@ -233,7 +241,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
 #else
     __auto_type dataSource = MSIDMacTokenCache.defaultCache;
 
-    MSIDDefaultTokenCacheAccessor *defaultAccessor = [[MSIDDefaultTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:nil factory:[MSIDAADV2Oauth2Factory new]];
+    MSIDDefaultTokenCacheAccessor *defaultAccessor = [[MSIDDefaultTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:nil factory:_oauth2Factory];
     self.tokenCache = defaultAccessor;
     _webviewType = MSALWebviewTypeWKWebView;
     
@@ -550,7 +558,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
 {
     MSALRequestParameters *params = [MSALRequestParameters new];
 
-    params.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
+    params.msidOAuthFactory = _oauth2Factory;
     params.correlationId = correlationId ? correlationId : [NSUUID new];
     params.logComponent = _component;
     params.apiId = apiId;
@@ -637,7 +645,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
     msidAuthority = [authorityFactory authorityFromUrl:msidAuthority.url rawTenant:account.homeAccountId.tenantId context:nil error:nil];
 
     MSALRequestParameters* params = [MSALRequestParameters new];
-    params.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
+    params.msidOAuthFactory = _oauth2Factory;
     params.correlationId = correlationId ? correlationId : [NSUUID new];
     params.account = account;
     params.apiId = apiId;

--- a/MSAL/src/instance/MSALOauth2FactoryProducer.h
+++ b/MSAL/src/instance/MSALOauth2FactoryProducer.h
@@ -1,0 +1,38 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+
+@class MSIDOauth2Factory;
+
+@interface MSALOauth2FactoryProducer : NSObject
+
++ (nullable MSIDOauth2Factory *)msidOauth2FactoryForAuthority:(nonnull NSURL *)authority
+                                                      context:(nullable id<MSIDRequestContext>)context
+                                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+
+@end

--- a/MSAL/src/instance/MSALOauth2FactoryProducer.m
+++ b/MSAL/src/instance/MSALOauth2FactoryProducer.m
@@ -1,0 +1,62 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALOauth2FactoryProducer.h"
+#import "MSIDOauth2Factory.h"
+#import "MSIDB2CAuthority.h"
+#import "MSIDAADAuthority.h"
+#import "MSIDAADV2Oauth2Factory.h"
+#import "MSIDB2COauth2Factory.h"
+
+@implementation MSALOauth2FactoryProducer
+
++ (MSIDOauth2Factory *)msidOauth2FactoryForAuthority:(NSURL *)authority
+                                             context:(id<MSIDRequestContext>)context
+                                               error:(NSError **)error
+{
+    if (!authority)
+    {
+        if (error)
+        {
+            *error = MSIDCreateError(MSALErrorDomain, MSALErrorInvalidParameter, @"Provided authority url is not a valid authority.", nil, nil, nil, nil, nil);
+            MSID_LOG_ERROR(context, @"Provided authority url is not a valid authority.");
+        }
+
+        return nil;
+    }
+
+    if ([MSIDB2CAuthority isAuthorityFormatValid:authority context:context error:nil])
+    {
+        return [MSIDB2COauth2Factory new];
+    }
+
+    // Create AAD v2 factory for everything else, but in future we might want to further separate this out
+    // (e.g. ADFS, Google, Oauth2 etc...)
+    return [MSIDAADV2Oauth2Factory new];
+}
+
+@end

--- a/MSAL/src/requests/MSALBaseRequest.h
+++ b/MSAL/src/requests/MSALBaseRequest.h
@@ -48,7 +48,7 @@ typedef void(^MSALAuthorityCompletion)(BOOL resolved, NSError * _Nullable error)
 @property (nullable) MSALTokenCacheItem *accessTokenItem;
 @property (nonnull, readonly) MSALRequestParameters *parameters;
 @property (nullable, nonatomic, readonly) MSIDDefaultTokenCacheAccessor *tokenCache;
-@property (nullable, nonatomic, readonly) MSIDAADV2Oauth2Factory *oauth2Factory;
+@property (nullable, nonatomic, readonly) MSIDOauth2Factory *oauth2Factory;
 
 /* Returns the complete set of scopes to be sent out with a token request */
 - (nonnull MSALScopes *)requestScopes:(nullable MSALScopes *)extraScopes;

--- a/MSAL/src/requests/MSALBaseRequest.m
+++ b/MSAL/src/requests/MSALBaseRequest.m
@@ -54,7 +54,7 @@ static MSALScopes *s_reservedScopes = nil;
 @interface MSALBaseRequest()
 
 @property (nullable, nonatomic) MSIDDefaultTokenCacheAccessor *tokenCache;
-@property (nullable, nonatomic) MSIDAADV2Oauth2Factory *oauth2Factory;
+@property (nullable, nonatomic) MSIDOauth2Factory *oauth2Factory;
 
 @end
 
@@ -97,7 +97,20 @@ static MSALScopes *s_reservedScopes = nil;
     }
     
     _tokenCache = tokenCache;
-    _oauth2Factory = [MSIDAADV2Oauth2Factory new];
+
+    if (!_tokenCache)
+    {
+        REQUIRED_PARAMETER_ERROR(tokenCache, _parameters);
+        return nil;
+    }
+
+    _oauth2Factory = _parameters.msidOAuthFactory;
+
+    if (!_oauth2Factory)
+    {
+        REQUIRED_PARAMETER_ERROR(_parameters.msidOAuthFactory, _parameters);
+        return nil;
+    }
 
     MSIDAADNetworkConfiguration.defaultConfiguration.aadApiVersion = @"v2.0";
     

--- a/MSAL/test/automation/tests/interactive/MSALB2CInteractiveTests.m
+++ b/MSAL/test/automation/tests/interactive/MSALB2CInteractiveTests.m
@@ -122,7 +122,7 @@
 
     request.accountIdentifier = homeAccountId;
     // B2C currently doesn't return "tid" claim in the id_token, so MSAL will use tenantId from the provided authority
-    request.cacheAuthority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", self.primaryAccount.tenantName];
+    request.cacheAuthority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", self.primaryAccount.homeTenantId];
     // 4. Run silent login
     request.testAccount = nil;
     [self runSharedSilentAADLoginWithTestRequest:request];
@@ -192,7 +192,7 @@
     [self runSharedAuthUIAppearsStepWithTestRequest:request];
 
     request.accountIdentifier = homeAccountId;
-    request.cacheAuthority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", self.primaryAccount.tenantName];
+    request.cacheAuthority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", self.primaryAccount.homeTenantId];
     // 4. Run silent login
     request.testAccount = nil;
     [self runSharedSilentAADLoginWithTestRequest:request];
@@ -251,14 +251,14 @@
     // 5. Get token silently for the first request
     request.accountIdentifier = homeAccountId;
     // B2C currently doesn't return "tid" claim in the id_token, so MSAL will use tenantId from the provided authority
-    request.cacheAuthority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", self.primaryAccount.tenantName];
+    request.cacheAuthority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", self.primaryAccount.homeTenantId];
     request.testAccount = nil;
     [self runSharedSilentAADLoginWithTestRequest:request];
 
     // 6. Get token silently for the second request
     profileRequest.accountIdentifier = profileHomeAccountId;
     // B2C currently doesn't return "tid" claim in the id_token, so MSAL will use tenantId from the provided authority
-    profileRequest.cacheAuthority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", self.primaryAccount.tenantName];
+    profileRequest.cacheAuthority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", self.primaryAccount.homeTenantId];
     profileRequest.testAccount = nil;
     [self runSharedSilentAADLoginWithTestRequest:profileRequest];
 

--- a/MSAL/test/unit/MSALInteractiveRequestTests.m
+++ b/MSAL/test/unit/MSALInteractiveRequestTests.m
@@ -100,12 +100,13 @@
     parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
 
     MSALInteractiveRequest *request =
     [[MSALInteractiveRequest alloc] initWithParameters:parameters
-                                      extraScopesToConsent:@[@"fakescope3"]
+                                  extraScopesToConsent:@[@"fakescope3"]
                                               behavior:MSALForceConsent
-                                            tokenCache:nil
+                                            tokenCache:[MSIDDefaultTokenCacheAccessor new]
                                                  error:&error];
 
     XCTAssertNotNil(request);
@@ -127,6 +128,7 @@
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSALWebviewTypeWKWebView;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
     
     __block MSALInteractiveRequest *request =
     [[MSALInteractiveRequest alloc] initWithParameters:parameters
@@ -345,6 +347,7 @@
     parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.correlationId = correlationId;
     parameters.webviewType = MSALWebviewTypeWKWebView;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
     
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"User"
                                                                  name:@"user@contoso.com"
@@ -465,6 +468,7 @@
     parameters.extraQueryParameters = @{ @"eqp1" : @"val1", @"eqp2" : @"val2" };
     parameters.correlationId = correlationId;
     parameters.webviewType = MSALWebviewTypeWKWebView;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
     
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"User"
                                                             name:@"user@contoso.com"
@@ -566,6 +570,7 @@
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.webviewType = MSALWebviewTypeWKWebView;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
 
     __block MSALInteractiveRequest *request =
     [[MSALInteractiveRequest alloc] initWithParameters:parameters

--- a/MSAL/test/unit/MSALOauth2FactoryProducerTests.m
+++ b/MSAL/test/unit/MSALOauth2FactoryProducerTests.m
@@ -1,0 +1,83 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <XCTest/XCTest.h>
+#import "MSALOauth2FactoryProducer.h"
+#import "MSIDOauth2Factory.h"
+#import "MSIDAADV2Oauth2Factory.h"
+#import "MSIDB2COauth2Factory.h"
+
+@interface MSALOauth2FactoryProducerTests : XCTestCase
+
+@end
+
+@implementation MSALOauth2FactoryProducerTests
+
+- (void)testOauth2FactoryForAuthority_whenNilAuthority_shouldReturnNilAndError
+{
+    NSError *error = nil;
+    NSURL *authorityURL = nil;
+    MSIDOauth2Factory *factory = [MSALOauth2FactoryProducer msidOauth2FactoryForAuthority:authorityURL context:nil error:&error];
+
+    XCTAssertNil(factory);
+    XCTAssertNotNil(error);
+}
+
+- (void)testOauth2FactoryForAuthority_whenB2CAuthority_shouldReturnB2CFactoryNilError
+{
+    NSError *error = nil;
+    NSURL *authorityURL = [NSURL URLWithString:@"https://login.microsoftonline.com/tfp/contoso.com/B2C_1_Signin"];
+    MSIDOauth2Factory *factory = [MSALOauth2FactoryProducer msidOauth2FactoryForAuthority:authorityURL context:nil error:&error];
+
+    XCTAssertNotNil(factory);
+    XCTAssertNil(error);
+    XCTAssertTrue([factory isKindOfClass:[MSIDB2COauth2Factory class]]);
+}
+
+- (void)testOauth2FactoryForAuthority_whenAADAuthority_shouldReturnAADV2FactoryNilError
+{
+    NSError *error = nil;
+    NSURL *authorityURL = [NSURL URLWithString:@"https://login.microsoftonline.com/contoso.com/"];
+    MSIDOauth2Factory *factory = [MSALOauth2FactoryProducer msidOauth2FactoryForAuthority:authorityURL context:nil error:&error];
+
+    XCTAssertNotNil(factory);
+    XCTAssertNil(error);
+    XCTAssertTrue([factory isKindOfClass:[MSIDAADV2Oauth2Factory class]]);
+}
+
+- (void)testOauth2FactoryForAuthority_whenADFSAuthority_shouldReturnAADV2FactoryNilError
+{
+    NSError *error = nil;
+    NSURL *authorityURL = [NSURL URLWithString:@"https://contoso.com/adfs"];
+    MSIDOauth2Factory *factory = [MSALOauth2FactoryProducer msidOauth2FactoryForAuthority:authorityURL context:nil error:&error];
+
+    XCTAssertNotNil(factory);
+    XCTAssertNil(error);
+    XCTAssertTrue([factory isKindOfClass:[MSIDAADV2Oauth2Factory class]]);
+}
+
+@end

--- a/MSAL/test/unit/MSALSilentRequestTests.m
+++ b/MSAL/test/unit/MSALSilentRequestTests.m
@@ -104,6 +104,7 @@
     parameters.clientId = UNIT_TEST_CLIENT_ID;
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
 
     MSALSilentRequest *request =
     [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
@@ -124,6 +125,7 @@
     parameters.clientId = UNIT_TEST_CLIENT_ID;
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
 
     MSALSilentRequest *request =
     [[MSALSilentRequest alloc] initWithParameters:parameters forceRefresh:NO tokenCache:self.tokenCacheAccessor expirationBuffer:300 error:&error];
@@ -162,6 +164,7 @@
     parameters.clientId = UNIT_TEST_CLIENT_ID;
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
     NSDictionary* idTokenClaims = @{ @"home_oid" : @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97", @"preferred_username": @"fakeuser@contoso.com"};
     NSDictionary* clientInfoClaims = @{ @"uid" : @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97", @"utid" : @"0287f963-2d72-4363-9e3a-5705c5b0f031"};
 
@@ -226,6 +229,7 @@
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.sliceParameters = @{ @"slice" : @"myslice" };
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
     NSDictionary* clientInfoClaims = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
 
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"preferredUserName"
@@ -330,6 +334,7 @@
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.sliceParameters = @{ @"slice" : @"myslice" };
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
     NSDictionary* clientInfoClaims = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
 
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"preferredUserName"
@@ -433,6 +438,7 @@
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.sliceParameters = @{ UT_SLICE_PARAMS_DICT };
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
 
     NSDictionary* clientInfoClaims = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
 
@@ -538,6 +544,7 @@
     parameters.clientId = UNIT_TEST_CLIENT_ID;
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
 
     NSDictionary* clientInfoClaims = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
 
@@ -610,6 +617,8 @@
     parameters.clientId = UNIT_TEST_CLIENT_ID;
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
+
     NSDictionary* clientInfoClaims = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
 
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"preferredUserName"
@@ -719,6 +728,7 @@
     parameters.clientId = UNIT_TEST_CLIENT_ID;
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
 
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"preferredUserName"
                                                             name:@"user@contoso.com"
@@ -765,6 +775,7 @@
     parameters.clientId = UNIT_TEST_CLIENT_ID;
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
 
     NSDictionary* clientInfoClaims = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
 
@@ -875,6 +886,7 @@
     parameters.clientId = UNIT_TEST_CLIENT_ID;
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
 
     NSDictionary* idTokenClaims = @{ @"home_oid" : @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97", @"preferred_username": @"fakeuser@contoso.com"};
     NSDictionary* clientInfoClaims = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
@@ -987,6 +999,8 @@
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.sliceParameters = @{ @"slice" : @"myslice" };
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
+
     NSDictionary* clientInfoClaims = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
 
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"preferredUserName"
@@ -1113,6 +1127,8 @@
     parameters.loginHint = @"fakeuser@contoso.com";
     parameters.correlationId = correlationId;
     parameters.sliceParameters = @{ @"slice" : @"myslice" };
+    parameters.msidOAuthFactory = [MSIDAADV2Oauth2Factory new];
+    
     NSDictionary* clientInfoClaims = @{ @"uid" : @"1", @"utid" : @"1234-5678-90abcdefg"};
 
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"preferredUserName"


### PR DESCRIPTION
This also fixes B2C access token lookups when tenantId is not returned in the id_token