### PR TITLE
MSAL API updates bug fixes

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -198,6 +198,8 @@
 		B25F1BC11EC3DD3200474D1B /* MSALUser+Automation.m in Sources */ = {isa = PBXBuildFile; fileRef = B25F1BC01EC3DD3200474D1B /* MSALUser+Automation.m */; };
 		B25F1BC41EC3E44500474D1B /* MSALResult+Automation.m in Sources */ = {isa = PBXBuildFile; fileRef = B25F1BC31EC3E44500474D1B /* MSALResult+Automation.m */; };
 		B277241E1EAE97D700375C53 /* MSALStressTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B277241D1EAE97D700375C53 /* MSALStressTestHelper.m */; };
+		B281B33B226BC225009619AB /* MSALPublicClientApplicationConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B281B33A226BC225009619AB /* MSALPublicClientApplicationConfigTests.m */; };
+		B281B33C226BC225009619AB /* MSALPublicClientApplicationConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B281B33A226BC225009619AB /* MSALPublicClientApplicationConfigTests.m */; };
 		B28BBD342211DC7D00F51723 /* MSALPublicClientStatusNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = B28BBD312211DC7D00F51723 /* MSALPublicClientStatusNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B28BBD352211DC7D00F51723 /* MSALPublicClientStatusNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = B28BBD322211DC7D00F51723 /* MSALPublicClientStatusNotifications.m */; };
 		B28BBD362211DC7D00F51723 /* MSALPublicClientStatusNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = B28BBD322211DC7D00F51723 /* MSALPublicClientStatusNotifications.m */; };
@@ -718,6 +720,7 @@
 		B2734C1D21253B1B00DAB1CD /* MSALDotNetCacheCoexistenceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALDotNetCacheCoexistenceTests.m; sourceTree = "<group>"; };
 		B277241C1EAE97D700375C53 /* MSALStressTestHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSALStressTestHelper.h; sourceTree = "<group>"; };
 		B277241D1EAE97D700375C53 /* MSALStressTestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSALStressTestHelper.m; sourceTree = "<group>"; };
+		B281B33A226BC225009619AB /* MSALPublicClientApplicationConfigTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALPublicClientApplicationConfigTests.m; sourceTree = "<group>"; };
 		B28BBD312211DC7D00F51723 /* MSALPublicClientStatusNotifications.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALPublicClientStatusNotifications.h; sourceTree = "<group>"; };
 		B28BBD322211DC7D00F51723 /* MSALPublicClientStatusNotifications.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALPublicClientStatusNotifications.m; sourceTree = "<group>"; };
 		B28BDA8C217E9EAB003E5670 /* MSALOauth2FactoryProducer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALOauth2FactoryProducer.h; sourceTree = "<group>"; };
@@ -1455,6 +1458,7 @@
 				B256121A217EA44900999876 /* MSALOauth2FactoryProducerTests.m */,
 				1E8FC6A2221F370C00B4D4C1 /* MSALResultTests.m */,
 				232D6191224C53E500260C42 /* MSALClaimsRequestTests.m */,
+				B281B33A226BC225009619AB /* MSALPublicClientApplicationConfigTests.m */,
 			);
 			path = unit;
 			sourceTree = "<group>";
@@ -2463,6 +2467,7 @@
 				23CDA9B31FA45A9E00FDD5C0 /* MSALTelemetryTests.m in Sources */,
 				E02396FB1E7B005C004D6278 /* MSALTelemetryTestDispatcher.m in Sources */,
 				232D6192224C53E500260C42 /* MSALClaimsRequestTests.m in Sources */,
+				B281B33B226BC225009619AB /* MSALPublicClientApplicationConfigTests.m in Sources */,
 				D6B58A541EB2C4A8000B3A5F /* MSALAcquireTokenTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2480,6 +2485,7 @@
 				04D32CD11FD8AFF3000B123E /* MSALErrorConverterTests.m in Sources */,
 				232D6193224C53E500260C42 /* MSALClaimsRequestTests.m in Sources */,
 				D69ADB3E1E516F9B00952049 /* MSIDTestURLSession+MSAL.m in Sources */,
+				B281B33C226BC225009619AB /* MSALPublicClientApplicationConfigTests.m in Sources */,
 				960751BC2183E82C00F2BF2F /* MSALAccountIdTests.m in Sources */,
 				D69ADB361E516F9B00952049 /* MSALTestBundle.m in Sources */,
 				B2D6672D210E766F00952595 /* MSALPublicClientApplicationTests.m in Sources */,
@@ -2701,7 +2707,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MultiAppiOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "MSAL Test Automation (iOS)";
 			};
@@ -2764,7 +2770,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MultiAppiOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "MSAL Test Automation (iOS)";
 				VALIDATE_PRODUCT = YES;
@@ -2832,7 +2838,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "MSAL Test Automation (iOS)";
 			};
@@ -2895,7 +2901,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.InteractiveiOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "MSAL Test Automation (iOS)";
 				VALIDATE_PRODUCT = YES;

--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -66,7 +66,7 @@ static NSSet *s_recoverableErrorCode;
                                    // Interactive flow
                                    @(MSIDErrorAuthorizationFailed) : @(MSALInternalErrorAuthorizationFailed),
                                    @(MSIDErrorUserCancel) : @(MSALErrorUserCanceled),
-                                   @(MSIDErrorSessionCanceledProgrammatically) : @(MSALInternalErrorSessionCanceled),
+                                   @(MSIDErrorSessionCanceledProgrammatically) : @(MSALErrorUserCanceled),
                                    @(MSIDErrorInteractiveSessionStartFailure) : @(MSALErrorInternal),
                                    @(MSIDErrorInteractiveSessionAlreadyRunning) : @(MSALInternalErrorInteractiveSessionAlreadyRunning),
                                    @(MSIDErrorNoMainViewController) : @(MSALInternalErrorNoViewController),

--- a/MSAL/src/MSALPublicClientApplication+Internal.h
+++ b/MSAL/src/MSALPublicClientApplication+Internal.h
@@ -28,11 +28,13 @@
 #import "MSALPublicClientApplication.h"
 
 @class MSIDDefaultTokenCacheAccessor;
+@class MSIDAuthority;
 
 @interface MSALPublicClientApplication (Internal)
 
 @property (nonatomic, nonnull) MSIDDefaultTokenCacheAccessor *tokenCache;
 
 + (nonnull NSOrderedSet *)defaultOIDCScopes;
+- (BOOL)shouldDisableValidationForAuthority:(nonnull MSIDAuthority *)authority;
 
 @end

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -91,6 +91,7 @@
 }
 
 @property (nonatomic) MSIDDefaultTokenCacheAccessor *tokenCache;
+@property (nonatomic) MSALPublicClientApplicationConfig *internalConfig;
 
 @end
 
@@ -111,27 +112,25 @@
 }
 
 #pragma mark - Properties
-- (BOOL)validateAuthority { return _configuration.validateAuthority; }
-- (void)setValidateAuthority:(BOOL)validateAuthority { _configuration.validateAuthority = validateAuthority; }
 
-- (MSALAuthority *)authority { return self.configuration.authority; }
-- (NSString *)clientId { return self.configuration.clientId; }
-- (MSALRedirectUri *)redirectUri { return self.configuration.verifiedRedirectUri; }
+- (MSALAuthority *)authority { return self.internalConfig.authority; }
+- (NSString *)clientId { return self.internalConfig.clientId; }
+- (MSALRedirectUri *)redirectUri { return self.internalConfig.verifiedRedirectUri; }
 
