### PR TITLE
Changed prompt from string to enum and handle scenarios with select account + login_hint

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -638,7 +638,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
 
     // Configure optional parameters
     params.loginHint = loginHint;
-    params.promptType = MSALParameterStringForBehavior(uiBehavior);
+    params.promptType = MSIDPromptTypeForBehavior(uiBehavior);
     params.extraQueryParameters = extraQueryParameters;
     params.accountIdentifier = account.lookupAccountIdentifier;
     params.validateAuthority = _validateAuthority;

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -637,8 +637,20 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
     }
 
     // Configure optional parameters
+    BOOL accountHintPresent = (![NSString msidIsStringNilOrBlank:loginHint] || account);
+
+    // Select account experience is undefined if user identity is passed (login_hint or account)
+    // Therefore, if there's user identity, we don't pass select account prompt type
+    if (accountHintPresent && uiBehavior == MSALSelectAccount)
+    {
+        params.promptType = MSIDPromptTypePromptIfNecessary;
+    }
+    else
+    {
+        params.promptType = MSIDPromptTypeForBehavior(uiBehavior);
+    }
+
     params.loginHint = loginHint;
-    params.promptType = MSIDPromptTypeForBehavior(uiBehavior);
     params.extraQueryParameters = extraQueryParameters;
     params.accountIdentifier = account.lookupAccountIdentifier;
     params.validateAuthority = _validateAuthority;

--- a/MSAL/src/MSALUIBehavior.m
+++ b/MSAL/src/MSALUIBehavior.m
@@ -35,6 +35,7 @@ NSString *MSALStringForMSALUIBehavior(MSALUIBehavior behavior)
             STRING_CASE(MSALSelectAccount);
             STRING_CASE(MSALForceLogin);
             STRING_CASE(MSALForceConsent);
+            STRING_CASE(MSALPromptIfNecessary);
     }
     
     @throw @"Unrecognized MSALUIBehavior";
@@ -47,6 +48,7 @@ MSIDPromptType MSIDPromptTypeForBehavior(MSALUIBehavior behavior)
         case MSALForceLogin : return MSIDPromptTypeLogin;
         case MSALForceConsent : return MSIDPromptTypeConsent;
         case MSALSelectAccount : return MSIDPromptTypeSelectAccount;
+        case MSALPromptIfNecessary : return MSIDPromptTypePromptIfNecessary;
         default : return MSIDPromptTypeDefault;
     }
 }
@@ -58,5 +60,6 @@ NSString *MSALParameterStringForBehavior(MSALUIBehavior behavior)
         case MSALForceLogin : return @"login";
         case MSALForceConsent : return @"consent";
         case MSALSelectAccount : return @"select_account";
+        case MSALPromptIfNecessary : return @"";
     }
 }

--- a/MSAL/src/MSALUIBehavior.m
+++ b/MSAL/src/MSALUIBehavior.m
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
+#import "MSIDConstants.h"
 
 NSString *MSALStringForMSALUIBehavior(MSALUIBehavior behavior)
 {
@@ -37,6 +38,17 @@ NSString *MSALStringForMSALUIBehavior(MSALUIBehavior behavior)
     }
     
     @throw @"Unrecognized MSALUIBehavior";
+}
+
+MSIDPromptType MSIDPromptTypeForBehavior(MSALUIBehavior behavior)
+{
+    switch (behavior)
+    {
+        case MSALForceLogin : return MSIDPromptTypeLogin;
+        case MSALForceConsent : return MSIDPromptTypeConsent;
+        case MSALSelectAccount : return MSIDPromptTypeSelectAccount;
+        default : return MSIDPromptTypeDefault;
+    }
 }
 
 NSString *MSALParameterStringForBehavior(MSALUIBehavior behavior)

--- a/MSAL/src/MSALUIBehavior_Internal.h
+++ b/MSAL/src/MSALUIBehavior_Internal.h
@@ -28,7 +28,10 @@
 #ifndef MSALUIBehavior_Internal_h
 #define MSALUIBehavior_Internal_h
 
+#import "MSIDConstants.h"
+
 extern NSString *MSALStringForMSALUIBehavior(MSALUIBehavior behavior);
+extern MSIDPromptType MSIDPromptTypeForBehavior(MSALUIBehavior behavior);
 extern NSString *MSALParameterStringForBehavior(MSALUIBehavior behavior);
 
 #endif /* MSALUIBehavior_Internal_h */

--- a/MSAL/src/public/MSALConstants.h
+++ b/MSAL/src/public/MSALConstants.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSUInteger, MSALUIBehavior) {
      signed in for the user to select among.
      */
     MSALSelectAccount,
-    
+
     /*!
      Require the user to authenticate in the webview
      */
@@ -80,6 +80,12 @@ typedef NS_ENUM(NSUInteger, MSALUIBehavior) {
      Require the user to consent to the current set of scopes for the request.
      */
     MSALForceConsent,
+    /*!
+     The SSO experience will be determined by the presence of cookies in the webview and account type.
+     User won't be prompted unless necessary.
+     If multiple users are signed in, select account experience will be presented.
+     */
+    MSALPromptIfNecessary,
     MSALUIBehaviorDefault = MSALSelectAccount,
 };
 

--- a/MSAL/test/app/ios/MSALTestAppUserViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppUserViewController.m
@@ -88,7 +88,10 @@
     [application allAccountsFilteredByAuthority:^(NSArray<MSALAccount *> *accounts, NSError *error) {
 
         _accounts = accounts;
-        [super refresh];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [super refresh];
+        });
     }];
 }
 

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -435,7 +435,7 @@
          XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          XCTAssertNotNil(params.correlationId);
          XCTAssertNil(params.extraScopesToConsent);
