### PR TITLE
Don't require checking query schemes when on broker

### DIFF
--- a/MSAL/src/util/ios/MSALRedirectUriVerifier.m
+++ b/MSAL/src/util/ios/MSALRedirectUriVerifier.m
@@ -138,8 +138,9 @@
     return NO;
 }
 
-+ (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(NSError **)error
++ (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(__unused NSError **)error
 {
+#if !AD_BROKER
     NSArray *querySchemes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"LSApplicationQueriesSchemes"];
     
     if (![querySchemes containsObject:@"msauthv2"]
@@ -153,6 +154,7 @@
         
         return NO;
     }
+#endif
     
     return YES;
 }


### PR DESCRIPTION
When Authenticator is calling MSAL, msauthv2 and msauthv3 schemes shouldn't be required as broker discovery relies on different mechanisms. 