### PR TITLE
BugFix: MSALTestApp does not support default profile

### DIFF
--- a/MSAL/test/app/MSALTestAppSettings.m
+++ b/MSAL/test/app/MSALTestAppSettings.m
@@ -176,6 +176,9 @@ static NSDictionary *s_currentProfile = nil;
 
 - (void)readFromDefaults
 {
+    s_currentProfileIdx = 0;
+    s_currentProfile = [s_profiles objectForKey:[s_profileTitles objectAtIndex:s_currentProfileIdx]];
+    
     NSDictionary *settings = [[NSUserDefaults standardUserDefaults] dictionaryForKey:MSAL_APP_SETTINGS_KEY];
     if (!settings)
     {
@@ -183,16 +186,11 @@ static NSDictionary *s_currentProfile = nil;
     }
     
     NSString* currentProfile = [settings objectForKey:MSAL_APP_PROFILE];
-    if (!currentProfile)
-    {
-        s_currentProfileIdx = 0;
-    }
-    else
+    if (currentProfile)
     {
         s_currentProfileIdx = [s_profileTitles indexOfObject:currentProfile];
+        s_currentProfile = [s_profiles objectForKey:[s_profileTitles objectAtIndex:s_currentProfileIdx]];
     }
-    
-    s_currentProfile = [s_profiles objectForKey:[s_profileTitles objectAtIndex:s_currentProfileIdx]];
     
     NSString *authorityString = [settings objectForKey:@"authority"];
     if (authorityString)


### PR DESCRIPTION
Default profile was never set when settings was nil. Modified code to set the default profile in all cases and update it when different profile is selected. 