### PR TITLE
Classify MSAL errors in MSAL error converter

### DIFF
--- a/MSAL/src/MSALErrorConverter+Internal.h
+++ b/MSAL/src/MSALErrorConverter+Internal.h
@@ -39,6 +39,7 @@
              underlyingError:(NSError *)underlyingError
                correlationId:(NSUUID *)correlationId
                     userInfo:(NSDictionary *)userInfo
+              classifyErrors:(BOOL)shouldClassifyErrors
           msalOauth2Provider:(MSALOauth2Provider *)oauth2Provider;
 
 @end

--- a/MSAL/src/MSALErrorConverter.h
+++ b/MSAL/src/MSALErrorConverter.h
@@ -32,6 +32,6 @@
 @interface MSALErrorConverter : NSObject
 
 + (NSError *)msalErrorFromMsidError:(NSError *)msidError;
-+ (NSError *)msalErrorFromMsidError:(NSError *)msidError msalOauth2Provider:(MSALOauth2Provider *)oauth2Provider;
++ (NSError *)msalErrorFromMsidError:(NSError *)msidError classifyErrors:(BOOL)shouldClassifyErrors msalOauth2Provider:(MSALOauth2Provider *)oauth2Provider;
 
 @end

--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -163,7 +163,7 @@ static NSSet *s_recoverableErrorCode;
     // errorCode mapping is needed only if domain is mapped to MSALErrorDomain
     NSNumber *mappedCode = nil;
     NSNumber *internalCode = nil;
-    if (mappedDomain == MSALErrorDomain)
+    if ([mappedDomain isEqualToString:MSALErrorDomain])
     {
         mappedCode = s_errorCodeMapping[mappedDomain][@(code)];
         if (mappedCode == nil)
@@ -171,15 +171,18 @@ static NSSet *s_recoverableErrorCode;
             MSID_LOG_WITH_CTX(MSIDLogLevelWarning,nil, @"MSALErrorConverter could not find the error code mapping entry for domain (%@) + error code (%ld).", domain, (long)code);
             mappedCode = @(MSALErrorInternal);
         }
-        
-        if (![s_recoverableErrorCode containsObject:mappedCode])
-        {
-            // If mapped code is MSALErrorInternal, set internalCode to MSALInternalErrorUnexpected
-            // to avoid the case when both mapped and internal code are MSALErrorInternal.
-            internalCode = [mappedCode isEqual:@(MSALErrorInternal)] ? @(MSALInternalErrorUnexpected) : mappedCode;
-            
-            mappedCode = @(MSALErrorInternal);
-        }
+    }
+    else if ([domain isEqualToString:MSALErrorDomain])
+    {
+        mappedCode = @(code);
+    }
+    
+    if (mappedCode != nil && ![s_recoverableErrorCode containsObject:mappedCode])
+    {
+        // If mapped code is MSALErrorInternal, set internalCode to MSALInternalErrorUnexpected
+        // to avoid the case when both mapped and internal code are MSALErrorInternal.
+        internalCode = [mappedCode isEqual:@(MSALErrorInternal)] ? @(MSALInternalErrorUnexpected) : mappedCode;
+        mappedCode = @(MSALErrorInternal);
     }
     
     NSMutableDictionary *msalUserInfo = [NSMutableDictionary new];

--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -125,10 +125,12 @@ static NSSet *s_recoverableErrorCode;
 
 + (NSError *)msalErrorFromMsidError:(NSError *)msidError
 {
-    return [self msalErrorFromMsidError:msidError msalOauth2Provider:nil];
+    return [self msalErrorFromMsidError:msidError classifyErrors:YES msalOauth2Provider:nil];
 }
 
