### PR TITLE
Implement global signout with SSO extension and the browser

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -495,9 +495,9 @@
 		B27CCDF5229F9F4700CAD565 /* MSALAccountEnumerationParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = B27CCDF1229F9F4700CAD565 /* MSALAccountEnumerationParameters.m */; };
 		B281B33B226BC225009619AB /* MSALPublicClientApplicationConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B281B33A226BC225009619AB /* MSALPublicClientApplicationConfigTests.m */; };
 		B281B33C226BC225009619AB /* MSALPublicClientApplicationConfigTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B281B33A226BC225009619AB /* MSALPublicClientApplicationConfigTests.m */; };
+		B286B9E42389E751007833AD /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2EE86E223751CAE00D0BC96 /* AuthenticationServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B286B9FD238A07A5007833AD /* MSALAcquireTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D6B58A531EB2C4A8000B3A5F /* MSALAcquireTokenTests.m */; };
 		B286BA00238A08F6007833AD /* MSALB2CPolicyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B25F1BB21EC257F900474D1B /* MSALB2CPolicyTests.m */; };
-		B286B9E42389E751007833AD /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2EE86E223751CAE00D0BC96 /* AuthenticationServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B28BBD342211DC7D00F51723 /* MSALPublicClientStatusNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = B28BBD312211DC7D00F51723 /* MSALPublicClientStatusNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B28BBD352211DC7D00F51723 /* MSALPublicClientStatusNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = B28BBD322211DC7D00F51723 /* MSALPublicClientStatusNotifications.m */; };
 		B28BBD362211DC7D00F51723 /* MSALPublicClientStatusNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = B28BBD322211DC7D00F51723 /* MSALPublicClientStatusNotifications.m */; };
@@ -634,6 +634,10 @@
 		B2D478C4230E3EC4005AE186 /* MSALAccountEnumerationParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = B27CCDF1229F9F4700CAD565 /* MSALAccountEnumerationParameters.m */; };
 		B2D478C5230E3EC5005AE186 /* MSALAccountEnumerationParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = B27CCDF1229F9F4700CAD565 /* MSALAccountEnumerationParameters.m */; };
 		B2D6672D210E766F00952595 /* MSALPublicClientApplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D673F07C1E4AAB0D0018BA91 /* MSALPublicClientApplicationTests.m */; };
+		B2E2A9422393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E2A9402393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h */; };
+		B2E2A9432393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E2A9412393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.m */; };
+		B2E2A94A2393192400BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E2A9402393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h */; };
+		B2E2A94C2393192700BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E2A9412393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.m */; };
 		B2F4572A211C0B4800818910 /* MSALBaseAADUITest.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F45729211C0B4800818910 /* MSALBaseAADUITest.m */; };
 		B2F45738211D376F00818910 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96902DEC20E1574F00200E6F /* WebKit.framework */; };
 		B2FE601A20E5BB5700502BA6 /* MSAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D65A6F431E3FD30A00C69FBA /* MSAL.framework */; };
@@ -1233,6 +1237,8 @@
 		B2C17B091FC8DB2E0070A514 /* MSIDVersion.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDVersion.m; sourceTree = "<group>"; };
 		B2C2329F21224C21008092C1 /* MSALBlackforestUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALBlackforestUITests.m; sourceTree = "<group>"; };
 		B2C232AA2122A6A5008092C1 /* MSALCacheRemovalTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALCacheRemovalTests.m; sourceTree = "<group>"; };
+		B2E2A9402393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDInteractiveRequestParameters+MSALRequest.h"; sourceTree = "<group>"; };
+		B2E2A9412393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDInteractiveRequestParameters+MSALRequest.m"; sourceTree = "<group>"; };
 		B2EE86E223751CAE00D0BC96 /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
 		B2F4571D2116B26C00818910 /* MSALAADMultiUserTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAADMultiUserTests.m; sourceTree = "<group>"; };
 		B2F45729211C0B4800818910 /* MSALBaseAADUITest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALBaseAADUITest.m; sourceTree = "<group>"; };
@@ -2006,6 +2012,8 @@
 				232D68DB223DBA0700594BBD /* MSALInteractiveTokenParameters.m */,
 				232D68D5223DB8C200594BBD /* MSALSilentTokenParameters.m */,
 				B27CCDF1229F9F4700CAD565 /* MSALAccountEnumerationParameters.m */,
+				B2E2A9402393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h */,
+				B2E2A9412393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.m */,
 			);
 			path = src;
 			sourceTree = "<group>";
@@ -2551,6 +2559,7 @@
 				B273D09B226E856A005A7BB4 /* MSAL_Internal.h in Headers */,
 				96CF95162268FD0400D97374 /* MSALGlobalConfig.h in Headers */,
 				96CF951F2268FD0400D97374 /* MSALPublicClientApplication.h in Headers */,
+				B2E2A9422393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h in Headers */,
 				B27CCDE0229F65D700CAD565 /* MSALAccount+MultiTenantAccount.h in Headers */,
 				B203459D21AFA1FB00B221AA /* MSALRedirectUri+Internal.h in Headers */,
 			);
@@ -2627,6 +2636,7 @@
 				B2D478A4230E3E56005AE186 /* MSALTelemetryEventsObservingProxy.h in Headers */,
 				232D616322485BA700260C42 /* MSALIndividualClaimRequestAdditionalInfo.h in Headers */,
 				B273D0AA226E8580005A7BB4 /* MSALTelemetryApiId.h in Headers */,
+				B2E2A94A2393192400BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h in Headers */,
 				B26756DA22922375000F01D7 /* MSALOauth2Authority.h in Headers */,
 				23FB5C1E22542B99002BF1EB /* MSALJsonDeserializable.h in Headers */,
 				1EDAE331218A4FA2001898E1 /* MSALAuthority_Internal.h in Headers */,
@@ -3464,6 +3474,7 @@
 				B26756DB22922375000F01D7 /* MSALOauth2Authority.m in Sources */,
 				96B5E6E82256D174002232F9 /* MSALLoggerConfig.m in Sources */,
 				B221CEDD20C0AC60002F5E94 /* MSALAccountId.m in Sources */,
+				B2E2A9432393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.m in Sources */,
 				04D32CAE1FD615B3000B123E /* MSALErrorConverter.m in Sources */,
 				B26756D222921C6D000F01D7 /* MSALADFSOauth2Provider.m in Sources */,
 				232D614C2248484C00260C42 /* MSALClaimsRequest.m in Sources */,
@@ -3553,6 +3564,7 @@
 				94E876CE1E492D6000FB96ED /* MSALAuthority.m in Sources */,
 				B26756C722921C42000F01D7 /* MSALAADOauth2Provider.m in Sources */,
 				04D32CAF1FD615B3000B123E /* MSALErrorConverter.m in Sources */,
+				B2E2A94C2393192700BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.m in Sources */,
 				B28BBD362211DC7D00F51723 /* MSALPublicClientStatusNotifications.m in Sources */,
 				D673F0931E4CE6D70018BA91 /* MSALResult.m in Sources */,
 				23A68A7D20F538B90071E435 /* MSALB2CAuthority.m in Sources */,

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		B20E246021FEB3E20037CA5E /* MSAL.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D65A6F431E3FD30A00C69FBA /* MSAL.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B20E246221FEB8160037CA5E /* MSALNonUnifiedADALCoexistenceCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B29E2AC821238F2200B170ED /* MSALNonUnifiedADALCoexistenceCacheTests.m */; };
 		B20E246421FEB8DB0037CA5E /* MSALUnifiedADALCacheCoexistenceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2734C1921253ABB00DAB1CD /* MSALUnifiedADALCacheCoexistenceTests.m */; };
