### PR TITLE
Error on missing broker query scheme

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -194,6 +194,7 @@
         return nil;
     }
         
+#if TARGET_OS_IPHONE
     if (MSALGlobalConfig.brokerAvailability == MSALBrokeredAvailabilityAuto
         && msalRedirectUri.brokerCapable
         && ![MSALRedirectUriVerifier verifyAdditionalRequiredSchemesAreRegistered:&msidError])
@@ -201,6 +202,7 @@
         if (error) *error = [MSALErrorConverter msalErrorFromMsidError:msidError];
         return nil;
     }
+#endif
     
     config.verifiedRedirectUri = msalRedirectUri;
     

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -193,6 +193,14 @@
         if (error) *error = [MSALErrorConverter msalErrorFromMsidError:msidError];
         return nil;
     }
+        
+    if (MSALGlobalConfig.brokerAvailability == MSALBrokeredAvailabilityAuto
+        && msalRedirectUri.brokerCapable
+        && ![MSALRedirectUriVerifier verifyAdditionalRequiredSchemesAreRegistered:&msidError])
+    {
+        if (error) *error = [MSALErrorConverter msalErrorFromMsidError:msidError];
+        return nil;
+    }
     
     config.verifiedRedirectUri = msalRedirectUri;
     

--- a/MSAL/src/util/MSALRedirectUriVerifier.h
+++ b/MSAL/src/util/MSALRedirectUriVerifier.h
@@ -35,4 +35,6 @@
                                          clientId:(NSString *)clientId
                                             error:(NSError * __autoreleasing *)error;
 
++ (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(NSError **)error;
+
 @end

--- a/MSAL/src/util/ios/MSALRedirectUriVerifier.m
+++ b/MSAL/src/util/ios/MSALRedirectUriVerifier.m
@@ -138,4 +138,23 @@
     return NO;
 }
 
++ (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(NSError **)error
+{
+    NSArray *querySchemes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"LSApplicationQueriesSchemes"];
+    
+    if (![querySchemes containsObject:@"msauthv2"]
+        || ![querySchemes containsObject:@"msauthv3"])
+    {
+        if (error)
+        {
+            NSString *message = @"The required query schemes \"msauthv2\" and \"msauthv3\" are not registered in the app's info.plist file. Please add \"msauthv2\" and \"msauthv3\" into Info.plist under LSApplicationQueriesSchemes without any whitespaces.";
+            MSIDFillAndLogError(error, MSIDErrorRedirectSchemeNotRegistered, message, nil);
+        }
+        
+        return NO;
+    }
+    
+    return YES;
+}
+
 @end

--- a/MSAL/src/util/mac/MSALRedirectUriVerifier.m
+++ b/MSAL/src/util/mac/MSALRedirectUriVerifier.m
@@ -44,4 +44,9 @@
                                           brokerCapable:NO];
 }
 
++ (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(__unused NSError **)error
+{
+    return YES;
+}
+
 @end

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -234,6 +234,29 @@
     XCTAssertEqualObjects(error.domain, MSALErrorDomain);
 }
 
+- (void)testInitWithClientId_whenBrokerQuerySchemeIsNotRegistered_shouldReturnNilApplicationAndFillError
+{
+    NSArray *schemes = @[@"msauthv2", @"msauthv-wrong"];
+    [MSALTestBundle overrideObject:schemes forKey:@"LSApplicationQueriesSchemes"];
+    
+    NSArray *urlTypes = @[@{@"CFBundleURLSchemes": @[@"msauth.test.bundle.identifier"]}];
+    [MSALTestBundle overrideObject:urlTypes forKey:@"CFBundleURLTypes"];
+    [MSALTestBundle overrideBundleId:@"test.bundle.identifier"];
+    
+    MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityAuto;
+    
+    NSError *error;
+    __auto_type application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
+                                                                              error:&error];
+    
+    XCTAssertNil(application);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, MSALErrorInternal);
+    NSInteger internalErrorCode = [error.userInfo[MSALInternalErrorCodeKey] integerValue];
+    XCTAssertEqual(internalErrorCode, MSALInternalErrorRedirectSchemeNotRegistered);
+    XCTAssertEqualObjects(error.domain, MSALErrorDomain);
+}
+
 - (void)testInitWithClientIdAndAuthorityAndRedirectUri_whenInvalidSchemeRegistered_shouldReturnNilApplicationAndFillError
 {
     NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[@"mycustom.redirect"] } ];

--- a/MSAL/test/unit/ios/MSALRedirectUriVerifierTests.m
+++ b/MSAL/test/unit/ios/MSALRedirectUriVerifierTests.m
@@ -159,4 +159,30 @@
     XCTAssertTrue([error.userInfo[MSIDErrorDescriptionKey] containsString:@"\"msauth.test.bundle.identifier://auth\""]);
 }
 
+- (void)testVerifyRegisteredSchemes_whenAllSchemesAreRegistered_shouldReturnYESAndNilError
+{
+    NSArray *urlTypes = @[@"myotherscheme", @"msauthv2", @"msauthv3"];
+    [MSALTestBundle overrideObject:urlTypes forKey:@"LSApplicationQueriesSchemes"];
+    
+    NSError *error;
+    BOOL result = [MSALRedirectUriVerifier verifyAdditionalRequiredSchemesAreRegistered:&error];
+    
+    XCTAssertTrue(result);
+    XCTAssertNil(error);
+}
+
+- (void)testVerifyRegisteredSchemes_whenSchemeIsNotRegistered_shouldReturnNOAndFillError
+{
+    NSArray *urlTypes = @[@"msauthv2", @"msauthv-wrong"];
+    [MSALTestBundle overrideObject:urlTypes forKey:@"LSApplicationQueriesSchemes"];
+    
+    NSError *error;
+    BOOL result = [MSALRedirectUriVerifier verifyAdditionalRequiredSchemesAreRegistered:&error];
+    
+    XCTAssertFalse(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+    XCTAssertEqual(error.code, MSIDErrorRedirectSchemeNotRegistered);
+}
+
 @end


### PR DESCRIPTION
We've had a couple of incidents during last months which where caused by apps not adding correct query schemes and therefore ADAL/MSAL couldn't find broker on the device. As a result, the agreed recovery item was to make it easier for developers to detect this issue, and MSAL/ADAL will now return an error when required scheme is missing (msauthv2 and msauthv3). 