### PR TITLE
MSAL account collapsing improvements for guest users

### DIFF
--- a/MSAL/src/MSALAccount+Internal.h
+++ b/MSAL/src/MSALAccount+Internal.h
@@ -42,7 +42,7 @@
 @property (nonatomic) MSALAccountId *homeAccountId;
 @property (nonatomic) NSString *username;
 @property (nonatomic) NSString *environment;
-@property (nonatomic) NSMutableArray<MSALTenantProfile *> *mTenantProfiles;
+@property (nonatomic) NSMutableDictionary<NSString *, MSALTenantProfile *> *mTenantProfiles;
 @property (nonatomic) NSDictionary<NSString *, NSString *> *accountClaims;
 @property (nonatomic) NSString *identifier;
 @property (nonatomic) MSIDAccountIdentifier *lookupAccountIdentifier;

--- a/MSAL/src/MSALAccount.m
+++ b/MSAL/src/MSALAccount.m
@@ -61,10 +61,7 @@
         _identifier = homeAccountId.identifier;
         _lookupAccountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:username homeAccountId:homeAccountId.identifier];
         
-        if (tenantProfiles.count > 0)
-        {
-            self.mTenantProfiles = [[NSMutableArray alloc] initWithArray:tenantProfiles];
-        }
+        [self addTenantProfiles:tenantProfiles];
     }
 
     return self;
@@ -80,7 +77,7 @@
         
         MSALTenantProfile *tenantProfile = [[MSALTenantProfile alloc] initWithIdentifier:account.localAccountId
                                                                                 tenantId:account.realm
-                                                                             environment:account.environment
+                                                                             environment:account.storageEnvironment ?: account.environment
                                                                      isHomeTenantProfile:account.isHomeTenantAccount
                                                                                   claims:allClaims];
         if (tenantProfile)
@@ -95,7 +92,7 @@
     
     return [self initWithUsername:account.username
                     homeAccountId:homeAccountId
-                      environment:account.environment
+                      environment:account.storageEnvironment ?: account.environment
                    tenantProfiles:tenantProfiles];
 }
 
@@ -135,7 +132,7 @@
     NSString *username = [self.username copyWithZone:zone];
     MSALAccountId *homeAccountId = [self.homeAccountId copyWithZone:zone];
     NSString *environment = [self.environment copyWithZone:zone];
-    NSArray *tenantProfiles = [[NSMutableArray alloc] initWithArray:self.mTenantProfiles copyItems:YES];
+    NSArray *tenantProfiles = [[NSMutableArray alloc] initWithArray:[self tenantProfiles] copyItems:YES];
     
     MSALAccount *account = [[MSALAccount allocWithZone:zone] initWithUsername:username homeAccountId:homeAccountId environment:environment tenantProfiles:tenantProfiles];
     account.accountClaims = [self.accountClaims copyWithZone:zone];
@@ -162,8 +159,6 @@
 - (NSUInteger)hash
 {
     NSUInteger hash = 0;
-    hash = hash * 31 + self.username.hash;
-    hash = hash * 31 + self.homeAccountId.hash;
     hash = hash * 31 + self.environment.hash;
     return hash;
 }
@@ -173,8 +168,16 @@
     if (!user) return NO;
 
     BOOL result = YES;
-    result &= (!self.username && !user.username) || [self.username isEqualToString:user.username];
-    result &= (!self.homeAccountId && !user.homeAccountId) || [self.homeAccountId.identifier isEqualToString:user.homeAccountId.identifier];
+    
+    if (self.homeAccountId.identifier && user.homeAccountId.identifier)
+    {
+        result &= [self.homeAccountId.identifier isEqualToString:user.homeAccountId.identifier];
+    }
+    else if (self.username || user.username)
+    {
+        result &= [self.username.lowercaseString isEqualToString:user.username.lowercaseString];
+    }
+    
     result &= (!self.environment && !user.environment) || [self.environment isEqualToString:user.environment];
     return result;
 }