+		B217861B23A580B200839CE8 /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2EE86E223751CAE00D0BC96 /* AuthenticationServices.framework */; };
 		B21E07B1210E542C007E3A3C /* MSALRedirectUriVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = B21E07AF210E542C007E3A3C /* MSALRedirectUriVerifier.h */; };
 		B21E07B2210E542C007E3A3C /* MSALRedirectUriVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = B21E07AF210E542C007E3A3C /* MSALRedirectUriVerifier.h */; };
 		B21E07B3210E542C007E3A3C /* MSALRedirectUriVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = B21E07B0210E542C007E3A3C /* MSALRedirectUriVerifier.m */; };
@@ -1465,6 +1466,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B217861B23A580B200839CE8 /* AuthenticationServices.framework in Frameworks */,
 				96902DF420E1578700200E6F /* WebKit.framework in Frameworks */,
 				231CE9DE1FEC684C00E95D3E /* Security.framework in Frameworks */,
 				231CE9DC1FEC682000E95D3E /* libIdentityTest.a in Frameworks */,

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -539,6 +539,12 @@
 		B2A3C28B2145FD0F0082525C /* MSALAccountsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B2A3C2882145FD0F0082525C /* MSALAccountsProvider.m */; };
 		B2A3C28C2145FD0F0082525C /* MSALAccountsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B2A3C2882145FD0F0082525C /* MSALAccountsProvider.m */; };
 		B2A3C29721460D290082525C /* MSALAuthority.h in Headers */ = {isa = PBXBuildFile; fileRef = 94E876CA1E492D6000FB96ED /* MSALAuthority.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B2AA5D6823A353F200BD47D8 /* MSALSignoutParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = B2AA5D6623A353F200BD47D8 /* MSALSignoutParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B2AA5D6923A353F200BD47D8 /* MSALSignoutParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = B2AA5D6623A353F200BD47D8 /* MSALSignoutParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B2AA5D6A23A353F200BD47D8 /* MSALSignoutParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = B2AA5D6723A353F200BD47D8 /* MSALSignoutParameters.m */; };
+		B2AA5D6B23A353F200BD47D8 /* MSALSignoutParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = B2AA5D6723A353F200BD47D8 /* MSALSignoutParameters.m */; };
+		B2AA5D7223A3540300BD47D8 /* MSALSignoutParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = B2AA5D6623A353F200BD47D8 /* MSALSignoutParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B2AA5D7323A3540400BD47D8 /* MSALSignoutParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = B2AA5D6623A353F200BD47D8 /* MSALSignoutParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B2AD634A1EA5663800EFEEF1 /* MSALTestAppTelemetryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B2AD63491EA5663800EFEEF1 /* MSALTestAppTelemetryViewController.m */; };
 		B2ADD76E22C08B6A0093FD43 /* MSALLegacySharedAccountTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B2ADD76D22C08B6A0093FD43 /* MSALLegacySharedAccountTestUtil.m */; };
 		B2BB73732112C32C000EA4C5 /* MSALAADBasicInteractiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2BB73722112C32C000EA4C5 /* MSALAADBasicInteractiveTests.m */; };
@@ -1212,6 +1218,8 @@
 		B29E2ACE21238F5200B170ED /* MultiAppiOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MultiAppiOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2A3C2872145FD0F0082525C /* MSALAccountsProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALAccountsProvider.h; sourceTree = "<group>"; };
 		B2A3C2882145FD0F0082525C /* MSALAccountsProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAccountsProvider.m; sourceTree = "<group>"; };
+		B2AA5D6623A353F200BD47D8 /* MSALSignoutParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALSignoutParameters.h; sourceTree = "<group>"; };
+		B2AA5D6723A353F200BD47D8 /* MSALSignoutParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALSignoutParameters.m; sourceTree = "<group>"; };
 		B2AD63481EA5663800EFEEF1 /* MSALTestAppTelemetryViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSALTestAppTelemetryViewController.h; sourceTree = "<group>"; };
 		B2AD63491EA5663800EFEEF1 /* MSALTestAppTelemetryViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSALTestAppTelemetryViewController.m; sourceTree = "<group>"; };
 		B2ADD76C22C08B6A0093FD43 /* MSALLegacySharedAccountTestUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALLegacySharedAccountTestUtil.h; sourceTree = "<group>"; };
@@ -2011,6 +2019,7 @@
 				232D68C9223DB00500594BBD /* MSALTokenParameters.m */,
 				232D68DB223DBA0700594BBD /* MSALInteractiveTokenParameters.m */,
 				232D68D5223DB8C200594BBD /* MSALSilentTokenParameters.m */,
+				B2AA5D6723A353F200BD47D8 /* MSALSignoutParameters.m */,
 				B27CCDF1229F9F4700CAD565 /* MSALAccountEnumerationParameters.m */,
 				B2E2A9402393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h */,
 				B2E2A9412393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.m */,
@@ -2043,6 +2052,7 @@
 				232D68C8223DB00500594BBD /* MSALTokenParameters.h */,
 				232D68D4223DB8C200594BBD /* MSALSilentTokenParameters.h */,
 				232D68DA223DBA0700594BBD /* MSALInteractiveTokenParameters.h */,
+				B2AA5D6623A353F200BD47D8 /* MSALSignoutParameters.h */,
 				232D61482248484C00260C42 /* MSALClaimsRequest.h */,
 				232D615A22485B4600260C42 /* MSALIndividualClaimRequest.h */,
 				232D616022485BA700260C42 /* MSALIndividualClaimRequestAdditionalInfo.h */,
@@ -2358,6 +2368,7 @@
 				B273D0F6226E86C2005A7BB4 /* MSALAuthority_Internal.h in Headers */,
 				04A6B5F7226937EB0035C7C2 /* MSALAccountId.h in Headers */,
 				B273D070226E84C3005A7BB4 /* MSALGlobalConfig.h in Headers */,
+				B2AA5D7323A3540400BD47D8 /* MSALSignoutParameters.h in Headers */,
 				B273D09A226E8569005A7BB4 /* MSAL_Internal.h in Headers */,
 				B2D47897230E3DF5005AE186 /* MSALCacheConfig.h in Headers */,
 				04A6B5F2226937D80035C7C2 /* MSALAADAuthority.h in Headers */,
@@ -2468,6 +2479,7 @@
 				B2D478A5230E3E57005AE186 /* MSALTelemetryEventsObservingProxy.h in Headers */,
 				B273D0AB226E8580005A7BB4 /* MSALTelemetryApiId.h in Headers */,
 				B2D478B0230E3E88005AE186 /* MSALLegacySharedAccountFactory.h in Headers */,
+				B2AA5D7223A3540300BD47D8 /* MSALSignoutParameters.h in Headers */,
 				B273D0BA226E85A0005A7BB4 /* MSALPublicClientApplicationConfig+Internal.h in Headers */,
 				B273D0D7226E85D6005A7BB4 /* MSALLoggerConfig+Internal.h in Headers */,
 				04A6B5EE226937CA0035C7C2 /* MSALADFSAuthority.h in Headers */,
@@ -2555,6 +2567,7 @@
 				963377BF211E14C600943EE0 /* MSALWebviewType_Internal.h in Headers */,
 				B223B0C522AE215D00FB8713 /* MSALLegacySharedAccountFactory.h in Headers */,
 				B273D0B7226E8597005A7BB4 /* MSALPublicClientApplication+Internal.h in Headers */,
+				B2AA5D6823A353F200BD47D8 /* MSALSignoutParameters.h in Headers */,
 				96CF95312268FD0500D97374 /* MSALJsonSerializable.h in Headers */,
 				B273D09B226E856A005A7BB4 /* MSAL_Internal.h in Headers */,
 				96CF95162268FD0400D97374 /* MSALGlobalConfig.h in Headers */,
