### PR TITLE
Update common core and improve UTs

### DIFF
--- a/MSAL/test/unit/MSALPublicClientApplicationAccountUpdateTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationAccountUpdateTests.m
@@ -64,6 +64,12 @@
     [MSALTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
 }
 
+- (void)tearDown
+{
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID error:nil];
+    [application.tokenCache clearWithContext:nil error:nil];
+}
+
 #pragma mark - Tests
 
 - (void)testAcquireToken_whenSuccessfulResponse_shouldUpdateExternalAccount


### PR DESCRIPTION
This PR is needed for updating UTs in broker SSO operations.

Common core changes are [here](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/656).