### PR TITLE
[Broker patch] Fixed account lookups and validation with the same email

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -886,6 +886,7 @@
     msidParams.tokenExpirationBuffer = self.internalConfig.tokenExpirationBuffer;
     msidParams.extendedLifetimeEnabled = self.internalConfig.extendedLifetimeEnabled;
     msidParams.clientCapabilities = self.internalConfig.clientApplicationCapabilities;
+    msidParams.shouldValidateResultAccount = YES;
     
     msidParams.validateAuthority = _validateAuthority;
     //TODO: address/decide public header to allow setting instace_aware for requests;

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2274,7 +2274,7 @@
     XCTAssertEqual([application allAccounts:nil].count, 0);
     
     // 5. Make sure account and FOCI tokens are still in cache
-    MSIDAccount *cachedAccount = [self.tokenCacheAccessor getAccountForIdentifier:account.accountIdentifier authority:authority context:nil error:nil];
+    MSIDAccount *cachedAccount = [self.tokenCacheAccessor getAccountForIdentifier:account.accountIdentifier authority:authority realmHint:nil context:nil error:nil];
     XCTAssertNotNil(cachedAccount);
     
     MSIDRefreshToken *fociToken = [self.tokenCacheAccessor getRefreshTokenWithAccount:account.accountIdentifier familyId:@"1" configuration:configuration context:nil error:nil];

--- a/build.py
+++ b/build.py
@@ -35,7 +35,7 @@ from timeit import default_timer as timer
 
 script_start_time = timer()
 
-ios_sim_device = "iPhone 6"
+ios_sim_device = "iPhone 8"
 ios_sim_dest = "-destination 'platform=iOS Simulator,name=" + ios_sim_device + ",OS=latest'"
 ios_sim_flags = "-sdk iphonesimulator CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
 


### PR DESCRIPTION
With the introduction of Google B2B accounts, there’s now a potential conflict between MSA accounts and Google B2B accounts with the same email address. In this scenario, home account id-s for accounts with the same email address will be different, and refresh token for one account won’t work for another account.

The mitigation for developers is to always provide us home account id, and only lookup accounts by home account id. When looking up accounts by displayable id, there’s no guarantee that we get the right account in the above mentioned scenario.  

However, to ensure backward compatibility, and not break SSO, iOS broker should still be able to lookup accounts by only email/upn. In normal scenarios, it will be reliable. In Google B2B scenarios it will be the best effort, and we fallback to interactive auth to resolve accounts. 

In current broker SDK, there were two problems that were preventing this scenario from working:
1. Broker SDK sets accountIdentifier for InteractiveTokenRequest based on the email/upn even when developer didn’t provide us accountIdentifier. In this case, if accountIdentifier mismatched, it returned account mismatch error. The fix is to only enable account verification if developer provided us account identifier. If developer only provided us displayable id, this matching is unreliable and will now be disabled.
2. Broker SDK resolves home account identifier by email without accounting for the requested tenantId. This PR introduces a fix to also account for a tenantId hint when looking up accounts. Note that this is a best effort (hence it is a hint), because developer might be requesting token for tenantId not previously requested, in which case there will be no account in cache. We still want to ensure best effort account lookup in that scenario. In case we lookup wrong account (e.g. we find MSA account and developer wanted to get a token for Google B2B account), silent broker request will fail and we fall back to interactive request, which will resolve account correctly. Server side ensures here final account resolution based on which account is present in the tenant, and possibly a user choice during interactive token acquisition. 

Other PRs for this fix:
Common core: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/668
MSAL: https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/826
Broker: https://github.com/AzureAD/azure-activedirectory-tokenbroker-for-objc/pull/431

Note that since broker is using MSAL 1.0.0, this hot fix is based off that release to minimize changes. 