### PR TITLE
update code for metadata family id

### DIFF
--- a/MSAL/src/requests/MSALSilentRequest.m
+++ b/MSAL/src/requests/MSALSilentRequest.m
@@ -370,7 +370,7 @@
         //reset family id if set in app's metadata
         if (appMetadata && ![NSString msidIsStringNilOrBlank:appMetadata.familyId])
         {
-            appMetadata.familyId = nil;
+            appMetadata.familyId = @"";
             [self.tokenCache updateAppMetadata:appMetadata context:_parameters error:cacheError];
         }
     }

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -2014,7 +2014,7 @@
          
          XCTAssertEqual([metadataEntries count], 1);
          MSIDAppMetadataCacheItem *appMetadata = metadataEntries[0];
-         XCTAssertNil(appMetadata.familyId);
+         XCTAssertEqualObjects(appMetadata.familyId,@"");
          XCTAssertNotNil(error);
          XCTAssertNil(result);
          XCTAssertEqual(error.code, MSALErrorInteractionRequired);


### PR DESCRIPTION
*Added schema validation tests for Foci
*Save familyId as blank string instead of nil for non foci clients.