-+ (NSError *)msalErrorFromMsidError:(NSError *)msidError msalOauth2Provider:(MSALOauth2Provider *)oauth2Provider
++ (NSError *)msalErrorFromMsidError:(NSError *)msidError
+                     classifyErrors:(BOOL)shouldClassifyErrors
+                 msalOauth2Provider:(MSALOauth2Provider *)oauth2Provider
 {
     return [self errorWithDomain:msidError.domain
                             code:msidError.code
@@ -138,6 +140,7 @@ static NSSet *s_recoverableErrorCode;
                  underlyingError:msidError.userInfo[NSUnderlyingErrorKey]
                    correlationId:msidError.userInfo[MSIDCorrelationIdKey]
                         userInfo:msidError.userInfo
+                  classifyErrors:shouldClassifyErrors
               msalOauth2Provider:oauth2Provider];
 }
 
@@ -149,6 +152,7 @@ static NSSet *s_recoverableErrorCode;
              underlyingError:(NSError *)underlyingError
                correlationId:(NSUUID *)correlationId
                     userInfo:(NSDictionary *)userInfo
+              classifyErrors:(BOOL)shouldClassifyErrors
           msalOauth2Provider:(MSALOauth2Provider *)oauth2Provider
 {
     if ([NSString msidIsStringNilOrBlank:domain])
@@ -177,7 +181,7 @@ static NSSet *s_recoverableErrorCode;
         mappedCode = @(code);
     }
     
-    if (mappedCode != nil && ![s_recoverableErrorCode containsObject:mappedCode])
+    if (shouldClassifyErrors && mappedCode != nil && ![s_recoverableErrorCode containsObject:mappedCode])
     {
         // If mapped code is MSALErrorInternal, set internalCode to MSALInternalErrorUnexpected
         // to avoid the case when both mapped and internal code are MSALErrorInternal.

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -594,7 +594,7 @@
     
     MSALCompletionBlock block = ^(MSALResult *result, NSError *msidError)
     {
-        NSError *msalError = [MSALErrorConverter msalErrorFromMsidError:msidError msalOauth2Provider:self.msalOauth2Provider];
+        NSError *msalError = [MSALErrorConverter msalErrorFromMsidError:msidError classifyErrors:YES msalOauth2Provider:self.msalOauth2Provider];
         [MSALPublicClientApplication logOperation:@"acquireToken" result:result error:msalError context:msidParams];
         
         if ([NSThread isMainThread])
@@ -895,7 +895,7 @@
     
     MSALCompletionBlock block = ^(MSALResult *result, NSError *msidError)
     {
-        NSError *msalError = [MSALErrorConverter msalErrorFromMsidError:msidError msalOauth2Provider:self.msalOauth2Provider];
+        NSError *msalError = [MSALErrorConverter msalErrorFromMsidError:msidError classifyErrors:YES msalOauth2Provider:self.msalOauth2Provider];
         [MSALPublicClientApplication logOperation:@"acquireTokenSilent" result:result error:msalError context:msidParams];
         completionBlock(result, msalError);
     };

--- a/MSAL/test/unit/MSALErrorConverterTests.m
+++ b/MSAL/test/unit/MSALErrorConverterTests.m
@@ -70,6 +70,7 @@
                                              underlyingError:nil
                                                correlationId:nil
                                                     userInfo:nil
+                                              classifyErrors:YES
                                           msalOauth2Provider:nil];
     XCTAssertNil(msalError);
 }
@@ -94,6 +95,7 @@
                                                     userInfo:@{MSIDHTTPHeadersKey : httpHeaders,
                                                                MSIDHTTPResponseCodeKey : httpResponseCode,
                                                                @"additional_user_info": @"unmapped_userinfo"}
+                                              classifyErrors:YES
                                           msalOauth2Provider:nil];
     
     NSString *expectedErrorDomain = NSOSStatusErrorDomain;
@@ -129,6 +131,7 @@
                                              underlyingError:nil
                                                correlationId:nil
                                                     userInfo:nil
+                                              classifyErrors:YES
                                           msalOauth2Provider:nil];
     
     NSString *expectedErrorDomain = MSALErrorDomain;
@@ -156,12 +159,41 @@
                                              underlyingError:nil
                                                correlationId:nil
                                                     userInfo:nil