-- (NSDictionary<NSString *,NSString *> *)sliceParameters { return self.configuration.sliceConfig.sliceDictionary; }
+- (NSDictionary<NSString *,NSString *> *)sliceParameters { return self.internalConfig.sliceConfig.sliceDictionary; }
 - (void)setSliceParameters:(NSDictionary<NSString *,NSString *> *)sliceParameters
 {
     if (!sliceParameters) MSID_LOG_WARN(nil, @"setting slice parameter with nil object.");
     if (!sliceParameters[@"slice"] && !sliceParameters[@"dc"]) MSID_LOG_WARN(nil, @"slice parameter does not contain slice nor dc");
     
-    self.configuration.sliceConfig = [MSALSliceConfig configWithSlice:sliceParameters[@"slice"] dc:sliceParameters[@"dc"]];
+    self.internalConfig.sliceConfig = [MSALSliceConfig configWithSlice:sliceParameters[@"slice"] dc:sliceParameters[@"dc"]];
 }
 
 - (MSALWebviewType)webviewType { return MSALGlobalConfig.defaultWebviewType; }
 - (void)setWebviewType:(MSALWebviewType)webviewType { MSALGlobalConfig.defaultWebviewType = webviewType; }
 
 #if TARGET_OS_IPHONE
-- (NSString *)keychainGroup { return _configuration.cacheConfig.keychainSharingGroup; }
+- (NSString *)keychainGroup { return self.internalConfig.cacheConfig.keychainSharingGroup; }
 #endif
 
 #pragma mark - Initializers
@@ -203,6 +202,8 @@
         return nil;
     }
     
