### PR TITLE
Added MSAL internal podspec for legacy account handlers

### DIFF
--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -64,6 +64,8 @@ Pod::Spec.new do |s|
 
     legacyapp.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*", "MSAL/src-internal/public/ios/*"
     legacyapp.requires_arc = true
+    legacyapp.prefix_header_contents = "#define MSAL_LEGACY_ENABLED 1"
+
 
   end
 

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -64,8 +64,7 @@ Pod::Spec.new do |s|
 
     legacyapp.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*", "MSAL/src-internal/public/ios/*"
     legacyapp.requires_arc = true
-    legacyapp.prefix_header_contents = "#define MSAL_LEGACY_ENABLED 1"
-
+    legacyapp.compiler_flags = '-DMSAL_LEGACY_ENABLED=1'
 
   end
 

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -53,4 +53,16 @@ Pod::Spec.new do |s|
   	
   	ext.requires_arc = true
   end
+
+  s.subspec 'MSALBackwardCompat' do |legacyapp|
+
+    legacyapp.dependency 'MSAL/app-lib'
+    legacyapp.source_files = "MSAL/internal-src/**/*.{h,m}"
+    legacyapp.ios.public_header_files = "MSAL/src-internal/public/*.h"
+    legacyapp.ios.exclude_files = "MSAL/src-internal/public/mac/*.h"
+    legacyapp.osx.exclude_files = "MSAL/src-internal/public/ios/*.h"
+    legacyapp.requires_arc = true
+
+  end
+
 end

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -56,11 +56,13 @@ Pod::Spec.new do |s|
 
   s.subspec 'MSALBackwardCompat' do |legacyapp|
 
-    legacyapp.dependency 'MSAL/app-lib'
-    legacyapp.source_files = "MSAL/internal-src/**/*.{h,m}"
-    legacyapp.ios.public_header_files = "MSAL/src-internal/public/*.h"
-    legacyapp.ios.exclude_files = "MSAL/src-internal/public/mac/*.h"
-    legacyapp.osx.exclude_files = "MSAL/src-internal/public/ios/*.h"
+    legacyapp.source_files = "MSAL/src/**/*.{h,m}", "MSAL/IdentityCore/IdentityCore/src/**/*.{h,m}", "MSAL/src-internal/**/*.{h,m}"
+    legacyapp.ios.public_header_files = "MSAL/src/public/*.h","MSAL/src/public/ios/*.h", "MSAL/src/public/configuration/**/*.h", "MSAL/src-internal/public/*.h"
+    legacyapp.osx.public_header_files = "MSAL/src/public/mac/*.h","MSAL/src/public/*.h", "MSAL/src/public/configuration/**/*.h"
+
+    legacyapp.ios.exclude_files = "MSAL/src/**/mac/*", "MSAL/IdentityCore/IdentityCore/src/**/mac/*"
+
+    legacyapp.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*", "MSAL/src-internal/public/ios/*"
     legacyapp.requires_arc = true
 
   end

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -57,7 +57,7 @@ Pod::Spec.new do |s|
   s.subspec 'MSALBackwardCompat' do |legacyapp|
 
     legacyapp.source_files = "MSAL/src/**/*.{h,m}", "MSAL/IdentityCore/IdentityCore/src/**/*.{h,m}", "MSAL/src-internal/**/*.{h,m}"
-    legacyapp.ios.public_header_files = "MSAL/src/public/*.h","MSAL/src/public/ios/*.h", "MSAL/src/public/configuration/**/*.h", "MSAL/src-internal/public/*.h"
+    legacyapp.ios.public_header_files = "MSAL/src/public/*.h","MSAL/src/public/ios/*.h", "MSAL/src/public/configuration/**/*.h", "MSAL/src-internal/public/ios/*.h"
     legacyapp.osx.public_header_files = "MSAL/src/public/mac/*.h","MSAL/src/public/*.h", "MSAL/src/public/configuration/**/*.h"
 
     legacyapp.ios.exclude_files = "MSAL/src/**/mac/*", "MSAL/IdentityCore/IdentityCore/src/**/mac/*"

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -289,7 +289,7 @@
 		B223B0C022ADFACB00FB8713 /* MSALLegacySharedAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = B223B0BE22ADFACB00FB8713 /* MSALLegacySharedAccount.m */; };
 		B223B0C522AE215D00FB8713 /* MSALLegacySharedAccountFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = B223B0C322AE215D00FB8713 /* MSALLegacySharedAccountFactory.h */; };
 		B223B0C622AE215D00FB8713 /* MSALLegacySharedAccountFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = B223B0C422AE215D00FB8713 /* MSALLegacySharedAccountFactory.m */; };