@@ -183,20 +186,24 @@
 
 - (NSArray<MSALTenantProfile *> *)tenantProfiles
 {
-    return self.mTenantProfiles;
+    return self.mTenantProfiles.allValues;
 }
 
 - (void)addTenantProfiles:(NSArray<MSALTenantProfile *> *)tenantProfiles
 {
     if (tenantProfiles.count <= 0) return;
     
-    if (self.mTenantProfiles)
+    if (!self.mTenantProfiles)
     {
-        [self.mTenantProfiles addObjectsFromArray:tenantProfiles];
+        self.mTenantProfiles = [NSMutableDictionary new];
     }
-    else
+    
+    for (MSALTenantProfile *profile in tenantProfiles)
     {
-        self.mTenantProfiles = [[NSMutableArray alloc] initWithArray:tenantProfiles];
+        if (profile.tenantId && !self.mTenantProfiles[profile.tenantId])
+        {
+            self.mTenantProfiles[profile.tenantId] = profile;
+        }
     }
 }
 

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedADALAccount.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedADALAccount.m
@@ -95,6 +95,20 @@ static NSString *kADALAccountType = @"ADAL";
         {
             _identifier = [MSIDAccountIdentifier homeAccountIdentifierFromUid:_objectId utid:_tenantId];
         }
+        else
+        {
+            NSDictionary *additionalPropertiesDictionary = [jsonDictionary msidObjectForKey:@"additionalProperties" ofClass:[NSDictionary class]];
+            
+            if (additionalPropertiesDictionary)
+            {
+                NSString *homeAccountId = [additionalPropertiesDictionary msidObjectForKey:@"home_account_id" ofClass:[NSString class]];
+                
+                if (![NSString msidIsStringNilOrBlank:homeAccountId])
+                {
+                    _identifier = homeAccountId;
+                }
+            }
+        }
         
         NSMutableDictionary *claims = [NSMutableDictionary new];
         

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccount.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccount.m
@@ -104,7 +104,11 @@ static NSDateFormatter *s_updateDateFormatter = nil;
     
     jsonDictionary[@"signInStatus"] = @{appBundleId : @"SignedIn"};
     jsonDictionary[@"username"] = account.username;
-    jsonDictionary[@"additionalProperties"] = @{@"createdBy": appName};
+    
+    NSMutableDictionary *additionalProperties = [NSMutableDictionary new];
+    [additionalProperties addEntriesFromDictionary:@{@"createdBy": appName}];
+    [additionalProperties addEntriesFromDictionary:[self additionalPropertiesFromMSALAccount:account claims:claims]];
+    jsonDictionary[@"additionalProperties"] = additionalProperties;
     [jsonDictionary addEntriesFromDictionary:[self claimsFromMSALAccount:account claims:claims]];
     return [self initWithJSONDictionary:jsonDictionary error:error];
 }
@@ -180,6 +184,7 @@ static NSDateFormatter *s_updateDateFormatter = nil;
     
     mutableAdditionalInfo[@"updatedBy"] = appName;
     mutableAdditionalInfo[@"updatedAt"] = [[[self class] dateFormatter] stringFromDate:[NSDate date]];
+    [mutableAdditionalInfo addEntriesFromDictionary:[self additionalPropertiesFromMSALAccount:account claims:nil]];
     
     oldDictionary[@"additionalProperties"] = mutableAdditionalInfo;
     
@@ -195,6 +200,16 @@ static NSDateFormatter *s_updateDateFormatter = nil;
 
 - (NSDictionary *)claimsFromMSALAccount:(id<MSALAccount>)account claims:(NSDictionary *)claims
 {
+    return nil;
+}
+
+- (NSDictionary *)additionalPropertiesFromMSALAccount:(id<MSALAccount>)account claims:(NSDictionary *)claims
+{
+    if (account.identifier)
+    {
+        return @{@"home_account_id": account.identifier};
+    }
+    
     return nil;
 }
 

--- a/MSAL/src/instance/MSALAccountsProvider.m
+++ b/MSAL/src/instance/MSALAccountsProvider.m
@@ -47,6 +47,7 @@
 #import "MSALAccountEnumerationParameters.h"
 #import "MSALErrorConverter.h"
 #import "MSALTenantProfile.h"
+#import "MSALAccount+MultiTenantAccount.h"
 
 @interface MSALAccountsProvider()
 