+                                              classifyErrors:YES
                                           msalOauth2Provider:nil];
     
     NSString *expectedErrorDomain = MSALErrorDomain;
     XCTAssertNotNil(msalError);
     XCTAssertEqualObjects(msalError.domain, expectedErrorDomain);
     XCTAssertEqual(msalError.code, MSALErrorUserCanceled);
+    XCTAssertEqualObjects(msalError.userInfo[MSALErrorDescriptionKey], errorDescription);
+    XCTAssertEqualObjects(msalError.userInfo[MSALOAuthErrorKey], oauthError);
+    XCTAssertEqualObjects(msalError.userInfo[MSALOAuthSubErrorKey], subError);
+    XCTAssertNil(msalError.userInfo[MSALInternalErrorCodeKey]);
+}
+
+- (void)testErrorConversion_whenUnclassifiedUnrecoverableErrorPassed_andClassifyErrorsNO_shouldNotClassify
+{
+    NSInteger errorCode = -42400;
+    NSString *errorDescription = @"a fake error description.";
+    NSString *oauthError = @"a fake oauth error message.";
+    NSString *subError = @"a fake suberror";
+    
+    NSError *msalError = [MSALErrorConverter errorWithDomain:MSALErrorDomain
+                                                        code:errorCode
+                                            errorDescription:errorDescription
+                                                  oauthError:oauthError
+                                                    subError:subError
+                                             underlyingError:nil
+                                               correlationId:nil
+                                                    userInfo:nil
+                                              classifyErrors:NO
+                                          msalOauth2Provider:nil];
+    
+    NSString *expectedErrorDomain = MSALErrorDomain;
+    XCTAssertNotNil(msalError);
+    XCTAssertEqualObjects(msalError.domain, expectedErrorDomain);
+    XCTAssertEqual(msalError.code, -42400);
     XCTAssertEqualObjects(msalError.userInfo[MSALErrorDescriptionKey], errorDescription);
     XCTAssertEqualObjects(msalError.userInfo[MSALOAuthErrorKey], oauthError);
     XCTAssertEqualObjects(msalError.userInfo[MSALOAuthSubErrorKey], subError);
@@ -189,6 +221,7 @@
                                                                MSIDHTTPResponseCodeKey : httpResponseCode,
                                                                @"additional_user_info": @"unmapped_userinfo",
                                                                MSIDInvalidTokenResultKey : [self testTokenResult]}
+                                              classifyErrors:YES
                                           msalOauth2Provider:[[MSALAADOauth2Provider alloc] initWithClientId:@"someClientId"
                                                                                                   tokenCache:nil
                                                                                         accountMetadataCache:nil]];
@@ -274,6 +307,7 @@
                                                  underlyingError:nil
                                                    correlationId:nil
                                                         userInfo:nil
+                                                  classifyErrors:YES
                                               msalOauth2Provider:nil];
             
             XCTAssertNotEqual(error.code, errorCode);
@@ -293,6 +327,7 @@
                                              underlyingError:nil
                                                correlationId:nil
                                                     userInfo:nil
+                                              classifyErrors:YES
                                           msalOauth2Provider:nil];
     
     XCTAssertEqualObjects(msalError.domain, MSALErrorDomain);
@@ -310,6 +345,7 @@
                                              underlyingError:nil
                                                correlationId:nil
                                                     userInfo:nil
+                                              classifyErrors:YES
                                           msalOauth2Provider:nil];
     
     XCTAssertEqualObjects(msalError.domain, @"Unmapped Domain");
@@ -326,6 +362,7 @@
                                              underlyingError:nil
                                                correlationId:nil
                                                     userInfo:nil
+                                              classifyErrors:YES
                                           msalOauth2Provider:nil];
     
     XCTAssertEqualObjects(msalError.domain, MSALErrorDomain);

--- a/MSAL/test/unit/MSALErrorConverterTests.m
+++ b/MSAL/test/unit/MSALErrorConverterTests.m
@@ -114,6 +114,60 @@
     XCTAssertEqualObjects(msalError.userInfo[@"additional_user_info"], @"unmapped_userinfo");
 }
 
