### PR TITLE
Fixed Identitycore build for macOS

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -496,6 +496,7 @@
 		B27CCDF5229F9F4700CAD565 /* MSALAccountEnumerationParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = B27CCDF1229F9F4700CAD565 /* MSALAccountEnumerationParameters.m */; };
 		B281B33B226BC225009619AB /* MSALPublicClientApplicationConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B281B33A226BC225009619AB /* MSALPublicClientApplicationConfigTests.m */; };
 		B281B33C226BC225009619AB /* MSALPublicClientApplicationConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B281B33A226BC225009619AB /* MSALPublicClientApplicationConfigTests.m */; };
+		B286B9E42389E751007833AD /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2EE86E223751CAE00D0BC96 /* AuthenticationServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B28BBD342211DC7D00F51723 /* MSALPublicClientStatusNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = B28BBD312211DC7D00F51723 /* MSALPublicClientStatusNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B28BBD352211DC7D00F51723 /* MSALPublicClientStatusNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = B28BBD322211DC7D00F51723 /* MSALPublicClientStatusNotifications.m */; };
 		B28BBD362211DC7D00F51723 /* MSALPublicClientStatusNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = B28BBD322211DC7D00F51723 /* MSALPublicClientStatusNotifications.m */; };
@@ -1463,6 +1464,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B286B9E42389E751007833AD /* AuthenticationServices.framework in Frameworks */,
 				96902DF920E157B400200E6F /* WebKit.framework in Frameworks */,
 				231CE9DF1FEC7E8400E95D3E /* libIdentityTest.a in Frameworks */,
 				D65A6FD51E3FF49C00C69FBA /* MSAL.framework in Frameworks */,

--- a/MSAL/test/app/mac/MSALAcquireTokenViewController.m
+++ b/MSAL/test/app/mac/MSALAcquireTokenViewController.m
@@ -102,14 +102,14 @@ static NSString * const defaultScope = @"User.Read";
     }
 }
 
-- (IBAction)selectedProfileChanged:(id)sender
+- (IBAction)selectedProfileChanged:(__unused id)sender
 {
     [self.settings setCurrentProfile:[self.profilesPopUp indexOfSelectedItem]];
     self.clientIdTextField.stringValue = [[MSALTestAppSettings currentProfile] objectForKey:clientId];
     self.redirectUriTextField.stringValue = [[MSALTestAppSettings currentProfile] objectForKey:redirectUri];
 }
 
-- (void)prepareForSegue:(NSStoryboardSegue *)segue sender:(id)sender
+- (void)prepareForSegue:(NSStoryboardSegue *)segue sender:(__unused id)sender
 {
     if ([segue.identifier isEqualToString:@"addScopesSegue"])
     {
@@ -193,7 +193,7 @@ static NSString * const defaultScope = @"User.Read";
     });
 }
 
-- (IBAction)clearCache:(id)sender
+- (IBAction)clearCache:(__unused id)sender
 {
     MSALTestAppSettings *settings = [MSALTestAppSettings settings];
     
@@ -236,7 +236,7 @@ static NSString * const defaultScope = @"User.Read";
     }
 }
 
