### PR TITLE
Renamed account lookup property

### DIFF
--- a/MSAL/src-internal/ios/MSALLegacySharedAccount.m
+++ b/MSAL/src-internal/ios/MSALLegacySharedAccount.m
@@ -113,7 +113,7 @@ static NSDateFormatter *s_updateDateFormatter = nil;
 
 - (BOOL)matchesParameters:(MSALAccountEnumerationParameters *)parameters
 {
-    if (parameters.needsAssociatedRefreshToken)
+    if (parameters.returnOnlySignedInAccounts)
     {
         NSString *appIdentifier = [[NSBundle mainBundle] bundleIdentifier];
         NSString *signinStatus = [self.signinStatusDictionary msidStringObjectForKey:appIdentifier];

--- a/MSAL/src-internal/ios/MSALLegacySharedAccountFactory.m
+++ b/MSAL/src-internal/ios/MSALLegacySharedAccountFactory.m
@@ -90,13 +90,13 @@
     if ([self isMSAAccount:account])
     {
         MSALAccountEnumerationParameters *parameters = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:account.identifier];
-        parameters.needsAssociatedRefreshToken = NO;
+        parameters.returnOnlySignedInAccounts = NO;
         return parameters;
     }
     else if (![NSString msidIsStringNilOrBlank:tenantProfileIdentifier])
     {
         MSALAccountEnumerationParameters *parameters =  [[MSALAccountEnumerationParameters alloc] initWithTenantProfileIdentifier:tenantProfileIdentifier];
-        parameters.needsAssociatedRefreshToken = NO;
+        parameters.returnOnlySignedInAccounts = NO;
         return parameters;
     }
     

--- a/MSAL/src/MSALAccountEnumerationParameters.m
+++ b/MSAL/src/MSALAccountEnumerationParameters.m
@@ -43,7 +43,7 @@
     
     if (self)
     {
-        _needsAssociatedRefreshToken = YES;
+        _returnOnlySignedInAccounts = YES;
     }
     
     return self;
@@ -56,7 +56,7 @@
     if (self)
     {
         _identifier = accountIdentifier;
-        _needsAssociatedRefreshToken = YES;
+        _returnOnlySignedInAccounts = YES;
     }
     
     return self;
@@ -71,7 +71,7 @@
     {
         _identifier = accountIdentifier;
         _username = username;
-        _needsAssociatedRefreshToken = YES;
+        _returnOnlySignedInAccounts = YES;
     }
     
     return self;
@@ -84,7 +84,7 @@
     if (self)
     {
         _tenantProfileIdentifier = tenantProfileIdentifier;
-        _needsAssociatedRefreshToken = YES;
+        _returnOnlySignedInAccounts = YES;
     }
     
     return self;
@@ -94,7 +94,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"Account identifier %@, username %@, tenant profile identifier %@, needs associated refresh token %d", self.identifier, self.username, self.tenantProfileIdentifier, self.needsAssociatedRefreshToken];
+    return [NSString stringWithFormat:@"Account identifier %@, username %@, tenant profile identifier %@, return only signed in accounts %d", self.identifier, self.username, self.tenantProfileIdentifier, self.returnOnlySignedInAccounts];
 }
 
 @end

--- a/MSAL/src/instance/MSALAccountsProvider.m
+++ b/MSAL/src/instance/MSALAccountsProvider.m
@@ -138,12 +138,13 @@
     NSString *queryClientId = nil;
     NSString *queryFamilyId = nil;
     
-    if (!parameters || parameters.needsAssociatedRefreshToken)
+    if (!parameters || parameters.returnOnlySignedInAccounts)
     {
         MSIDAppMetadataCacheItem *appMetadata = [self appMetadataItem];
         NSString *familyId = appMetadata ? appMetadata.familyId : MSID_DEFAULT_FAMILY_ID;
         
         queryClientId = self.clientId;
+        
         queryFamilyId = familyId;
     }
     
