### PR TITLE
Revert home authority logic for silent lookups

### DIFF
--- a/MSAL/src/instance/oauth2/aad/MSALAADOauth2Provider.m
+++ b/MSAL/src/instance/oauth2/aad/MSALAADOauth2Provider.m
@@ -132,6 +132,18 @@
                 || aadAuthority.tenant.type == MSIDAADTenantTypeConsumers
                 || aadAuthority.tenant.type == MSIDAADTenantTypeOrganizations)
             {
+                // This is just a precaution to ensure tenantId is a valid AAD tenant semantically
+                NSUUID *tenantUUID = [[NSUUID alloc] initWithUUIDString:account.homeAccountId.tenantId];
+                
+                if (tenantUUID)
+                {
+                    authority = [[MSIDAADAuthority alloc] initWithURL:authority.url rawTenant:account.homeAccountId.tenantId context:nil error:error];
+                }
+                else
+                {
+                    MSID_LOG_WITH_CTX_PII(MSIDLogLevelWarning, nil, @"Unexpected tenantId found %@", MSID_PII_LOG_MASKABLE(account.homeAccountId.tenantId));
+                }
+                
                 authority = [[MSIDAADAuthority alloc] initWithURL:authority.url rawTenant:account.homeAccountId.tenantId context:nil error:error];
             }
 


### PR DESCRIPTION
All previous MSAL versions had a behavior of changing common, organizations and consumers to home tenant for silent lookups. Account metadata was meant to replace this behavior. However, there's currently an AAD bug in which sending request to tenantless endpoint with a refresh token from a tenanted endpoint results in an id_token with a wrong issuer.

Therefore, I'm putting the previous logic back as a fallback for cases where there's no tenanted authority in cache present until server side issue is fixed to avoid regression on MSAL update. 