-         XCTAssertEqual(params.promptType, MSIDPromptTypeSelectAccount);
+         XCTAssertEqual(params.promptType, MSIDPromptTypePromptIfNecessary);
          XCTAssertNil(params.extraQueryParameters);
          XCTAssertEqualObjects(params.loginHint, @"fakeuser@contoso.com");
          
@@ -611,7 +611,7 @@
          XCTAssertNil(params.extraQueryParameters);
          XCTAssertNil(params.loginHint);
          XCTAssertNil(params.extraScopesToConsent);
-         XCTAssertEqual(params.promptType, MSIDPromptTypeSelectAccount);
+         XCTAssertEqual(params.promptType, MSIDPromptTypePromptIfNecessary);
 
          XCTAssertEqualObjects(params.accountIdentifier, account.lookupAccountIdentifier);
          
@@ -671,7 +671,7 @@
          XCTAssertEqualObjects(params.extraQueryParameters, (@{ @"eqp1" : @"val1", @"eqp2" : @"val2" }));
          XCTAssertNil(params.loginHint);
          XCTAssertNil(params.extraScopesToConsent);
-         XCTAssertEqual(params.promptType, MSIDPromptTypeSelectAccount);
+         XCTAssertEqual(params.promptType, MSIDPromptTypePromptIfNecessary);
          XCTAssertEqualObjects(params.accountIdentifier, account.lookupAccountIdentifier);
          
          completionBlock(nil, nil);
@@ -735,7 +735,7 @@
          XCTAssertNil(params.loginHint);
          XCTAssertEqualObjects(params.accountIdentifier, account.lookupAccountIdentifier);
          XCTAssertEqualObjects(params.extraScopesToConsent, @"fakescope3");
-         XCTAssertEqual(params.promptType, MSIDPromptTypeSelectAccount);
+         XCTAssertEqual(params.promptType, MSIDPromptTypePromptIfNecessary);
          
          completionBlock(nil, nil);
      }];

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -435,7 +435,7 @@
          XCTAssertEqualObjects(params.sliceParameters, @{ @"slice" : @"myslice" });
          XCTAssertNotNil(params.correlationId);
          XCTAssertNil(params.extraScopesToConsent);
-         XCTAssertEqualObjects(params.promptType, @"select_account");
+         XCTAssertEqual(params.promptType, MSIDPromptTypeSelectAccount);
          XCTAssertNil(params.extraQueryParameters);
          XCTAssertEqualObjects(params.loginHint, @"fakeuser@contoso.com");
          
@@ -489,7 +489,7 @@
          XCTAssertEqualObjects(params.extraQueryParameters, (@{ @"eqp1" : @"val1", @"eqp2" : @"val2" }));
          XCTAssertEqualObjects(params.loginHint, @"fakeuser@contoso.com");
          XCTAssertNil(params.extraScopesToConsent);
-         XCTAssertEqualObjects(params.promptType, @"login");
+         XCTAssertEqual(params.promptType, MSIDPromptTypeLogin);
          
          completionBlock(nil, nil);
      }];
@@ -545,7 +545,7 @@
          XCTAssertEqualObjects(params.extraQueryParameters, (@{ @"eqp1" : @"val1", @"eqp2" : @"val2" }));
          XCTAssertEqualObjects(params.loginHint, @"fakeuser@contoso.com");
          XCTAssertEqualObjects(params.extraScopesToConsent, @"fakescope3");
-         XCTAssertEqualObjects(params.promptType, @"consent");
+         XCTAssertEqual(params.promptType, MSIDPromptTypeConsent);
          
          completionBlock(nil, nil);
      }];
@@ -611,7 +611,7 @@
          XCTAssertNil(params.extraQueryParameters);
          XCTAssertNil(params.loginHint);
          XCTAssertNil(params.extraScopesToConsent);
-         XCTAssertEqualObjects(params.promptType, @"select_account");
+         XCTAssertEqual(params.promptType, MSIDPromptTypeSelectAccount);
 
          XCTAssertEqualObjects(params.accountIdentifier, account.lookupAccountIdentifier);
          
@@ -671,7 +671,7 @@
          XCTAssertEqualObjects(params.extraQueryParameters, (@{ @"eqp1" : @"val1", @"eqp2" : @"val2" }));
          XCTAssertNil(params.loginHint);
          XCTAssertNil(params.extraScopesToConsent);
-         XCTAssertEqualObjects(params.promptType, @"select_account");
+         XCTAssertEqual(params.promptType, MSIDPromptTypeSelectAccount);
          XCTAssertEqualObjects(params.accountIdentifier, account.lookupAccountIdentifier);
          
          completionBlock(nil, nil);
@@ -735,7 +735,7 @@
          XCTAssertNil(params.loginHint);
          XCTAssertEqualObjects(params.accountIdentifier, account.lookupAccountIdentifier);
          XCTAssertEqualObjects(params.extraScopesToConsent, @"fakescope3");
-         XCTAssertEqualObjects(params.promptType, @"select_account");
+         XCTAssertEqual(params.promptType, MSIDPromptTypeSelectAccount);
          
          completionBlock(nil, nil);
      }];


### PR DESCRIPTION
Corresponding common core PR here: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/308