### PR TITLE
Only log in debug in samples

### DIFF
--- a/MSAL/src/MSALAccount.m
+++ b/MSAL/src/MSALAccount.m
@@ -115,7 +115,7 @@
     
     if (tenantProfileError)
     {
-        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Failed to create tenant profile with error code %ld, domain %@", tenantProfileError.code, tenantProfileError.domain);
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"Failed to create tenant profile with error code %ld, domain %@", (long)tenantProfileError.code, tenantProfileError.domain);
     }
     
     NSArray *tenantProfiles = tenantProfile ? @[tenantProfile] : nil;

--- a/MSAL/src/public/MSALLogger.h
+++ b/MSAL/src/public/MSALLogger.h
@@ -55,7 +55,6 @@
  
     Additionally, MSAL makes determination regarding PII status of a particular parameter based on the parameter type. It wouldn't automatically detect a case where PII information is passed into non-PII parameter due to a developer mistake (e.g. MSAL doesn't consider clientId PII and it expects developers to exersice caution and never pass any unexpected sensitive information into that parameter).
  */
- */
-- (void)setCallback:(nonnull MSALLogCallback)callback DEPRECATED_MSG_ATTRIBUTE("use MSALGlobalConfig.loggerConfig setLogCallback: instead");;
+- (void)setCallback:(nonnull MSALLogCallback)callback DEPRECATED_MSG_ATTRIBUTE("use MSALGlobalConfig.loggerConfig setLogCallback: instead");
 
 @end

--- a/MSAL/src/public/MSALLogger.h
+++ b/MSAL/src/public/MSALLogger.h
@@ -50,6 +50,11 @@
  
     NOTE: Once this is set this can not be unset, and it should be set early in
           the program's execution.
+ 
+    NOTE: MSAL logs might contain potentially sensitive information. When implementing MSAL logging, you should never output MSAL logs with NSLog or print directly, unless you're running your application in the debug mode. If you're writing MSAL logs to file, you must take necessary precautions to store the file securely.
+ 
+    Additionally, MSAL makes determination regarding PII status of a particular parameter based on the parameter type. It wouldn't automatically detect a case where PII information is passed into non-PII parameter due to a developer mistake (e.g. MSAL doesn't consider clientId PII and it expects developers to exersice caution and never pass any unexpected sensitive information into that parameter).
+ */
  */
 - (void)setCallback:(nonnull MSALLogCallback)callback DEPRECATED_MSG_ATTRIBUTE("use MSALGlobalConfig.loggerConfig setLogCallback: instead");;
 

--- a/MSAL/src/public/configuration/global/MSALLoggerConfig.h
+++ b/MSAL/src/public/configuration/global/MSALLoggerConfig.h
@@ -46,6 +46,10 @@ NS_ASSUME_NONNULL_BEGIN
  
  NOTE: Once this is set this can not be unset, and it should be set early in
  the program's execution.
+ 
+ NOTE: MSAL logs might contain potentially sensitive information. When implementing MSAL logging, you should never output MSAL logs with NSLog or print directly, unless you're running your application in the debug mode. If you're writing MSAL logs to file, you must take necessary precautions to store the file securely.
+ 
+    Additionally, MSAL makes determination regarding PII status of a particular parameter based on the parameter type. It wouldn't automatically detect a case where PII information is passed into non-PII parameter due to a developer mistake (e.g. MSAL doesn't consider clientId PII and it expects developers to exersice caution and never pass any unexpected sensitive information into that parameter). 
  */
 - (void)setLogCallback:(MSALLogCallback)callback;
 - (MSALLogCallback)callback;