@@ -2597,6 +2610,7 @@
 				23A68A7520F5386A0071E435 /* MSALAADAuthority.h in Headers */,
 				23A68A7B20F538B90071E435 /* MSALB2CAuthority.h in Headers */,
 				B273D0D8226E85D7005A7BB4 /* MSALLoggerConfig+Internal.h in Headers */,
+				B2AA5D6923A353F200BD47D8 /* MSALSignoutParameters.h in Headers */,
 				B267569E228F335E000F01D7 /* MSALExternalAccountHandler.h in Headers */,
 				B273D0E3226E85F2005A7BB4 /* MSALPromptType_Internal.h in Headers */,
 				23A68A8120F538DE0071E435 /* MSALADFSAuthority.h in Headers */,
@@ -3486,6 +3500,7 @@
 				B223B0C022ADFACB00FB8713 /* MSALLegacySharedAccount.m in Sources */,
 				D61BD2AF1EBD09F90007E484 /* MSALLogger.m in Sources */,
 				B28BDA90217E9EAB003E5670 /* MSALOauth2ProviderFactory.m in Sources */,
+				B2AA5D6A23A353F200BD47D8 /* MSALSignoutParameters.m in Sources */,
 				D61BD2B01EBD09F90007E484 /* MSALPublicClientApplication.m in Sources */,
 				D61BD2AD1EBD09F90007E484 /* MSALError.m in Sources */,
 				96B5E6F42256D197002232F9 /* MSALExtraQueryParameters.m in Sources */,
@@ -3552,6 +3567,7 @@
 				B29A56BB228266B40023F5E6 /* MSALSerializedADALCacheProvider.m in Sources */,
 				B27CCDF5229F9F4700CAD565 /* MSALAccountEnumerationParameters.m in Sources */,
 				232D616522485BA700260C42 /* MSALIndividualClaimRequestAdditionalInfo.m in Sources */,
+				B2AA5D6B23A353F200BD47D8 /* MSALSignoutParameters.m in Sources */,
 				963377C2211E14C600943EE0 /* MSALWebviewType.m in Sources */,
 				23B1D36A22EA6E2F000954AF /* MSALPublicClientApplicationConfig.m in Sources */,
 				B221CEDE20C0AC60002F5E94 /* MSALAccountId.m in Sources */,

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -49,7 +49,7 @@
 #import "MSALResult+Internal.h"
 #import "MSIDRequestControllerFactory.h"
 #import "MSIDRequestParameters.h"
-#import "MSIDInteractiveRequestParameters.h"
+#import "MSIDInteractiveTokenRequestParameters.h"
 #import "MSIDTelemetry+Internal.h"
 #import "MSIDDefaultTokenRequestProvider.h"
 #import "MSIDAADNetworkConfiguration.h"
@@ -94,7 +94,10 @@
 #import "MSIDMacKeychainTokenCache.h"
 #endif
 
+#import "MSIDInteractiveRequestParameters+MSALRequest.h"
 #import "MSIDKeychainTokenCache.h"
+#import "MSIDAccountRequestFactory.h"
+#import "MSIDLogoutRequest.h"
 
 @interface MSALPublicClientApplication()
 {
@@ -104,6 +107,7 @@
 
 @property (nonatomic) MSALPublicClientApplicationConfig *internalConfig;
 @property (nonatomic) MSIDExternalAADCacheSeeder *externalCacheSeeder;
+@property (nonatomic) MSIDCache *currentRequests;
 
 @end
 
@@ -170,6 +174,7 @@
         return nil;
     }
     
+    _currentRequests = [MSIDCache new];
     _validateAuthority = YES;
     
     // Verify required fields
@@ -681,10 +686,14 @@
         return;
     }
     
+    NSString *requestId = [NSString stringWithFormat:@"silent_%@", [NSUUID UUID].UUIDString];
+    [self.currentRequests setObject:requestController forKey:requestId];
+    
     [requestController acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable error) {
         
         if (error)
         {
+            [self.currentRequests removeObjectForKey:requestId];
             block(nil, error, msidParams);
             return;
         }
@@ -692,6 +701,7 @@
         NSError *resultError = nil;
         MSALResult *msalResult = [self.msalOauth2Provider resultWithTokenResult:result error:&resultError];
         [self updateExternalAccountsWithResult:msalResult context:msidParams];
+        [self.currentRequests removeObjectForKey:requestId];
         block(msalResult, resultError, msidParams);
     }];
 }
@@ -794,9 +804,12 @@
     useWebviewTypeFromGlobalConfig:(BOOL)useWebviewTypeFromGlobalConfig
                    completionBlock:(MSALCompletionBlock)completionBlock
 {
+    __weak typeof(self) weakSelf = self;
+    NSString *requestId = [NSString stringWithFormat:@"interactive_%@", [NSUUID UUID].UUIDString];
+    
     __auto_type block = ^(MSALResult *result, NSError *msidError, id<MSIDRequestContext> context)
     {
-        NSError *msalError = [MSALErrorConverter msalErrorFromMsidError:msidError classifyErrors:YES msalOauth2Provider:self.msalOauth2Provider];
+        NSError *msalError = [MSALErrorConverter msalErrorFromMsidError:msidError classifyErrors:YES msalOauth2Provider:weakSelf.msalOauth2Provider];
         [MSALPublicClientApplication logOperation:@"acquireToken" result:result error:msalError context:context];
         
         if (!completionBlock) return;
@@ -813,13 +826,12 @@
         }
     };
     
-    MSIDAuthority *requestAuthority = parameters.authority.msidAuthority ?: self.internalConfig.authority.msidAuthority;
+    NSError *authorityError;
+    MSIDAuthority *requestAuthority = [self interactiveRequestAuthorityWithCustomAuthority:parameters.authority.msidAuthority error:&authorityError];
     
-    if (![self.msalOauth2Provider isSupportedAuthority:requestAuthority])
+    if (!requestAuthority)
     {
-        NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"Unsupported authority type. Please configure MSALPublicClientApplication with the same authority type", nil, nil, nil, nil, nil, YES);
-        block(nil, msidError, nil);
-        
+        block(nil, authorityError, nil);
         return;
     }
     
@@ -850,8 +862,8 @@
                                                                   aadRequestVersion:MSIDBrokerAADRequestVersionV2];
 
 #endif
