### PR TITLE
Added acquire token API that accepts claims and login hint

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -436,6 +436,29 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
                 completionBlock:completionBlock];
 }
 
+- (void)acquireTokenForScopes:(nonnull NSArray<NSString *> *)scopes
+         extraScopesToConsent:(nullable NSArray<NSString *> *)extraScopesToConsent
+                    loginHint:(nullable NSString *)loginHint
+                   uiBehavior:(MSALUIBehavior)uiBehavior
+         extraQueryParameters:(nullable NSDictionary <NSString *, NSString *> *)extraQueryParameters
+                       claims:(nullable NSString *)claims
+                    authority:(nullable MSALAuthority *)authority
+                correlationId:(nullable NSUUID *)correlationId
+              completionBlock:(nonnull MSALCompletionBlock)completionBlock
+{
+    [self acquireTokenForScopes:scopes
+           extraScopesToConsent:extraScopesToConsent
+                        account:nil
+                      loginHint:loginHint
+                     uiBehavior:uiBehavior
+           extraQueryParameters:extraQueryParameters
+                         claims:claims
+                      authority:authority
+                  correlationId:correlationId
+                          apiId:MSALTelemetryApiIdAcquireWithHintBehaviorParametersAuthorityAndClaimsAndCorrelationId
+                completionBlock:completionBlock];
+}
+
 #pragma mark -
 #pragma mark Account
 

--- a/MSAL/src/MSALTelemetryApiId.h
+++ b/MSAL/src/MSALTelemetryApiId.h
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSInteger, MSALTelemetryApiId)
     MSALTelemetryApiIdAcquireWithHintBehaviorParametersAuthorityAndCorrelationId = 163,
     MSALTelemetryApiIdAcquireWithUserBehaviorAndParameters = 164,
     MSALTelemetryApiIdAcquireWithUserBehaviorParametersAuthorityAndCorrelationId = 165,
+    MSALTelemetryApiIdAcquireWithHintBehaviorParametersAuthorityAndClaimsAndCorrelationId = 166,
     MSALTelemetryApiIdAcquireSilentWithUser = 30,
     MSALTelemetryApiIdAcquireSilentWithUserAndAuthority = 31,
     MSALTelemetryApiIdAcquireSilentWithUserAuthorityForceRefreshAndCorrelationId = 32

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -358,6 +358,42 @@
                 correlationId:(nullable NSUUID *)correlationId
               completionBlock:(nonnull MSALCompletionBlock)completionBlock;
 
+/*!
+    Acquire a token for a new account using interactive authentication
+ 
+    @param  scopes                  Permissions you want included in the access token received
+                                    in the result in the completionBlock. Not all scopes are
+                                    guaranteed to be included in the access token returned.
+    @param  extraScopesToConsent    Permissions you want the account to consent to in the same
+                                    authentication flow, but won't be included in the returned
+                                    access token
+    @param  loginHint               A loginHint (usually an email) to pass to the service at the
+                                    beginning of the interactive authentication flow. The account returned
+                                    in the completion block is not guaranteed to match the loginHint.
+    @param  uiBehavior              A UI behavior for the interactive authentication flow
+    @param  extraQueryParameters    Key-value pairs to pass to the authentication server during
+                                    the interactive authentication flow.
+    @param  authority               Authority indicating a directory that MSAL can use to obtain tokens. Azure AD
+                                    it is of the form https://<instance/<tenant>, where <instance> is the
+                                    directory host (e.g. https://login.microsoftonline.com) and <tenant> is a
+                                    identifier within the directory itself (e.g. a domain associated to the
+                                    tenant, such as contoso.onmicrosoft.com, or the GUID representing the
+                                    TenantID property of the directory)
+    @param  claims                  The claims parameter that needs to be sent to authorization endpoint.
+    @param  correlationId           UUID to correlate this request with the server
+    @param  completionBlock         The completion block that will be called when the authentication
+                                    flow completes, or encounters an error.
+ */
+- (void)acquireTokenForScopes:(nonnull NSArray<NSString *> *)scopes
+         extraScopesToConsent:(nullable NSArray<NSString *> *)extraScopesToConsent
+                    loginHint:(nullable NSString *)loginHint
+                   uiBehavior:(MSALUIBehavior)uiBehavior
+         extraQueryParameters:(nullable NSDictionary <NSString *, NSString *> *)extraQueryParameters
+                       claims:(nullable NSString *)claims
+                    authority:(nullable MSALAuthority *)authority
+                correlationId:(nullable NSUUID *)correlationId
+              completionBlock:(nonnull MSALCompletionBlock)completionBlock;
+
 #pragma mark -
 #pragma mark acquireToken using Account
 

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -810,6 +810,99 @@
     [self waitForExpectations:@[expectation] timeout:1];
 }
 