@@ -211,6 +212,11 @@
     
     for (MSIDAccount *msidAccount in msidAccounts)
     {
+        // if requiresRefreshToken
+        // make sure account hasn't been marked as removed explicitly
+        // if it has, don't return it
+        // also don't flip familyId on account removal anymore
+        
         MSALAccount *msalAccount = [[MSALAccount alloc] initWithMSIDAccount:msidAccount createTenantProfile:YES];
         if (!msalAccount) continue;
         

--- a/MSAL/src/public/MSALAccountEnumerationParameters.h
+++ b/MSAL/src/public/MSALAccountEnumerationParameters.h
@@ -45,11 +45,14 @@
 @property (nonatomic, readonly, nullable) NSString *username;
 
 /*!
- Filter accounts by whether there's a refresh token present for the account.
- YES by default.
- Set it to NO to query all accounts regardless if there's a refresh token present or not.
+ Filter accounts by whether this account is in the signed in state for the current client.
+ Signed in state is determined by the presence of a refresh token credential for the requesting client.
+ If account has been explicitly removed through the "removeAccount" API, it will be also marked as "signed out" as MSAL will remove refresh token for the client.
+ 
+ YES by default (== only returns signed in accounts).
+ Set it to NO to query all accounts visible to your application regardless if there's a refresh token present or not.
  */
-@property (nonatomic, readwrite) BOOL needsAssociatedRefreshToken;
+@property (nonatomic, readwrite) BOOL returnOnlySignedInAccounts;
 
 - (nonnull instancetype)initWithIdentifier:(nonnull NSString *)accountIdentifier;
 

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -112,8 +112,6 @@
     self.accountMetadataCache = [[MSIDAccountMetadataCacheAccessor alloc] initWithDataSource:[MSIDTestCacheDataSource new]];
 #endif
     
-    [self.tokenCacheAccessor clearWithContext:nil error:nil];
-
     NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
     [MSALTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
     [self.tokenCacheAccessor clearWithContext:nil error:nil];
@@ -2015,8 +2013,11 @@
     headers[@"Accept"] = @"application/json";
     headers[@"x-ms-PkeyAuth"] = @"1.0";
     response->_requestHeaders = headers;
+    
+    NSString *endpoint = [NSString stringWithFormat:@"%@/v2.0/.well-known/openid-configuration", authority];
+    
     __auto_type responseJson = @{
-                                 @"tenant_discovery_endpoint" : @"https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
+                                 @"tenant_discovery_endpoint" : endpoint,
                                  @"metadata" : @[
                                          @{
                                              @"preferred_network" : @"login.microsoftonline.com",

--- a/MSAL/test/unit/ios/external-cache/MSALLegacySharedADALAccountTests.m
+++ b/MSAL/test/unit/ios/external-cache/MSALLegacySharedADALAccountTests.m
@@ -265,7 +265,7 @@
     MSALLegacySharedADALAccount *account = [[MSALLegacySharedADALAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [MSALAccountEnumerationParameters new];
-    params.needsAssociatedRefreshToken = YES;
+    params.returnOnlySignedInAccounts = YES;
     BOOL result = [account matchesParameters:params];
     XCTAssertFalse(result);
 }
@@ -287,7 +287,7 @@
     MSALLegacySharedADALAccount *account = [[MSALLegacySharedADALAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:@"oid.utid"];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertTrue(result);
 }
@@ -299,7 +299,7 @@
     MSALLegacySharedADALAccount *account = [[MSALLegacySharedADALAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:@"oid.utid" username:@"user@contoso.com"];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertTrue(result);
 }
@@ -313,7 +313,7 @@
     MSALLegacySharedADALAccount *account = [[MSALLegacySharedADALAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:@"oID.UTid" username:@"USER@contoso.COM"];
-    params.needsAssociatedRefreshToken = YES;
+    params.returnOnlySignedInAccounts = YES;
     BOOL result = [account matchesParameters:params];
     XCTAssertTrue(result);
 }
@@ -325,7 +325,7 @@
     MSALLegacySharedADALAccount *account = [[MSALLegacySharedADALAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithTenantProfileIdentifier:@"myoid"];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertTrue(result);
 }
@@ -337,7 +337,7 @@
     MSALLegacySharedADALAccount *account = [[MSALLegacySharedADALAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:nil username:@"user2@contoso.com"];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertFalse(result);
 }
@@ -349,7 +349,7 @@
     MSALLegacySharedADALAccount *account = [[MSALLegacySharedADALAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithTenantProfileIdentifier:@"myoid2"];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertFalse(result);
 }
@@ -361,7 +361,7 @@
     MSALLegacySharedADALAccount *account = [[MSALLegacySharedADALAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:@"oid.utid2"];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertFalse(result);
 }

--- a/MSAL/test/unit/ios/external-cache/MSALLegacySharedAccountTests.m
+++ b/MSAL/test/unit/ios/external-cache/MSALLegacySharedAccountTests.m
@@ -116,7 +116,7 @@
     XCTAssertTrue(result);
 }
 
-- (void)testMatchesParameters_whenNeedsAssociatedRefreshTokenNO_andAppSignedOut_shouldReturnYES
+- (void)testMatchesParameters_whenReturnOnlySignedInAccountsNO_andAppSignedOut_shouldReturnYES
 {
     NSMutableDictionary *jsonDictionary = [[MSALLegacySharedAccountTestUtil sampleADALJSONDictionary] mutableCopy];
     
@@ -126,12 +126,12 @@
     MSALLegacySharedAccount *account = [[MSALLegacySharedAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [MSALAccountEnumerationParameters new];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertTrue(result);
 }
 
-- (void)testMatchesParameters_whenNeedsAssociatedRefreshTokenYES_andAppSignedIn_shouldReturnYES
+- (void)testMatchesParameters_whenReturnOnlySignedInAccountsYES_andAppSignedIn_shouldReturnYES
 {
     NSMutableDictionary *jsonDictionary = [[MSALLegacySharedAccountTestUtil sampleADALJSONDictionary] mutableCopy];
     
@@ -141,12 +141,12 @@
     MSALLegacySharedAccount *account = [[MSALLegacySharedAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [MSALAccountEnumerationParameters new];
-    params.needsAssociatedRefreshToken = YES;
+    params.returnOnlySignedInAccounts = YES;
     BOOL result = [account matchesParameters:params];
     XCTAssertTrue(result);
 }
 
-- (void)testMatchesParameters_whenNeedsAssociatedRefreshTokenYES_andAppSignedOut_shouldReturnNO
+- (void)testMatchesParameters_whenReturnOnlySignedInAccountsYES_andAppSignedOut_shouldReturnNO
 {
     NSMutableDictionary *jsonDictionary = [[MSALLegacySharedAccountTestUtil sampleADALJSONDictionary] mutableCopy];
     
@@ -156,7 +156,7 @@
     MSALLegacySharedAccount *account = [[MSALLegacySharedAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [MSALAccountEnumerationParameters new];
-    params.needsAssociatedRefreshToken = YES;
+    params.returnOnlySignedInAccounts = YES;
     BOOL result = [account matchesParameters:params];
     XCTAssertFalse(result);
 }

--- a/MSAL/test/unit/ios/external-cache/MSALLegacySharedAccountsProviderTests.m
+++ b/MSAL/test/unit/ios/external-cache/MSALLegacySharedAccountsProviderTests.m
@@ -97,7 +97,7 @@
     [self saveAccountsBlob:accountsBlob version:@"AccountsV2"];
     
     MSALAccountEnumerationParameters *parameters = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:nil username:@"user@contoso.com"];
-    parameters.needsAssociatedRefreshToken = NO;
+    parameters.returnOnlySignedInAccounts = NO;
     
     NSError *error = nil;
     NSArray *results = [self.accountsProvider accountsWithParameters:parameters error:&error];
@@ -132,7 +132,7 @@
     [self saveAccountsBlob:oldAccountsBlob version:@"AccountsV2"];
     
     MSALAccountEnumerationParameters *parameters = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:nil username:@"user@contoso.com"];
-    parameters.needsAssociatedRefreshToken = NO;
+    parameters.returnOnlySignedInAccounts = NO;
     
     NSError *error = nil;
     NSArray *results = [self.accountsProvider accountsWithParameters:parameters error:&error];
@@ -156,7 +156,7 @@
     [self saveAccountsBlob:accountsBlob version:@"AccountsV3"];
     
     MSALAccountEnumerationParameters *parameters = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:nil username:@"user@contoso.com"];
-    parameters.needsAssociatedRefreshToken = NO;
+    parameters.returnOnlySignedInAccounts = NO;
     
     NSError *error = nil;
     NSArray *results = [self.accountsProvider accountsWithParameters:parameters error:&error];
@@ -174,7 +174,7 @@
     [self saveAccountsBlob:accountsBlob version:@"AccountsV3"];
     
     MSALAccountEnumerationParameters *parameters = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:nil username:@"user@contoso.com"];
-    parameters.needsAssociatedRefreshToken = NO;
+    parameters.returnOnlySignedInAccounts = NO;
     
     NSError *error = nil;
     NSArray *results = [self.accountsProvider accountsWithParameters:parameters error:&error];

--- a/MSAL/test/unit/ios/external-cache/MSALLegacySharedMSAAccountTests.m
+++ b/MSAL/test/unit/ios/external-cache/MSALLegacySharedMSAAccountTests.m
@@ -104,7 +104,7 @@ static NSString *kDefaultTestCid = @"40c03bac188d0d10";
     MSALLegacySharedMSAAccount *account = [[MSALLegacySharedMSAAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [MSALAccountEnumerationParameters new];
-    params.needsAssociatedRefreshToken = YES;
+    params.returnOnlySignedInAccounts = YES;
     BOOL result = [account matchesParameters:params];
     XCTAssertFalse(result);
 }
@@ -126,7 +126,7 @@ static NSString *kDefaultTestCid = @"40c03bac188d0d10";
     MSALLegacySharedMSAAccount *account = [[MSALLegacySharedMSAAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     NSString *expectedIdentifier = [NSString stringWithFormat:@"%@.%@", kDefaultTestUid, MSID_DEFAULT_MSA_TENANTID.lowercaseString];
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:expectedIdentifier];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertTrue(result);
 }
@@ -139,7 +139,7 @@ static NSString *kDefaultTestCid = @"40c03bac188d0d10";
     
     NSString *expectedIdentifier = [NSString stringWithFormat:@"%@.%@", kDefaultTestUid, MSID_DEFAULT_MSA_TENANTID.lowercaseString];
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:expectedIdentifier username:@"user@outlook.com"];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertTrue(result);
 }
@@ -152,7 +152,7 @@ static NSString *kDefaultTestCid = @"40c03bac188d0d10";
     
     NSString *expectedIdentifier = [NSString stringWithFormat:@"%@.%@", kDefaultTestUid.uppercaseString, MSID_DEFAULT_MSA_TENANTID];
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:expectedIdentifier username:@"USER@outlOOK.com"];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertTrue(result);
 }
@@ -164,7 +164,7 @@ static NSString *kDefaultTestCid = @"40c03bac188d0d10";
     MSALLegacySharedMSAAccount *account = [[MSALLegacySharedMSAAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithTenantProfileIdentifier:@"myoid"];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertFalse(result);
 }
@@ -176,7 +176,7 @@ static NSString *kDefaultTestCid = @"40c03bac188d0d10";
     MSALLegacySharedMSAAccount *account = [[MSALLegacySharedMSAAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:nil username:@"user2@contoso.com"];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertFalse(result);
 }
@@ -188,7 +188,7 @@ static NSString *kDefaultTestCid = @"40c03bac188d0d10";
     MSALLegacySharedMSAAccount *account = [[MSALLegacySharedMSAAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
     
     MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:@"oid.utid2"];
-    params.needsAssociatedRefreshToken = NO;
+    params.returnOnlySignedInAccounts = NO;
     BOOL result = [account matchesParameters:params];
     XCTAssertFalse(result);
 }


### PR DESCRIPTION
Renamed needsAssociatedRefreshToken to something "hopefully" more intuitive to developer, which is "returnOnlySignedInAccounts"