### PR TITLE
Added optimizations for legacy accounts provider

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -549,6 +549,7 @@
 		B2BB739C2112C7F9000EA4C5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2BB739B2112C7F9000EA4C5 /* Security.framework */; };
 		B2BB739D2112C82E000EA4C5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2BB739B2112C7F9000EA4C5 /* Security.framework */; };
 		B2BDEEE821FEA205001EBB8B /* MSALMultiAppCacheCoexistenceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2734C1B21253AD300DAB1CD /* MSALMultiAppCacheCoexistenceTests.m */; };
+		B2C0E80923AF06DB006C9CAD /* MSALLegacySharedAccountsProvider+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2C0E80723AF06DB006C9CAD /* MSALLegacySharedAccountsProvider+Internal.h */; };
 		B2C17B071FC8DAC50070A514 /* libIdentityCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A206231FC50A4D00755A51 /* libIdentityCore.a */; };
 		B2C17B081FC8DACC0070A514 /* libIdentityCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A206251FC50A4D00755A51 /* libIdentityCore.a */; };
 		B2C17B0A1FC8DB2E0070A514 /* MSIDVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C17B091FC8DB2E0070A514 /* MSIDVersion.m */; };
@@ -1228,6 +1229,7 @@
 		B2BB73962112C4B3000EA4C5 /* msal__ui_test__ios.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = msal__ui_test__ios.xcconfig; sourceTree = "<group>"; };
 		B2BB73982112C51E000EA4C5 /* MSALUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALUITests.swift; sourceTree = "<group>"; };
 		B2BB739B2112C7F9000EA4C5 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.4.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		B2C0E80723AF06DB006C9CAD /* MSALLegacySharedAccountsProvider+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSALLegacySharedAccountsProvider+Internal.h"; sourceTree = "<group>"; };
 		B2C17B091FC8DB2E0070A514 /* MSIDVersion.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIDVersion.m; sourceTree = "<group>"; };
 		B2C2329F21224C21008092C1 /* MSALBlackforestUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALBlackforestUITests.m; sourceTree = "<group>"; };
 		B2C232AA2122A6A5008092C1 /* MSALCacheRemovalTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALCacheRemovalTests.m; sourceTree = "<group>"; };
@@ -1719,6 +1721,7 @@
 				B223B0C422AE215D00FB8713 /* MSALLegacySharedAccountFactory.m */,
 				B266391922B4B84600FEB673 /* NSString+MSALAccountIdenfiers.h */,
 				B266391A22B4B84600FEB673 /* NSString+MSALAccountIdenfiers.m */,
+				B2C0E80723AF06DB006C9CAD /* MSALLegacySharedAccountsProvider+Internal.h */,
 			);
 			path = ios;
 			sourceTree = "<group>";
@@ -2497,6 +2500,7 @@
 				B29A56C122826EE00023F5E6 /* MSALSerializedADALCacheProvider.h in Headers */,
 				96CF95212268FD0400D97374 /* MSALAccount.h in Headers */,
 				B267569D228F335E000F01D7 /* MSALExternalAccountHandler.h in Headers */,
+				B2C0E80923AF06DB006C9CAD /* MSALLegacySharedAccountsProvider+Internal.h in Headers */,
 				B26756C422921C42000F01D7 /* MSALAADOauth2Provider.h in Headers */,
 				232D6195224C62FF00260C42 /* MSALIndividualClaimRequest+Internal.h in Headers */,
 				B26756BE22921A71000F01D7 /* MSALOauth2Provider.h in Headers */,

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -94,6 +94,7 @@
 #import "MSIDMacKeychainTokenCache.h"
 #endif
 
+#import "MSIDTokenResult.h"
 #import "MSIDKeychainTokenCache.h"
 
 @interface MSALPublicClientApplication()
@@ -696,7 +697,13 @@
         
         NSError *resultError = nil;
         MSALResult *msalResult = [self.msalOauth2Provider resultWithTokenResult:result error:&resultError];