+- (void)testAcquireTokenInteractive_whenClaimsIsPassedAndLoginHintNotNil_shouldSendClaimsAndLoginHintToServer
+{
+    NSString *claims = @"{\"access_token\":{\"polids\":{\"values\":[\"5ce770ea-8690-4747-aa73-c5b3cd509cd4\"],\"essential\":true}}}";
+    
+    [MSALTestBundle overrideBundleId:@"com.microsoft.unittests"];
+    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
+    [MSALTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
+    
+    MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:DEFAULT_TEST_AUTHORITY];
+    
+    // Mock tenant discovery response
+    MSIDTestURLResponse *oidcResponse =
+    [MSIDTestURLResponse oidcResponseForAuthority:DEFAULT_TEST_AUTHORITY
+                                      responseUrl:DEFAULT_TEST_AUTHORITY
+                                            query:nil];
+    // Mock auth code grant response
+    MSIDTestURLResponse *tokenResponse =
+    [MSIDTestURLResponse authCodeResponse:@"i am an auth code"
+                                authority:DEFAULT_TEST_AUTHORITY
+                                    query:nil
+                                   scopes:[NSOrderedSet orderedSetWithArray:@[@"fakescopes", @"openid", @"profile", @"offline_access"]]
+                                   claims:claims];
+    
+    [MSIDTestURLSession addResponses:@[discoveryResponse, oidcResponse, tokenResponse]];
+    
+    // Check claims is in start url
+    [MSIDTestSwizzle classMethod:@selector(startEmbeddedWebviewAuthWithConfiguration:oauth2Factory:webview:context:completionHandler:)
+                           class:[MSIDWebviewAuthorization class]
+                           block:(id)^(id obj, MSIDWebviewConfiguration *configuration, MSIDOauth2Factory *oauth2Factory, WKWebView *webview, id<MSIDRequestContext>context, MSIDWebviewAuthCompletionHandler completionHandler)
+     {
+         NSURL *url = [oauth2Factory.webviewFactory startURLFromConfiguration:configuration requestState:[[NSUUID UUID] UUIDString]];
+         XCTAssertNotNil(url);
+         NSDictionary *QPs = [NSDictionary msidDictionaryFromWWWFormURLEncodedString:url.query];
+         
+         NSMutableDictionary *expectedQPs =
+         [@{
+            @"claims" : claims, //claims should be in the QPs
+            @"client-request-id" : [MSIDTestRequireValueSentinel sentinel],
+            @"return-client-request-id" : @"true",
+            @"state" : [MSIDTestRequireValueSentinel sentinel],
+            @"client_id" : UNIT_TEST_CLIENT_ID,
+            @"scope" : @"fakescopes openid profile offline_access",
+            @"client_info" : @"1",
+            @"redirect_uri" : UNIT_TEST_DEFAULT_REDIRECT_URI,
+            @"response_type" : @"code",
+            @"code_challenge": [MSIDTestRequireValueSentinel sentinel],
+            @"code_challenge_method" : @"S256",
+            @"haschrome" : @"1",
+            @"eqpKey" : @"eqpValue",
+            @"login_hint": @"upn@test.com"
+            UT_SLICE_PARAMS_DICT
+            } mutableCopy];
+         [expectedQPs addEntriesFromDictionary:[MSIDDeviceId deviceId]];
+         
+         XCTAssertTrue([expectedQPs compareAndPrintDiff:QPs]);
+         
+         NSString *responseString = [NSString stringWithFormat:UNIT_TEST_DEFAULT_REDIRECT_URI"?code=%@&state=%@&client_info=%@", @"i+am+an+auth+code", QPs[@"state"], @"eyJ1aWQiOiI5ZjQ4ODBkOC04MGJhLTRjNDAtOTdiYy1mN2EyM2M3MDMwODQiLCJ1dGlkIjoiZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhIn0"];
+         MSIDWebAADAuthResponse *oauthResponse = [[MSIDWebAADAuthResponse alloc] initWithURL:[NSURL URLWithString:responseString]
+                                                                                     context:nil error:nil];
+         completionHandler(oauthResponse, nil);
+     }];
+    
+    // Acquire token call
+    NSError *error = nil;
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
+                                                                                           authority:[DEFAULT_TEST_AUTHORITY msalAuthority]
+                                                                                               error:&error];
+    XCTAssertNotNil(application);
+    XCTAssertNil(error);
+    
+    application.brokerAvailability = MSALBrokeredAvailabilityNone;
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquireToken"];
+    application.webviewType = MSALWebviewTypeWKWebView;
+    [application acquireTokenForScopes:@[@"fakescopes"]
+                  extraScopesToConsent:nil
+                             loginHint:@"upn@test.com"
+                            uiBehavior:MSALUIBehaviorDefault
+                  extraQueryParameters:@{@"eqpKey":@"eqpValue"}
+                                claims:claims
+                             authority:nil
+                         correlationId:nil
+                       completionBlock:^(MSALResult *result, NSError *error)
+     {
+         XCTAssertNil(error);
+         XCTAssertNotNil(result);
+         XCTAssertEqualObjects(result.accessToken, @"i am an updated access token!");
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+}
+
 - (void)testAcquireTokenInteractive_whenClaimsNotProperJson_shouldReturnError
 {
     [MSALTestBundle overrideBundleId:@"com.microsoft.unittests"];

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -815,7 +815,7 @@
     NSString *claims = @"{\"access_token\":{\"polids\":{\"values\":[\"5ce770ea-8690-4747-aa73-c5b3cd509cd4\"],\"essential\":true}}}";
     
     [MSALTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
+    NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
     [MSALTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
     
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:DEFAULT_TEST_AUTHORITY];


### PR DESCRIPTION
Note, that this one and most of other overloads will be soon (version after broker) deprecated in favor of parameters.