### PR TITLE
Return internal error for expected, but non mapped error code.

### DIFF
--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -99,9 +99,6 @@ static NSDictionary *s_userInfoKeyMapping;
                                    @(MSIDErrorServerInvalidState) : @(MSALErrorInvalidState),
                                    @(MSIDErrorServerProtectionPoliciesRequired) : @(MSALErrorServerProtectionPoliciesRequired),
                                    @(MSIDErrorServerUnhandledResponse) : @(MSALErrorUnhandledResponse)
-                                   },
-                           MSIDHttpErrorCodeDomain: @{
-                                   @(MSIDErrorServerUnhandledResponse) : @(MSALErrorUnhandledResponse)
                                    }
                            };
     
@@ -150,17 +147,18 @@ static NSDictionary *s_userInfoKeyMapping;
     NSString *mappedDomain = s_errorDomainMapping[domain];
     
     // Map errorCode
-    // errorCode mapping is needed only if domain is mapped
+    // errorCode mapping is needed only if domain is mapped to MSALErrorDomain
     NSNumber *mappedCode = nil;
-    if (mappedDomain && s_errorCodeMapping[mappedDomain])
+    if (mappedDomain == MSALErrorDomain)
     {
         mappedCode = s_errorCodeMapping[mappedDomain][@(code)];
         if (!mappedCode)
         {
-            MSID_LOG_WARN(nil, @"MSALErrorConverter could not find the error code mapping entry for domain (%@) + error code (%ld).", domain, code);
+            MSID_LOG_ERROR(nil, @"MSALErrorConverter could not find the error code mapping entry for domain (%@) + error code (%ld).", domain, code);
+            NSAssert(NO, @"Error converter assert - Error mapping incomplete  for domain (%@) + error code (%ld).", domain, code);
         }
     }
-
+    
     NSMutableDictionary *msalUserInfo = [NSMutableDictionary new];
 
     for (NSString *key in [userInfo allKeys])

--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -154,8 +154,8 @@ static NSDictionary *s_userInfoKeyMapping;
         mappedCode = s_errorCodeMapping[mappedDomain][@(code)];
         if (!mappedCode)
         {
-            MSID_LOG_ERROR(nil, @"MSALErrorConverter could not find the error code mapping entry for domain (%@) + error code (%ld).", domain, code);
-            NSAssert(NO, @"Error converter assert - Error mapping incomplete  for domain (%@) + error code (%ld).", domain, code);
+            MSID_LOG_WARN(nil, @"MSALErrorConverter could not find the error code mapping entry for domain (%@) + error code (%ld).", domain, code);
+            mappedCode = @(MSALErrorInternal);
         }
     }
     

--- a/MSAL/test/unit/MSALErrorConverterTests.m
+++ b/MSAL/test/unit/MSALErrorConverterTests.m
@@ -222,5 +222,32 @@
     }
 }
 
+- (void)testErrorConversion_whenDomainIsMappedAndCodeMissing_shouldThrowAssert
+{
+    XCTAssertThrows([MSALErrorConverter errorWithDomain:MSIDErrorDomain
+                                                   code:123456
+                                       errorDescription:@"Unmapped code error"
+                                             oauthError:nil
+                                               subError:nil
+                                        underlyingError:nil
+                                          correlationId:nil
+                                               userInfo:nil]);
+}
+
+- (void)testErrorConversion_whenDomainNotMapped_shouldNotTouchCode
+{
+    NSError *msalError = [MSALErrorConverter errorWithDomain:@"Unmapped Domain"
+                                                        code:MSIDErrorUserCancel
+                                            errorDescription:nil
+                                                  oauthError:nil
+                                                    subError:nil
+                                             underlyingError:nil
+                                               correlationId:nil
+                                                    userInfo:nil];
+    
+    XCTAssertEqualObjects(msalError.domain, @"Unmapped Domain");
+    XCTAssertEqual(msalError.code, MSIDErrorUserCancel);
+}
+
 @end
 

--- a/MSAL/test/unit/MSALErrorConverterTests.m
+++ b/MSAL/test/unit/MSALErrorConverterTests.m
@@ -222,16 +222,20 @@
     }
 }
 
-- (void)testErrorConversion_whenDomainIsMappedAndCodeMissing_shouldThrowAssert
+- (void)testErrorConversion_whenDomainIsMappedAndCodeMissing_shouldReturnMSALInternalError
 {
-    XCTAssertThrows([MSALErrorConverter errorWithDomain:MSIDErrorDomain
-                                                   code:123456
-                                       errorDescription:@"Unmapped code error"
-                                             oauthError:nil
-                                               subError:nil
-                                        underlyingError:nil
-                                          correlationId:nil
-                                               userInfo:nil]);
+    NSError *msalError = [MSALErrorConverter errorWithDomain:MSIDErrorDomain
+                                                        code:123456
+                                            errorDescription:@"Unmapped code error"
+                                                  oauthError:nil
+                                                    subError:nil
+                                             underlyingError:nil
+                                               correlationId:nil
+                                                    userInfo:nil];
+    
+    XCTAssertEqualObjects(msalError.domain, MSALErrorDomain);
+    XCTAssertEqual(msalError.code, MSALErrorInternal);
+    
 }
 
 - (void)testErrorConversion_whenDomainNotMapped_shouldNotTouchCode


### PR DESCRIPTION
Except keychain domain which is not mapped in the first place for msal.