-    MSIDInteractiveRequestParameters *msidParams =
-    [[MSIDInteractiveRequestParameters alloc] initWithAuthority:requestAuthority
+    MSIDInteractiveTokenRequestParameters *msidParams =
+    [[MSIDInteractiveTokenRequestParameters alloc] initWithAuthority:requestAuthority
                                                     redirectUri:self.internalConfig.verifiedRedirectUri.url.absoluteString
                                                        clientId:self.internalConfig.clientId
                                                          scopes:[[NSOrderedSet alloc] initWithArray:parameters.scopes copyItems:YES]
@@ -870,11 +882,22 @@
         return;
     }
     
+    NSError *webViewParamsError;
+    BOOL webViewParamsResult = [msidParams fillWithWebViewParameters:parameters.webviewParameters
+                                                             account:parameters.account
+                                      useWebviewTypeFromGlobalConfig:useWebviewTypeFromGlobalConfig
+                                                       customWebView:_customWebview
+                                                               error:&webViewParamsError];
+    
+    if (!webViewParamsResult)
+    {
+        block(nil, webViewParamsError, nil);
+        return;
+    }
+    
     msidParams.promptType = MSIDPromptTypeForPromptType(parameters.promptType);
     msidParams.loginHint = parameters.loginHint;
     msidParams.extraAuthorizeURLQueryParameters = parameters.extraQueryParameters;
-    msidParams.accountIdentifier = parameters.account.lookupAccountIdentifier;
-    
     msidParams.extraURLQueryParameters = self.internalConfig.extraQueryParameters.extraURLQueryParameters;
     
     NSMutableDictionary *extraAuthorizeURLQueryParameters = [self.internalConfig.extraQueryParameters.extraAuthorizeURLQueryParameters mutableCopy];
@@ -886,62 +909,9 @@
     msidParams.extendedLifetimeEnabled = self.internalConfig.extendedLifetimeEnabled;
     msidParams.clientCapabilities = self.internalConfig.clientApplicationCapabilities;
     
-    msidParams.validateAuthority = _validateAuthority;
+    msidParams.validateAuthority = [self shouldValidateAuthorityForRequestAuthority:requestAuthority];
     msidParams.instanceAware = self.internalConfig.multipleCloudsSupported;
     msidParams.keychainAccessGroup = self.internalConfig.cacheConfig.keychainSharingGroup;
-    
-    if (msidParams.validateAuthority
-        && [self shouldExcludeValidationForAuthority:requestAuthority])
-    {
-        msidParams.validateAuthority = NO;
-    }
-    
-#if TARGET_OS_IPHONE
-    if (@available(iOS 13.0, *))
-    {
-        if (parameters.webviewParameters.parentViewController == nil)
-        {
-            NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"parentViewController is a required parameter on iOS 13.", nil, nil, nil, nil, nil, YES);
-            block(nil, msidError, msidParams);
-            return;
-        }
-        
-        if (parameters.webviewParameters.parentViewController.view.window == nil)
-        {
-            NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"parentViewController has no window! Provide a valid controller with view and window.", nil, nil, nil, nil, nil, YES);
-            block(nil, msidError, msidParams);
-            return;
-        }
-    }
-    
-    msidParams.presentationType = parameters.webviewParameters.presentationStyle;
-#endif
-    
-    msidParams.parentViewController = parameters.webviewParameters.parentViewController;
-    
-    if (@available(iOS 13.0, macOS 10.15, *))
-    {
-        msidParams.prefersEphemeralWebBrowserSession = parameters.webviewParameters.prefersEphemeralWebBrowserSession;
-    }
-    
-    // Configure webview
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    MSALWebviewType webviewType = useWebviewTypeFromGlobalConfig ? MSALGlobalConfig.defaultWebviewType : parameters.webviewParameters.webviewType;
-#pragma clang diagnostic pop
-    
-    NSError *msidWebviewError = nil;
-    MSIDWebviewType msidWebViewType = MSIDWebviewTypeFromMSALType(webviewType, &msidWebviewError);
-    
-    if (msidWebviewError)
-    {
-        block(nil, msidWebviewError, msidParams);
-        return;
-    }
-    
-    msidParams.webviewType = msidWebViewType;
-    msidParams.telemetryWebviewType = MSALStringForMSALWebviewType(webviewType);
-    msidParams.customWebview = parameters.webviewParameters.customWebview ?: _customWebview;
     msidParams.claimsRequest = parameters.claimsRequest.msidClaimsRequest;
     msidParams.providedAuthority = requestAuthority;
     
@@ -965,7 +935,7 @@
                           MSALStringForPromptType(parameters.promptType),
                           parameters.extraQueryParameters,
                           parameters.authority,
-                          MSALStringForMSALWebviewType(webviewType),
+                          MSALStringForMSALWebviewType(parameters.webviewParameters.webviewType),
                           parameters.webviewParameters.customWebview ? @"Yes" : @"No",
                           parameters.correlationId,
                           self.internalConfig.clientApplicationCapabilities,
@@ -988,10 +958,13 @@
         return;
     }
     
+    [self.currentRequests setObject:controller forKey:requestId];
+    
     [controller acquireToken:^(MSIDTokenResult * _Nullable result, NSError * _Nullable error)
     {
         if (error)
         {
+            [self.currentRequests removeObjectForKey:requestId];
             block(nil, error, msidParams);
             return;
         }
@@ -1000,6 +973,7 @@
         MSALResult *msalResult = [self.msalOauth2Provider resultWithTokenResult:result error:&resultError];
         [self updateExternalAccountsWithResult:msalResult context:msidParams];
         
+        [self.currentRequests removeObjectForKey:requestId];
         block(msalResult, resultError, msidParams);
     }];
 }
@@ -1064,6 +1038,117 @@
     return YES;
 }
 
+- (void)signoutWithAccount:(nonnull MSALAccount *)account
+         webViewParameters:(nonnull MSALWebviewParameters *)webViewParameters
+           completionBlock:(nonnull MSALSignoutCompletionBlock)signoutCompletionBlock
+{
+    __auto_type block = ^(BOOL result, NSError *msidError, id<MSIDRequestContext> context)
+    {
+        NSError *msalError = [MSALErrorConverter msalErrorFromMsidError:msidError classifyErrors:YES msalOauth2Provider:self.msalOauth2Provider];
+        
+        if (!result)
+        {
+            MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, context, @"Failed to complete signout operation for account %@ with error %@", MSID_PII_LOG_EMAIL(account.username), MSID_PII_LOG_MASKABLE(msalError));
+        }
+        else
+        {
+            MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, context, @"Successfully completed signout operation for account %@", MSID_PII_LOG_EMAIL(account.username));
+        }
+        
+        if (!signoutCompletionBlock) return;
+        
+        if ([NSThread isMainThread])
+        {
+            signoutCompletionBlock(result, msalError);
+        }
+        else
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{ // TODO: allow passing custom queue?
+                signoutCompletionBlock(result, msalError);
+            });
+        }
+    };
+    
+    NSError *localError;
+    BOOL localRemovalResult = [self removeAccount:account error:&localError];
+    
+    if (!localRemovalResult)
+    {
+        block(NO, localError, nil);
+        return;
+    }
+    
+    NSError *authorityError;
+    MSIDAuthority *requestAuthority = [self interactiveRequestAuthorityWithCustomAuthority:nil error:&authorityError];
+    
+    if (!requestAuthority)
+    {
+        block(NO, authorityError, nil);
+        return;
+    }
+    
+    NSError *paramsError;
+    MSIDInteractiveRequestParameters *msidParams = [[MSIDInteractiveRequestParameters alloc] initWithAuthority:requestAuthority
+                                                                                                   redirectUri:self.internalConfig.verifiedRedirectUri.url.absoluteString
+                                                                                                      clientId:self.internalConfig.clientId
+                                                                                                        scopes:nil
+                                                                                                    oidcScopes:nil
+                                                                                                 correlationId:[NSUUID UUID]
+                                                                                                telemetryApiId:nil
+                                                                                           intuneAppIdentifier:nil
+                                                                                                   requestType:[self requestType]
+                                                                                                         error:&paramsError];
+    
+    if (!msidParams)
+    {
+        block(NO, paramsError, nil);
+        return;
+    }
+    
+    NSError *webViewParamsError;
+    BOOL webViewParamsResult = [msidParams fillWithWebViewParameters:webViewParameters
+                                                             account:account
+                                      useWebviewTypeFromGlobalConfig:NO
+                                                       customWebView:_customWebview
+                                                               error:&webViewParamsError];
+    
+    if (!webViewParamsResult)
+    {
+        block(NO, webViewParamsError, msidParams);
+        return;
+    }
+    
+    msidParams.validateAuthority = [self shouldValidateAuthorityForRequestAuthority:requestAuthority];
+    msidParams.keychainAccessGroup = self.internalConfig.cacheConfig.keychainSharingGroup;
+    msidParams.providedAuthority = requestAuthority;
+    
+    MSIDLogoutRequest *logoutRequest = [MSIDAccountRequestFactory logoutRequestWithRequestParameters:msidParams
+                                                                                        oauthFactory:self.msalOauth2Provider.msidOauth2Factory];
+    
+    NSString *requestId = [NSString stringWithFormat:@"logout_%@", [NSUUID UUID].UUIDString];
+    [self.currentRequests setObject:logoutRequest forKey:requestId];
+    
+    [logoutRequest executeRequestWithCompletion:^(BOOL success, NSError * _Nullable error) {
+        [self.currentRequests removeObjectForKey:requestId];
+        block(success, error, msidParams);
+    }];
+}
+
+#pragma mark - Authority validation
+
+- (BOOL)shouldValidateAuthorityForRequestAuthority:(MSIDAuthority *)requestAuthority
+{
+    BOOL validateAuthority = _validateAuthority;
+    
+    if (validateAuthority
+        && [self shouldExcludeValidationForAuthority:requestAuthority])
+    {
+        return NO;
+    }
+    
+    return validateAuthority;
+}
+
 - (BOOL)shouldExcludeValidationForAuthority:(MSIDAuthority *)authority
 {
     if (self.internalConfig.knownAuthorities)
@@ -1111,6 +1196,21 @@
 #endif
     
     return requestType;
+}
+
+- (MSIDAuthority *)interactiveRequestAuthorityWithCustomAuthority:(MSIDAuthority *)customAuthority
+                                                            error:(NSError **)error
+{
+    MSIDAuthority *requestAuthority = customAuthority ?: self.internalConfig.authority.msidAuthority;
+    
+    if (![self.msalOauth2Provider isSupportedAuthority:requestAuthority])
+    {
+        NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"Unsupported authority type. Please configure MSALPublicClientApplication with the same authority type", nil, nil, nil, nil, nil, YES);
+        if (error) *error = msidError;
+        return nil;
+    }
+    
+    return requestAuthority;
 }
 
 @end

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1089,6 +1089,13 @@
         }
     };
     