-        [self updateExternalAccountsWithResult:msalResult context:msidParams];
+        
+        if (result.tokenResponse)
+        {
+            // Only update external accounts if we got new result from network as an optimization
+            [self updateExternalAccountsWithResult:msalResult context:msidParams];
+        }
+        
         block(msalResult, resultError, msidParams);
     }];
 }

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider+Internal.h
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider+Internal.h
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSALLegacySharedAccountsProvider.h"
+#import "MSALLegacySharedAccount.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALLegacySharedAccountsProvider (Internal)
+
+- (void)updateAccountAsync:(id<MSALAccount>)account
+             idTokenClaims:(nullable NSDictionary *)idTokenClaims
+            tenantProfiles:(nullable NSArray<MSALTenantProfile *> *)tenantProfiles
+                 operation:(MSALLegacySharedAccountWriteOperation)operation
+                completion:(void (^)(BOOL result, NSError *error))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
@@ -184,11 +184,12 @@
 {
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Updating account %@", MSID_PII_LOG_MASKABLE(account));
     
-    return [self updateAccount:account
-                 idTokenClaims:idTokenClaims
-                tenantProfiles:nil
-                     operation:MSALLegacySharedAccountUpdateOperation
-                         error:error];
+    [self updateAccountAsync:account
+               idTokenClaims:idTokenClaims
+              tenantProfiles:nil
+                   operation:MSALLegacySharedAccountUpdateOperation
+                  completion:nil];
+    return YES;
 }
 
 - (nullable NSArray<MSALLegacySharedAccount *> *)updatableAccountsFromJsonObject:(NSDictionary *)jsonDictionary
@@ -247,11 +248,29 @@
                 error:(NSError * _Nullable * _Nullable)error
 {
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Removing account %@", MSID_PII_LOG_MASKABLE(account));
-    return [self updateAccount:account
-                 idTokenClaims:nil
-                tenantProfiles:tenantProfiles
-                     operation:MSALLegacySharedAccountRemoveOperation
-                         error:error];
+    
+    __block BOOL result = YES;
+    __block NSError *removeError;
+    
+    dispatch_barrier_sync(self.synchronizationQueue, ^{
+        result = [self updateAccountImpl:account
+                           idTokenClaims:nil
+                          tenantProfiles:tenantProfiles
+                               operation:MSALLegacySharedAccountRemoveOperation
+                                   error:&removeError];
+        
+        if (!result)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Encountered an error updating legacy accounts %@", MSID_PII_LOG_MASKABLE(removeError));
+        }
+    });
+    
+    if (error)
+    {
+        *error = removeError;
+    }
+    
+    return result;
 }
 
 - (nullable NSArray<MSALLegacySharedAccount *> *)removableAccountsFromJsonObject:(NSDictionary *)jsonDictionary
@@ -303,11 +322,11 @@
 
 #pragma mark - Write
 
