### PR TITLE
Warn for empty issues and PRs

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,19 @@
+requestInfoReplyComment: >
+  Please add additional information about this issue or PR. Please be as descriptive as possible.
+
+# *OPTIONAL* Label to be added to Issues and Pull Requests with insufficient information given
+requestInfoLabelToAdd: needs-information
+
+# *OPTIONAL* Require Issues to contain more information than what is provided in the issue templates
+# Will fail if the issue's body is equal to a provided template
+checkIssueTemplate: true
+
+# *OPTIONAL* Require Pull Requests to contain more information than what is provided in the PR template
+# Will fail if the pull request's body is equal to the provided template
+checkPullRequestTemplate: true
+
+# *OPTIONAL* Only warn about insufficient information on these events type
+# Keys must be lowercase. Valid values are 'issue' and 'pullRequest'
+requestInfoOn:
+  pullRequest: true
+  issue: true


### PR DESCRIPTION
This change will send a message to any PR or an issue that is missing description. The goal is encourage to provide more details in PRs and issues.