+    if (!account)
+    {
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"Account is required", nil, nil, nil, nil, nil, NO);
+        block(NO, error, nil);
+        return;
+    }
+    
     NSError *localError;
     BOOL localRemovalResult = [self removeAccount:account error:&localError];
     

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -97,7 +97,7 @@
 #import "MSIDInteractiveRequestParameters+MSALRequest.h"
 #import "MSIDKeychainTokenCache.h"
 #import "MSIDAccountRequestFactory.h"
-#import "MSIDLogoutRequest.h"
+#import "MSIDOIDCSignoutRequest.h"
 
 @interface MSALPublicClientApplication()
 {
@@ -1122,13 +1122,13 @@
     msidParams.keychainAccessGroup = self.internalConfig.cacheConfig.keychainSharingGroup;
     msidParams.providedAuthority = requestAuthority;
     
-    MSIDLogoutRequest *logoutRequest = [MSIDAccountRequestFactory logoutRequestWithRequestParameters:msidParams
-                                                                                        oauthFactory:self.msalOauth2Provider.msidOauth2Factory];
+    MSIDOIDCSignoutRequest *signoutRequest = [MSIDAccountRequestFactory signoutRequestWithRequestParameters:msidParams
+                                                                                               oauthFactory:self.msalOauth2Provider.msidOauth2Factory];
     
     NSString *requestId = [NSString stringWithFormat:@"logout_%@", [NSUUID UUID].UUIDString];
-    [self.currentRequests setObject:logoutRequest forKey:requestId];
+    [self.currentRequests setObject:signoutRequest forKey:requestId];
     
-    [logoutRequest executeRequestWithCompletion:^(BOOL success, NSError * _Nullable error) {
+    [signoutRequest executeRequestWithCompletion:^(BOOL success, NSError * _Nullable error) {
         [self.currentRequests removeObjectForKey:requestId];
         block(success, error, msidParams);
     }];

--- a/MSAL/src/MSALSignoutParameters.m
+++ b/MSAL/src/MSALSignoutParameters.m
@@ -1,0 +1,44 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALSignoutParameters.h"
+#import "MSALWebviewParameters.h"
+
+@implementation MSALSignoutParameters
+
+- (instancetype)initWithWebviewParameters:(MSALWebviewParameters *)webviewParameters
+{
+    self = [super init];
+    if (self)
+    {
+        _webviewParameters = [webviewParameters copy];
+        _signoutFromBrowser = YES;
+    }
+    return self;
+}
+
+@end

--- a/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.h
+++ b/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.h
@@ -1,0 +1,46 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSIDInteractiveRequestParameters.h"
+
+@class MSALWebviewParameters;
+@class WKWebView;
+@class MSALAccount;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIDInteractiveRequestParameters (MSALRequest)
+
+- (BOOL)fillWithWebViewParameters:(nonnull MSALWebviewParameters *)webParameters
+                          account:(nullable MSALAccount *)account
+   useWebviewTypeFromGlobalConfig:(BOOL)useWebviewTypeFromGlobalConfig
+                    customWebView:(nullable WKWebView *)customWebView
+                            error:(NSError * _Nullable * _Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.m
+++ b/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.m
@@ -1,0 +1,93 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSIDInteractiveRequestParameters+MSALRequest.h"
+#import "MSALWebviewParameters.h"
+#import "MSALAccount+Internal.h"
+#import "MSALGlobalConfig.h"
+#import "MSALWebviewType_Internal.h"
+
+@implementation MSIDInteractiveRequestParameters (MSALRequest)
+
+- (BOOL)fillWithWebViewParameters:(MSALWebviewParameters *)webParameters
+                          account:(MSALAccount *)account
+   useWebviewTypeFromGlobalConfig:(BOOL)useWebviewTypeFromGlobalConfig
+                    customWebView:(WKWebView *)customWebView
+                            error:(NSError **)error
+{
+    self.accountIdentifier = account.lookupAccountIdentifier;
+    
+    #if TARGET_OS_IPHONE
+    if (@available(iOS 13.0, *))
+    {
+        if (webParameters.parentViewController == nil)
+        {
+            NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"parentViewController is a required parameter on iOS 13.", nil, nil, nil, nil, nil, YES);
+            if (error) *error = msidError;
+            return NO;
+        }
+        
+        if (webParameters.parentViewController.view.window == nil)
+        {
+            NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"parentViewController has no window! Provide a valid controller with view and window.", nil, nil, nil, nil, nil, YES);
+            if (error) *error = msidError;
+            return NO;
+        }
+    }
+    
+    self.presentationType = webParameters.presentationStyle;
+#endif
+        
+    self.parentViewController = webParameters.parentViewController;
+        
+    if (@available(iOS 13.0, macOS 10.15, *))
+    {
+        self.prefersEphemeralWebBrowserSession = webParameters.prefersEphemeralWebBrowserSession;
+    }
+        
+        // Configure webview
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    MSALWebviewType webviewType = useWebviewTypeFromGlobalConfig ? MSALGlobalConfig.defaultWebviewType : webParameters.webviewType;
+#pragma clang diagnostic pop
+        
+    NSError *msidWebviewError = nil;
+    MSIDWebviewType msidWebViewType = MSIDWebviewTypeFromMSALType(webviewType, &msidWebviewError);
+        
+    if (msidWebviewError)
+    {
+        if (error) *error = msidWebviewError;
+        return NO;
+    }
+        
+    self.webviewType = msidWebViewType;
+    self.telemetryWebviewType = MSALStringForMSALWebviewType(webviewType);
+    self.customWebview = webParameters.customWebview ?: customWebView;
+    return YES;
+}
+
+@end

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -76,6 +76,7 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALWebviewParameters.h>
 #import <MSAL/MSALSerializedADALCacheProvider.h>
 #import <MSAL/MSALWebviewParameters.h>
+#import <MSAL/MSALSignoutParameters.h>
 #if TARGET_OS_IPHONE
 #import <MSAL/MSALLegacySharedAccountsProvider.h>
 #endif

--- a/MSAL/src/public/MSALDefinitions.h
+++ b/MSAL/src/public/MSALDefinitions.h
@@ -150,6 +150,11 @@ typedef void (^MSALCompletionBlock)(MSALResult * _Nullable result, NSError * _Nu
 typedef void (^MSALAccountsCompletionBlock)(NSArray<MSALAccount *> * _Nullable accounts, NSError * _Nullable error);
 
 /**
+    The completion block that will be called when sign out is completed, or MSAL encountered an error.
+ */
+typedef void (^MSALSignoutCompletionBlock)(BOOL success, NSError * _Nullable error);
+
+/**
  The block that returns a MSAL log message.
  
  @param  level                     The level of the log message

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -38,6 +38,7 @@
 @class MSALClaimsRequest;
 @class MSALAccountEnumerationParameters;
 @class MSALWebviewParameters;
+@class MSALSignoutParameters;
 @class WKWebView;
 
 /**
@@ -438,14 +439,14 @@
 
 /**
    Removes all tokens from the cache for this application for the provided account.
-   Additionally, this API will remove account from the system browser or the embedded webView by navigating to the OIDC end session endpoint (see more https://openid.net/specs/openid-connect-session-1_0.html).
-   Additionally, if device has an SSO extension installed, the signoit request will be handled through the SSO extension.
+   Additionally, this API will remove account from the system browser or the embedded webView by navigating to the OIDC end session endpoint if requested in parameters (see more https://openid.net/specs/openid-connect-session-1_0.html).
+   Moreover, if device has an SSO extension installed, the signout request will be handled through the SSO extension.
  
    As a result of the signout operation, application will not be able to get tokens for the given account without user entering credentials.
    However, this will not sign out from other signed in apps on the device, unless it is explicitly enabled by the administrator configuration through an MDM profile.
 */
 - (void)signoutWithAccount:(nonnull MSALAccount *)account
-         webViewParameters:(nonnull MSALWebviewParameters *)webViewParameters
+         signoutParameters:(nonnull MSALSignoutParameters *)signoutParameters
            completionBlock:(nonnull MSALSignoutCompletionBlock)signoutCompletionBlock;
 
 

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -37,6 +37,7 @@
 @class MSALInteractiveTokenParameters;
 @class MSALClaimsRequest;
 @class MSALAccountEnumerationParameters;
+@class MSALWebviewParameters;
 @class WKWebView;
 
 /**
@@ -434,6 +435,18 @@
  */
 - (BOOL)removeAccount:(nonnull MSALAccount *)account
                 error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+
+/**
+   Removes all tokens from the cache for this application for the provided account.
+   Additionally, this API will remove account from the system browser or the embedded webView by navigating to the OIDC end session endpoint (see more https://openid.net/specs/openid-connect-session-1_0.html).
+   Additionally, if device has an SSO extension installed, the signoit request will be handled through the SSO extension.
+ 
+   As a result of the signout operation, application will not be able to get tokens for the given account without user entering credentials.
+   However, this will not sign out from other signed in apps on the device, unless it is explicitly enabled by the administrator configuration through an MDM profile.
+*/
+- (void)signoutWithAccount:(nonnull MSALAccount *)account
+         webViewParameters:(nonnull MSALWebviewParameters *)webViewParameters
+           completionBlock:(nonnull MSALSignoutCompletionBlock)signoutCompletionBlock;
 
 
 @end

--- a/MSAL/src/public/MSALSignoutParameters.h
+++ b/MSAL/src/public/MSALSignoutParameters.h
@@ -1,0 +1,79 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class MSALWebviewParameters;
+
+@interface MSALSignoutParameters : NSObject
+
+/**
+ A copy of the configuration which was provided in the initializer.
+ */
+@property (nonatomic, readonly, copy) MSALWebviewParameters *webviewParameters;
+
+/**
+  Specifies whether signout should also open the browser and send a network request to the end_session_endpoint.
+  YES by default.
+ */
+@property (nonatomic) BOOL signoutFromBrowser;
+
+/**
+ The dispatch queue on which to dispatch the completion block with MSAL result.
+ This configuration is optional.
+ MSAL default behavior when this property is not set depends on the token acquisition type:
+ 1. For interactive token acquisition and signout requests, MSAL will call completion block on the main thread
+ 2. For silent token acquisition, MSAL doesn't guarantee any specific queue for the completion block dispatch if this property is not set.
+    This means that by default MSAL will call its completion block on the queue that it receives server response on.
+    For example, if MSAL receives a token refresh response on the background queue, it will dispatch the completion block on the same queue and developer needs to make sure to not update any UI elements in the MSAL completion block without checking for the main thread first.
+ */
+@property (nonatomic, nullable) dispatch_queue_t completionBlockQueue;
+
+/**
+ Initialize MSALSignoutParameters with web parameters.
+ 
+ @param webviewParameters   User Interface configuration that MSAL uses when getting a token interactively or authorizing an end user.
+ */
+- (instancetype)initWithWebviewParameters:(MSALWebviewParameters *)webviewParameters NS_DESIGNATED_INITIALIZER;
+
+#pragma mark - Unavailable initializers
+
+/**
+    Use `[MSALSignoutParameters initWithWebviewParameters:]` instead
+ */
++ (instancetype)new NS_UNAVAILABLE;
+
+/**
+   Use `[MSALSignoutParameters initWithWebviewParameters:]` instead
+*/
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -248,10 +248,13 @@
     __block BOOL fBlockHit = NO;
     
     MSALTestAppSettings *settings = [MSALTestAppSettings settings];
+    
+    MSALSignoutParameters *signoutParameters = [[MSALSignoutParameters alloc] initWithWebviewParameters:[self msalTestWebViewParameters]];
+    
     [application signoutWithAccount:settings.currentAccount
-                  webViewParameters:[self msalTestWebViewParameters]
-                    completionBlock:^(BOOL success, NSError * _Nullable error)
-    {
+                  signoutParameters:signoutParameters
+                    completionBlock:^(BOOL success, NSError * _Nullable error) {
+        
         if (fBlockHit)
         {
             [self showCompletionBlockHitMultipleTimesAlert];

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -149,19 +149,15 @@
     
 }
 
-#pragma mark - IBAction
+#pragma mark - Helper
 
-- (IBAction)onAcquireTokenInteractiveButtonTapped:(id)sender
+- (MSALPublicClientApplication *)msalTestPublicClientApplication
 {
-    (void)sender;
-    
     MSALTestAppSettings *settings = [MSALTestAppSettings settings];
     NSDictionary *currentProfile = [MSALTestAppSettings currentProfile];
     NSString *clientId = [currentProfile objectForKey:MSAL_APP_CLIENT_ID];
     NSString *redirectUri = [currentProfile objectForKey:MSAL_APP_REDIRECT_URI];
     MSALAuthority *authority = [settings authority];
-    NSDictionary *extraQueryParameters = [NSDictionary msidDictionaryFromWWWFormURLEncodedString:self.extraQueryParamsTextField.text];
-    
     MSALPublicClientApplicationConfig *pcaConfig = [[MSALPublicClientApplicationConfig alloc] initWithClientId:clientId
                                                                                                    redirectUri:redirectUri
                                                                                                      authority:authority];
@@ -179,22 +175,120 @@
     {
         NSString *resultText = [NSString stringWithFormat:@"Failed to create PublicClientApplication:\n%@", error];
         [self.resultTextView setText:resultText];
+        return nil;
+    }
+    
+    return application;
+}
+
+- (MSALWebviewParameters *)msalTestWebViewParameters
+{
+    MSALWebviewParameters *webviewParameters = [[MSALWebviewParameters alloc] initWithParentViewController:self];
+    webviewParameters.webviewType = self.webviewTypeSegmentControl.selectedSegmentIndex == 0 ? MSALWebviewTypeWKWebView : MSALWebviewTypeDefault;
+    
+    if (webviewParameters.webviewType == MSALWebviewTypeWKWebView
+        && self.customWebviewTypeSegmentControl.selectedSegmentIndex == TEST_EMBEDDED_WEBVIEW_CUSTOM)
+    {
+        webviewParameters.customWebview = self.customWebview;
+        self.customWebviewContainer.hidden = NO;
+    }
+    
+    if (@available(iOS 13.0, *))
+    {
+        webviewParameters.parentViewController = self;
+        webviewParameters.prefersEphemeralWebBrowserSession = self.systemWebviewSSOSegmentControl.selectedSegmentIndex == 1; // 0 - Yes, 1 - No.
+    }
+    
+    return webviewParameters;
+}
+
+- (BOOL)checkAccountSelected
+{
+    MSALTestAppSettings *settings = [MSALTestAppSettings settings];
+    if (!settings.currentAccount)
+    {
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Error!"
+                                                                       message:@"User needs to be selected for acquire token silent call"
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"Close" style:UIAlertActionStyleDefault handler:nil]];
+        [self presentViewController:alert animated:YES completion:nil];
+        return NO;
+    }
+    
+    return YES;
+}
+
+- (void)showCompletionBlockHitMultipleTimesAlert
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Error!"
+                                                                       message:@"Completion block was hit multiple times!"
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"Close" style:UIAlertActionStyleDefault handler:nil]];
+        [self presentViewController:alert animated:YES completion:nil];
+    });
+}
+
+#pragma mark - IBAction
+
+- (IBAction)onSignoutTapped:(__unused id)sender
+{
+    if (![self checkAccountSelected])
+    {
         return;
     }
     
+    MSALPublicClientApplication *application = [self msalTestPublicClientApplication];
+    
+    if (!application)
+    {
+        return;
+    }
+    
+    __block BOOL fBlockHit = NO;
+    
+    MSALTestAppSettings *settings = [MSALTestAppSettings settings];
+    [application signoutWithAccount:settings.currentAccount
+                  webViewParameters:[self msalTestWebViewParameters]
+                    completionBlock:^(BOOL success, NSError * _Nullable error)
+    {
+        if (fBlockHit)
+        {
+            [self showCompletionBlockHitMultipleTimesAlert];
+            return;
+        }
+        
+        fBlockHit = YES;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            
+            if (!success)
+            {
+                [self updateResultViewError:error];
+            }
+            else
+            {
+                NSString *successText = [NSString stringWithFormat:@"Signout succeeded for user %@", settings.currentAccount.username];
+                self.resultTextView.text = successText;
+            }
+        });
+    }];
+}
+
+- (IBAction)onAcquireTokenInteractiveButtonTapped:(__unused id)sender
+{
+    MSALPublicClientApplication *application = [self msalTestPublicClientApplication];
+    
+    if (!application)
+    {
+        return;
+    }
+        
     __block BOOL fBlockHit = NO;
     void (^completionBlock)(MSALResult *result, NSError *error) = ^(MSALResult *result, NSError *error) {
         
         if (fBlockHit)
         {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Error!"
-                                                                               message:@"Completion block was hit multiple times!"
-                                                                        preferredStyle:UIAlertControllerStyleAlert];
-                [alert addAction:[UIAlertAction actionWithTitle:@"Close" style:UIAlertActionStyleDefault handler:nil]];
-                [self presentViewController:alert animated:YES completion:nil];
-            });
-            
+            [self showCompletionBlockHitMultipleTimesAlert];
             return;
         }
         