-- (BOOL)updateAccount:(id<MSALAccount>)account
-        idTokenClaims:(NSDictionary *)idTokenClaims
-       tenantProfiles:(NSArray<MSALTenantProfile *> *)tenantProfiles
-            operation:(MSALLegacySharedAccountWriteOperation)operation
-                error:(__unused NSError **)error
+- (void)updateAccountAsync:(id<MSALAccount>)account
+             idTokenClaims:(NSDictionary *)idTokenClaims
+            tenantProfiles:(NSArray<MSALTenantProfile *> *)tenantProfiles
+                 operation:(MSALLegacySharedAccountWriteOperation)operation
+                completion:(void (^)(BOOL result, NSError *error))completion
 {
     dispatch_barrier_async(self.synchronizationQueue, ^{
         NSError *updateError;
@@ -321,9 +340,9 @@
         {
             MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Encountered an error updating legacy accounts %@", MSID_PII_LOG_MASKABLE(updateError));
         }
+        
+        if (completion) completion(result, updateError);
     });
-    
-    return YES;
 }
 
 - (BOOL)updateAccountImpl:(id<MSALAccount>)account

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
@@ -309,7 +309,7 @@
             operation:(MSALLegacySharedAccountWriteOperation)operation
                 error:(__unused NSError **)error
 {
-    dispatch_barrier_sync(self.synchronizationQueue, ^{
+    dispatch_barrier_async(self.synchronizationQueue, ^{
         NSError *updateError;
         BOOL result = [self updateAccountImpl:account
                                 idTokenClaims:idTokenClaims

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
@@ -307,25 +307,23 @@
         idTokenClaims:(NSDictionary *)idTokenClaims
        tenantProfiles:(NSArray<MSALTenantProfile *> *)tenantProfiles
             operation:(MSALLegacySharedAccountWriteOperation)operation
-                error:(NSError **)error
+                error:(__unused NSError **)error
 {
-    __block BOOL result = YES;
-    __block NSError *updateError = nil;
-    
     dispatch_barrier_sync(self.synchronizationQueue, ^{
-        result = [self updateAccountImpl:account
-                           idTokenClaims:idTokenClaims
-                          tenantProfiles:tenantProfiles
-                               operation:operation
-                                   error:&updateError];
+        NSError *updateError;
+        BOOL result = [self updateAccountImpl:account
+                                idTokenClaims:idTokenClaims
+                               tenantProfiles:tenantProfiles
+                                    operation:operation
+                                        error:&updateError];
+        
+        if (!result)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Encountered an error updating legacy accounts %@", MSID_PII_LOG_MASKABLE(updateError));
+        }
     });
     
-    if (error && updateError)
-    {
-        *error = updateError;
-    }
-    
-    return result;
+    return YES;
 }
 
 - (BOOL)updateAccountImpl:(id<MSALAccount>)account

--- a/MSAL/test/app/MSALStressTestHelper.m
+++ b/MSAL/test/app/MSALStressTestHelper.m
@@ -92,8 +92,6 @@ static BOOL s_runningTest = NO;
                 MSALAccount *account = accounts[userIndex];
                 account = [application accountForIdentifier:account.identifier error:nil];
                 
-                NSLog(@"Retrieved account: %@", account.username);
-
                 if (multipleUsers)
                 {
                     userIndex = ++userIndex >= [accounts count] ? 0 : userIndex;
@@ -108,9 +106,7 @@ static BOOL s_runningTest = NO;
                      {
                          [self expireAllAccessTokens];
                      }
-                    
-                     NSLog(@"Retrieved token %@", result.account.username);
-                     
+                                         
                      dispatch_semaphore_signal(sem);
                  }];
             });

--- a/MSAL/test/app/MSALStressTestHelper.m
+++ b/MSAL/test/app/MSALStressTestHelper.m
@@ -38,6 +38,7 @@
 #import "MSALPublicClientApplication.h"
 #import "MSALResult.h"
 #import "MSALSilentTokenParameters.h"
+#import "MSALAccount.h"
 
 @implementation MSALStressTestHelper
 
@@ -79,7 +80,7 @@ static BOOL s_runningTest = NO;
 {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 
-        __block dispatch_semaphore_t sem = dispatch_semaphore_create(10);
+        __block dispatch_semaphore_t sem = dispatch_semaphore_create(50);
         __block NSUInteger userIndex = 0;
 
         while (!s_stop)
@@ -89,6 +90,9 @@ static BOOL s_runningTest = NO;
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 
                 MSALAccount *account = accounts[userIndex];
+                account = [application accountForIdentifier:account.identifier error:nil];
+                
+                NSLog(@"Retrieved account: %@", account.username);
 
                 if (multipleUsers)
                 {
@@ -104,6 +108,8 @@ static BOOL s_runningTest = NO;
                      {
                          [self expireAllAccessTokens];
                      }
+                    
+                     NSLog(@"Retrieved token %@", result.account.username);
                      
                      dispatch_semaphore_signal(sem);
                  }];

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -549,6 +549,10 @@
                                                                                                    redirectUri:redirectUri
                                                                                                      authority:authority];
     
+    MSALLegacySharedAccountsProvider *provider = [[MSALLegacySharedAccountsProvider alloc] initWithSharedKeychainAccessGroup:@"com.microsoft.adalcache" serviceIdentifier:@"legacy-accounts-service" applicationIdentifier:@"my.msal.testapp"];
+    provider.sharedAccountMode = MSALLegacySharedAccountModeReadWrite;
+    [pcaConfig.cacheConfig addExternalAccountProvider:provider];
+    
     NSError *error;
     MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:pcaConfig error:&error];
     