--- a/MSAL/test/app/ios/MSALTestAppLogViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppLogViewController.m
@@ -65,12 +65,12 @@ static NSAttributedString* s_attrNewLine = nil;
     [MSALGlobalConfig.loggerConfig setLogCallback:^(MSALLogLevel level, NSString * _Nullable message, BOOL containsPII)
     {
         (void)level;
-        if (!containsPII)
-        {
-            return;
-        }
-        
+
+#if DEBUG
+        // NB! This sample uses NSLog just for testing purposes
+        // You should only ever log to NSLog in debug mode to prevent leaking potentially sensitive information
         NSLog(@"%@", message);
+#endif
         
         NSAttributedString* attrLog = [[NSAttributedString alloc] initWithString:message];
         

--- a/Samples/ios/SampleApp/SampleAppiOS/SampleMSALUtil.m
+++ b/Samples/ios/SampleApp/SampleAppiOS/SampleMSALUtil.m
@@ -54,10 +54,9 @@
 {
     [MSALGlobalConfig.loggerConfig setLogCallback:^(MSALLogLevel level, NSString *message, BOOL containsPII)
     {
-        // If PiiLoggingEnabled is set YES, this block will be called twice; containsPII == YES and
-        // containsPII == NO. In this case, you only need to capture either one set of messages.
-        // however the containsPII version might contain Personally Identifiable Information (PII)
-        // about the account being logged in.
+        // If PiiLoggingEnabled is set YES, this block will potentially contain sensitive information (Personally Identifiable Information), but not all messages will contain it.
+        // containsPII == YES indicates if a particular message contains PII.
+        // You might want to capture PII only in debug builds, or only if you take necessary actions to handle PII properly according to legal requirements of the region
         
         // if message is "redirect to https://somehost.com",
         if (!containsPII)

--- a/Samples/ios/SampleApp/SampleAppiOS/SampleMSALUtil.m
+++ b/Samples/ios/SampleApp/SampleAppiOS/SampleMSALUtil.m
@@ -64,7 +64,10 @@
         {
             // WILL CONTAIN EVERYTHING
             // so message contains "redirect to https://somehost.com"
+#if DEBUG
+            // Only print to console using NSLog in debug mode
             NSLog(@"%@", message);
+#endif
         }
         
         else

--- a/Samples/ios/SampleApp/SampleAppiOS/SampleMSALUtil.m
+++ b/Samples/ios/SampleApp/SampleAppiOS/SampleMSALUtil.m
@@ -65,7 +65,8 @@
             // WILL CONTAIN EVERYTHING
             // so message contains "redirect to https://somehost.com"
 #if DEBUG
-            // Only print to console using NSLog in debug mode
+            // NB! This sample uses print just for testing purposes
+            // You should only ever log to NSLog in debug mode to prevent leaking potentially sensitive information
             NSLog(@"%@", message);
 #endif
         }

--- a/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SampleMSALAuthentication.swift
+++ b/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SampleMSALAuthentication.swift
@@ -42,10 +42,9 @@ class SampleMSALAuthentication {
     func setup() {
         MSALGlobalConfig.loggerConfig.setLogCallback {
             (level: MSALLogLevel, message: String?, containsPII: Bool) in
-            // If PiiLoggingEnabled is set YES, this block will be called twice; containsPII == YES and
-            // containsPII == NO. In this case, you only need to capture either one set of messages.
-            // however the containsPII version might contain Personally Identifiable Information (PII)
-            // about the account being logged in.
+            // If PiiLoggingEnabled is set YES, this block will potentially contain sensitive information (Personally Identifiable Information), but not all messages will contain it.
+            // containsPII == YES indicates if a particular message contains PII.
+            // You might want to capture PII only in debug builds, or only if you take necessary actions to handle PII properly according to legal requirements of the region
             if let displayableMessage = message {
                 if (!containsPII) {
 #if DEBUG

--- a/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SampleMSALAuthentication.swift
+++ b/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SampleMSALAuthentication.swift
@@ -49,7 +49,8 @@ class SampleMSALAuthentication {
             if let displayableMessage = message {
                 if (!containsPII) {
 #if DEBUG
-                    // Only print to console using print in debug mode
+                    // NB! This sample uses print just for testing purposes
+                    // You should only ever log to NSLog in debug mode to prevent leaking potentially sensitive information
                     print(displayableMessage)
 #endif
                 }

--- a/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SampleMSALAuthentication.swift
+++ b/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SampleMSALAuthentication.swift
@@ -48,7 +48,10 @@ class SampleMSALAuthentication {
             // about the account being logged in.
             if let displayableMessage = message {
                 if (!containsPII) {
+#if DEBUG
+                    // Only print to console using print in debug mode
                     print(displayableMessage)
+#endif
                 }
             }
         }


### PR DESCRIPTION
It's not the best practice to always NSLog identity logs in samples. 