@@ -216,73 +310,34 @@
             [[NSNotificationCenter defaultCenter] postNotificationName:MSALTestAppCacheChangeNotification object:self];
         });
     };
-
-    MSALWebviewParameters *webviewParameters = [[MSALWebviewParameters alloc] initWithParentViewController:self];
-    webviewParameters.webviewType = self.webviewTypeSegmentControl.selectedSegmentIndex == 0 ? MSALWebviewTypeWKWebView : MSALWebviewTypeDefault;
     
-    if (webviewParameters.webviewType == MSALWebviewTypeWKWebView
-        && self.customWebviewTypeSegmentControl.selectedSegmentIndex == TEST_EMBEDDED_WEBVIEW_CUSTOM)
-    {
-        webviewParameters.customWebview = self.customWebview;
-        self.customWebviewContainer.hidden = NO;
-    }
-    
-    if (@available(iOS 13.0, *))
-    {
-        webviewParameters.parentViewController = self;
-        webviewParameters.prefersEphemeralWebBrowserSession = self.systemWebviewSSOSegmentControl.selectedSegmentIndex == 1; // 0 - Yes, 1 - No.
-    }
+    MSALTestAppSettings *settings = [MSALTestAppSettings settings];
     
     MSALInteractiveTokenParameters *parameters = [[MSALInteractiveTokenParameters alloc] initWithScopes:[settings.scopes allObjects]
-                                                                                      webviewParameters:webviewParameters];
+                                                                                      webviewParameters:[self msalTestWebViewParameters]];
     parameters.loginHint = self.loginHintTextField.text;
     parameters.account = settings.currentAccount;
     parameters.promptType = [self promptTypeValue];
