### PR TITLE
Don't normalize scopes in request

### DIFF
--- a/MSAL/test/app/MSALTestAppSettings.m
+++ b/MSAL/test/app/MSALTestAppSettings.m
@@ -91,7 +91,7 @@ static NSDictionary *s_profiles = nil;
     
     s_authorities = authorities;
     
-    s_scopes_available = @[MSAL_APP_SCOPE_USER_READ, @"Tasks.Read", @"https://graph.microsoft.com/.default",@"https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read"];
+    s_scopes_available = @[MSAL_APP_SCOPE_USER_READ, @"Tasks.Read", @"https://graph.microsoft.com/.default",@"https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read", @"TASKS.read"];
     
     __auto_type signinPolicyAuthority = @"https://login.microsoftonline.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_SignInPolicy";
     __auto_type signupPolicyAuthority = @"https://login.microsoftonline.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_SignUpPolicy";

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -2188,7 +2188,7 @@
     // Set up the network responses for OIDC discovery
     NSString *authority = @"https://login.microsoftonline.com/1234-5678-90abcdefg";
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
-    NSOrderedSet *expectedScopes = [NSOrderedSet orderedSetWithArray:@[@"user.read", @"openid", @"profile", @"offline_access"]];
+    NSOrderedSet *expectedScopes = [NSOrderedSet orderedSetWithArray:@[@"USER.read", @"openid", @"profile", @"offline_access"]];
     // Set up a 200 network responses
     MSIDTestURLResponse *tokenResponse = [MSIDTestURLResponse rtResponseForScopes:expectedScopes
                                                                         authority:authority
@@ -2208,7 +2208,7 @@
     XCTAssertNotNil(application);
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentForScopes"];
-    [application acquireTokenSilentForScopes:@[@"user.read"]
+    [application acquireTokenSilentForScopes:@[@"USER.read"]
                                      account:account
                              completionBlock:^(MSALResult *result, NSError *error)
      {


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/395