### PR TITLE
Propagate return only signed in accounts flag

### DIFF
--- a/MSAL/src/instance/MSALAccountsProvider.m
+++ b/MSAL/src/instance/MSALAccountsProvider.m
@@ -334,6 +334,7 @@
     
     NSError *requestError;
     MSIDSSOExtensionGetAccountsRequest *ssoExtensionRequest = [[MSIDSSOExtensionGetAccountsRequest alloc] initWithRequestParameters:requestParameters
+                                                                                                         returnOnlySignedInAccounts:parameters.returnOnlySignedInAccounts
                                                                                                                               error:&requestError];
     
     if (!ssoExtensionRequest)


### PR DESCRIPTION
This PR enables propagation of returnOnlySignedInAccounts into SSO extension request. Previously this was not set. 