-    parameters.extraQueryParameters = extraQueryParameters;
+    parameters.extraQueryParameters = [NSDictionary msidDictionaryFromWWWFormURLEncodedString:self.extraQueryParamsTextField.text];
     
     [application acquireTokenWithParameters:parameters completionBlock:completionBlock];
 }
 
-- (IBAction)onAcquireTokenSilentButtonTapped:(id)sender
+- (IBAction)onAcquireTokenSilentButtonTapped:(__unused id)sender
 {
-    (void)sender;
-    
-    MSALTestAppSettings *settings = [MSALTestAppSettings settings];
-    
-    if (!settings.currentAccount)
+    if (![self checkAccountSelected])
     {
-        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Error!"
-                                                                       message:@"User needs to be selected for acquire token silent call"
-                                                                preferredStyle:UIAlertControllerStyleAlert];
-        [alert addAction:[UIAlertAction actionWithTitle:@"Close" style:UIAlertActionStyleDefault handler:nil]];
-        [self presentViewController:alert animated:YES completion:nil];
         return;
     }
     
-    NSDictionary *currentProfile = [MSALTestAppSettings currentProfile];
-    NSString *clientId = [currentProfile objectForKey:MSAL_APP_CLIENT_ID];
-    NSString *redirectUri = [currentProfile objectForKey:MSAL_APP_REDIRECT_URI];
-    __auto_type authority = [settings authority];
+    MSALPublicClientApplication *application = [self msalTestPublicClientApplication];
     
-    MSALPublicClientApplicationConfig *pcaConfig = [[MSALPublicClientApplicationConfig alloc] initWithClientId:clientId
-                                                                                                   redirectUri:redirectUri
-                                                                                                     authority:authority];
-    
-    if (self.validateAuthoritySegmentControl.selectedSegmentIndex == 1)
-    {
-        pcaConfig.knownAuthorities = @[pcaConfig.authority];
-    }
-    
-    pcaConfig.multipleCloudsSupported = self.instanceAwareSegmentControl.selectedSegmentIndex == 0;
-    
-    NSError *error;
-    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:pcaConfig error:&error];
     if (!application)
     {
-        NSString *resultText = [NSString stringWithFormat:@"Failed to create PublicClientApplication:\n%@", error];
-        [self.resultTextView setText:resultText];
         return;
     }