+- (void)testErrorConversion_whenUnclassifiedInternalMSALErrorPassed_shouldMapToInternal
+{
+    NSInteger errorCode = -42400;
+    NSString *errorDescription = @"a fake error description.";
+    NSString *oauthError = @"a fake oauth error message.";
+    NSString *subError = @"a fake suberror";
+    
+    NSError *msalError = [MSALErrorConverter errorWithDomain:MSALErrorDomain
+                                                        code:errorCode
+                                            errorDescription:errorDescription
+                                                  oauthError:oauthError
+                                                    subError:subError
+                                             underlyingError:nil
+                                               correlationId:nil
+                                                    userInfo:nil
+                                          msalOauth2Provider:nil];
+    
+    NSString *expectedErrorDomain = MSALErrorDomain;
+    XCTAssertNotNil(msalError);
+    XCTAssertEqualObjects(msalError.domain, expectedErrorDomain);
+    XCTAssertEqual(msalError.code, MSALErrorInternal);
+    XCTAssertEqualObjects(msalError.userInfo[MSALErrorDescriptionKey], errorDescription);
+    XCTAssertEqualObjects(msalError.userInfo[MSALOAuthErrorKey], oauthError);
+    XCTAssertEqualObjects(msalError.userInfo[MSALOAuthSubErrorKey], subError);
+    XCTAssertEqualObjects(msalError.userInfo[MSALInternalErrorCodeKey], @(-42400));
+}
+
+- (void)testErrorConversion_whenUnclassifiedRecoverableErrorPassed_shouldMapToRecoverable
+{
+    NSInteger errorCode = MSALErrorUserCanceled;
+    NSString *errorDescription = @"a fake error description.";
+    NSString *oauthError = @"a fake oauth error message.";
+    NSString *subError = @"a fake suberror";
+    
+    NSError *msalError = [MSALErrorConverter errorWithDomain:MSALErrorDomain
+                                                        code:errorCode
+                                            errorDescription:errorDescription
+                                                  oauthError:oauthError
+                                                    subError:subError
+                                             underlyingError:nil
+                                               correlationId:nil
+                                                    userInfo:nil
+                                          msalOauth2Provider:nil];
+    
+    NSString *expectedErrorDomain = MSALErrorDomain;
+    XCTAssertNotNil(msalError);
+    XCTAssertEqualObjects(msalError.domain, expectedErrorDomain);
+    XCTAssertEqual(msalError.code, MSALErrorUserCanceled);
+    XCTAssertEqualObjects(msalError.userInfo[MSALErrorDescriptionKey], errorDescription);
+    XCTAssertEqualObjects(msalError.userInfo[MSALOAuthErrorKey], oauthError);
+    XCTAssertEqualObjects(msalError.userInfo[MSALOAuthSubErrorKey], subError);
+    XCTAssertNil(msalError.userInfo[MSALInternalErrorCodeKey]);
+}
+
 - (void)testErrorConversion_whenBothErrorDomainAndCodeAreMapped_shouldMapBoth {
     NSInteger errorCode = MSIDErrorInteractionRequired;
     NSString *errorDescription = @"a fake error description.";


### PR DESCRIPTION
There're cases when MSAL gets "unclassified" (internal vs recoverable) MSAL errors. Currently, MSAL doesn't handle it well and possibly returns the internal error as top level error, which is unexpected.

This change ensures that even if we get MSAL error, we classify it correctly before returning it to the developer.

One of the repro cases is broker. Broker doesn't send "classified" errors back to the client. It just sends the error code. Additionally, error classification was introduced after MSAL broker protocol. Therefore, we need to make MSAL backward compatible with that broker. Furthermore, it makes sense for broker to send unclassified error codes to keep the protocol flat and clean in the future, and for MSAL to return it to the developer as MSAL sees fit. 

Additionally, this PR adds a "classify" flag to MSAL error converter in order for broker to be able to convert MSID error to MSAL error without internal/recoverable classification and pass a "flat" error code back to the app. 