### PR TITLE
Fix pragma syntax in MSALPublicClientApplication.h

### DIFF
--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -236,7 +236,8 @@
  */
 - (void)allAccountsFilteredByAuthority:(nonnull MSALAccountsCompletionBlock)completionBlock;
 
-#pragma SafariViewController Support
+#pragma mark -
+#pragma mark SafariViewController Support
 
 #if TARGET_OS_IPHONE
 /*!


### PR DESCRIPTION
A pragma that was intended to structure the code in the `MSALPublicClientApplication.h` file was not using the correct syntax. This lead to compile time errors when integrating the SDK. 