### PR TITLE
Disable unused variable warnings for tests and fix warnings

### DIFF
--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -152,7 +152,7 @@ static NSSet *s_recoverableErrorCode;
                   oauthError:(NSString *)oauthError
                     subError:(NSString *)subError
              underlyingError:(NSError *)underlyingError
-               correlationId:(NSUUID *)correlationId
+               correlationId:(__unused NSUUID *)correlationId
                     userInfo:(NSDictionary *)userInfo
               classifyErrors:(BOOL)shouldClassifyErrors
           msalOauth2Provider:(MSALOauth2Provider *)oauth2Provider

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -732,7 +732,7 @@
 #pragma mark - private methods
 
 - (id)initPrivateWithClientId:(NSString *)clientId
-         keychainGroup:(NSString *)keychainGroup
+         keychainGroup:(__unused NSString *)keychainGroup
              authority:(MSALAuthority *)authority
            redirectUri:(NSString *)redirectUri
                  error:(NSError * __autoreleasing *)error

--- a/MSAL/src/configuration/MSALExtraQueryParameters.m
+++ b/MSAL/src/configuration/MSALExtraQueryParameters.m
@@ -43,7 +43,7 @@
 
 #pragma mark - NSCopying
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(__unused NSZone *)zone
 {
     MSALExtraQueryParameters *params = [MSALExtraQueryParameters new];
     params->_extraTokenURLParameters = [_extraTokenURLParameters mutableCopy];

--- a/MSAL/src/configuration/external/MSALSerializedADALCacheProvider.m
+++ b/MSAL/src/configuration/external/MSALSerializedADALCacheProvider.m
@@ -36,7 +36,7 @@
 @implementation MSALSerializedADALCacheProvider
 
 - (instancetype)initWithDelegate:(id<MSALSerializedADALCacheProviderDelegate>)delegate
-                           error:(NSError **)error
+                           error:(__unused NSError **)error
 {
     self = [super init];
     
@@ -52,7 +52,7 @@
     return self;
 }
 
-- (nullable NSData *)serializeDataWithError:(NSError **)error
+- (nullable NSData *)serializeDataWithError:(__unused NSError **)error
 {
     // TODO: error.
     return [self.macTokenCache serialize];
@@ -65,7 +65,7 @@
 
 #pragma mark - NSCopying
 
-- (id)copyWithZone:(NSZone *)zone
+- (id)copyWithZone:(__unused NSZone *)zone
 {
     MSALSerializedADALCacheProvider *copiedCacheProvider = [[MSALSerializedADALCacheProvider alloc] initWithDelegate:self.delegate error:nil];
     return copiedCacheProvider;
@@ -80,22 +80,22 @@
 
 #pragma mark - MSIDMacTokenCacheDelegate
 
-- (void)willAccessCache:(MSIDMacTokenCache *)cache
+- (void)willAccessCache:(__unused MSIDMacTokenCache *)cache
 {
     [self.delegate willAccessCache:self];
 }
 
-- (void)didAccessCache:(MSIDMacTokenCache *)cache
+- (void)didAccessCache:(__unused MSIDMacTokenCache *)cache
 {
     [self.delegate didAccessCache:self];
 }
 
-- (void)willWriteCache:(MSIDMacTokenCache *)cache
+- (void)willWriteCache:(__unused MSIDMacTokenCache *)cache
 {
     [self.delegate willWriteCache:self];
 }
 
-- (void)didWriteCache:(MSIDMacTokenCache *)cache
+- (void)didWriteCache:(__unused MSIDMacTokenCache *)cache
 {
     [self.delegate didWriteCache:self];
 }

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccount.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccount.m
@@ -140,7 +140,7 @@ static NSDateFormatter *s_updateDateFormatter = nil;
                      applicationName:(NSString *)appName
                            operation:(MSALLegacySharedAccountWriteOperation)operation
                       accountVersion:(MSALLegacySharedAccountVersion)accountVersion
-                               error:(NSError **)error
+                               error:(__unused NSError **)error
 {
     if (accountVersion == MSALLegacySharedAccountVersionV1)
     {
@@ -192,7 +192,7 @@ static NSDateFormatter *s_updateDateFormatter = nil;
     return YES;
 }
 
-- (NSDictionary *)claimsFromMSALAccount:(id<MSALAccount>)account claims:(NSDictionary *)claims
+- (NSDictionary *)claimsFromMSALAccount:(__unused id<MSALAccount>)account claims:(__unused NSDictionary *)claims
 {
     return nil;
 }

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
@@ -147,7 +147,7 @@
 
 - (nullable NSArray<MSALLegacySharedAccount *> *)accountsFromJsonObject:(NSDictionary *)jsonDictionary
                                                          withParameters:(MSALAccountEnumerationParameters *)parameters
-                                                                  error:(NSError **)error
+                                                                  error:(__unused NSError **)error
 {
     NSMutableArray *resultAccounts = [NSMutableArray new];
     

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedMSAAccount.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedMSAAccount.m
@@ -93,11 +93,11 @@ static NSString *kDefaultCacheAuthority = @"https://login.windows.net/common";
     return self;
 }
 
-- (instancetype)initWithMSALAccount:(id<MSALAccount>)account
-                      accountClaims:(NSDictionary *)claims
-                    applicationName:(NSString *)appName
-                     accountVersion:(MSALLegacySharedAccountVersion)accountVersion
-                              error:(NSError **)error
+- (instancetype)initWithMSALAccount:(__unused id<MSALAccount>)account
+                      accountClaims:(__unused NSDictionary *)claims
+                    applicationName:(__unused NSString *)appName
+                     accountVersion:(__unused MSALLegacySharedAccountVersion)accountVersion
+                              error:(__unused NSError **)error
 {
     return nil; // Creating new MSA accounts isn't supported currently and will be added at a later point
 }

--- a/MSAL/src/instance/MSALADFSAuthority.m
+++ b/MSAL/src/instance/MSALADFSAuthority.m
@@ -36,7 +36,7 @@
 
 #define ADFS_NOT_YET_SUPPORTED
 
-- (instancetype)initWithURL:(NSURL *)url
+- (instancetype)initWithURL:(__unused NSURL *)url
                       error:(NSError **)error
 {
 #ifdef ADFS_NOT_YET_SUPPORTED

--- a/MSAL/src/instance/MSALAccountsProvider.m
+++ b/MSAL/src/instance/MSALAccountsProvider.m
@@ -268,7 +268,7 @@
     [authority.msidAuthority resolveAndValidate:NO
                               userPrincipalName:nil
                                         context:nil
-                                completionBlock:^(NSURL * _Nullable openIdConfigurationEndpoint, BOOL validated, NSError * _Nullable error) {
+                                completionBlock:^(__unused NSURL * _Nullable openIdConfigurationEndpoint, __unused BOOL validated, NSError * _Nullable error) {
                                     
                                     if (error)
                                     {

--- a/MSAL/src/instance/MSALAuthority.m
+++ b/MSAL/src/instance/MSALAuthority.m
@@ -38,8 +38,8 @@
 
 @implementation MSALAuthority
 
-- (instancetype)initWithURL:(nonnull NSURL *)url
-                      error:(NSError * _Nullable __autoreleasing * _Nullable)error
+- (instancetype)initWithURL:(nonnull __unused NSURL *)url
+                      error:(__unused NSError * _Nullable __autoreleasing * _Nullable)error
 {
     return [super init];
 }

--- a/MSAL/src/instance/MSALOauth2ProviderFactory.m
+++ b/MSAL/src/instance/MSALOauth2ProviderFactory.m
@@ -39,7 +39,7 @@
                                          clientId:(NSString *)clientId
                                        tokenCache:(MSIDDefaultTokenCacheAccessor *)tokenCache
                              accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache
-                                          context:(id<MSIDRequestContext>)context
+                                          context:(__unused id<MSIDRequestContext>)context
                                             error:(NSError **)error
 {
     if (!authority)

--- a/MSAL/src/instance/oauth2/MSALOauth2Provider.m
+++ b/MSAL/src/instance/oauth2/MSALOauth2Provider.m
@@ -42,7 +42,7 @@
 
 - (instancetype)initWithClientId:(NSString *)clientId
                       tokenCache:(MSIDDefaultTokenCacheAccessor *)tokenCache
-            accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache;
+            accountMetadataCache:(MSIDAccountMetadataCacheAccessor *)accountMetadataCache
 
 {
     self = [super init];
@@ -76,15 +76,15 @@
 }
 
 - (BOOL)removeAdditionalAccountInfo:(__unused MSALAccount *)account
-                              error:(NSError **)error
+                              error:(__unused NSError **)error
 {
     return YES;
 }
 
-- (MSIDAuthority *)issuerAuthorityWithAccount:(MSALAccount *)account
+- (MSIDAuthority *)issuerAuthorityWithAccount:(__unused MSALAccount *)account
                              requestAuthority:(MSIDAuthority *)requestAuthority
-                                instanceAware:(BOOL)instanceAware
-                                        error:(NSError * _Nullable __autoreleasing *)error
+                                instanceAware:(__unused BOOL)instanceAware
+                                        error:(__unused NSError * _Nullable __autoreleasing *)error
 {
     // TODO: after authority->issuer cache is ready, this should always lookup cached issuer instead
     return requestAuthority;

--- a/MSAL/src/util/mac/MSALRedirectUriVerifier.m
+++ b/MSAL/src/util/mac/MSALRedirectUriVerifier.m
@@ -31,8 +31,8 @@
 @implementation MSALRedirectUriVerifier
 
 + (MSALRedirectUri *)msalRedirectUriWithCustomUri:(NSString *)customRedirectUri
-                                         clientId:(NSString *)clientId
-                                            error:(NSError * __autoreleasing *)error
+                                         clientId:(__unused NSString *)clientId
+                                            error:(__unused NSError * __autoreleasing *)error
 {
     if (![NSString msidIsStringNilOrBlank:customRedirectUri])
     {

--- a/MSAL/test/app/ios/MSALTestAppAuthorityViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAuthorityViewController.m
@@ -100,7 +100,7 @@
     [super viewDidLoad];
 }
 
-- (void)addAuthority:(id)sender
+- (void)addAuthority:(__unused id)sender
 {
     UIAlertController *controller = [UIAlertController alertControllerWithTitle:@"Add authority" message:nil preferredStyle:UIAlertControllerStyleAlert];
     [controller addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
@@ -108,7 +108,7 @@
     }];
     
     [controller addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
-    [controller addAction:[UIAlertAction actionWithTitle:@"Add" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+    [controller addAction:[UIAlertAction actionWithTitle:@"Add" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction * _Nonnull action) {
         NSString *authority = controller.textFields[0].text;
         [self saveAuthority:authority];
     }]];

--- a/MSAL/test/app/ios/MSALTestAppCacheViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppCacheViewController.m
@@ -281,14 +281,14 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
     return [_cacheSectionTitles count];
 }
 
-- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+- (NSInteger)tableView:(__unused UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
     NSString *sectionTitle = [_cacheSectionTitles objectAtIndex:section];
     NSArray *sectionObjects = [_cacheSections objectForKey:sectionTitle];
     return [sectionObjects count];
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (UIView *)tableView:(__unused UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
     UILabel *label = [[UILabel alloc] init];
     NSArray *sectionObjects = [_cacheSections objectForKey:[_cacheSectionTitles objectAtIndex:section]];
@@ -311,7 +311,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
     return label;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+- (CGFloat)tableView:(__unused UITableView *)tableView heightForHeaderInSection:(__unused NSInteger)section
 {
     return 30;
 }
@@ -406,7 +406,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
 
 #pragma mark - UITableViewDelegate
 
-- (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath API_AVAILABLE(ios(11.0))
+- (UISwipeActionsConfiguration *)tableView:(__unused UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath API_AVAILABLE(ios(11.0))
 {
     NSString *sectionTitle = [_cacheSectionTitles objectAtIndex:indexPath.section];
     NSArray *sectionObjects = [_cacheSections objectForKey:sectionTitle];
@@ -416,7 +416,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         MSIDAppMetadataCacheItem *appMetadata = (MSIDAppMetadataCacheItem *)cacheEntry;
         __auto_type deleteTokenAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive
                                                                                 title:@"Delete"
-                                                                              handler:^(UIContextualAction *action, __kindof UIView *sourceView, void (^completionHandler)(BOOL))
+                                                                              handler:^(__unused UIContextualAction *action, __unused __kindof UIView *sourceView, void (__unused ^completionHandler)(BOOL))
                                          {
                                              [self deleteAppMetadata:appMetadata];
                                          }];
@@ -429,14 +429,14 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         MSIDBaseToken *token = (MSIDBaseToken *)cacheEntry;
         __auto_type deleteTokenAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive
                                                                                 title:@"Delete"
-                                                                              handler:^(UIContextualAction *action, __kindof UIView *sourceView, void (^completionHandler)(BOOL))
+                                                                              handler:^(__unused UIContextualAction *action, __unused __kindof UIView *sourceView, void (__unused ^completionHandler)(BOOL))
                                          {
                                              [self deleteToken:token];
                                          }];
         
         __auto_type invalidateAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleNormal
                                                                                title:@"Invalidate"
-                                                                             handler:^(UIContextualAction *action, __kindof UIView *sourceView, void (^completionHandler)(BOOL))
+                                                                             handler:^(__unused UIContextualAction *action, __unused __kindof UIView *sourceView, void (__unused ^completionHandler)(BOOL))
                                         {
                                             [self invalidateRefreshToken:(MSIDRefreshToken *)token];
                                         }];
@@ -444,7 +444,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         
         __auto_type expireTokenAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleNormal
                                                                                 title:@"Expire"
-                                                                              handler:^(UIContextualAction *action, __kindof UIView *sourceView, void (^completionHandler)(BOOL))
+                                                                              handler:^(__unused UIContextualAction *action, __unused __kindof UIView *sourceView, void (__unused ^completionHandler)(BOOL))
                                          {
                                              [self expireAccessToken:(MSIDAccessToken *)token];
                                          }];
@@ -478,7 +478,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         MSIDAccount *account = (MSIDAccount *)cacheEntry;
         __auto_type deleteAccountAction = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive
                                                                                   title:@"Delete All"
-                                                                                handler:^(UIContextualAction *action, __kindof UIView *sourceView, void (^completionHandler)(BOOL))
+                                                                                handler:^(__unused UIContextualAction *action, __unused __kindof UIView *sourceView, void (__unused ^completionHandler)(BOOL))
                                            {
                                                [self deleteAllEntriesForAccount:account];
                                            }];
@@ -491,7 +491,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
 }
 
 #if !TARGET_OS_MACCATALYST
-- (nullable NSArray<UITableViewRowAction *> *)tableView:(UITableView *)tableView
+- (nullable NSArray<UITableViewRowAction *> *)tableView:( __unused UITableView *)tableView
                            editActionsForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     NSString *sectionTitle = [_cacheSectionTitles objectAtIndex:indexPath.section];
@@ -503,7 +503,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         UITableViewRowAction *deleteTokenAction =
         [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDestructive
                                            title:@"Delete"
-                                         handler:^(__unused UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath)
+                                         handler:^(__unused UITableViewRowAction * _Nonnull action, __unused NSIndexPath * _Nonnull indexPath)
          {
              [self deleteAppMetadata:appMetadata];
          }];
@@ -516,7 +516,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         UITableViewRowAction *deleteTokenAction =
         [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDestructive
                                            title:@"Delete"
-                                         handler:^(__unused UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath)
+                                         handler:^(__unused UITableViewRowAction * _Nonnull action, __unused NSIndexPath * _Nonnull indexPath)
          {
              [self deleteToken:token];
          }];
@@ -524,7 +524,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         UITableViewRowAction* invalidateAction =
         [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal
                                            title:@"Invalidate"
-                                         handler:^(__unused UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath)
+                                         handler:^(__unused UITableViewRowAction * _Nonnull action, __unused NSIndexPath * _Nonnull indexPath)
          {
              [self invalidateRefreshToken:(MSIDRefreshToken *)token];
          }];
@@ -534,7 +534,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         UITableViewRowAction* expireTokenAction =
         [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal
                                            title:@"Expire"
-                                         handler:^(__unused UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath)
+                                         handler:^(__unused UITableViewRowAction * _Nonnull action, __unused NSIndexPath * _Nonnull indexPath)
          {
              [self expireAccessToken:(MSIDAccessToken *)token];
          }];
@@ -568,7 +568,7 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         MSIDAccount *account = (MSIDAccount *)cacheEntry;
         return @[[UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDestructive
                                                     title:@"Delete All"
-                                                  handler:^(__unused UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath)
+                                                  handler:^(__unused UITableViewRowAction * _Nonnull action, __unused NSIndexPath * _Nonnull indexPath)
                   {
                       [self deleteAllEntriesForAccount:account];
                   }]];

--- a/MSAL/test/app/ios/MSALTestAppLogViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppLogViewController.m
@@ -62,7 +62,7 @@ static NSAttributedString* s_attrNewLine = nil;
     [self setEdgesForExtendedLayout:UIRectEdgeNone];
     
     MSALGlobalConfig.loggerConfig.piiEnabled = YES;
-    [MSALGlobalConfig.loggerConfig setLogCallback:^(MSALLogLevel level, NSString * _Nullable message, BOOL containsPII)
+    [MSALGlobalConfig.loggerConfig setLogCallback:^(MSALLogLevel level, NSString * _Nullable message, __unused BOOL containsPII)
     {
         (void)level;
 

--- a/MSAL/test/app/ios/MSALTestAppSettingsViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppSettingsViewController.m
@@ -169,7 +169,7 @@ static NSArray* s_deviceRows = nil;
     return 0;
 }
 
-- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView;
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
     (void)tableView;
     return 2;

--- a/MSAL/test/automation/ios/MSALAutoAppDelegate.m
+++ b/MSAL/test/automation/ios/MSALAutoAppDelegate.m
@@ -36,7 +36,7 @@
 {
     (void)application;
     (void)launchOptions;
-    [MSALGlobalConfig.loggerConfig setLogCallback:^(MSALLogLevel level, NSString * _Nullable message, BOOL containsPII) {
+    [MSALGlobalConfig.loggerConfig setLogCallback:^(__unused MSALLogLevel level, NSString * _Nullable message, __unused BOOL containsPII) {
         [MSIDAutomationMainViewController forwardIdentitySDKLog:message];
     }];
     

--- a/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenSilentAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenSilentAction.m
@@ -55,7 +55,7 @@
 }
 
 - (void)performActionWithParameters:(MSIDAutomationTestRequest *)testRequest
-                containerController:(MSIDAutoViewController *)containerController
+                containerController:(__unused MSIDAutoViewController *)containerController
                     completionBlock:(MSIDAutoCompletionBlock)completionBlock
 {
     NSError *applicationError = nil;

--- a/MSAL/test/automation/ios/actions/MSALAutomationBaseAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationBaseAction.m
@@ -71,9 +71,9 @@
     return NO;
 }
 
-- (void)performActionWithParameters:(MSIDAutomationTestRequest *)parameters
-                containerController:(MSIDAutomationMainViewController *)containerController
-                    completionBlock:(MSIDAutoCompletionBlock)completionBlock
+- (void)performActionWithParameters:(__unused MSIDAutomationTestRequest *)parameters
+                containerController:(__unused MSIDAutomationMainViewController *)containerController
+                    completionBlock:(__unused MSIDAutoCompletionBlock)completionBlock
 {
     NSAssert(NO, @"Abstract method, it should never be called!");
 }

--- a/MSAL/test/automation/ios/actions/MSALAutomationExpireATAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationExpireATAction.m
@@ -57,7 +57,7 @@
 }
 
 - (void)performActionWithParameters:(MSIDAutomationTestRequest *)testRequest
-                containerController:(MSIDAutoViewController *)containerController
+                containerController:(__unused MSIDAutoViewController *)containerController
                     completionBlock:(MSIDAutoCompletionBlock)completionBlock
 {
     NSString *authority = testRequest.cacheAuthority ?: testRequest.configurationAuthority;

--- a/MSAL/test/automation/ios/actions/MSALAutomationInvalidateRTAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationInvalidateRTAction.m
@@ -57,7 +57,7 @@
 }
 
 - (void)performActionWithParameters:(MSIDAutomationTestRequest *)testRequest
-                containerController:(MSIDAutoViewController *)containerController
+                containerController:(__unused MSIDAutoViewController *)containerController
                     completionBlock:(MSIDAutoCompletionBlock)completionBlock
 {
     NSString *authority = testRequest.cacheAuthority ?: testRequest.configurationAuthority;

--- a/MSAL/test/automation/ios/actions/MSALAutomationReadAccountsAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationReadAccountsAction.m
@@ -54,7 +54,7 @@
 }
 
 - (void)performActionWithParameters:(MSIDAutomationTestRequest *)testRequest
-                containerController:(MSIDAutoViewController *)containerController
+                containerController:(__unused MSIDAutoViewController *)containerController
                     completionBlock:(MSIDAutoCompletionBlock)completionBlock
 {
     NSError *applicationError = nil;

--- a/MSAL/test/automation/ios/actions/MSALAutomationRemoveAccountAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationRemoveAccountAction.m
@@ -50,7 +50,7 @@
 }
 
 - (void)performActionWithParameters:(MSIDAutomationTestRequest *)testRequest
-                containerController:(MSIDAutoViewController *)containerController
+                containerController:(__unused MSIDAutoViewController *)containerController
                     completionBlock:(MSIDAutoCompletionBlock)completionBlock
 {
     NSError *applicationError = nil;

--- a/MSAL/test/unit/mac/unit-test-host/AppDelegate.m
+++ b/MSAL/test/unit/mac/unit-test-host/AppDelegate.m
@@ -33,12 +33,12 @@
 
 @implementation AppDelegate
 
-- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+- (void)applicationDidFinishLaunching:(__unused NSNotification *)aNotification {
     // Insert code here to initialize your application
 }
 
 
-- (void)applicationWillTerminate:(NSNotification *)aNotification {
+- (void)applicationWillTerminate:(__unused NSNotification *)aNotification {
     // Insert code here to tear down your application
 }
 

--- a/MSAL/test/unit/utils/MSALTestURLSessionDataTask.m
+++ b/MSAL/test/unit/utils/MSALTestURLSessionDataTask.m
@@ -42,7 +42,7 @@
 
 - (id)initWithRequest:(NSURLRequest *)request
               session:(MSIDTestURLSession *)session
-    completionHandler:(MSALTestHttpCompletionBlock)completionHandler;
+    completionHandler:(MSALTestHttpCompletionBlock)completionHandler
 {
     (void)completionHandler;
     

--- a/MSAL/xcconfig/msal__unit_test__ios.xcconfig
+++ b/MSAL/xcconfig/msal__unit_test__ios.xcconfig
@@ -3,4 +3,4 @@
 INFOPLIST_FILE = test/automation/tests/interactive/Info.plist;
 PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSAL-iOS-Unit-Tests;
 PRODUCT_NAME = "MSAL-iOS-UI-Tests";
-
+GCC_WARN_UNUSED_PARAMETER = NO

--- a/MSAL/xcconfig/msal__unit_test__mac.xcconfig
+++ b/MSAL/xcconfig/msal__unit_test__mac.xcconfig
@@ -4,3 +4,4 @@
 INFOPLIST_FILE = test/unit/resources/mac/Info.plist;
 PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSAL-Mac-Unit-Tests;
 PRODUCT_NAME = "MSAL-Mac-Unit-Tests"
+GCC_WARN_UNUSED_PARAMETER = NO

--- a/MSAL/xcconfig/msal__unit_test_host__ios.xcconfig
+++ b/MSAL/xcconfig/msal__unit_test_host__ios.xcconfig
@@ -5,3 +5,4 @@ INFOPLIST_FILE = test/unit/ios/unit-test-host/Info.plist;
 LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.unit-test-host;
 PRODUCT_NAME = unit-test-host;
+GCC_WARN_UNUSED_PARAMETER = NO


### PR DESCRIPTION
Integrating this PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/605 and applying some additional fixes