--- a/MSAL/test/unit/MSALPublicClientApplicationAccountUpdateTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationAccountUpdateTests.m
@@ -45,6 +45,7 @@
 #import "MSALTestBundle.h"
 #import "MSALOauth2Provider.h"
 #import "XCTestCase+HelperMethods.h"
+#import "MSIDTokenResponse.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -117,10 +118,15 @@
                               class:[MSIDSilentController class]
                               block:(id)^(MSIDSilentController *obj, MSIDRequestCompletionBlock completionBlock)
      {
-         XCTAssertTrue([obj isKindOfClass:[MSIDSilentController class]]);
-         
-         completionBlock([self testTokenResult], nil);
+            XCTAssertTrue([obj isKindOfClass:[MSIDSilentController class]]);
+        
+            MSIDTokenResult *result = [self testTokenResult];
+            result.tokenResponse = [MSIDTokenResponse new];
+            completionBlock(result, nil);
      }];
+    
+    XCTestExpectation *updateExpectation = [self keyValueObservingExpectationForObject:mockExternalAccountHandler keyPath:@"updateInvokedCount" expectedValue:@1];
+    XCTestExpectation *acquireTokenExpectation = [self expectationWithDescription:@"Acquire token silent"];
     
     [application acquireTokenSilentForScopes:@[@"fakescope1", @"fakescope2"]
                                      account:[self testMSALAccount]
@@ -128,8 +134,10 @@
                                  
                                  XCTAssertNotNil(result);
                                  XCTAssertNil(error);
-                                 XCTAssertEqual(mockExternalAccountHandler.updateInvokedCount, 1);
+                                 [acquireTokenExpectation fulfill];
                              }];
+    
+    [self waitForExpectations:@[updateExpectation, acquireTokenExpectation] timeout:1];
 }
 
 - (void)testRemoveAccount_whenAccountExistsInExternalCache_shouldCallRemoveAccountFromExternalCache

--- a/MSAL/test/unit/ios/external-cache/MSALLegacySharedAccountsProviderTests.m
+++ b/MSAL/test/unit/ios/external-cache/MSALLegacySharedAccountsProviderTests.m
@@ -37,6 +37,7 @@
 #import "MSIDConstants.h"
 #import "MSALLegacySharedAccountTestUtil.h"
 #import "MSALAccountEnumerationParameters.h"
+#import "MSALLegacySharedAccountsProvider+Internal.h"
 
 @interface MSALLegacySharedAccountsProviderTests : XCTestCase
 
@@ -194,11 +195,21 @@
     [self saveAccountsBlob:accountsBlob version:@"AccountsV3"];
     
     MSALAccount *testAccount = [MSALLegacySharedAccountTestUtil testADALAccount];
-    NSError *error = nil;
-    BOOL result = [self.accountsProvider updateAccount:testAccount idTokenClaims:testAccount.accountClaims error:&error];
     