@@ -231,7 +232,7 @@
         
         if ([externalAccount.mTenantProfiles count])
         {
-            NSArray<MSALTenantProfile *> *homeTenantProfileArray = [externalAccount.mTenantProfiles filteredArrayUsingPredicate:self.homeTenantFilterPredicate];
+            NSArray<MSALTenantProfile *> *homeTenantProfileArray = [externalAccount.tenantProfiles filteredArrayUsingPredicate:self.homeTenantFilterPredicate];
             if ([homeTenantProfileArray count] == 1) accountClaims = homeTenantProfileArray[0].claims;
         }
     
@@ -252,12 +253,13 @@
     }
     else
     {
-        [existingAccount addTenantProfiles:account.mTenantProfiles];
+        [existingAccount addTenantProfiles:account.tenantProfiles];
     }
     
     if (accountClaims)
     {
         existingAccount.accountClaims = accountClaims;
+        existingAccount.username = account.username;
     }
 }
 

--- a/MSAL/test/unit/ios/external-cache/MSALLegacySharedADALAccountTests.m
+++ b/MSAL/test/unit/ios/external-cache/MSALLegacySharedADALAccountTests.m
@@ -115,6 +115,7 @@
     
     NSMutableDictionary *mutableDict = [adalAccountDictionary mutableCopy];
     mutableDict[@"authEndpointUrl"] = @"https://login.microsoftonline.com/contoso.com";
+    mutableDict[@"additionalProperties"] = @{@"home_account_id": @"uid.utid"};
     
     NSError *error = nil;
     MSALLegacySharedADALAccount *account = [[MSALLegacySharedADALAccount alloc] initWithJSONDictionary:mutableDict error:&error];
@@ -122,12 +123,12 @@
     XCTAssertNil(error);
     XCTAssertEqualObjects(account.accountType, @"ADAL");
     XCTAssertEqualObjects(account.environment, @"login.microsoftonline.com");
-    XCTAssertNil(account.identifier);
     XCTAssertEqualObjects(account.accountIdentifier, accountId);
     XCTAssertEqualObjects(account.username, @"user@contoso.com");
     XCTAssertEqualObjects(account.accountClaims[@"oid"], objectId);
     XCTAssertEqualObjects(account.accountClaims[@"tid"], tenantId);
     XCTAssertEqualObjects(account.accountClaims[@"name"], @"myDisplayName.contoso.user");
+    XCTAssertEqualObjects(account.identifier, @"uid.utid");
 }
 
 #pragma mark - InitWithMSALAccount

--- a/MSAL/test/unit/ios/external-cache/MSALLegacySharedAccountTests.m
+++ b/MSAL/test/unit/ios/external-cache/MSALLegacySharedAccountTests.m
@@ -208,6 +208,8 @@
     XCTAssertNotNil(updatedAt);
     XCTAssertEqualObjects(account.accountType, @"ADAL");
     XCTAssertEqualObjects(account.accountIdentifier, accountId);
+    NSString *homeAccountId = [account jsonDictionary][@"additionalProperties"][@"home_account_id"];
+    XCTAssertEqualObjects(homeAccountId, @"uid.utid");
 }
 
 - (void)testUpdateAccountWithMSALAccount_whenUpdateOperation_shouldUpdateSigninStatusAndUpdatedDict
@@ -238,6 +240,8 @@
     XCTAssertNotNil(updatedAt);
     XCTAssertEqualObjects(account.accountType, @"ADAL");
     XCTAssertEqualObjects(account.accountIdentifier, accountId);
+    NSString *homeAccountId = [account jsonDictionary][@"additionalProperties"][@"home_account_id"];
+    XCTAssertEqualObjects(homeAccountId, @"uid.utid");
 }
 
 @end


### PR DESCRIPTION
This is an attempt to improve some of the MSAL account results when multiple guest accounts are present with different usernames.

Some of the things to keep an eye (and maybe think how we can do better):

1. If tenant profile is already present, ignores additional tenant profile added later (this fixes a case when we ended with multiple duplicate tenant profiles).
2. Two accounts with same homeAccountId, but different usernames will now be treated as the same. Unfortunately, this is a bit problematic performance wise, because hashing function cannot account for those complex cases. But between returning duplicate accounts, and a bit less performance, I prefer to return correct results... 
3. Save home account id for legacy account cases to do more accurate account collapsing logic. 