### PR TITLE
ADAL macOS cache persistence

### DIFF
--- a/MSAL/src/configuration/external/MSALSerializedADALCacheProvider.m
+++ b/MSAL/src/configuration/external/MSALSerializedADALCacheProvider.m
@@ -25,6 +25,7 @@
 #import "MSIDMacTokenCache.h"
 #import "MSALErrorConverter.h"
 #import "MSALSerializedADALCacheProvider+Internal.h"
+#import "MSIDMacLegacyCachePersistenceHandler.h"
 
 @interface MSALSerializedADALCacheProvider() <MSIDMacTokenCacheDelegate>
 
@@ -47,6 +48,32 @@
         // Init datasource.
         _macTokenCache = [MSIDMacTokenCache new];
         _macTokenCache.delegate = self;
+    }
+    
+    return self;
+}
+
+- (nullable instancetype)initWithKeychainAttributes:(nonnull NSDictionary *)keychainAttributes
+                                trustedApplications:(nonnull NSArray *)trustedApplications
+                                        accessLabel:(nonnull NSString *)accessLabel
+                                              error:(NSError * _Nullable * _Nullable)error
+{
+    self = [super init];
+    
+    if (self)
+    {
+        MSIDMacLegacyCachePersistenceHandler *persistenceHandler = [[MSIDMacLegacyCachePersistenceHandler alloc] initWithTrustedApplications:trustedApplications
+                                                                                                                                 accessLabel:accessLabel
+                                                                                                                                  attributes:keychainAttributes
+                                                                                                                                       error:error];
+        
+        if (!persistenceHandler)
+        {
+            return nil;
+        }
+        
+        _macTokenCache = [MSIDMacTokenCache new];
+        _macTokenCache.delegate = persistenceHandler;
     }
     
     return self;

--- a/MSAL/src/configuration/external/MSALSerializedADALCacheProvider.m
+++ b/MSAL/src/configuration/external/MSALSerializedADALCacheProvider.m
@@ -25,7 +25,9 @@
 #import "MSIDMacTokenCache.h"
 #import "MSALErrorConverter.h"
 #import "MSALSerializedADALCacheProvider+Internal.h"
+#if TARGET_OS_OSX
 #import "MSIDMacLegacyCachePersistenceHandler.h"
+#endif
 
 @interface MSALSerializedADALCacheProvider() <MSIDMacTokenCacheDelegate>
 
@@ -53,6 +55,8 @@
     return self;
 }
 
+#if TARGET_OS_OSX
+
 - (nullable instancetype)initWithKeychainAttributes:(nonnull NSDictionary *)keychainAttributes
                                 trustedApplications:(nonnull NSArray *)trustedApplications
                                         accessLabel:(nonnull NSString *)accessLabel
@@ -78,6 +82,8 @@
     
     return self;
 }
+
+#endif
 
 - (nullable NSData *)serializeDataWithError:(NSError **)error
 {

--- a/MSAL/src/configuration/external/MSALSerializedADALCacheProvider.m
+++ b/MSAL/src/configuration/external/MSALSerializedADALCacheProvider.m
@@ -33,6 +33,9 @@
 
 @property (nonatomic, nonnull, readwrite) id<MSALSerializedADALCacheProviderDelegate> delegate;
 @property (nonatomic, readwrite) MSIDMacTokenCache *macTokenCache;
+#if TARGET_OS_OSX
+@property (nonatomic, readwrite) MSIDMacLegacyCachePersistenceHandler *cachePersistenceHandler;
+#endif
 
 @end
 
@@ -84,6 +87,7 @@
             return nil;
         }
         
+        _cachePersistenceHandler = persistenceHandler;
         _macTokenCache = [MSIDMacTokenCache new];
         _macTokenCache.delegate = persistenceHandler;
     }

