### PR TITLE
Fix failing automation test case

### DIFF
--- a/MSAL/test/automation/tests/interactive/MSALMSABasicInteractiveTests.m
+++ b/MSAL/test/automation/tests/interactive/MSALMSABasicInteractiveTests.m
@@ -154,7 +154,7 @@
     [self acceptAuthSessionDialog];
 
     [self selectAccountWithTitle:self.primaryAccount.account];
-    [self acceptMSSTSConsentIfNecessary:@"Yes" embeddedWebView:NO];
+    [self acceptMSSTSConsentIfNecessary:@"Continue" embeddedWebView:NO];
 
     [self assertAccessTokenNotNil];
     [self closeResultView];


### PR DESCRIPTION
Fix the failing automation test case where server seems to change the "Yes" button to "Continue" for select_account flow.