### PR TITLE
Cache cleanup and bug fixes

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -879,14 +879,14 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
     NSError *msidError = nil;
 
     BOOL result = [self.tokenCache clearCacheForAccount:account.lookupAccountIdentifier
-                                              authority:self.authority.msidAuthority
+                                              authority:nil
                                                clientId:self.clientId
+                                               familyId:nil
                                                 context:nil
                                                   error:&msidError];
-
     if (msidError && error)
     {
-        *error = msidError;
+        *error = msidError; // TODO: convert error!
     }
 
     return result;

--- a/MSAL/src/instance/MSALAccountsProvider.m
+++ b/MSAL/src/instance/MSALAccountsProvider.m
@@ -97,7 +97,7 @@
 {
     NSError *msidError = nil;
 
-    MSIDAppMetadataCacheItem *appMetadata = [self appmetadataItem];
+    MSIDAppMetadataCacheItem *appMetadata = [self appMetadataItem];
     NSString *familyId = appMetadata ? appMetadata.familyId : MSID_DEFAULT_FAMILY_ID;
 
     MSIDAccountIdentifier *accountIdentifier = [[MSIDAccountIdentifier alloc] initWithLegacyAccountId:nil homeAccountId:homeAccountId];
@@ -128,7 +128,7 @@
 {
     NSError *msidError = nil;
 
-    MSIDAppMetadataCacheItem *appMetadata = [self appmetadataItem];
+    MSIDAppMetadataCacheItem *appMetadata = [self appMetadataItem];
     NSString *familyId = appMetadata ? appMetadata.familyId : MSID_DEFAULT_FAMILY_ID;
 
     MSIDAccountIdentifier *accountIdentifier = [[MSIDAccountIdentifier alloc] initWithLegacyAccountId:username homeAccountId:nil];
@@ -162,7 +162,7 @@
 {
     NSError *msidError = nil;
 
-    MSIDAppMetadataCacheItem *appMetadata = [self appmetadataItem];
+    MSIDAppMetadataCacheItem *appMetadata = [self appMetadataItem];
     NSString *familyId = appMetadata ? appMetadata.familyId : MSID_DEFAULT_FAMILY_ID;
 
     NSArray *msidAccounts = [self.tokenCache accountsWithAuthority:authority
@@ -193,7 +193,7 @@
     return [msalAccounts allObjects];
 }
 
-- (MSIDAppMetadataCacheItem *)appmetadataItem
+- (MSIDAppMetadataCacheItem *)appMetadataItem
 {
     MSIDConfiguration *configuration = [[MSIDConfiguration alloc] initWithAuthority:nil redirectUri:nil clientId:self.clientId target:nil];
 

--- a/MSAL/src/instance/MSALAccountsProvider.m
+++ b/MSAL/src/instance/MSALAccountsProvider.m
@@ -93,7 +93,7 @@
 }
 
 - (MSALAccount *)accountForHomeAccountId:(NSString *)homeAccountId
-                                   error:(NSError * __autoreleasing *)error
+                                   error:(NSError * __autoreleasing *)error 
 {
     NSError *msidError = nil;
 

--- a/MSAL/src/instance/MSALAccountsProvider.m
+++ b/MSAL/src/instance/MSALAccountsProvider.m
@@ -95,24 +95,24 @@
 {
     NSError *msidError = nil;
 
-    __auto_type msidAccounts = [self.tokenCache allAccountsForAuthority:nil
-                                                               clientId:self.clientId
-                                                               familyId:nil
-                                                                context:nil
-                                                                  error:&msidError];
+    MSIDAccountIdentifier *accountIdentifier = [[MSIDAccountIdentifier alloc] initWithLegacyAccountId:nil homeAccountId:homeAccountId];
+    NSArray *msidAccounts = [self.tokenCache accountsWithAuthority:nil
+                                                          clientId:self.clientId
+                                                          familyId:@"1" // TODO
+                                                 accountIdentifier:accountIdentifier
+                                                           context:nil
+                                                             error:&msidError];
     
     if (msidError)
     {
         *error = msidError;
         return nil;
     }
-    
-    for (MSIDAccount *msidAccount in msidAccounts)
+
+    if ([msidAccounts count])
     {
-        if ([msidAccount.accountIdentifier.homeAccountId isEqualToString:homeAccountId])
-        {
-            return [[MSALAccount alloc] initWithMSIDAccount:msidAccount];
-        }
+        MSALAccount *msalAccount = [[MSALAccount alloc] initWithMSIDAccount:msidAccounts[0]];
+        return msalAccount;
     }
 
     return nil;
@@ -123,11 +123,14 @@
 {
     NSError *msidError = nil;
 
-    __auto_type msidAccounts = [self.tokenCache allAccountsForAuthority:nil
-                                                               clientId:self.clientId
-                                                               familyId:nil
-                                                                context:nil
-                                                                  error:&msidError];
+    MSIDAccountIdentifier *accountIdentifier = [[MSIDAccountIdentifier alloc] initWithLegacyAccountId:username homeAccountId:nil];
+
+    NSArray *msidAccounts = [self.tokenCache accountsWithAuthority:nil
+                                                          clientId:self.clientId
+                                                          familyId:@"1"
+                                                 accountIdentifier:accountIdentifier
+                                                           context:nil
+                                                             error:&msidError];
     
     if (msidError)
     {
@@ -135,12 +138,10 @@
         return nil;
     }
     
-    for (MSIDAccount *msidAccount in msidAccounts)
+    if ([msidAccounts count])
     {
-        if ([msidAccount.username isEqualToString:username])
-        {
-            return [[MSALAccount alloc] initWithMSIDAccount:msidAccount];
-        }
+        MSALAccount *msalAccount = [[MSALAccount alloc] initWithMSIDAccount:msidAccounts[0]];
+        return msalAccount;
     }
     
     return nil;
@@ -153,11 +154,12 @@
 {
     NSError *msidError = nil;
 
-    __auto_type msidAccounts = [self.tokenCache allAccountsForAuthority:authority
-                                                               clientId:self.clientId
-                                                               familyId:nil
-                                                                context:nil
-                                                                  error:&msidError];
+    NSArray *msidAccounts = [self.tokenCache accountsWithAuthority:authority
+                                                          clientId:self.clientId
+                                                          familyId:@"1"
+                                                 accountIdentifier:nil
+                                                           context:nil
+                                                             error:&msidError];
     
     if (msidError)
     {

--- a/MSAL/test/app/ios/MSALTestAppCacheViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppCacheViewController.m
@@ -162,13 +162,17 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         [self.defaultAccessor clearCacheForAccount:account.accountIdentifier
                                          authority:nil
                                           clientId:nil
+                                          familyId:nil
                                            context:nil
                                              error:nil];
-        
+
         [self.legacyAccessor clearCacheForAccount:account.accountIdentifier
-                                          context:nil
-                                            error:nil];
-        
+                                         authority:nil
+                                          clientId:nil
+                                          familyId:nil
+                                           context:nil
+                                             error:nil];
+
         [self loadCache];
     }
 }
@@ -221,12 +225,13 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 
-        [self setAccounts:[self.defaultAccessor allAccountsForAuthority:nil
-                                                               clientId:nil
-                                                               familyId:nil
-                                                                context:nil
-                                                                  error:nil]];
-        
+        [self setAccounts:[self.defaultAccessor accountsWithAuthority:nil
+                                                             clientId:nil
+                                                             familyId:nil
+                                                    accountIdentifier:nil
+                                                              context:nil
+                                                                error:nil]];
+
         [self setAppMetadataEntries:[self.defaultAccessor getAppMetadataEntries:nil context:nil error:nil]];
         
         _cacheSections = [NSMutableDictionary dictionary];

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -1164,9 +1164,9 @@
     MSALAccount *account = accounts[0];
     XCTAssertEqualObjects(account.username, @"fakeuser@contoso.com");
     XCTAssertEqualObjects(account.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(account.homeAccountId.identifier, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031");
-    XCTAssertEqualObjects(account.homeAccountId.objectId, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97");
-    XCTAssertEqualObjects(account.homeAccountId.tenantId, @"0287f963-2d72-4363-9e3a-5705c5b0f031");
+    XCTAssertEqualObjects(account.homeAccountId.identifier, @"myuid.utid");
+    XCTAssertEqualObjects(account.homeAccountId.objectId, @"myuid");
+    XCTAssertEqualObjects(account.homeAccountId.tenantId, @"utid");
 }
 
 - (void)testAllAccounts_when2AccountExists_shouldReturn2Accounts
@@ -1186,16 +1186,16 @@
     MSALAccount *account = accounts[0];
     XCTAssertEqualObjects(account.username, @"fakeuser@contoso.com");
     XCTAssertEqualObjects(account.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(account.homeAccountId.identifier, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031");
-    XCTAssertEqualObjects(account.homeAccountId.objectId, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97");
-    XCTAssertEqualObjects(account.homeAccountId.tenantId, @"0287f963-2d72-4363-9e3a-5705c5b0f031");
+    XCTAssertEqualObjects(account.homeAccountId.identifier, @"myuid.utid");
+    XCTAssertEqualObjects(account.homeAccountId.objectId, @"myuid");
+    XCTAssertEqualObjects(account.homeAccountId.tenantId, @"utid");
     
     MSALAccount *account2 = accounts[1];
     XCTAssertEqualObjects(account2.username, @"fakeuser@contoso.com");
     XCTAssertEqualObjects(account2.environment, @"example.com");
-    XCTAssertEqualObjects(account2.homeAccountId.identifier, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031");
-    XCTAssertEqualObjects(account2.homeAccountId.objectId, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97");
-    XCTAssertEqualObjects(account2.homeAccountId.tenantId, @"0287f963-2d72-4363-9e3a-5705c5b0f031");
+    XCTAssertEqualObjects(account2.homeAccountId.identifier, @"myuid.utid");
+    XCTAssertEqualObjects(account2.homeAccountId.objectId, @"myuid");
+    XCTAssertEqualObjects(account2.homeAccountId.tenantId, @"utid");
 }
 
 - (void)testAllAccount_whenFociTokenExistsForOtherClient_andAppMetadataWithSameFamilyIdInCache_shouldReturnAccountNoError
@@ -1204,14 +1204,13 @@
     MSIDAADV2TokenResponse *msidResponse = [self msalDefaultTokenResponseWithAuthority:@"https://login.microsoftonline.com/common" familyId:@"1"];
     MSIDConfiguration *configuration = [self msalDefaultConfigurationWithAuthority:@"https://login.microsoftonline.com/common"];
 
-    NSError *error = nil;
     BOOL result = [self.tokenCacheAccessor saveTokensWithConfiguration:configuration
                                                               response:msidResponse
                                                                factory:[MSIDAADV2Oauth2Factory new]
                                                                context:nil
-                                                                 error:&error];
+                                                                 error:nil];
     XCTAssertTrue(result);
-    XCTAssertNil(error);
+    XCTAssertEqual([[self.tokenCacheAccessor allTokensWithContext:nil error:nil] count], 4);
 
     NSString *clientId = @"myclient";
 
@@ -1226,6 +1225,7 @@
     XCTAssertNil(appError);
     application.tokenCache = self.tokenCacheAccessor;
 
+    NSError *error = nil;
     NSArray *allAccounts = [application allAccounts:&error];
 
     XCTAssertNil(error);
@@ -1246,7 +1246,7 @@
                                                                context:nil
                                                                  error:&error];
     XCTAssertTrue(result);
-    XCTAssertNil(error);
+    XCTAssertEqual([[self.tokenCacheAccessor allTokensWithContext:nil error:nil] count], 4);
 
     NSString *clientId = @"myclient";
 
@@ -1281,7 +1281,7 @@
                                                                context:nil
                                                                  error:&error];
     XCTAssertTrue(result);
-    XCTAssertNil(error);
+    XCTAssertEqual([[self.tokenCacheAccessor allTokensWithContext:nil error:nil] count], 3);
 
     NSString *clientId = @"myclient";
 
@@ -1322,9 +1322,9 @@
         MSALAccount *account = accounts[0];
         XCTAssertEqualObjects(account.username, @"fakeuser@contoso.com");
         XCTAssertEqualObjects(account.environment, @"login.microsoftonline.com");
-        XCTAssertEqualObjects(account.homeAccountId.identifier, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031");
-        XCTAssertEqualObjects(account.homeAccountId.objectId, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97");
-        XCTAssertEqualObjects(account.homeAccountId.tenantId, @"0287f963-2d72-4363-9e3a-5705c5b0f031");
+        XCTAssertEqualObjects(account.homeAccountId.identifier, @"myuid.utid");
+        XCTAssertEqualObjects(account.homeAccountId.objectId, @"myuid");
+        XCTAssertEqualObjects(account.homeAccountId.tenantId, @"utid");
         
         [expectation fulfill];
     }];
@@ -1351,9 +1351,9 @@
          MSALAccount *account = accounts[0];
          XCTAssertEqualObjects(account.username, @"fakeuser@contoso.com");
          XCTAssertEqualObjects(account.environment, @"login.microsoftonline.com");
-         XCTAssertEqualObjects(account.homeAccountId.identifier, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031");
-         XCTAssertEqualObjects(account.homeAccountId.objectId, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97");
-         XCTAssertEqualObjects(account.homeAccountId.tenantId, @"0287f963-2d72-4363-9e3a-5705c5b0f031");
+         XCTAssertEqualObjects(account.homeAccountId.identifier, @"myuid.utid");
+         XCTAssertEqualObjects(account.homeAccountId.objectId, @"myuid");
+         XCTAssertEqualObjects(account.homeAccountId.tenantId, @"utid");
          
          [expectation fulfill];
      }];
@@ -1370,7 +1370,7 @@
     NSString *clientId = UNIT_TEST_CLIENT_ID;
     __auto_type application = [[MSALPublicClientApplication alloc] initWithClientId:clientId error:nil];
     application.tokenCache = self.tokenCacheAccessor;
-    NSString *homeAccountId = @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031";
+    NSString *homeAccountId = @"myuid.utid";
     
     NSError *error;
     __auto_type account = [application accountForHomeAccountId:homeAccountId error:&error];
@@ -1379,9 +1379,9 @@
     XCTAssertNotNil(account);
     XCTAssertEqualObjects(account.username, @"fakeuser@contoso.com");
     XCTAssertEqualObjects(account.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(account.homeAccountId.identifier, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031");
-    XCTAssertEqualObjects(account.homeAccountId.objectId, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97");
-    XCTAssertEqualObjects(account.homeAccountId.tenantId, @"0287f963-2d72-4363-9e3a-5705c5b0f031");
+    XCTAssertEqualObjects(account.homeAccountId.identifier, @"myuid.utid");
+    XCTAssertEqualObjects(account.homeAccountId.objectId, @"myuid");
+    XCTAssertEqualObjects(account.homeAccountId.tenantId, @"utid");
 }
 
 - (void)testAccountWithHomeAccountId_whenAccountExistsButNotMatching_shouldReturnNoAccountNoError
@@ -1413,7 +1413,7 @@
                                                                context:nil
                                                                  error:&error];
     XCTAssertTrue(result);
-    XCTAssertNil(error);
+    XCTAssertEqual([[self.tokenCacheAccessor allTokensWithContext:nil error:nil] count], 4);
 
     NSString *clientId = @"myclient";
 
@@ -1433,7 +1433,7 @@
     XCTAssertNil(appError);
     application.tokenCache = self.tokenCacheAccessor;
 
-    NSString *homeAccountId = @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031";
+    NSString *homeAccountId = @"myuid.utid";
     __auto_type account = [application accountForHomeAccountId:homeAccountId error:&error];
 
     XCTAssertNil(error);
@@ -1457,9 +1457,9 @@
     XCTAssertNotNil(account);
     XCTAssertEqualObjects(account.username, @"fakeuser@contoso.com");
     XCTAssertEqualObjects(account.environment, @"login.microsoftonline.com");
-    XCTAssertEqualObjects(account.homeAccountId.identifier, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97.0287f963-2d72-4363-9e3a-5705c5b0f031");
-    XCTAssertEqualObjects(account.homeAccountId.objectId, @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97");
-    XCTAssertEqualObjects(account.homeAccountId.tenantId, @"0287f963-2d72-4363-9e3a-5705c5b0f031");
+    XCTAssertEqualObjects(account.homeAccountId.identifier, @"myuid.utid");
+    XCTAssertEqualObjects(account.homeAccountId.objectId, @"myuid");
+    XCTAssertEqualObjects(account.homeAccountId.tenantId, @"utid");
 }
 
 - (void)testAccountWithUsername_whenAccountExistsButNotMatching_shouldReturnNoAccountNoError
@@ -1490,7 +1490,7 @@
                                                                context:nil
                                                                  error:&error];
     XCTAssertTrue(result);
-    XCTAssertNil(error);
+    XCTAssertEqual([[self.tokenCacheAccessor allTokensWithContext:nil error:nil] count], 4);
 
     // Retrieve cache for a different clientId
     NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[@"msalmyclient"] } ];
@@ -1542,18 +1542,18 @@
 - (void)testRemoveAccount_whenAccountExists_andIsFociClient_shouldRemoveAccount_andMarkClientNonFoci
 {
     // 1. Save response for a different clientId
-    NSString *authorityUrl = @"https://login.microsoftonline.com/0287f963-2d72-4363-9e3a-5705c5b0f031";
+    NSString *authorityUrl = @"https://login.microsoftonline.com/utid";
     MSIDAADV2TokenResponse *msidResponse = [self msalDefaultTokenResponseWithAuthority:authorityUrl familyId:@"1"];
     MSIDConfiguration *configuration = [self msalDefaultConfigurationWithAuthority:authorityUrl];
 
-    NSError *error = nil;
     BOOL result = [self.tokenCacheAccessor saveTokensWithConfiguration:configuration
                                                               response:msidResponse
                                                                factory:[MSIDAADV2Oauth2Factory new]
                                                                context:nil
-                                                                 error:&error];
+                                                                 error:nil];
+
     XCTAssertTrue(result);
-    XCTAssertNil(error);
+    XCTAssertEqual([[self.tokenCacheAccessor allTokensWithContext:nil error:nil] count], 4);
 
     // 2. Create PublicClientApplication for a different app
     NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[@"msalmyclient"] } ];
@@ -1577,6 +1577,7 @@
     XCTAssertEqualObjects([application allAccounts:nil][0], msalAccount);
 
     // 3. Remove account
+    NSError *error = nil;
     result = [application removeAccount:msalAccount error:&error];
 
     XCTAssertTrue(result);
@@ -1597,7 +1598,8 @@
 
     [self msalAddDiscoveryResponse:authorityUrl appendDefaultHeaders:YES];
 
-    // 5. Try to acquire token silently
+    // 5. Try to acquire token silently, expecting to get interaction required back
+    // That means FOCI wasn't used by the app although present
     XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire token silent"];
 
     [application acquireTokenSilentForScopes:@[@"fakescope1"]
@@ -1731,8 +1733,8 @@
 
 - (MSIDAADV2TokenResponse *)msalDefaultTokenResponseWithAuthority:(NSString *)authorityString familyId:(NSString *)familyId
 {
-    NSDictionary* idTokenClaims = @{ @"home_oid" : @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97", @"preferred_username": @"fakeuser@contoso.com"};
-    NSDictionary* clientInfoClaims = @{ @"uid" : @"29f3807a-4fb0-42f2-a44a-236aa0cb3f97", @"utid" : @"0287f963-2d72-4363-9e3a-5705c5b0f031"};
+    NSDictionary* idTokenClaims = @{ @"home_oid" : @"myuid", @"preferred_username": @"fakeuser@contoso.com"};
+    NSDictionary* clientInfoClaims = @{ @"uid" : @"myuid", @"utid" : @"utid"};
     
     NSString *rawIdToken = [NSString stringWithFormat:@"fakeheader.%@.fakesignature",
                             [NSString msidBase64UrlEncodedStringFromData:[NSJSONSerialization dataWithJSONObject:idTokenClaims options:0 error:nil]]];

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -1389,9 +1389,9 @@
     
     MSALAccount *account = [MSALAccount new];
     
-    [MSIDTestSwizzle instanceMethod:@selector(clearCacheForAccount:authority:clientId:context:error:)
+    [MSIDTestSwizzle instanceMethod:@selector(clearCacheForAccount:authority:clientId:familyId:context:error:)
                               class:[MSIDDefaultTokenCacheAccessor class]
-                              block:(id)^(id obj, id account, MSIDAuthority *authority, NSString *clientId, id<MSIDRequestContext> ctx, NSError **error)
+                              block:(id)^(id obj, id account, MSIDAuthority *authority, NSString *clientId, NSString *familyId, id<MSIDRequestContext> ctx, NSError **error)
      {
          (void)authority;
          (void)account;

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -1215,12 +1215,7 @@
 
     NSString *clientId = @"myclient";
 
-    MSIDAppMetadataCacheItem *appMetadata = [MSIDAppMetadataCacheItem new];
-    appMetadata.clientId = clientId;
-    appMetadata.environment = @"login.microsoftonline.com";
-    appMetadata.familyId = @"1";
-
-    [self.tokenCacheAccessor updateAppMetadata:appMetadata context:nil error:nil];
+    [self.tokenCacheAccessor updateAppMetadataWithFamilyId:@"1" clientId:clientId authority:configuration.authority context:nil error:nil];
 
     // Retrieve cache for a different clientId
     NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[@"msalmyclient"] } ];
@@ -1255,12 +1250,7 @@
 
     NSString *clientId = @"myclient";
 
-    MSIDAppMetadataCacheItem *appMetadata = [MSIDAppMetadataCacheItem new];
-    appMetadata.clientId = clientId;
-    appMetadata.environment = @"login.microsoftonline.com";
-    appMetadata.familyId = @"";
-
-    [self.tokenCacheAccessor updateAppMetadata:appMetadata context:nil error:nil];
+    [self.tokenCacheAccessor updateAppMetadataWithFamilyId:@"" clientId:clientId authority:configuration.authority context:nil error:nil];
 
     // Retrieve cache for a different clientId
     NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[@"msalmyclient"] } ];
@@ -1432,7 +1422,7 @@
     appMetadata.environment = @"login.microsoftonline.com";
     appMetadata.familyId = @"1";
 
-    [self.tokenCacheAccessor updateAppMetadata:appMetadata context:nil error:nil];
+    [self.tokenCacheAccessor updateAppMetadataWithFamilyId:@"1" clientId:clientId authority:configuration.authority context:nil error:nil];
 
     // Retrieve cache for a different clientId
     NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[@"msalmyclient"] } ];
@@ -1571,13 +1561,7 @@
 
     MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:@"myclient" error:nil];
     application.tokenCache = self.tokenCacheAccessor;
-
-    MSIDAppMetadataCacheItem *appMetadata = [MSIDAppMetadataCacheItem new];
-    appMetadata.clientId = @"myclient";
-    appMetadata.environment = @"login.microsoftonline.com";
-    appMetadata.familyId = @"1";
-
-    [self.tokenCacheAccessor updateAppMetadata:appMetadata context:nil error:nil];
+    [self.tokenCacheAccessor updateAppMetadataWithFamilyId:@"1" clientId:@"myclient" authority:configuration.authority context:nil error:nil];
 
     MSIDAuthority *authority = [MSIDAuthorityFactory authorityFromUrl:[NSURL URLWithString:authorityUrl] context:nil error:nil];
 


### PR DESCRIPTION
This addresses following issues:
1. Remove expired access tokens
2. Remove invalid refresh tokens
3. Only return accounts with tokens in cache for that client or family id
4. Disassociate application from its family ID after account removal, so that app cannot continue using family refresh token without interactive login first.
5. Query accounts by application's familyId
6. Removed unnecessary cache accessor methods/minor code cleanup

Common core PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/313