### PR TITLE
Fix error description logging

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -773,22 +773,22 @@
              context:(id<MSIDRequestContext>)ctx
                 mask:(BOOL)mask
 {
-  if (error)
-  {
-    NSString *errorDescription = error.userInfo[MSALErrorDescriptionKey];
-    errorDescription = errorDescription ? errorDescription : @"emptyString";
-    if (mask) {
-      MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, ctx, @"%@ returning with error: (%@, %ld) %@", operation, error.domain, (long)error.code, MSID_PII_LOG_MASKABLE(errorDescription));
-    } else {
-      MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, ctx, @"%@ returning with error: (%@, %ld) %@", operation, error.domain, (long)error.code, errorDescription);
+    if (error)
+    {
+        NSString *errorDescription = error.userInfo[MSALErrorDescriptionKey];
+        errorDescription = errorDescription ? errorDescription : @"";
+        if (mask) {
+            MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, ctx, @"%@ returning with error: (%@, %ld) %@", operation, error.domain, (long)error.code, MSID_PII_LOG_MASKABLE(errorDescription));
+        } else {
+            MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, ctx, @"%@ returning with error: (%@, %ld) %@", operation, error.domain, (long)error.code, errorDescription);
+        }
     }
-  }
   
-  if (result)
-  {
-    NSString *hashedAT = [result.accessToken msidTokenHash];
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, ctx, @"%@ returning with at: %@ scopes:%@ expiration:%@", operation, hashedAT, result.scopes, result.expiresOn);
-  }
+    if (result)
+    {
+        NSString *hashedAT = [result.accessToken msidTokenHash];
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, ctx, @"%@ returning with at: %@ scopes:%@ expiration:%@", operation, hashedAT, result.scopes, result.expiresOn);
+    }
 }
 
 

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -929,16 +929,14 @@
         if (parameters.webviewParameters.parentViewController == nil)
         {
             NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"parentViewController is a required parameter on iOS 13.", nil, nil, nil, nil, nil);
-            NSError *msalError = [MSALErrorConverter msalErrorFromMsidError:msidError];
-            block(nil, msalError, msidParams);
+            block(nil, msidError, msidParams);
             return;
         }
         
         if (parameters.webviewParameters.parentViewController.view.window == nil)
         {
             NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"parentViewController has no window! Provide a valid controller with view and window.", nil, nil, nil, nil, nil);
-            NSError *msalError = [MSALErrorConverter msalErrorFromMsidError:msidError];
-            block(nil, msalError, msidParams);
+            block(nil, msidError, msidParams);
             return;
         }
         


### PR DESCRIPTION
[AB#68759](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/68759)

This PR will allow MSAL's errorDescription to be printed in raw; Also this PR fixes double conversion (msid>**msal**>**msal**)