-		B227037122A4BA3600030ADC /* MSALLegacySharedAccountsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B29A56BD228266E20023F5E6 /* MSALLegacySharedAccountsProvider.h */; };
+		B227037122A4BA3600030ADC /* MSALLegacySharedAccountsProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B29A56BD228266E20023F5E6 /* MSALLegacySharedAccountsProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B227037322A4BA3E00030ADC /* MSALLegacySharedAccountsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B29A56BE228266E20023F5E6 /* MSALLegacySharedAccountsProvider.m */; };
 		B2472CA3226FDC46008F22AB /* MSALB2CAuthority_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2472CA2226FDC46008F22AB /* MSALB2CAuthority_Internal.h */; };
 		B2472CA4226FDC46008F22AB /* MSALB2CAuthority_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2472CA2226FDC46008F22AB /* MSALB2CAuthority_Internal.h */; };

--- a/MSAL/src-internal/ios/MSALLegacySharedMSAAccount.m
+++ b/MSAL/src-internal/ios/MSALLegacySharedMSAAccount.m
@@ -28,7 +28,6 @@
 #import "MSIDAccountIdentifier.h"
 #import "NSString+MSALAccountIdenfiers.h"
 #import "MSALAccountEnumerationParameters.h"
-#import "MSALLegacySharedAccountTestUtil.h"
 
 static NSString *kMSAAccountType = @"MSA";
 

--- a/MSAL/src-internal/public/ios/MSALLegacySharedAccountsProvider.h
+++ b/MSAL/src-internal/public/ios/MSALLegacySharedAccountsProvider.h
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "MSALExternalAccountProviding.h"
+#import <MSAL/MSAL.h>
 
 typedef NS_ENUM(NSInteger, MSALLegacySharedAccountMode)
 {

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -74,7 +74,4 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALAccountEnumerationParameters.h>
 #import <MSAL/MSALExternalAccountProviding.h>
 #import <MSAL/MSALSerializedADALCacheProvider.h>
-
-#ifdef MSAL_LEGACY_ENABLED
 #import <MSAL/MSALLegacySharedAccountsProvider.h>
-#endif

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -74,3 +74,7 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALAccountEnumerationParameters.h>
 #import <MSAL/MSALExternalAccountProviding.h>
 #import <MSAL/MSALSerializedADALCacheProvider.h>
+
+#ifdef MSAL_LEGACY_ENABLED
+#import <MSAL/MSALLegacySharedAccountsProvider.h>
+#endif

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -74,4 +74,6 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALAccountEnumerationParameters.h>
 #import <MSAL/MSALExternalAccountProviding.h>
 #import <MSAL/MSALSerializedADALCacheProvider.h>
+#ifdef MSAL_LEGACY_ENABLED
 #import <MSAL/MSALLegacySharedAccountsProvider.h>
+#endif

--- a/MSAL/src/public/configuration/publicClientApplication/cache/MSALExternalAccountProviding.h
+++ b/MSAL/src/public/configuration/publicClientApplication/cache/MSALExternalAccountProviding.h
@@ -27,7 +27,10 @@
 
 
 #import <Foundation/Foundation.h>
-#import <MSAL/MSAL.h>
+
+@protocol MSALAccount;
+@class MSALTenantProfile;
+@class MSALAccountEnumerationParameters;
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
This uses CocoaPods feature of subspecs so that developers can take the variant that they need. In this case, MSAL already had a special "extension" version, this is adding an additional version for legacy accounts.
Because legacy accounts feature won't be needed by many apps outside of Microsoft, I'd like to keep it not fully publicly exposed for now. 