### PR TITLE
Flip legacy accounts flag

### DIFF
--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -37,6 +37,7 @@ Pod::Spec.new do |s|
   		
   	app.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*"
   	app.requires_arc = true
+    app.compiler_flags = '-DMSAL_LEGACY_ACCOUNTS_DISABLED=1'
   end
   
   # Note, MSAL has limited support for running in app extensions.
@@ -50,7 +51,7 @@ Pod::Spec.new do |s|
   	# for both the platform and overall.
   	ext.ios.exclude_files = "MSAL/src/**/mac/*", "MSAL/IdentityCore/IdentityCore/src/**/mac/*"
   	ext.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*"
-  	
+  	ext.compiler_flags = '-DMSAL_LEGACY_ACCOUNTS_DISABLED=1'
   	ext.requires_arc = true
   end
 
@@ -64,7 +65,6 @@ Pod::Spec.new do |s|
 
     legacyapp.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*", "MSAL/src-internal/public/ios/*"
     legacyapp.requires_arc = true
-    legacyapp.compiler_flags = '-DMSAL_LEGACY_ENABLED=1'
 
   end
 

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   		
   	app.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*"
   	app.requires_arc = true
-    app.compiler_flags = '-DMSAL_LEGACY_ACCOUNTS_DISABLED=1'
+    	app.compiler_flags = '-DMSAL_LEGACY_ACCOUNTS_DISABLED=1'
   end
   
   # Note, MSAL has limited support for running in app extensions.

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   		
   	app.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*"
   	app.requires_arc = true
-      app.prefix_header_contents = "#define MSAL_LEGACY_ACCOUNTS_DISABLED 1"
+        app.prefix_header_contents = "#define MSAL_LEGACY_ACCOUNTS_DISABLED 1"
   end
   
   # Note, MSAL has limited support for running in app extensions.
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
   	# for both the platform and overall.
   	ext.ios.exclude_files = "MSAL/src/**/mac/*", "MSAL/IdentityCore/IdentityCore/src/**/mac/*"
   	ext.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*"
-      ext.prefix_header_contents = "#define MSAL_LEGACY_ACCOUNTS_DISABLED 1"
+        ext.prefix_header_contents = "#define MSAL_LEGACY_ACCOUNTS_DISABLED 1"
   	ext.requires_arc = true
   end
 

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   		
   	app.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*"
   	app.requires_arc = true
-    	app.compiler_flags = '-DMSAL_LEGACY_ACCOUNTS_DISABLED=1'
+      app.prefix_header_contents = "#define MSAL_LEGACY_ACCOUNTS_DISABLED 1"
   end
   
   # Note, MSAL has limited support for running in app extensions.
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
   	# for both the platform and overall.
   	ext.ios.exclude_files = "MSAL/src/**/mac/*", "MSAL/IdentityCore/IdentityCore/src/**/mac/*"
   	ext.osx.exclude_files = "MSAL/src/**/ios/*", "MSAL/IdentityCore/IdentityCore/src/**/ios/*"
-  	ext.compiler_flags = '-DMSAL_LEGACY_ACCOUNTS_DISABLED=1'
+      ext.prefix_header_contents = "#define MSAL_LEGACY_ACCOUNTS_DISABLED 1"
   	ext.requires_arc = true
   end
 

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -74,6 +74,6 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALAccountEnumerationParameters.h>
 #import <MSAL/MSALExternalAccountProviding.h>
 #import <MSAL/MSALSerializedADALCacheProvider.h>
-#ifndef MSAL_LEGACY_ACCOUNTS_DISABLED
+#if !MSAL_LEGACY_ACCOUNTS_DISABLED
 #import <MSAL/MSALLegacySharedAccountsProvider.h>
 #endif

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -74,6 +74,6 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALAccountEnumerationParameters.h>
 #import <MSAL/MSALExternalAccountProviding.h>
 #import <MSAL/MSALSerializedADALCacheProvider.h>
-#if !MSAL_LEGACY_ACCOUNTS_DISABLED
+#ifndef MSAL_LEGACY_ACCOUNTS_DISABLED
 #import <MSAL/MSALLegacySharedAccountsProvider.h>
 #endif

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -74,6 +74,6 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALAccountEnumerationParameters.h>
 #import <MSAL/MSALExternalAccountProviding.h>
 #import <MSAL/MSALSerializedADALCacheProvider.h>
-#ifdef MSAL_LEGACY_ENABLED
+#ifndef MSAL_LEGACY_ACCOUNTS_DISABLED
 #import <MSAL/MSALLegacySharedAccountsProvider.h>
 #endif


### PR DESCRIPTION
Flip default from disabled to enabled such as building MSAL from source would work.
Follow up on this PR: https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/612