+    
+    MSALTestAppSettings *settings = [MSALTestAppSettings settings];
     
     __auto_type scopes = [settings.scopes allObjects];
     __auto_type account = settings.currentAccount;
@@ -294,15 +349,7 @@
     {
         if (fBlockHit)
         {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                self.acquireSilentButton.enabled = YES;
-                UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Error!"
-                                                                               message:@"Completion block was hit multiple times!"
-                                                                        preferredStyle:UIAlertControllerStyleAlert];
-                [alert addAction:[UIAlertAction actionWithTitle:@"Close" style:UIAlertActionStyleDefault handler:nil]];
-                [self presentViewController:alert animated:YES completion:nil];
-            });
-            
+            [self showCompletionBlockHitMultipleTimesAlert];
             return;
         }
         

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.storyboard
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15508"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -402,7 +402,7 @@
                                         <rect key="frame" x="0.0" y="788" width="414" height="30"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="tWi-d4-WNB">
-                                                <rect key="frame" x="78" y="0.0" width="258" height="30"/>
+                                                <rect key="frame" x="13.5" y="0.0" width="387" height="30"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ToY-db-bYT">
                                                         <rect key="frame" x="0.0" y="0.0" width="129" height="30"/>
@@ -416,6 +416,13 @@
                                                         <state key="normal" title="acquireTokenSilent"/>
                                                         <connections>
                                                             <action selector="onAcquireTokenSilentButtonTapped:" destination="7Mt-tc-cPe" eventType="touchUpInside" id="0I8-uv-sYn"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uxy-eI-Fvx">
+                                                        <rect key="frame" x="258" y="0.0" width="129" height="30"/>
+                                                        <state key="normal" title="signout"/>
+                                                        <connections>
+                                                            <action selector="onSignoutTapped:" destination="7Mt-tc-cPe" eventType="touchUpInside" id="QO0-2S-gHh"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2392,8 +2392,11 @@
     XCTAssertNotNil(application);
     XCTAssertNil(error);
     
-    MSALViewController *controller = nil;
-    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithParentViewController:controller];
+#if TARGET_OS_IPHONE
+    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithParentViewController:[self.class sharedViewControllerStub]];
+#else
+    MSALWebviewParameters *webParams = [MSALWebviewParameters new];
+#endif
     MSALSignoutParameters *parameters = [[MSALSignoutParameters alloc] initWithWebviewParameters:webParams];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Signout"];

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -58,7 +58,7 @@
 #import "MSIDAADNetworkConfiguration.h"
 #import "NSString+MSIDTestUtil.h"
 #import "MSIDLocalInteractiveController.h"
-#import "MSIDInteractiveRequestParameters.h"
+#import "MSIDInteractiveTokenRequestParameters.h"
 #import "MSALTelemetryApiId.h"
 #import "MSIDSilentController.h"
 #import "MSALRedirectUri.h"
@@ -385,7 +385,7 @@
                               block:(id)^(MSIDLocalInteractiveController *obj, MSIDRequestCompletionBlock completionBlock)
      {
          XCTAssertTrue([obj isKindOfClass:[MSIDLocalInteractiveController class]]);
-         MSIDInteractiveRequestParameters *params = [obj interactiveRequestParamaters];
+         MSIDInteractiveTokenRequestParameters *params = [obj interactiveRequestParamaters];
          XCTAssertNotNil(params);
          
          NSString *expectedTelemetryAPIId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquire];
@@ -440,7 +440,7 @@
      {
          XCTAssertTrue([obj isKindOfClass:[MSIDLocalInteractiveController class]]);
          
-         MSIDInteractiveRequestParameters *params = [obj interactiveRequestParamaters];
+         MSIDInteractiveTokenRequestParameters *params = [obj interactiveRequestParamaters];
          XCTAssertNotNil(params);
          
          XCTAssertTrue(params.validateAuthority);
@@ -782,7 +782,7 @@
      {
          XCTAssertTrue([obj isKindOfClass:[MSIDLocalInteractiveController class]]);
          
-         MSIDInteractiveRequestParameters *params = [obj interactiveRequestParamaters];
+         MSIDInteractiveTokenRequestParameters *params = [obj interactiveRequestParamaters];
          XCTAssertNotNil(params);
          
          XCTAssertFalse(params.validateAuthority);
@@ -916,7 +916,7 @@
      {
          XCTAssertTrue([obj isKindOfClass:[MSIDLocalInteractiveController class]]);
          
-         MSIDInteractiveRequestParameters *params = [obj interactiveRequestParamaters];
+         MSIDInteractiveTokenRequestParameters *params = [obj interactiveRequestParamaters];
          XCTAssertNotNil(params);
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireWithHint];
@@ -972,7 +972,7 @@
      {
          XCTAssertTrue([obj isKindOfClass:[MSIDLocalInteractiveController class]]);
          
-         MSIDInteractiveRequestParameters *params = [obj interactiveRequestParamaters];
+         MSIDInteractiveTokenRequestParameters *params = [obj interactiveRequestParamaters];
          XCTAssertNotNil(params);
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireWithTokenParameters];
@@ -1041,7 +1041,7 @@
      {
          XCTAssertTrue([obj isKindOfClass:[MSIDLocalInteractiveController class]]);
          
-         MSIDInteractiveRequestParameters *params = [obj interactiveRequestParamaters];
+         MSIDInteractiveTokenRequestParameters *params = [obj interactiveRequestParamaters];
          XCTAssertNotNil(params);
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireWithTokenParameters];
@@ -1119,7 +1119,7 @@
      {
          XCTAssertTrue([obj isKindOfClass:[MSIDLocalInteractiveController class]]);
          
-         MSIDInteractiveRequestParameters *params = [obj interactiveRequestParamaters];
+         MSIDInteractiveTokenRequestParameters *params = [obj interactiveRequestParamaters];
          XCTAssertNotNil(params);
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireWithUserPromptTypeAndParameters];
@@ -1183,7 +1183,7 @@
      {
          XCTAssertTrue([obj isKindOfClass:[MSIDLocalInteractiveController class]]);
          
-         MSIDInteractiveRequestParameters *params = [obj interactiveRequestParamaters];
+         MSIDInteractiveTokenRequestParameters *params = [obj interactiveRequestParamaters];
          XCTAssertNotNil(params);
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireWithTokenParameters];
@@ -1259,7 +1259,7 @@
      {
          XCTAssertTrue([obj isKindOfClass:[MSIDLocalInteractiveController class]]);
          
-         MSIDInteractiveRequestParameters *params = [obj interactiveRequestParamaters];
+         MSIDInteractiveTokenRequestParameters *params = [obj interactiveRequestParamaters];
          XCTAssertNotNil(params);
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireWithTokenParameters];


### PR DESCRIPTION
Common core PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/637 (contains description for common core pieces).

This PR provides MSAL pieces to execute signout requests for the browser (by navigating to the OIDC end_session_endpoint in the browser), and send a signout request to the SSO extension.

Things to note:
1. Since there was a lot of duplicate logic between interactive request and signout request when creating MSIDParams, some of the logic got combined into a category and some logic got moved to separate functions (see MSALPublicClientApplication.m)
2. Added new public class MSALSignoutParameters - this contains parameters that modify signout API behavior. Right now it only modifies whether browser should also signed out from, and result block execution queue
3. Refactored/combined some logic in the test app since it was duplicated across operations

In order to test this PR, build MSAL test app with this branch and SSO extension with the corresponding branch from the broker. Make sure you get one account into the cache, and then "press" signout in the MSAL test app.