+    _validateAuthority = YES;
+    
     // Verify required fields
     if ([NSString msidIsStringNilOrBlank:config.clientId])
     {
@@ -241,7 +242,10 @@
     MSIDDefaultTokenCacheAccessor *defaultAccessor = [[MSIDDefaultTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:nil];
     self.tokenCache = defaultAccessor;
 #endif
+    // Maintain an internal copy of config.
+    // Developers shouldn't be able to change any properties on config after PCA has been created
     _configuration = config;
+    _internalConfig = [config copy];
     
     MSIDAADNetworkConfiguration.defaultConfiguration.aadApiVersion = @"v2.0";
     
@@ -272,7 +276,7 @@
 - (NSArray <MSALAccount *> *)allAccounts:(NSError * __autoreleasing *)error
 {
     MSALAccountsProvider *request = [[MSALAccountsProvider alloc] initWithTokenCache:self.tokenCache
-                                                                            clientId:self.configuration.clientId];
+                                                                            clientId:self.internalConfig.clientId];
     NSError *msidError = nil;
     NSArray *accounts = [request allAccounts:&msidError];
     if (error) *error = [MSALErrorConverter msalErrorFromMsidError:msidError];
@@ -284,7 +288,7 @@
                                    error:(NSError * __autoreleasing *)error
 {
     MSALAccountsProvider *request = [[MSALAccountsProvider alloc] initWithTokenCache:self.tokenCache
-                                                                            clientId:self.configuration.clientId];
+                                                                            clientId:self.internalConfig.clientId];
     NSError *msidError = nil;
     MSALAccount *account = [request accountForHomeAccountId:homeAccountId error:&msidError];
 
@@ -297,7 +301,7 @@
                               error:(NSError * __autoreleasing *)error
 {
     MSALAccountsProvider *request = [[MSALAccountsProvider alloc] initWithTokenCache:self.tokenCache
-                                                                            clientId:self.configuration.clientId];
+                                                                            clientId:self.internalConfig.clientId];
     NSError *msidError = nil;
     MSALAccount *account = [request accountForUsername:username error:&msidError];
 
@@ -310,9 +314,9 @@
 - (void)allAccountsFilteredByAuthority:(MSALAccountsCompletionBlock)completionBlock
 {
     MSALAccountsProvider *request = [[MSALAccountsProvider alloc] initWithTokenCache:self.tokenCache
-                                                                            clientId:self.configuration.clientId];
+                                                                            clientId:self.internalConfig.clientId];
 
-    [request allAccountsFilteredByAuthority:self.configuration.authority
+    [request allAccountsFilteredByAuthority:self.internalConfig.authority
                             completionBlock:^(NSArray<MSALAccount *> *accounts, NSError *msidError) {
         completionBlock(accounts, [MSALErrorConverter msalErrorFromMsidError:msidError]);
     }];
@@ -713,7 +717,7 @@
                         apiId:(MSALTelemetryApiId)apiId
               completionBlock:(MSALCompletionBlock)completionBlock
 {
-    MSIDAuthority *requestAuthority = authority.msidAuthority ?: self.configuration.authority.msidAuthority;
+    MSIDAuthority *requestAuthority = authority.msidAuthority ?: self.internalConfig.authority.msidAuthority;
     NSOrderedSet *requestScopes = [[NSOrderedSet alloc] initWithArray:scopes copyItems:YES];
     NSOrderedSet *requestExtraScopes = extraScopesToConsent ? [[NSOrderedSet alloc] initWithArray:extraScopesToConsent copyItems:YES] : nil;
     NSOrderedSet *requestOIDCScopes = [self.class defaultOIDCScopes];
@@ -728,14 +732,14 @@
     {
         interactiveRequestType = MSIDInteractiveRequestLocalType;
     }
-    else if (!_configuration.verifiedRedirectUri.brokerCapable)
+    else if (!self.internalConfig.verifiedRedirectUri.brokerCapable)
     {
         interactiveRequestType = MSIDInteractiveRequestLocalType;
     }
 #endif
     MSIDInteractiveRequestParameters *params = [[MSIDInteractiveRequestParameters alloc] initWithAuthority:requestAuthority
-                                                                                               redirectUri:_configuration.verifiedRedirectUri.url.absoluteString
-                                                                                                  clientId:_configuration.clientId
+                                                                                               redirectUri:self.internalConfig.verifiedRedirectUri.url.absoluteString
+                                                                                                  clientId:self.internalConfig.clientId
                                                                                                     scopes:requestScopes
                                                                                                 oidcScopes:requestOIDCScopes
                                                                                       extraScopesToConsent:requestExtraScopes
@@ -769,29 +773,23 @@
     params.extraAuthorizeURLQueryParameters = extraQueryParameters;
     params.accountIdentifier = account.lookupAccountIdentifier;
     
-    params.extraURLQueryParameters = _configuration.extraQueryParameters.extraURLQueryParameters;
+    params.extraURLQueryParameters = self.internalConfig.extraQueryParameters.extraURLQueryParameters;
 
-    NSMutableDictionary *extraAuthorizeURLQueryParameters = [_configuration.extraQueryParameters.extraAuthorizeURLQueryParameters mutableCopy];
+    NSMutableDictionary *extraAuthorizeURLQueryParameters = [self.internalConfig.extraQueryParameters.extraAuthorizeURLQueryParameters mutableCopy];
     [extraAuthorizeURLQueryParameters addEntriesFromDictionary:extraQueryParameters];
     params.extraAuthorizeURLQueryParameters = extraAuthorizeURLQueryParameters;
-    params.extraTokenRequestParameters = _configuration.extraQueryParameters.extraTokenURLParameters;
+    params.extraTokenRequestParameters = self.internalConfig.extraQueryParameters.extraTokenURLParameters;
     
-    params.tokenExpirationBuffer = _configuration.tokenExpirationBuffer;
-    params.extendedLifetimeEnabled = _configuration.extendedLifetimeEnabled;
-    params.clientCapabilities = _configuration.clientApplicationCapabilities;
+    params.tokenExpirationBuffer = self.internalConfig.tokenExpirationBuffer;
+    params.extendedLifetimeEnabled = self.internalConfig.extendedLifetimeEnabled;
+    params.clientCapabilities = self.internalConfig.clientApplicationCapabilities;
 
-    params.validateAuthority = _configuration.validateAuthority;
+    params.validateAuthority = _validateAuthority;
     
-    if (params.validateAuthority && _configuration.knownAuthorities)
+    if (params.validateAuthority
+        && [self shouldDisableValidationForAuthority:requestAuthority])
     {
-        for (MSALAuthority *knownAuthority in _configuration.knownAuthorities)
-        {
-            if ([params.authority isKindOfClass:knownAuthority.class]
-                && [knownAuthority.url isEqual:params.authority.url])
-            {
-                params.validateAuthority = NO;
-            }
-        }
+        params.validateAuthority = NO;
     }
     
     // Configure webview
@@ -806,7 +804,7 @@
 
     params.webviewType = msidWebViewType;
     params.telemetryWebviewType = MSALStringForMSALWebviewType(webviewType);
-    params.customWebview = customWebview;
+    params.customWebview = customWebview ?: self.customWebview;
     params.claimsRequest = claimsRequest.msidClaimsRequest;
     
     MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, params,
@@ -823,7 +821,7 @@
               "                                       capabilities:%@\n"
               "                                      claimsRequest:%@]",
 
-             _PII_NULLIFY(scopes), _PII_NULLIFY(extraScopesToConsent), _PII_NULLIFY(account.homeAccountId), _PII_NULLIFY(loginHint), MSALStringForPromptType(promptType), extraQueryParameters, _PII_NULLIFY(authority), MSALStringForMSALWebviewType(webviewType), customWebview, correlationId, _configuration.clientApplicationCapabilities, claimsRequest);
+             _PII_NULLIFY(scopes), _PII_NULLIFY(extraScopesToConsent), _PII_NULLIFY(account.homeAccountId), _PII_NULLIFY(loginHint), MSALStringForPromptType(promptType), extraQueryParameters, _PII_NULLIFY(authority), MSALStringForMSALWebviewType(webviewType), params.customWebview, correlationId, self.internalConfig.clientApplicationCapabilities, claimsRequest);
     MSID_LOG_PII(MSIDLogLevelInfo, nil, params,
                  @"-[MSALPublicClientApplication acquireTokenForScopes:%@\n"
                   "                               extraScopesToConsent:%@\n"
@@ -837,7 +835,7 @@
                   "                                      correlationId:%@\n"
                   "                                       capabilities:%@\n"
                   "                                      claimsRequest:%@]",
-                 scopes, extraScopesToConsent, account.homeAccountId, loginHint, MSALStringForPromptType(promptType), extraQueryParameters, authority, MSALStringForMSALWebviewType(webviewType), customWebview, correlationId, _configuration.clientApplicationCapabilities, claimsRequest);
+                 scopes, extraScopesToConsent, account.homeAccountId, loginHint, MSALStringForPromptType(promptType), extraQueryParameters, authority, MSALStringForMSALWebviewType(webviewType), params.customWebview, correlationId, self.internalConfig.clientApplicationCapabilities, claimsRequest);
 
     MSALCompletionBlock block = ^(MSALResult *result, NSError *msidError)
     {
@@ -858,7 +856,7 @@
 
     NSError *requestError = nil;
 
-    MSIDOauth2Factory *oauth2Factory = [MSALOauth2FactoryProducer msidOauth2FactoryForAuthority:_configuration.authority.url context:nil error:&requestError];
+    MSIDOauth2Factory *oauth2Factory = [MSALOauth2FactoryProducer msidOauth2FactoryForAuthority:self.internalConfig.authority.url context:nil error:&requestError];
 
     if (!oauth2Factory)
     {
@@ -902,7 +900,7 @@
                     completionBlock:(MSALCompletionBlock)completionBlock
 {
     
-    MSIDAuthority *msidAuthority = authority.msidAuthority ?: self.configuration.authority.msidAuthority;
+    MSIDAuthority *msidAuthority = authority.msidAuthority ?: self.internalConfig.authority.msidAuthority;
 
     /*
      In the acquire token silent call we assume developer wants to get access token for account's home tenant,
@@ -918,8 +916,8 @@
 
     // add known authorities here.
     MSIDRequestParameters *params = [[MSIDRequestParameters alloc] initWithAuthority:msidAuthority
-                                                                         redirectUri:_configuration.verifiedRedirectUri.url.absoluteString
-                                                                            clientId:_configuration.clientId
+                                                                         redirectUri:self.internalConfig.verifiedRedirectUri.url.absoluteString
+                                                                            clientId:self.internalConfig.clientId
                                                                               scopes:requestScopes
                                                                           oidcScopes:requestOIDCScopes
                                                                        correlationId:correlationId
@@ -934,13 +932,19 @@
 
     // Set optional params
     params.accountIdentifier = account.lookupAccountIdentifier;
-    params.validateAuthority = _configuration.validateAuthority;
-    params.extendedLifetimeEnabled = _configuration.extendedLifetimeEnabled;
-    params.clientCapabilities = _configuration.clientApplicationCapabilities;
-    params.extraURLQueryParameters = _configuration.extraQueryParameters.extraURLQueryParameters;
-    params.extraTokenRequestParameters = _configuration.extraQueryParameters.extraTokenURLParameters;
-    params.tokenExpirationBuffer = _configuration.tokenExpirationBuffer;
+    params.validateAuthority = _validateAuthority;
+    params.extendedLifetimeEnabled = self.internalConfig.extendedLifetimeEnabled;
+    params.clientCapabilities = self.internalConfig.clientApplicationCapabilities;
+    params.extraURLQueryParameters = self.internalConfig.extraQueryParameters.extraURLQueryParameters;
+    params.extraTokenRequestParameters = self.internalConfig.extraQueryParameters.extraTokenURLParameters;
+    params.tokenExpirationBuffer = self.internalConfig.tokenExpirationBuffer;
     params.claimsRequest = claimsRequest.msidClaimsRequest;
+    
+    if (params.validateAuthority
+        && [self shouldDisableValidationForAuthority:msidAuthority])
+    {
+        params.validateAuthority = NO;
+    }
     
     MSID_LOG_NO_PII(MSIDLogLevelInfo, nil, params,
              @"-[MSALPublicClientApplication acquireTokenSilentForScopes:%@\n"
@@ -950,7 +954,7 @@
               "                                            correlationId:%@\n"
               "                                             capabilities:%@\n"
               "                                            claimsRequest:%@]",
-             _PII_NULLIFY(scopes), _PII_NULLIFY(account), _PII_NULLIFY(authority), forceRefresh ? @"Yes" : @"No", correlationId, _configuration.clientApplicationCapabilities, claimsRequest);
+             _PII_NULLIFY(scopes), _PII_NULLIFY(account), _PII_NULLIFY(authority), forceRefresh ? @"Yes" : @"No", correlationId, self.internalConfig.clientApplicationCapabilities, claimsRequest);
 
     MSID_LOG_PII(MSIDLogLevelInfo, nil, params,
                  @"-[MSALPublicClientApplication acquireTokenSilentForScopes:%@\n"
@@ -960,7 +964,7 @@
                   "                                            correlationId:%@\n"
                   "                                             capabilities:%@\n"
                   "                                            claimsRequest:%@]",
-                 scopes, account, _PII_NULLIFY(authority), forceRefresh ? @"Yes" : @"No", correlationId, _configuration.clientApplicationCapabilities, claimsRequest);
+                 scopes, account, _PII_NULLIFY(authority), forceRefresh ? @"Yes" : @"No", correlationId, self.internalConfig.clientApplicationCapabilities, claimsRequest);
 
     MSALCompletionBlock block = ^(MSALResult *result, NSError *msidError)
     {
@@ -970,7 +974,7 @@
     };
 
     NSError *requestError = nil;
-    MSIDOauth2Factory *oauth2Factory = [MSALOauth2FactoryProducer msidOauth2FactoryForAuthority:_configuration.authority.url context:nil error:&requestError];
+    MSIDOauth2Factory *oauth2Factory = [MSALOauth2FactoryProducer msidOauth2FactoryForAuthority:self.internalConfig.authority.url context:nil error:&requestError];
 
     if (!oauth2Factory)
     {
@@ -1018,7 +1022,7 @@
 
     BOOL result = [self.tokenCache clearCacheForAccount:account.lookupAccountIdentifier
                                               authority:nil
-                                               clientId:_configuration.clientId
+                                               clientId:self.internalConfig.clientId
                                                familyId:nil
                                                 context:nil
                                                   error:&msidError];
@@ -1036,7 +1040,7 @@
     MSIDAuthority *authority = [MSIDAuthorityFactory authorityFromUrl:authorityURL context:nil error:nil];
 
     BOOL metadataResult = [self.tokenCache updateAppMetadataWithFamilyId:@""
-                                                                clientId:_configuration.clientId
+                                                                clientId:self.internalConfig.clientId
                                                                authority:authority
                                                                  context:nil
                                                                    error:&metadataError];
@@ -1054,6 +1058,26 @@
 
 
 @implementation MSALPublicClientApplication (Internal)
+
+- (BOOL)shouldDisableValidationForAuthority:(MSIDAuthority *)authority
+{
+    if (self.internalConfig.knownAuthorities)
+    {
+        for (MSALAuthority *knownAuthority in self.internalConfig.knownAuthorities)
+        {
+            if ([authority isKindOfClass:knownAuthority.msidAuthority.class]
+                // Treat  AAD authorities differently, since they should always succeed validation
+                // Therefore, even if they are added to known authorities, still do validation
+                && ![authority isKindOfClass:[MSIDAADAuthority class]]
+                && [knownAuthority.url isEqual:authority.url])
+            {
+                return YES;
+            }
+        }
+    }
+    
+    return NO;
+}
 
 + (NSOrderedSet *)defaultOIDCScopes
 {

--- a/MSAL/src/configuration/MSALCacheConfig.m
+++ b/MSAL/src/configuration/MSALCacheConfig.m
@@ -64,4 +64,12 @@
 #endif
 }
 
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    NSString *keychainSharingGroup = [_keychainSharingGroup copyWithZone:zone];
+    return [[self.class alloc] initWithKeychainSharingGroup:keychainSharingGroup];
+}
+
 @end

--- a/MSAL/src/configuration/MSALExtraQueryParameters.h
+++ b/MSAL/src/configuration/MSALExtraQueryParameters.h
@@ -29,7 +29,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MSALExtraQueryParameters : NSObject
+@interface MSALExtraQueryParameters : NSObject <NSCopying>
 
 @property NSMutableDictionary<NSString *, NSString *> *extraURLQueryParameters;
 @property NSMutableDictionary<NSString *, NSString *> *extraTokenURLParameters;

--- a/MSAL/src/configuration/MSALExtraQueryParameters.m
+++ b/MSAL/src/configuration/MSALExtraQueryParameters.m
@@ -41,4 +41,15 @@
     return self;
 }
 
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    MSALExtraQueryParameters *params = [MSALExtraQueryParameters new];
+    params->_extraTokenURLParameters = [_extraTokenURLParameters mutableCopy];
+    params->_extraURLQueryParameters = [_extraURLQueryParameters mutableCopy];
+    params->_extraAuthorizeURLQueryParameters = [_extraAuthorizeURLQueryParameters mutableCopy];
+    return params;
+}
+
 @end

--- a/MSAL/src/configuration/MSALHTTPConfig.m
+++ b/MSAL/src/configuration/MSALHTTPConfig.m
@@ -49,21 +49,12 @@
 - (NSTimeInterval)retryInterval { return MSIDHttpRequest.retryIntervalSetting; }
 - (void)setRetryInterval:(NSTimeInterval)retryInterval { MSIDHttpRequest.retryIntervalSetting = retryInterval; }
 
-- (NSTimeInterval)timeoutIntervalForResource
-{
-    return MSIDURLSessionManager.defaultManager.configuration.timeoutIntervalForResource;
-}
-- (void)setTimeoutIntervalForResource:(NSTimeInterval)timeoutIntervalForResource
-{
-    MSIDURLSessionManager.defaultManager.configuration.timeoutIntervalForResource = timeoutIntervalForResource;
-}
-
 - (NSTimeInterval)timeoutIntervalForRequest {
-    return MSIDURLSessionManager.defaultManager.configuration.timeoutIntervalForRequest;
+    return MSIDHttpRequest.requestTimeoutInterval;
 }
 - (void)setTimeoutIntervalForRequest:(NSTimeInterval)timeoutIntervalForRequest
 {
-    MSIDURLSessionManager.defaultManager.configuration.timeoutIntervalForRequest = timeoutIntervalForRequest;
+    MSIDHttpRequest.requestTimeoutInterval = timeoutIntervalForRequest;
 }
 
 @end

--- a/MSAL/src/configuration/MSALSliceConfig.m
+++ b/MSAL/src/configuration/MSALSliceConfig.m
@@ -59,4 +59,14 @@
     return dict;
 }
 
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    NSString *dc = [_dc copyWithZone:zone];
+    NSString *slice = [_slice copyWithZone:zone];
+    MSALSliceConfig *config = [[MSALSliceConfig alloc] initWithSlice:slice dc:dc];
+    return config;
+}
+
 @end

--- a/MSAL/src/instance/MSALAuthority.m
+++ b/MSAL/src/instance/MSALAuthority.m
@@ -45,4 +45,46 @@
                                             error:error];
 }
 
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    MSALAuthority *authority = [[self.class alloc] init];
+    authority->_msidAuthority = [_msidAuthority copyWithZone:zone];
+    return authority;
+}
+
+#pragma mark - NSObject
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object)
+    {
+        return YES;
+    }
+    
+    if (![object isKindOfClass:MSALAuthority.class])
+    {
+        return NO;
+    }
+    
+    return [self isEqualToAuthority:(MSALAuthority *)object];
+}
+
+- (NSUInteger)hash
+{
+    NSUInteger hash = 0;
+    hash = hash * 31 + self.msidAuthority.hash;
+    return hash;
+}
+
+- (BOOL)isEqualToAuthority:(MSALAuthority *)authority
+{
+    if (!authority) return NO;
+    
+    BOOL result = YES;
+    result &= (!self.msidAuthority && !authority.msidAuthority) || [self.msidAuthority isEqual:authority.msidAuthority];
+    return result;
+}
+
 @end

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -66,4 +66,6 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALIndividualClaimRequestAdditionalInfo.h>
 #import <MSAL/MSALJsonSerializable.h>
 #import <MSAL/MSALJsonDeserializable.h>
+#import <MSAL/MSALLogger.h>
+#import <MSAL/MSALTelemetry.h>
 

--- a/MSAL/src/public/MSALAuthority.h
+++ b/MSAL/src/public/MSALAuthority.h
@@ -29,7 +29,7 @@
 
 @protocol MSIDRequestContext;
 
-@interface MSALAuthority : NSObject
+@interface MSALAuthority : NSObject <NSCopying>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -53,7 +53,7 @@
     templates representing well-formed authorities. It is useful when the authority is obtained at
     run time to prevent MSAL from displaying authentication prompts from malicious pages.
  */
-@property BOOL validateAuthority;
+@property BOOL validateAuthority DEPRECATED_MSG_ATTRIBUTE("MSALPublicClientApplicationConfig.knownAuthorities instead");
 
 /*! The authority the application will use to obtain tokens */
 @property (readonly, nonnull) MSALAuthority *authority;
@@ -84,6 +84,10 @@
 
 /*!
  Initialize a MSALPublicClientApplication with a given configuration
+ 
+ Note, it is important to configure your MSALPublicClientApplicationConfig object before calling MSALPublicClientApplication's initializer.
+ MSALPublicClientApplication  makes a copy of the configuration object you provide on initialization.
+ Once configured, MSALPublicClientApplication object ignores any changes you make to the MSALPublicClientApplicationConfig object.
  
  @param  config       Configuration for PublicClientApplication
  @param  error        The error that occurred creating the application object, if any (optional)

--- a/MSAL/src/public/MSALRedirectUri.h
+++ b/MSAL/src/public/MSALRedirectUri.h
@@ -29,7 +29,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MSALRedirectUri : NSObject
+@interface MSALRedirectUri : NSObject <NSCopying>
 
 /* Redirect URI that will be used for network requests */
 @property (nonatomic, readonly) NSURL *url;

--- a/MSAL/src/public/configuration/MSALPublicClientApplicationConfig.h
+++ b/MSAL/src/public/configuration/MSALPublicClientApplicationConfig.h
@@ -36,7 +36,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MSALPublicClientApplicationConfig : NSObject
+@interface MSALPublicClientApplicationConfig : NSObject <NSCopying>
 
 /*! The client ID of the application, this should come from the app developer portal. */
 @property NSString *clientId;
@@ -53,15 +53,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property NSArray<MSALAuthority *> *knownAuthorities;
 
-/*!
- When set to YES (default), MSAL will compare the application's authority against well-known URLs
- templates representing well-formed authorities. It is useful when the authority is obtained at
- run time to prevent MSAL from displaying authentication prompts from malicious pages.
- 
- Authorities that are in knownAuthorities will not be validated regardless of this setting.
- */
-@property BOOL validateAuthority;
-
 /*! Enable to return access token with extended lifttime during server outage. */
 @property BOOL extendedLifetimeEnabled;
 
@@ -75,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property double tokenExpirationBuffer;
 
 /*! slice configuration for testing. */
-@property(nullable) MSALSliceConfig *sliceConfig;
+@property (nullable) MSALSliceConfig *sliceConfig;
 
 /*! Cache configurations, refer to MSALCacheConfig.h for more detail */
 @property (readonly) MSALCacheConfig *cacheConfig;

--- a/MSAL/src/public/configuration/global/MSALHTTPConfig.h
+++ b/MSAL/src/public/configuration/global/MSALHTTPConfig.h
@@ -42,17 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSTimeInterval retryInterval;
 
 /*!
- The maximum amount of time that a resource request should be allowed to take.
- visit https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1408259-timeoutintervalforrequest?language=objc
- for more detail.
- */
-@property NSTimeInterval timeoutIntervalForResource; // In miliseconds
-/*!
  The timeout interval to use when waiting for additional data.
  visit https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1408153-timeoutintervalforresource?language=objc
  for more detail.
  */
-@property NSTimeInterval timeoutIntervalForRequest;  // In miliseconds
+@property NSTimeInterval timeoutIntervalForRequest;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
 + (nonnull instancetype)new NS_UNAVAILABLE;

--- a/MSAL/src/public/configuration/publicClientApplication/MSALCacheConfig.h
+++ b/MSAL/src/public/configuration/publicClientApplication/MSALCacheConfig.h
@@ -29,7 +29,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MSALCacheConfig : NSObject
+@interface MSALCacheConfig : NSObject <NSCopying>
 
 /*!
     The keychain sharing group to use for the token cache.

--- a/MSAL/src/public/configuration/publicClientApplication/MSALSliceConfig.h
+++ b/MSAL/src/public/configuration/publicClientApplication/MSALSliceConfig.h
@@ -29,7 +29,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MSALSliceConfig : NSObject
+@interface MSALSliceConfig : NSObject <NSCopying>
 
 @property NSString *slice;
 @property NSString *dc;

--- a/MSAL/src/util/MSALRedirectUri.m
+++ b/MSAL/src/util/MSALRedirectUri.m
@@ -43,4 +43,13 @@
     return self;
 }
 
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    NSURL *url = [_url copyWithZone:zone];
+    MSALRedirectUri *redirectUri = [[MSALRedirectUri alloc] initWithRedirectUri:url brokerCapable:_brokerCapable];
+    return redirectUri;
+}
+
 @end

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -45,6 +45,7 @@
 #import "MSALAuthority.h"
 #import <MSAL/MSALGlobalConfig.h>
 #import <MSAL/MSALLoggerConfig.h>
+#import "MSALHTTPConfig.h"
 
 #define TEST_EMBEDDED_WEBVIEW_TYPE_INDEX 0
 #define TEST_SYSTEM_WEBVIEW_TYPE_INDEX 1
@@ -493,7 +494,10 @@
     MSALPublicClientApplicationConfig *pcaConfig = [[MSALPublicClientApplicationConfig alloc] initWithClientId:clientId
                                                                                                    redirectUri:redirectUri
                                                                                                      authority:authority];
-    pcaConfig.validateAuthority = (_validateAuthority.selectedSegmentIndex == 0);
+    if (_validateAuthority.selectedSegmentIndex == 1)
+    {
+        pcaConfig.knownAuthorities = @[pcaConfig.authority];
+    }
     
     MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:pcaConfig error:&error];
     
@@ -593,7 +597,10 @@
                                                                                                    redirectUri:redirectUri
                                                                                                      authority:authority];
     
-    pcaConfig.validateAuthority = (_validateAuthority.selectedSegmentIndex == 0);
+    if (_validateAuthority.selectedSegmentIndex == 1)
+    {
+        pcaConfig.knownAuthorities = @[pcaConfig.authority];
+    }
     
     MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:pcaConfig error:&error];
     if (!application)

--- a/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenAction.m
@@ -86,13 +86,18 @@
     NSOrderedSet *extraScopes = [NSOrderedSet msidOrderedSetFromString:testRequest.extraScopes];
     NSUUID *correlationId = [NSUUID new];
     
-    NSError *claimsError;
-    MSALClaimsRequest *claimsRequest = [[MSALClaimsRequest alloc] initWithJsonString:testRequest.claims error:&claimsError];
-    if (claimsError)
+    MSALClaimsRequest *claimsRequest = nil;
+    
+    if (testRequest.claims.length)
     {
-        MSIDAutomationTestResult *result = [self testResultWithMSALError:claimsError];
-        completionBlock(result);
-        return;
+        NSError *claimsError;
+        claimsRequest = [[MSALClaimsRequest alloc] initWithJsonString:testRequest.claims error:&claimsError];
+        if (claimsError)
+        {
+            MSIDAutomationTestResult *result = [self testResultWithMSALError:claimsError];
+            completionBlock(result);
+            return;
+        }
     }
     
     NSDictionary *extraQueryParameters = testRequest.extraQueryParameters;
@@ -159,6 +164,8 @@
         parameters.customWebview = containerController.passedinWebView;
         [containerController showPassedInWebViewControllerWithContext:@{@"context": application}];
     }
+    
+    NSLog(@"Application: %@", application);
     
     [application acquireTokenWithParameters:parameters completionBlock:^(MSALResult *result, NSError *error)
      {

--- a/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenAction.m
@@ -164,9 +164,7 @@
         parameters.customWebview = containerController.passedinWebView;
         [containerController showPassedInWebViewControllerWithContext:@{@"context": application}];
     }
-    
-    NSLog(@"Application: %@", application);
-    
+        
     [application acquireTokenWithParameters:parameters completionBlock:^(MSALResult *result, NSError *error)
      {
          MSIDAutomationTestResult *testResult = [self testResultWithMSALResult:result error:error];

--- a/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenSilentAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenSilentAction.m
@@ -35,6 +35,7 @@
 #import "MSIDAutomationErrorResult.h"
 #import "MSALSilentTokenParameters.h"
 #import "MSALError.h"
+#import "MSALClaimsRequest.h"
 
 @implementation MSALAutomationAcquireTokenSilentAction
 
@@ -101,6 +102,20 @@
     {
         // In case we want to pass a different authority to silent call, we can use "silent authority" parameter
         silentAuthority = [MSALAuthority authorityWithURL:[NSURL URLWithString:testRequest.acquireTokenAuthority] error:nil];
+    }
+    
+    MSALClaimsRequest *claimsRequest = nil;
+    
+    if (testRequest.claims.length)
+    {
+        NSError *claimsError;
+        claimsRequest = [[MSALClaimsRequest alloc] initWithJsonString:testRequest.claims error:&claimsError];
+        if (claimsError)
+        {
+            MSIDAutomationTestResult *result = [self testResultWithMSALError:claimsError];
+            completionBlock(result);
+            return;
+        }
     }
     
     MSALSilentTokenParameters *parameters = [[MSALSilentTokenParameters alloc] initWithScopes:[scopes array] account:account];

--- a/MSAL/test/automation/ios/actions/MSALAutomationBaseAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationBaseAction.m
@@ -97,7 +97,12 @@
     MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:parameters.clientId
                                                                                                 redirectUri:parameters.redirectUri
                                                                                                   authority:authority];
-    config.validateAuthority = validateAuthority;
+    
+    if (!validateAuthority)
+    {
+        config.knownAuthorities = @[config.authority];
+    }
+    
     config.sliceConfig = [[MSALSliceConfig alloc] initWithSlice:parameters.sliceParameters[@"slice"] dc:parameters.sliceParameters[@"dc"]];
     
     MSALPublicClientApplication *clientApplication = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:error];

--- a/MSAL/test/automation/tests/MSALBaseAADUITest.m
+++ b/MSAL/test/automation/tests/MSALBaseAADUITest.m
@@ -95,8 +95,8 @@
 
     [self assertAuthUIAppearsUsingEmbeddedWebView:request.usesEmbeddedWebView];
     [self closeAuthUIUsingWebViewType:request.webViewType passedInWebView:request.usePassedWebView];
-
-    [self assertErrorCode:request.usePassedWebView ? MSALInternalErrorSessionCanceled : MSALErrorUserCanceled];
+    
+    [self assertErrorCode:MSALErrorUserCanceled];
     [self closeResultView];
 }
 

--- a/MSAL/test/automation/tests/MSALBaseUITest.h
+++ b/MSAL/test/automation/tests/MSALBaseUITest.h
@@ -43,6 +43,7 @@
 - (void)assertAccessTokenExpired;
 - (void)assertAuthUIAppearsUsingEmbeddedWebView:(BOOL)useEmbedded;
 - (void)assertErrorCode:(NSInteger)expectedErrorCode;
+- (void)assertInternalErrorCode:(NSInteger)internalErrorCode;
 - (void)assertErrorDescription:(NSString *)errorDescription;
 - (void)assertErrorSubcode:(NSString *)errorSubcode;
 - (void)assertAccessTokenNotNil;

--- a/MSAL/test/automation/tests/MSALBaseUITest.m
+++ b/MSAL/test/automation/tests/MSALBaseUITest.m
@@ -111,6 +111,12 @@ static MSIDTestConfigurationProvider *s_confProvider;
     XCTAssertEqual(expectedErrorCode, result.errorCode);
 }
 
+- (void)assertInternalErrorCode:(NSInteger)internalErrorCode
+{
+    MSIDAutomationErrorResult *result = [self automationErrorResult];
+    XCTAssertEqual(internalErrorCode, [result.errorUserInfo[MSALInternalErrorCodeKey] integerValue]);
+}
+
 - (void)assertErrorDescription:(NSString *)errorDescription
 {
     MSIDAutomationErrorResult *result = [self automationErrorResult];

--- a/MSAL/test/automation/tests/MSALBaseiOSUITest.m
+++ b/MSAL/test/automation/tests/MSALBaseiOSUITest.m
@@ -161,6 +161,7 @@
         XCUIApplication *springBoardApp = [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
         __auto_type allowButton = springBoardApp.alerts.buttons[@"Continue"];
         [self waitForElement:allowButton];
+        sleep(1);
         [allowButton tap];
     }
 }

--- a/MSAL/test/automation/tests/interactive/MSALAADBasicInteractiveTests.m
+++ b/MSAL/test/automation/tests/interactive/MSALAADBasicInteractiveTests.m
@@ -99,7 +99,7 @@
     request.requestScopes = [self.class.confProvider scopesForEnvironment:self.testEnvironment type:@"unsupported"];
     NSDictionary *config = [self configWithTestRequest:request];
     [self acquireTokenSilent:config];
-    [self assertErrorCode:MSALInternalErrorInvalidScope];
+    [self assertInternalErrorCode:MSALInternalErrorInvalidScope];
     [self closeResultView];
 
     // 6. Run silent with not consented scopes
@@ -342,7 +342,7 @@
     XCUIElement *acceptButton = self.testApp.webViews.buttons[@"Cancel"];
     [acceptButton msidTap];
 
-    [self assertErrorCode:MSALInternalErrorAuthorizationFailed];
+    [self assertInternalErrorCode:MSALInternalErrorAuthorizationFailed];
 }
 
 #pragma mark - MDM
@@ -413,7 +413,7 @@
     [self waitForElement:getTheAppButton];
     [self.testApp activate];
 
-    [self assertErrorCode:MSALInternalErrorSessionCanceled];
+    [self assertErrorCode:MSALErrorUserCanceled];
 }
 
 #pragma mark - Login hint

--- a/MSAL/test/automation/tests/interactive/MSALAADMultiUserTests.m
+++ b/MSAL/test/automation/tests/interactive/MSALAADMultiUserTests.m
@@ -139,13 +139,18 @@
     XCUIElement *signIn = self.testApp.staticTexts[@"Sign in with another account"];
     [self waitForElement:signIn];
     [signIn msidTap];
+    
+    XCUIElement *otherAccount = self.testApp.staticTexts[@"Use another account"];
+    [self waitForElement:otherAccount];
+    [otherAccount msidTap];
 
     self.primaryAccount = self.testConfiguration.accounts[1];
     [self loadPasswordForAccount:self.primaryAccount];
     [self aadEnterEmail];
     [self aadEnterPassword];
     [self acceptMSSTSConsentIfNecessary:@"Accept" embeddedWebView:NO];
-    [self assertErrorCode:MSALInternalErrorMismatchedUser];
+    [self assertErrorCode:MSALErrorInternal];
+    [self assertInternalErrorCode:MSALInternalErrorMismatchedUser];
 }
 
 @end

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -688,17 +688,17 @@
          completionHandler(oauthResponse, nil);
      }];
     
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID
+                                                                                                redirectUri:nil
+                                                                                                  authority:[DEFAULT_TEST_AUTHORITY msalAuthority]];
+    config.clientApplicationCapabilities = @[@"llt"];
+    
     // Acquire token call
     NSError *error = nil;
-    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
-                                                                                           authority:[DEFAULT_TEST_AUTHORITY msalAuthority]
-                                                                                               error:&error];
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
     XCTAssertNotNil(application);
     XCTAssertNil(error);
     
-    
-    application.configuration.clientApplicationCapabilities = @[@"llt"];
-
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"acquireToken"];
@@ -787,17 +787,18 @@
          completionHandler(oauthResponse, nil);
      }];
     
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID
+                                                                                                redirectUri:nil
+                                                                                                  authority:[DEFAULT_TEST_AUTHORITY msalAuthority]];
+    config.clientApplicationCapabilities = @[@"llt"];;
+    
     // Acquire token call
     NSError *error = nil;
-    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
-                                                                                           authority:[DEFAULT_TEST_AUTHORITY msalAuthority]
-                                                                                               error:&error];
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
     XCTAssertNotNil(application);
     XCTAssertNil(error);
 
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
-    
-    application.configuration.clientApplicationCapabilities = @[@"llt"];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"acquireToken"];
     application.webviewType = MSALWebviewTypeWKWebView;
@@ -1089,13 +1090,14 @@
     [MSIDTestURLSession addResponse:tokenResponse]; //Add the responsce twice because retry will happen
     [MSIDTestURLSession addResponse:tokenResponse];
     
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID];
+    config.extendedLifetimeEnabled = YES; //Turn on extended lifetime token
+    
     // Enable extended lifetime token and acquire token
     NSError *error = nil;
-    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
-                                                                                               error:&error];
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
     XCTAssertNotNil(application);
     application.tokenCache = self.tokenCache;
-    application.configuration.extendedLifetimeEnabled = YES; //Turn on extended lifetime token
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentForScopes"];
     [application acquireTokenSilentForScopes:@[@"user.read"]
@@ -1159,13 +1161,14 @@
     [MSIDTestURLSession addResponse:tokenResponse]; //Add the responsce twice because retry will happen
     [MSIDTestURLSession addResponse:tokenResponse];
     
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID];
+    config.extendedLifetimeEnabled = NO;
+    
     // Enable extended lifetime token and acquire token
     NSError *error = nil;
-    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
-                                                                                               error:&error];
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
     XCTAssertNotNil(application);
     application.tokenCache = self.tokenCache;
-    application.configuration.extendedLifetimeEnabled = NO; //default is NO
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentForScopes"];
     [application acquireTokenSilentForScopes:@[@"user.read"]
@@ -1364,12 +1367,14 @@
     [MSIDTestURLSession addResponse:tokenResponse];
     
     // Enable extended lifetime token and acquire token
+    
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID];
+    config.extendedLifetimeEnabled = YES;
+    
     NSError *error = nil;
-    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
-                                                                                               error:&error];
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
     XCTAssertNotNil(application);
     application.tokenCache = self.tokenCache;
-    application.configuration.extendedLifetimeEnabled = YES; //Turn on extended lifetime token
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentForScopes"];
     [application acquireTokenSilentForScopes:@[@"user.read"]
@@ -1665,15 +1670,15 @@
     MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:authority];
     [MSIDTestURLSession addResponses:@[discoveryResponse, oidcResponse]];
     
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID];
+    config.clientApplicationCapabilities = @[@"cp1"];
+    
     // Acquire a token silently
     NSError *error = nil;
     MSALPublicClientApplication *application =
-    [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
-                                                    error:&error];
+    [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
     XCTAssertNotNil(application);
     application.tokenCache = self.tokenCache;
-    
-    application.configuration.clientApplicationCapabilities = @[@"cp1"];
     
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"preferredUserName"
                                                             name:@"user@contoso.com"
@@ -1732,15 +1737,15 @@
     MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:authority];
     [MSIDTestURLSession addResponses:@[discoveryResponse, oidcResponse]];
     
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID];
+    config.clientApplicationCapabilities = @[@"cp1"];
+    
     // Acquire a token silently
     NSError *error = nil;
     MSALPublicClientApplication *application =
-    [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
-                                                    error:&error];
+    [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
     XCTAssertNotNil(application);
     application.tokenCache = self.tokenCache;
-    
-    application.configuration.clientApplicationCapabilities = @[@"cp1"];
     
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"preferredUserName"
                                                             name:@"user@contoso.com"
@@ -1823,14 +1828,15 @@
     [MSIDTestURLSession addResponses:@[tokenResponse]];
     
     // Acquire a token silently
+    
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID];
+    config.clientApplicationCapabilities = @[@"cp1", @"llt"];
+    
     NSError *error = nil;
     MSALPublicClientApplication *application =
-    [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
-                                                    error:&error];
+    [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
     XCTAssertNotNil(application);
     application.tokenCache = self.tokenCache;
-    
-    application.configuration.clientApplicationCapabilities = @[@"cp1", @"llt"];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentForScopes"];
     [application acquireTokenSilentForScopes:@[@"user.read"]
@@ -1907,14 +1913,15 @@
     [MSIDTestURLSession addResponses:@[tokenResponse]];
     
     // Acquire a token silently
+    
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID];
+    config.clientApplicationCapabilities = @[@"llt"];
+    
     NSError *error = nil;
     MSALPublicClientApplication *application =
-    [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
-                                                    error:&error];
+    [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
     XCTAssertNotNil(application);
     application.tokenCache = self.tokenCache;
-    
-    application.configuration.clientApplicationCapabilities = @[@"llt"];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentForScopes"];
     [application acquireTokenSilentForScopes:@[@"user.read"]

--- a/MSAL/test/unit/MSALPublicClientApplicationConfigTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationConfigTests.m
@@ -54,7 +54,9 @@
     XCTAssertNil(config.sliceConfig.slice);
     XCTAssertNil(config.sliceConfig);
     XCTAssertNotNil(config.cacheConfig);
+#if TARGET_OS_IPHONE
     XCTAssertEqualObjects(config.cacheConfig.keychainSharingGroup, @"com.microsoft.adalcache");
+#endif
     XCTAssertNil(config.verifiedRedirectUri);
     XCTAssertNotNil(config.extraQueryParameters);
     XCTAssertFalse(config.extendedLifetimeEnabled);
@@ -76,7 +78,9 @@
     XCTAssertNil(config.sliceConfig.slice);
     XCTAssertNil(config.sliceConfig);
     XCTAssertNotNil(config.cacheConfig);
+#if TARGET_OS_IPHONE
     XCTAssertEqualObjects(config.cacheConfig.keychainSharingGroup, @"com.microsoft.adalcache");
+#endif
     XCTAssertNil(config.verifiedRedirectUri);
     XCTAssertNotNil(config.extraQueryParameters);
     XCTAssertFalse(config.extendedLifetimeEnabled);
@@ -100,7 +104,9 @@
     XCTAssertNil(copiedConfig.sliceConfig.slice);
     XCTAssertNil(copiedConfig.sliceConfig);
     XCTAssertNotNil(copiedConfig.cacheConfig);
+#if TARGET_OS_IPHONE
     XCTAssertEqualObjects(copiedConfig.cacheConfig.keychainSharingGroup, @"com.microsoft.adalcache");
+#endif
     XCTAssertNil(copiedConfig.verifiedRedirectUri);
     XCTAssertNotNil(copiedConfig.extraQueryParameters);
     XCTAssertFalse(copiedConfig.extendedLifetimeEnabled);
@@ -134,7 +140,9 @@
     XCTAssertEqualObjects(copiedConfig.sliceConfig.slice, @"myslice");
     XCTAssertNotNil(copiedConfig.sliceConfig);
     XCTAssertNotNil(copiedConfig.cacheConfig);
+#if TARGET_OS_IPHONE
     XCTAssertEqualObjects(copiedConfig.cacheConfig.keychainSharingGroup, @"my.test.group");
+#endif
     XCTAssertNil(copiedConfig.verifiedRedirectUri);
     XCTAssertNotNil(copiedConfig.extraQueryParameters);
     NSDictionary *expectedQP = @{@"slice":@"myslice", @"dc": @"mydc"};

--- a/MSAL/test/unit/MSALPublicClientApplicationConfigTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationConfigTests.m
@@ -1,0 +1,147 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <XCTest/XCTest.h>
+#import "MSALPublicClientApplicationConfig.h"
+#import "MSALAADAuthority.h"
+#import "MSALSliceConfig.h"
+#import "MSALCacheConfig.h"
+#import "MSALPublicClientApplicationConfig+Internal.h"
+#import "MSALExtraQueryParameters.h"
+
+@interface MSALPublicClientApplicationConfigTests : XCTestCase
+
+@end
+
+@implementation MSALPublicClientApplicationConfigTests
+
+- (void)testInitWithClient_shouldSetClientId_andInitializeDefaultValues
+{
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"test_client_id"];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(config.clientId, @"test_client_id");
+    XCTAssertNil(config.redirectUri);
+    NSURL *expectedAuthorityURL = [NSURL URLWithString:@"https://login.microsoftonline.com/common"];
+    XCTAssertEqualObjects(config.authority.url, expectedAuthorityURL);
+    XCTAssertNil(config.knownAuthorities);
+    XCTAssertNil(config.clientApplicationCapabilities);
+    XCTAssertEqualWithAccuracy(config.tokenExpirationBuffer, 300, 1);
+    XCTAssertNil(config.sliceConfig.dc);
+    XCTAssertNil(config.sliceConfig.slice);
+    XCTAssertNil(config.sliceConfig);
+    XCTAssertNotNil(config.cacheConfig);
+    XCTAssertEqualObjects(config.cacheConfig.keychainSharingGroup, @"com.microsoft.adalcache");
+    XCTAssertNil(config.verifiedRedirectUri);
+    XCTAssertNotNil(config.extraQueryParameters);
+    XCTAssertFalse(config.extendedLifetimeEnabled);
+}
+
+- (void)testInitWithClientId_andRedirectUri_andAuthority_shouldSetParameters_andInitializeDefaultValues
+{
+    MSALAADAuthority *testAuthority = [[MSALAADAuthority alloc] initWithURL:[NSURL URLWithString:@"https://login.microsoftonline.com/mytesttenant"] error:nil];
+    
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"test_client_id" redirectUri:@"testredirect" authority:testAuthority];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(config.clientId, @"test_client_id");
+    XCTAssertEqualObjects(config.redirectUri, @"testredirect");
+    XCTAssertEqualObjects(config.authority.url, testAuthority.url);
+    XCTAssertNil(config.knownAuthorities);
+    XCTAssertNil(config.clientApplicationCapabilities);
+    XCTAssertEqualWithAccuracy(config.tokenExpirationBuffer, 300, 1);
+    XCTAssertNil(config.sliceConfig.dc);
+    XCTAssertNil(config.sliceConfig.slice);
+    XCTAssertNil(config.sliceConfig);
+    XCTAssertNotNil(config.cacheConfig);
+    XCTAssertEqualObjects(config.cacheConfig.keychainSharingGroup, @"com.microsoft.adalcache");
+    XCTAssertNil(config.verifiedRedirectUri);
+    XCTAssertNotNil(config.extraQueryParameters);
+    XCTAssertFalse(config.extendedLifetimeEnabled);
+}
+
+- (void)testCopyConfig_whenNotAllConfigSet_shouldCreateExactCopy
+{
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"test_client_id"];
+    XCTAssertNotNil(config);
+    
+    MSALPublicClientApplicationConfig *copiedConfig = [config copy];
+    
+    XCTAssertEqualObjects(copiedConfig.clientId, @"test_client_id");
+    XCTAssertNil(copiedConfig.redirectUri);
+    NSURL *expectedAuthorityURL = [NSURL URLWithString:@"https://login.microsoftonline.com/common"];
+    XCTAssertEqualObjects(copiedConfig.authority.url, expectedAuthorityURL);
+    XCTAssertNil(copiedConfig.knownAuthorities);
+    XCTAssertNil(copiedConfig.clientApplicationCapabilities);
+    XCTAssertEqualWithAccuracy(copiedConfig.tokenExpirationBuffer, 300, 1);
+    XCTAssertNil(copiedConfig.sliceConfig.dc);
+    XCTAssertNil(copiedConfig.sliceConfig.slice);
+    XCTAssertNil(copiedConfig.sliceConfig);
+    XCTAssertNotNil(copiedConfig.cacheConfig);
+    XCTAssertEqualObjects(copiedConfig.cacheConfig.keychainSharingGroup, @"com.microsoft.adalcache");
+    XCTAssertNil(copiedConfig.verifiedRedirectUri);
+    XCTAssertNotNil(copiedConfig.extraQueryParameters);
+    XCTAssertFalse(copiedConfig.extendedLifetimeEnabled);
+}
+
+- (void)testCopyConfig_whenAllConfigSet_shouldCreateExactCopy
+{
+    MSALAADAuthority *testAuthority = [[MSALAADAuthority alloc] initWithURL:[NSURL URLWithString:@"https://login.microsoftonline.com/mytesttenant"] error:nil];
+    MSALAADAuthority *knownAuthority = [[MSALAADAuthority alloc] initWithURL:[NSURL URLWithString:@"https://login.microsoftonline.com/myknowntenant"] error:nil];
+    
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"test_client_id" redirectUri:@"testredirect" authority:testAuthority];
+    config.knownAuthorities = @[knownAuthority];
+    config.clientApplicationCapabilities = @[@"cp1", @"cp2"];
+    config.tokenExpirationBuffer = 333;
+    config.sliceConfig = [[MSALSliceConfig alloc] initWithSlice:@"myslice" dc:@"mydc"];
+    config.cacheConfig.keychainSharingGroup = @"my.test.group";
+    config.extendedLifetimeEnabled = YES;
+    
+    MSALPublicClientApplicationConfig *copiedConfig = [config copy];
+    XCTAssertNotNil(copiedConfig);
+    XCTAssertEqualObjects(copiedConfig.clientId, @"test_client_id");
+    XCTAssertEqualObjects(copiedConfig.redirectUri, @"testredirect");
+    XCTAssertEqualObjects(copiedConfig.authority.url, testAuthority.url);
+    XCTAssertEqual([copiedConfig.knownAuthorities count], 1);
+    XCTAssertEqualObjects(copiedConfig.knownAuthorities[0].url, knownAuthority.url);
+    XCTAssertEqual([copiedConfig.clientApplicationCapabilities count], 2);
+    NSArray *expectedCapabilities = @[@"cp1", @"cp2"];
+    XCTAssertEqualObjects(copiedConfig.clientApplicationCapabilities, expectedCapabilities);
+    XCTAssertEqualWithAccuracy(copiedConfig.tokenExpirationBuffer, 333, 1);
+    XCTAssertEqualObjects(copiedConfig.sliceConfig.dc, @"mydc");
+    XCTAssertEqualObjects(copiedConfig.sliceConfig.slice, @"myslice");
+    XCTAssertNotNil(copiedConfig.sliceConfig);
+    XCTAssertNotNil(copiedConfig.cacheConfig);
+    XCTAssertEqualObjects(copiedConfig.cacheConfig.keychainSharingGroup, @"my.test.group");
+    XCTAssertNil(copiedConfig.verifiedRedirectUri);
+    XCTAssertNotNil(copiedConfig.extraQueryParameters);
+    NSDictionary *expectedQP = @{@"slice":@"myslice", @"dc": @"mydc"};
+    XCTAssertEqualObjects(copiedConfig.extraQueryParameters.extraURLQueryParameters, expectedQP);
+    XCTAssertEqualObjects(copiedConfig.extraQueryParameters.extraAuthorizeURLQueryParameters, @{});
+    XCTAssertEqualObjects(copiedConfig.extraQueryParameters.extraTokenURLParameters, @{});
+    XCTAssertTrue(copiedConfig.extendedLifetimeEnabled);
+}
+
+@end


### PR DESCRIPTION
Fixes for following issues:
1. Translate programmatic cancel error to user cancel for MSAL (otherwise developer using passed in web view would need to look for internal error)
2. Don’t let configuration be editable after Public client is created, so copy it (follows the logic of NSURLSessionConfiguration)
3. Deprecate validateAuthority flag in public client application (Android already removed the flag, so might be a good idea to deprecate it)
4. Removes validateAuthority flag from public client conf (since we’re trying to get rid of the flag, no need to add new place for it)
5. Added known authorities logic for acquire token silent
6. Fixed known authorities logic: previously it was always comparing MSALAuthority with MSIDAuthority which failed
7. Added an exception for AAD authority: even if it’s a known authority, validate it
8. Fixed customWebView being not picked up from public client application
9. Fixed setting timeout interval in MSALHttpConfig: the problem here is that after session is created, modifying config doesn’t have any effect. Recreating session in the middle of something is not a good idea either. Therefore, I removed second timeout setting and only left per request timeout, as a short term fix. We can add second timeout in future separately once we figure out how to modify session settings.