-    XCTAssertTrue(result);
-    XCTAssertNil(error);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Update async"];
+    
+    [self.accountsProvider updateAccountAsync:testAccount
+                                idTokenClaims:testAccount.accountClaims
+                               tenantProfiles:nil
+                                    operation:MSALLegacySharedAccountUpdateOperation
+                                   completion:^(BOOL result, NSError * _Nonnull error)
+    {
+        XCTAssertTrue(result);
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
     
     [self verifyBlobCountWithV1Count:1 v2Count:2 v3Count:2];
 }
@@ -214,11 +225,21 @@
     [self saveAccountsBlob:accountsBlob version:@"AccountsV3"];
     
     MSALAccount *testAccount = [MSALLegacySharedAccountTestUtil testADALAccount];
-    NSError *error = nil;
-    BOOL result = [self.accountsProvider updateAccount:testAccount idTokenClaims:testAccount.accountClaims error:&error];
     
-    XCTAssertTrue(result);
-    XCTAssertNil(error);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Update async"];
+    
+    [self.accountsProvider updateAccountAsync:testAccount
+                                idTokenClaims:testAccount.accountClaims
+                               tenantProfiles:nil
+                                    operation:MSALLegacySharedAccountUpdateOperation
+                                   completion:^(BOOL result, NSError * _Nonnull error)
+    {
+        XCTAssertTrue(result);
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
     
     [self verifyBlobCountWithV1Count:1 v2Count:2 v3Count:3];
 }
@@ -234,11 +255,21 @@
     [self saveAccountsBlob:accountsBlob version:@"AccountsV2"];
     
     MSALAccount *testAccount = [MSALLegacySharedAccountTestUtil testADALAccount];
-    NSError *error = nil;
-    BOOL result = [self.accountsProvider updateAccount:testAccount idTokenClaims:testAccount.accountClaims error:&error];
     
-    XCTAssertTrue(result);
-    XCTAssertNil(error);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Update async"];
+    
+    [self.accountsProvider updateAccountAsync:testAccount
+                                idTokenClaims:testAccount.accountClaims
+                               tenantProfiles:nil
+                                    operation:MSALLegacySharedAccountUpdateOperation
+                                   completion:^(BOOL result, NSError * _Nonnull error)
+    {
+        XCTAssertTrue(result);
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
     
     [self verifyBlobCountWithV1Count:1 v2Count:2 v3Count:2];
 
@@ -263,11 +294,21 @@
     [self saveAccountsBlob:accountsBlob version:@"AccountsV2"];
     
     MSALAccount *testAccount = [MSALLegacySharedAccountTestUtil testMSAAccount];
-    NSError *error = nil;
-    BOOL result = [self.accountsProvider updateAccount:testAccount idTokenClaims:testAccount.accountClaims error:&error];
     
-    XCTAssertTrue(result);
-    XCTAssertNil(error);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Update async"];
+    
+    [self.accountsProvider updateAccountAsync:testAccount
+                                idTokenClaims:testAccount.accountClaims
+                               tenantProfiles:nil
+                                    operation:MSALLegacySharedAccountUpdateOperation
+                                   completion:^(BOOL result, NSError * _Nonnull error)
+    {
+        XCTAssertTrue(result);
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
     
     [self verifyBlobCountWithV1Count:1 v2Count:2 v3Count:2];
     
@@ -292,11 +333,21 @@
     [self saveAccountsBlob:accountsBlob version:@"AccountsV2"];
     
     MSALAccount *testAccount = [MSALLegacySharedAccountTestUtil testADALAccount];
-    NSError *error = nil;
-    BOOL result = [self.accountsProvider updateAccount:testAccount idTokenClaims:testAccount.accountClaims error:&error];
     
-    XCTAssertTrue(result);
-    XCTAssertNil(error);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Update async"];
+    
+    [self.accountsProvider updateAccountAsync:testAccount
+                                idTokenClaims:testAccount.accountClaims
+                               tenantProfiles:nil
+                                    operation:MSALLegacySharedAccountUpdateOperation
+                                   completion:^(BOOL result, NSError * _Nonnull error)
+    {
+        XCTAssertTrue(result);
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
     
     [self verifyBlobCountWithV1Count:1 v2Count:3 v3Count:3];
 }


### PR DESCRIPTION
Added some minor optimizations for external accounts logic:
1. Only update external accounts for requests that went to network. For silent AT retrievals, no need to update external accounts. 
2. Instead of using dispatch_barrier_sync, switch to async version and don't wait for result in the default implementation - we never return the error to the app, so seems like a reasonable optimization. 