### PR TITLE
Fixed MSAL underlying error conversion

### DIFF
--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -202,7 +202,12 @@ static NSSet *s_recoverableErrorCode;
     msalUserInfo[MSALErrorDescriptionKey] = errorDescription;
     msalUserInfo[MSALOAuthErrorKey] = oauthError;
     msalUserInfo[MSALOAuthSubErrorKey] = subError;
-    msalUserInfo[NSUnderlyingErrorKey] = underlyingError;
+    
+    if (underlyingError)
+    {
+        msalUserInfo[NSUnderlyingErrorKey] = [MSALErrorConverter msalErrorFromMsidError:underlyingError];
+    }
+    
     msalUserInfo[MSALInternalErrorCodeKey] = internalCode;
 
     if (userInfo[MSIDInvalidTokenResultKey] && oauth2Provider)

--- a/MSAL/test/unit/MSALErrorConverterTests.m
+++ b/MSAL/test/unit/MSALErrorConverterTests.m
@@ -205,7 +205,7 @@
     NSString *errorDescription = @"a fake error description.";
     NSString *oauthError = @"a fake oauth error message.";
     NSString *subError = @"a fake suberror";
-    NSError *underlyingError = [NSError errorWithDomain:NSOSStatusErrorDomain code:errSecItemNotFound userInfo:nil];
+    NSError *underlyingError = [NSError errorWithDomain:MSIDErrorDomain code:MSIDErrorServerInvalidGrant userInfo:@{MSIDOAuthSubErrorKey : @"basic_action"}];
     NSUUID *correlationId = [NSUUID UUID];
     NSDictionary *httpHeaders = @{@"fake header key" : @"fake header value"};
     NSString *httpResponseCode = @"-99999";
@@ -237,7 +237,6 @@
     XCTAssertNil(msalError.userInfo[MSIDOAuthErrorKey]);
     XCTAssertEqualObjects(msalError.userInfo[MSALOAuthSubErrorKey], subError);
     XCTAssertNil(msalError.userInfo[MSIDOAuthSubErrorKey]);
-    XCTAssertEqualObjects(msalError.userInfo[NSUnderlyingErrorKey], underlyingError);
     XCTAssertEqualObjects(msalError.userInfo[MSALHTTPHeadersKey], httpHeaders);
     XCTAssertNil(msalError.userInfo[MSIDHTTPHeadersKey]);
     XCTAssertEqualObjects(msalError.userInfo[MSALHTTPResponseCodeKey], httpResponseCode);
@@ -247,6 +246,12 @@
     XCTAssertNotNil(msalError.userInfo[MSALInvalidResultKey]);
     MSALResult *result = msalError.userInfo[MSALInvalidResultKey];
     XCTAssertEqualObjects(result.accessToken, @"access-token");
+    
+    NSError *mappedUnderlyingError = msalError.userInfo[NSUnderlyingErrorKey];
+    XCTAssertEqualObjects(mappedUnderlyingError.domain, MSALErrorDomain);
+    XCTAssertEqual(mappedUnderlyingError.code, MSALErrorInternal);
+    XCTAssertEqual(mappedUnderlyingError.userInfo[MSALOAuthSubErrorKey], @"basic_action");
+    XCTAssertEqual([mappedUnderlyingError.userInfo[MSALInternalErrorCodeKey] integerValue], MSALInternalErrorInvalidGrant);
 }
 
 - (MSIDTokenResult *)testTokenResult


### PR DESCRIPTION
Underlying error wasn't converted correctly from MSID to MSAL