--- a/MSAL/src/configuration/external/MSALSerializedADALCacheProvider.m
+++ b/MSAL/src/configuration/external/MSALSerializedADALCacheProvider.m
@@ -66,13 +66,21 @@
     
     if (self)
     {
+        NSError *msidError = nil;
         MSIDMacLegacyCachePersistenceHandler *persistenceHandler = [[MSIDMacLegacyCachePersistenceHandler alloc] initWithTrustedApplications:trustedApplications
                                                                                                                                  accessLabel:accessLabel
                                                                                                                                   attributes:keychainAttributes
-                                                                                                                                       error:error];
+                                                                                                                                       error:&msidError];
         
         if (!persistenceHandler)
         {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to initialize persistent ADAL cache handler");
+            
+            if (error)
+            {
+                *error = [MSALErrorConverter msalErrorFromMsidError:msidError];
+            }
+            
             return nil;
         }
         

--- a/MSAL/src/public/configuration/publicClientApplication/cache/MSALSerializedADALCacheProvider.h
+++ b/MSAL/src/public/configuration/publicClientApplication/cache/MSALSerializedADALCacheProvider.h
@@ -105,6 +105,9 @@ NS_ASSUME_NONNULL_BEGIN
     @param trustedApplications            List of apps that the item should be shared with.
     @param accessLabel                              Title for the ADAL cache item access control.
     @param error                                           Error if present
+ 
+    @note By using this initializer, application delegates writing and reading from the keychain to MSAL.
+    This might or might not work for all apps. If you have your own implementation of ADAL cache serialization when migrating to MSAL, you should use initWithDelegate:error: initializer and implement your own ADAL cache persistence.
 */
 - (nullable instancetype)initWithKeychainAttributes:(nonnull NSDictionary *)keychainAttributes
                                 trustedApplications:(nonnull NSArray *)trustedApplications

--- a/MSAL/src/public/configuration/publicClientApplication/cache/MSALSerializedADALCacheProvider.h
+++ b/MSAL/src/public/configuration/publicClientApplication/cache/MSALSerializedADALCacheProvider.h
@@ -97,6 +97,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithDelegate:(nonnull id<MSALSerializedADALCacheProviderDelegate>)delegate
                                     error:(NSError * _Nullable * _Nullable)error;
 
+/**
+   Initializes MSALSerializedADALCacheProvider with attributes allowing MSAL to write item into the keychain.
+    @param keychainAttributes              All keychain attributes needed to write ADAL cache item (at minimum kSecAttrService and kSecAttrAccount)
+    @param trustedApplications            List of apps that the item should be shared with.
+    @param accessLabel                              Title for the ADAL cache item access control.
+    @param error                                           Error if present
+*/
+- (nullable instancetype)initWithKeychainAttributes:(nonnull NSDictionary *)keychainAttributes
+                                trustedApplications:(nonnull NSArray *)trustedApplications
+                                        accessLabel:(nonnull NSString *)accessLabel
+                                              error:(NSError * _Nullable * _Nullable)error;
+
 
 @end
 

--- a/MSAL/src/public/configuration/publicClientApplication/cache/MSALSerializedADALCacheProvider.h
+++ b/MSAL/src/public/configuration/publicClientApplication/cache/MSALSerializedADALCacheProvider.h
@@ -97,6 +97,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithDelegate:(nonnull id<MSALSerializedADALCacheProviderDelegate>)delegate
                                     error:(NSError * _Nullable * _Nullable)error;
 
+#if TARGET_OS_OSX
+
 /**
    Initializes MSALSerializedADALCacheProvider with attributes allowing MSAL to write item into the keychain.
     @param keychainAttributes              All keychain attributes needed to write ADAL cache item (at minimum kSecAttrService and kSecAttrAccount)
@@ -108,6 +110,8 @@ NS_ASSUME_NONNULL_BEGIN
                                 trustedApplications:(nonnull NSArray *)trustedApplications
                                         accessLabel:(nonnull NSString *)accessLabel
                                               error:(NSError * _Nullable * _Nullable)error;
+
+#endif
 
 
 @end


### PR DESCRIPTION
Allow reusing of existing MSAL ACL code to support backward compatibility with ADAL cache. 