### PR TITLE
Move homeAccountId to category

### DIFF
--- a/MSAL/src/MSALAccount+Internal.h
+++ b/MSAL/src/MSALAccount+Internal.h
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 #import "MSALAccount.h"
+#import "MSALTenantProfile+Internal.h"
 
 @class MSIDAccountIdentifier;
 @class MSIDAADV2IdTokenClaims;

--- a/MSAL/src/public/MSALAccount+MultiTenantAccount.h
+++ b/MSAL/src/public/MSALAccount+MultiTenantAccount.h
@@ -28,6 +28,7 @@
 #import "MSALAccount.h"
 
 @class MSALTenantProfile;
+@class MSALAccountId;
 
 @interface MSALAccount (MultiTenantAccount)
 
@@ -43,5 +44,11 @@
  The field will be nil in other scenarios. E.g., account returned as part of the result of an acquire token interactive/silent call.
  */
 @property (readonly, nullable) NSArray<MSALTenantProfile *> *tenantProfiles;
+
+/*!
+ Unique identifier of the account in the home tenant.
+ Provides additional information regarding account's home objectId and home tenantId in case of AAD.
+ */
+@property (readonly, nullable) MSALAccountId *homeAccountId;
 
 @end

--- a/MSAL/src/public/MSALAccount.h
+++ b/MSAL/src/public/MSALAccount.h
@@ -27,8 +27,6 @@
 
 #import <Foundation/Foundation.h>
 
-@class MSALAccountId;
-@class MSALTenantProfile;
 @class MSALPublicClientApplication;
 
 @protocol MSALAccount <NSObject>
@@ -77,12 +75,6 @@
 @end
 
 @interface MSALAccount : NSObject <MSALAccount, NSCopying>
-
-/*!
- Unique identifier of the account in the home tenant.
- Provides additional information regarding account's home objectId and home tenantId in case of AAD.
- */
-@property (readonly, nullable) MSALAccountId *homeAccountId;
 
 + (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)init NS_UNAVAILABLE;

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ These libraries are suitable to use in a production environment. We provide the 
                 let accessToken = authResult.accessToken
                 
                 // You'll want to get the account identifier to retrieve and reuse the account for later acquireToken calls
-                let accountIdentifier = authResult.account.homeAccountId?.identifier
+                let accountIdentifier = authResult.account.identifier
             })
         }
         else {
@@ -58,7 +58,7 @@ These libraries are suitable to use in a production environment. We provide the 
         {
             // You'll want to get the account identifier to retrieve and reuse the account
             // for later acquireToken calls
-            NSString *accountIdentifier = result.account.homeAccountId.identifier;
+            NSString *accountIdentifier = result.account.identifier;
             
             NSString *accessToken = result.accessToken;
         }
@@ -168,7 +168,7 @@ NSError *msalError;
 MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"<your-client-id-here>"];
 MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&msalError];
     
-```                                                
+```
 ### Acquiring Your First Token
 Swift
 ```swift
@@ -184,7 +184,7 @@ Swift
                 let accessToken = authResult.accessToken
                 
                 // You'll want to get the account identifier to retrieve and reuse the account for later acquireToken calls
-                let accountIdentifier = authResult.account.homeAccountId?.identifier
+                let accountIdentifier = authResult.account.identifier
             })
 ```
 Objective-C
@@ -195,7 +195,7 @@ Objective-C
         {
             // You'll want to get the account identifier to retrieve and reuse the account
             // for later acquireToken calls
-            NSString *accountIdentifier = result.account.homeAccountId.identifier;
+            NSString *accountIdentifier = result.account.identifier;
             
             NSString *accessToken = result.accessToken;
         }
@@ -210,7 +210,7 @@ Objective-C
 ### Silently Acquiring an Updated Token
 Swift
 ```swift
-guard let account = try? application.account(forHomeAccountId: accountIdentifier) else { return }
+guard let account = try? application.account(forIdentifier: accountIdentifier) else { return }
         let silentParameters = MSALSilentTokenParameters(scopes: scopes, account: account)
         application.acquireTokenSilent(with: silentParameters) { (result, error) in
             
@@ -234,7 +234,7 @@ guard let account = try? application.account(forHomeAccountId: accountIdentifier
 Objective-C
 ```objective-c
     NSError *error = nil;
-    MSALAccount *account = [application accountForHomeAccountId:accountIdentifier error:&error];
+    MSALAccount *account = [application accountForIdentifier:accountIdentifier error:&error];
     if (!account)
     {
         // handle error


### PR DESCRIPTION
In the spirit of keeping all AAD multi-tenant terms separated from base accounts, moving homeAccountId to multi tenant category similarly to tenantProfiles, and updating README.