-- (IBAction)clearCookies:(id)sender
+- (IBAction)clearCookies:(__unused id)sender
 {
     // Clear WKWebView cookies
     if (@available(macOS 10.11, *)) {

--- a/MSAL/test/app/mac/MSALAppDelegate.m
+++ b/MSAL/test/app/mac/MSALAppDelegate.m
@@ -33,12 +33,12 @@
 
 @implementation MSALAppDelegate
 
-- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+- (void)applicationDidFinishLaunching:(__unused NSNotification *)aNotification {
     // Insert code here to initialize your application
 }
 
 
-- (void)applicationWillTerminate:(NSNotification *)aNotification {
+- (void)applicationWillTerminate:(__unused NSNotification *)aNotification {
     // Insert code here to tear down your application
 }
 

--- a/MSAL/test/app/mac/MSALCacheViewController.m
+++ b/MSAL/test/app/mac/MSALCacheViewController.m
@@ -212,13 +212,13 @@ static NSString *s_badRefreshToken = @"Bad-Refresh-Token";
 
 #pragma mark Button Actions
 
-- (IBAction)refreshCache:(id)sender
+- (IBAction)refreshCache:(__unused id)sender
 {
     [self loadCache];
 }
 
 
-- (IBAction)expireOrInvalidateToken:(id)sender
+- (IBAction)expireOrInvalidateToken:(__unused id)sender
 {
     id item = [self.outLineView itemAtRow:[self.outLineView selectedRow]];
     
@@ -235,7 +235,7 @@ static NSString *s_badRefreshToken = @"Bad-Refresh-Token";
     }
 }
 
-- (IBAction)deleteItem:(id)sender
+- (IBAction)deleteItem:(__unused id)sender
 {
     id item = [self.outLineView itemAtRow:[self.outLineView selectedRow]];
     if ([item isKindOfClass:[MSIDAccount class]])
@@ -254,17 +254,17 @@ static NSString *s_badRefreshToken = @"Bad-Refresh-Token";
 
 #pragma mark NSOutlineView Data Source Test Methods
 
-- (NSInteger)outlineView:(NSOutlineView *)outlineView numberOfChildrenOfItem:(id)item
+- (NSInteger)outlineView:(__unused NSOutlineView *)outlineView numberOfChildrenOfItem:(id)item
 {
     return item ? [[self.cacheDict objectForKey:item] count] : [[self.cacheDict allKeys] count];
 }
 
-- (BOOL)outlineView:(NSOutlineView *)outlineView isItemExpandable:(id)item
+- (BOOL)outlineView:(__unused NSOutlineView *)outlineView isItemExpandable:(id)item
 {
     return item ? [[self.cacheDict objectForKey:item] count] : YES;
 }
 
-- (id)outlineView:(NSOutlineView *)outlineView child:(NSInteger)index ofItem:(id)item
+- (id)outlineView:(__unused NSOutlineView *)outlineView child:(NSInteger)index ofItem:(id)item
 {
     return item ? [[self.cacheDict objectForKey:item] objectAtIndex:index] : [[self.cacheDict allKeys] objectAtIndex:index];
 }

--- a/MSAL/test/app/mac/MSALScopesViewController.m
+++ b/MSAL/test/app/mac/MSALScopesViewController.m
@@ -48,7 +48,7 @@
     [self.scopesView reloadData];
 }
 
-- (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView
+- (NSInteger)numberOfRowsInTableView:(__unused NSTableView *)tableView
 {
     return [self.scopesList count];
 }
@@ -66,7 +66,7 @@
     return nil;
 }
 
-- (IBAction)insertNewRow:(id)sender
+- (IBAction)insertNewRow:(__unused id)sender
 {
     NSString *scope = [self.scopesText stringValue];
     
@@ -82,14 +82,14 @@
     }
 }
 
-- (IBAction)deleteSelectedRows:(id)sender
+- (IBAction)deleteSelectedRows:(__unused id)sender
 {
     NSIndexSet *indexes = [self.scopesView selectedRowIndexes];
     [self.scopesList removeObjectsAtIndexes:indexes];
     [self.scopesView removeRowsAtIndexes:indexes withAnimation:NSTableViewAnimationSlideDown];
 }
 
-- (IBAction)done:(id)sender
+- (IBAction)done:(__unused id)sender
 {
     NSIndexSet *indexes = [self.scopesView selectedRowIndexes];
     NSMutableArray *selectedScopes = [[NSMutableArray alloc] init];


### PR DESCRIPTION
SSO extension classes were not in "iOS" specific folders, but were not included in macOS target either. This was causing build issues for CPP team, and also for CocoaPods build.

Since we're planning to have SSO extension for macOS as well shortly, it doesn't make much sense to move SSO extension classes to iOS folder and then move them back. Therefore, this PR is enabling SSO extension classes for macOS target and making sure it compiles. Note that it doesn't attempt to actually activate SSO extension code path for macOS yet, this is simply about compilation of the code.

Additionally, fixed unused variable warnings for macOS test app. 