### PR TITLE
Added support to read device info from MSAL

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -304,6 +304,21 @@
 		B2472CA4226FDC46008F22AB /* MSALB2CAuthority_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2472CA2226FDC46008F22AB /* MSALB2CAuthority_Internal.h */; };
 		B2472CA5226FDC46008F22AB /* MSALB2CAuthority_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2472CA2226FDC46008F22AB /* MSALB2CAuthority_Internal.h */; };
 		B2472CA6226FDC46008F22AB /* MSALB2CAuthority_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2472CA2226FDC46008F22AB /* MSALB2CAuthority_Internal.h */; };
+		B253151923DD607600432133 /* MSALDeviceInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = B253151723DD607600432133 /* MSALDeviceInformation.h */; };
+		B253151A23DD607600432133 /* MSALDeviceInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = B253151723DD607600432133 /* MSALDeviceInformation.h */; };
+		B253151B23DD607600432133 /* MSALDeviceInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = B253151823DD607600432133 /* MSALDeviceInformation.m */; };
+		B253151C23DD607600432133 /* MSALDeviceInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = B253151823DD607600432133 /* MSALDeviceInformation.m */; };
+		B253152A23DD66A300432133 /* MSALDeviceInfoProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B253152823DD66A300432133 /* MSALDeviceInfoProvider.h */; };
+		B253152B23DD66A300432133 /* MSALDeviceInfoProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B253152823DD66A300432133 /* MSALDeviceInfoProvider.h */; };
+		B253152C23DD66A300432133 /* MSALDeviceInfoProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B253152923DD66A300432133 /* MSALDeviceInfoProvider.m */; };
+		B253152D23DD66A300432133 /* MSALDeviceInfoProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = B253152923DD66A300432133 /* MSALDeviceInfoProvider.m */; };
+		B253153023DD684E00432133 /* MSALSSOExtensionRequestHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B253152E23DD684E00432133 /* MSALSSOExtensionRequestHandler.h */; };
+		B253153123DD684E00432133 /* MSALSSOExtensionRequestHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B253152E23DD684E00432133 /* MSALSSOExtensionRequestHandler.h */; };
+		B253153223DD684E00432133 /* MSALSSOExtensionRequestHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B253152F23DD684E00432133 /* MSALSSOExtensionRequestHandler.m */; };
+		B253153323DD684E00432133 /* MSALSSOExtensionRequestHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B253152F23DD684E00432133 /* MSALSSOExtensionRequestHandler.m */; };
+		B253153523DD692600432133 /* MSALDeviceInformation+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B253153423DD692600432133 /* MSALDeviceInformation+Internal.h */; };
+		B253153623DD692600432133 /* MSALDeviceInformation+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B253153423DD692600432133 /* MSALDeviceInformation+Internal.h */; };
+		B253153B23DD717900432133 /* MSALDeviceInfoProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B253153A23DD717900432133 /* MSALDeviceInfoProviderTests.m */; };
 		B256121B217EA44900999876 /* MSALOauth2FactoryProducerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B256121A217EA44900999876 /* MSALOauth2FactoryProducerTests.m */; };
 		B256121C217EA44900999876 /* MSALOauth2FactoryProducerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B256121A217EA44900999876 /* MSALOauth2FactoryProducerTests.m */; };
 		B25A39D921C4C49D00213A62 /* MSALAutomationExpireATAction.m in Sources */ = {isa = PBXBuildFile; fileRef = B25A39D821C4C49D00213A62 /* MSALAutomationExpireATAction.m */; };
@@ -1145,6 +1160,14 @@
 		B223B0C322AE215D00FB8713 /* MSALLegacySharedAccountFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALLegacySharedAccountFactory.h; sourceTree = "<group>"; };
 		B223B0C422AE215D00FB8713 /* MSALLegacySharedAccountFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALLegacySharedAccountFactory.m; sourceTree = "<group>"; };
 		B2472CA2226FDC46008F22AB /* MSALB2CAuthority_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALB2CAuthority_Internal.h; sourceTree = "<group>"; };
+		B253151723DD607600432133 /* MSALDeviceInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALDeviceInformation.h; sourceTree = "<group>"; };
+		B253151823DD607600432133 /* MSALDeviceInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALDeviceInformation.m; sourceTree = "<group>"; };
+		B253152823DD66A300432133 /* MSALDeviceInfoProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALDeviceInfoProvider.h; sourceTree = "<group>"; };
+		B253152923DD66A300432133 /* MSALDeviceInfoProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALDeviceInfoProvider.m; sourceTree = "<group>"; };
+		B253152E23DD684E00432133 /* MSALSSOExtensionRequestHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALSSOExtensionRequestHandler.h; sourceTree = "<group>"; };
+		B253152F23DD684E00432133 /* MSALSSOExtensionRequestHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALSSOExtensionRequestHandler.m; sourceTree = "<group>"; };
+		B253153423DD692600432133 /* MSALDeviceInformation+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSALDeviceInformation+Internal.h"; sourceTree = "<group>"; };
+		B253153A23DD717900432133 /* MSALDeviceInfoProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALDeviceInfoProviderTests.m; sourceTree = "<group>"; };
 		B256121A217EA44900999876 /* MSALOauth2FactoryProducerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALOauth2FactoryProducerTests.m; sourceTree = "<group>"; };
 		B25A39D721C4C49D00213A62 /* MSALAutomationExpireATAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALAutomationExpireATAction.h; sourceTree = "<group>"; };
 		B25A39D821C4C49D00213A62 /* MSALAutomationExpireATAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAutomationExpireATAction.m; sourceTree = "<group>"; };
@@ -1532,6 +1555,10 @@
 				B2A3C2882145FD0F0082525C /* MSALAccountsProvider.m */,
 				B26756D722922375000F01D7 /* MSALOauth2Authority.h */,
 				B26756D822922375000F01D7 /* MSALOauth2Authority.m */,
+				B253152823DD66A300432133 /* MSALDeviceInfoProvider.h */,
+				B253152923DD66A300432133 /* MSALDeviceInfoProvider.m */,
+				B253152E23DD684E00432133 /* MSALSSOExtensionRequestHandler.h */,
+				B253152F23DD684E00432133 /* MSALSSOExtensionRequestHandler.m */,
 			);
 			path = instance;
 			sourceTree = "<group>";
@@ -2012,6 +2039,8 @@
 				D65A6F771E3FF3D900C69FBA /* MSALLogger.m */,
 				D65A6F781E3FF3D900C69FBA /* MSALPublicClientApplication.m */,
 				D62746D11E9B38AF00EFCE99 /* MSALPublicClientApplication+Internal.h */,
+				B253151823DD607600432133 /* MSALDeviceInformation.m */,
+				B253153423DD692600432133 /* MSALDeviceInformation+Internal.h */,
 				9626D153225835D50019417B /* configuration */,
 				D65A6F791E3FF3D900C69FBA /* MSALResult.m */,
 				2342584A20649A9800621AFE /* MSALAccount+Internal.h */,
@@ -2077,6 +2106,7 @@
 				23FB5C1C22542B99002BF1EB /* MSALJsonDeserializable.h */,
 				B27CCDF0229F9F4700CAD565 /* MSALAccountEnumerationParameters.h */,
 				B2968C4122F24259005AFC33 /* ios */,
+				B253151723DD607600432133 /* MSALDeviceInformation.h */,
 			);
 			path = public;
 			sourceTree = "<group>";
@@ -2154,6 +2184,7 @@
 				B29A56CE2283D7430023F5E6 /* MSALAADAuthorityTests.m */,
 				B2725EAB22BF2759009B454A /* MSALExternalAccountHandlerTests.m */,
 				B2725EB422BF2774009B454A /* MSALPublicClientApplicationAccountUpdateTests.m */,
+				B253153A23DD717900432133 /* MSALDeviceInfoProviderTests.m */,
 			);
 			path = unit;
 			sourceTree = "<group>";
@@ -2513,6 +2544,7 @@
 			files = (
 				96CF952A2268FD0500D97374 /* MSALPublicClientStatusNotifications.h in Headers */,
 				96CF95292268FD0500D97374 /* MSALRedirectUri.h in Headers */,
+				B253153523DD692600432133 /* MSALDeviceInformation+Internal.h in Headers */,
 				B273D0AF226E8587005A7BB4 /* MSALErrorConverter+Internal.h in Headers */,
 				B26756D022921C6D000F01D7 /* MSALADFSOauth2Provider.h in Headers */,
 				1EDAE32C218A4FA0001898E1 /* MSALAuthority_Internal.h in Headers */,
@@ -2567,8 +2599,10 @@
 				B273D0CC226E85C8005A7BB4 /* MSALHTTPConfig+Internal.h in Headers */,
 				B223B0B922ADF8E600FB8713 /* MSALLegacySharedMSAAccount.h in Headers */,
 				B2D478A3230E3E54005AE186 /* MSALTelemetryEventsObservingProxy.h in Headers */,
+				B253152A23DD66A300432133 /* MSALDeviceInfoProvider.h in Headers */,
 				B21786A523A72DFC00839CE8 /* MSALPublicClientApplication+SingleAccount.h in Headers */,
 				B273D0B3226E858B005A7BB4 /* MSALErrorConverter.h in Headers */,
+				B253153023DD684E00432133 /* MSALSSOExtensionRequestHandler.h in Headers */,
 				B223B0B322ADF8C500FB8713 /* MSALLegacySharedADALAccount.h in Headers */,
 				2342584B20649A9800621AFE /* MSALAccount+Internal.h in Headers */,
 				B26756D522921CC4000F01D7 /* MSALOauth2Provider+Internal.h in Headers */,
@@ -2595,6 +2629,7 @@
 				B2E2A9422393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h in Headers */,
 				B27CCDE0229F65D700CAD565 /* MSALAccount+MultiTenantAccount.h in Headers */,
 				B203459D21AFA1FB00B221AA /* MSALRedirectUri+Internal.h in Headers */,
+				B253151923DD607600432133 /* MSALDeviceInformation.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2606,6 +2641,7 @@
 				B27CCDF3229F9F4700CAD565 /* MSALAccountEnumerationParameters.h in Headers */,
 				B273D09C226E856B005A7BB4 /* MSAL_Internal.h in Headers */,
 				9626D14D225828780019417B /* MSALGlobalConfig.h in Headers */,
+				B253152B23DD66A300432133 /* MSALDeviceInfoProvider.h in Headers */,
 				B273D0E7226E85FA005A7BB4 /* MSALResult+Internal.h in Headers */,
 				96B5E6ED2256D180002232F9 /* MSALSliceConfig.h in Headers */,
 				2338295522D7DC9E001B8AD6 /* MSALWebviewParameters.h in Headers */,
@@ -2622,6 +2658,7 @@
 				D65A6FAB1E3FF3D900C69FBA /* MSALPublicClientApplication.h in Headers */,
 				D65A6FAC1E3FF3D900C69FBA /* MSALResult.h in Headers */,
 				B2D478C1230E3EBB005AE186 /* MSALTenantProfile+Internal.h in Headers */,
+				B253151A23DD607600432133 /* MSALDeviceInformation.h in Headers */,
 				B273D0B0226E8587005A7BB4 /* MSALErrorConverter+Internal.h in Headers */,
 				B2C0E79E23AC7996006C9CAD /* MSALParameters.h in Headers */,
 				D65A6FAD1E3FF3D900C69FBA /* MSALAccount.h in Headers */,
@@ -2634,6 +2671,7 @@
 				B2AA5D6923A353F200BD47D8 /* MSALSignoutParameters.h in Headers */,
 				B267569E228F335E000F01D7 /* MSALExternalAccountHandler.h in Headers */,
 				B273D0E3226E85F2005A7BB4 /* MSALPromptType_Internal.h in Headers */,
+				B253153623DD692600432133 /* MSALDeviceInformation+Internal.h in Headers */,
 				23A68A8120F538DE0071E435 /* MSALADFSAuthority.h in Headers */,
 				D65A6FAA1E3FF3D900C69FBA /* MSALLogger.h in Headers */,
 				96D9A5451E4AB1DC00674A85 /* MSALTelemetry.h in Headers */,
@@ -2644,6 +2682,7 @@
 				B26756C522921C42000F01D7 /* MSALAADOauth2Provider.h in Headers */,
 				B27CCDE1229F65D700CAD565 /* MSALAccount+MultiTenantAccount.h in Headers */,
 				232D614B2248484C00260C42 /* MSALClaimsRequest.h in Headers */,
+				B253153123DD684E00432133 /* MSALSSOExtensionRequestHandler.h in Headers */,
 				B26756D622921CC4000F01D7 /* MSALOauth2Provider+Internal.h in Headers */,
 				232D68D7223DB8C200594BBD /* MSALSilentTokenParameters.h in Headers */,
 				B29A56BA228266B40023F5E6 /* MSALSerializedADALCacheProvider.h in Headers */,
@@ -3503,6 +3542,7 @@
 				B223B0B522ADF8C500FB8713 /* MSALLegacySharedADALAccount.m in Sources */,
 				B267569F228F335E000F01D7 /* MSALExternalAccountHandler.m in Sources */,
 				232D68CC223DB00500594BBD /* MSALTokenParameters.m in Sources */,
+				B253153223DD684E00432133 /* MSALSSOExtensionRequestHandler.m in Sources */,
 				23B1D35F22EA4798000954AF /* MSALPublicClientApplicationConfig.m in Sources */,
 				9626D14E225828780019417B /* MSALGlobalConfig.m in Sources */,
 				96B5E6DC2256D15A002232F9 /* MSALHTTPConfig.m in Sources */,
@@ -3521,6 +3561,7 @@
 				6077D4A922498D87001798A2 /* MSALTenantProfile.m in Sources */,
 				B223B0C022ADFACB00FB8713 /* MSALLegacySharedAccount.m in Sources */,
 				D61BD2AF1EBD09F90007E484 /* MSALLogger.m in Sources */,
+				B253152C23DD66A300432133 /* MSALDeviceInfoProvider.m in Sources */,
 				B28BDA90217E9EAB003E5670 /* MSALOauth2ProviderFactory.m in Sources */,
 				B2AA5D6A23A353F200BD47D8 /* MSALSignoutParameters.m in Sources */,
 				D61BD2B01EBD09F90007E484 /* MSALPublicClientApplication.m in Sources */,
@@ -3529,6 +3570,7 @@
 				B223B0C622AE215D00FB8713 /* MSALLegacySharedAccountFactory.m in Sources */,
 				B26756CC22921C5B000F01D7 /* MSALB2COauth2Provider.m in Sources */,
 				96B5E6E22256D166002232F9 /* MSALTelemetryConfig.m in Sources */,
+				B253151B23DD607600432133 /* MSALDeviceInformation.m in Sources */,
 				963377C1211E14C600943EE0 /* MSALWebviewType.m in Sources */,
 				B27CCDF4229F9F4700CAD565 /* MSALAccountEnumerationParameters.m in Sources */,
 				B227037322A4BA3E00030ADC /* MSALLegacySharedAccountsProvider.m in Sources */,
@@ -3574,6 +3616,7 @@
 				B26756D322921C6D000F01D7 /* MSALADFSOauth2Provider.m in Sources */,
 				232D614D2248484C00260C42 /* MSALClaimsRequest.m in Sources */,
 				B203459721AF77FC00B221AA /* MSALRedirectUri.m in Sources */,
+				B253152D23DD66A300432133 /* MSALDeviceInfoProvider.m in Sources */,
 				D69ADB1C1E50531300952049 /* MSALPromptType.m in Sources */,
 				233E96FE22653EFC007FCE2A /* MSALTelemetryEventsObservingProxy.m in Sources */,
 				96D9A54A1E4AB23100674A85 /* MSALTelemetry.m in Sources */,
@@ -3598,9 +3641,11 @@
 				232D615F22485B4600260C42 /* MSALIndividualClaimRequest.m in Sources */,
 				B26756C122921A71000F01D7 /* MSALOauth2Provider.m in Sources */,
 				D673F0921E4CE6D70018BA91 /* MSALPublicClientApplication.m in Sources */,
+				B253153323DD684E00432133 /* MSALSSOExtensionRequestHandler.m in Sources */,
 				B2C17B0B1FC8DB2E0070A514 /* MSIDVersion.m in Sources */,
 				96B5E6D12256D152002232F9 /* MSALCacheConfig.m in Sources */,
 				232D68DF223DBA0700594BBD /* MSALInteractiveTokenParameters.m in Sources */,
+				B253151C23DD607600432133 /* MSALDeviceInformation.m in Sources */,
 				94E876CE1E492D6000FB96ED /* MSALAuthority.m in Sources */,
 				B26756C722921C42000F01D7 /* MSALAADOauth2Provider.m in Sources */,
 				04D32CAF1FD615B3000B123E /* MSALErrorConverter.m in Sources */,
@@ -3639,6 +3684,7 @@
 				B2725ECE22C04679009B454A /* MSALLegacySharedMSAAccountTests.m in Sources */,
 				233E970B226571AB007FCE2A /* MSALTelemetryAggregatedTests.m in Sources */,
 				B2725ECA22C04661009B454A /* MSALLegacySharedAccountTests.m in Sources */,
+				B253153B23DD717900432133 /* MSALDeviceInfoProviderTests.m in Sources */,
 				23A68A9320F59E6B0071E435 /* NSString+MSALTestUtil.m in Sources */,
 				1E8FC6A3221F370C00B4D4C1 /* MSALResultTests.m in Sources */,
 				B2ADD76E22C08B6A0093FD43 /* MSALLegacySharedAccountTestUtil.m in Sources */,

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -304,8 +304,8 @@
 		B2472CA4226FDC46008F22AB /* MSALB2CAuthority_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2472CA2226FDC46008F22AB /* MSALB2CAuthority_Internal.h */; };
 		B2472CA5226FDC46008F22AB /* MSALB2CAuthority_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2472CA2226FDC46008F22AB /* MSALB2CAuthority_Internal.h */; };
 		B2472CA6226FDC46008F22AB /* MSALB2CAuthority_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2472CA2226FDC46008F22AB /* MSALB2CAuthority_Internal.h */; };
-		B253151923DD607600432133 /* MSALDeviceInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = B253151723DD607600432133 /* MSALDeviceInformation.h */; };
-		B253151A23DD607600432133 /* MSALDeviceInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = B253151723DD607600432133 /* MSALDeviceInformation.h */; };
+		B253151923DD607600432133 /* MSALDeviceInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = B253151723DD607600432133 /* MSALDeviceInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B253151A23DD607600432133 /* MSALDeviceInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = B253151723DD607600432133 /* MSALDeviceInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B253151B23DD607600432133 /* MSALDeviceInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = B253151823DD607600432133 /* MSALDeviceInformation.m */; };
 		B253151C23DD607600432133 /* MSALDeviceInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = B253151823DD607600432133 /* MSALDeviceInformation.m */; };
 		B253152A23DD66A300432133 /* MSALDeviceInfoProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B253152823DD66A300432133 /* MSALDeviceInfoProvider.h */; };

--- a/MSAL/src/MSALDeviceInformation+Internal.h
+++ b/MSAL/src/MSALDeviceInformation+Internal.h
@@ -1,10 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
 //
-//  MSALDeviceInformation_Internal.h
-//  MSAL
+// This code is licensed under the MIT License.
 //
-//  Created by Olga Dalton on 1/25/20.
-//  Copyright © 2020 Microsoft. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import "MSALDeviceInformation.h"
 

--- a/MSAL/src/MSALDeviceInformation+Internal.h
+++ b/MSAL/src/MSALDeviceInformation+Internal.h
@@ -1,0 +1,21 @@
+//
+//  MSALDeviceInformation_Internal.h
+//  MSAL
+//
+//  Created by Olga Dalton on 1/25/20.
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+
+#import "MSALDeviceInformation.h"
+
+@class MSIDDeviceInfo;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALDeviceInformation()
+
+- (instancetype)initWithMSIDDeviceInfo:(MSIDDeviceInfo *)deviceInfo;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/MSALDeviceInformation+Internal.h
+++ b/MSAL/src/MSALDeviceInformation+Internal.h
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MSALDeviceInformation()
 
+@property (nonatomic, readwrite) MSALDeviceMode deviceMode;
+
 - (instancetype)initWithMSIDDeviceInfo:(MSIDDeviceInfo *)deviceInfo;
 
 @end

--- a/MSAL/src/MSALDeviceInformation.m
+++ b/MSAL/src/MSALDeviceInformation.m
@@ -1,0 +1,73 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALDeviceInformation.h"
+#import "MSALDeviceInformation+Internal.h"
+#import "MSIDDeviceInfo.h"
+
+@implementation MSALDeviceInformation
+
+- (instancetype)initWithMSIDDeviceInfo:(MSIDDeviceInfo *)deviceInfo
+{
+    self = [super init];
+    
+    if (self)
+    {
+        _deviceMode = [self msalDeviceModeFromMSIDMode:deviceInfo.deviceMode];
+    }
+    
+    return self;
+}
+
+- (MSALDeviceMode)msalDeviceModeFromMSIDMode:(MSIDDeviceMode)msidDeviceMode
+{
+    switch (msidDeviceMode) {
+        case MSIDDeviceModeShared:
+            return MSALDeviceModeShared;
+            
+        default:
+            return MSALDeviceModeDefault;
+    }
+}
+
+- (NSString *)msalDeviceModeString
+{
+    switch (self.deviceMode) {
+        case MSALDeviceModeShared:
+            return @"shared";
+            
+        default:
+            return @"default";
+    }
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"Device mode %@", self.msalDeviceModeString];
+}
+
+@end

--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -89,6 +89,7 @@ static NSSet *s_recoverableErrorCode;
                                    @(MSIDErrorBrokerUnknown): @(MSALInternalErrorBrokerUnknown),
                                    @(MSIDErrorBrokerApplicationTokenReadFailed): @(MSALInternalErrorBrokerApplicationTokenReadFailed),
                                    @(MSIDErrorBrokerApplicationTokenWriteFailed): @(MSALInternalErrorBrokerApplicationTokenWriteFailed),
+                                   @(MSIDErrorBrokerNotAvailable) : @(MSALInternalBrokerNotAvailable),
 
                                    // Oauth2 errors
                                    @(MSIDErrorServerOauth) : @(MSALInternalErrorAuthorizationFailed),

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -111,7 +111,6 @@
 
 @property (nonatomic) MSALPublicClientApplicationConfig *internalConfig;
 @property (nonatomic) MSIDExternalAADCacheSeeder *externalCacheSeeder;
-@property (nonatomic) MSALDeviceInfoProvider *deviceInfoProvider;
 
 @end
 
@@ -179,7 +178,6 @@
     }
     
     _validateAuthority = YES;
-    _deviceInfoProvider = [MSALDeviceInfoProvider new];
     
     // Verify required fields
     if ([NSString msidIsStringNilOrBlank:config.clientId])
@@ -1370,7 +1368,8 @@
         return;
     }
     
-    [self.deviceInfoProvider deviceInfoWithRequestParameters:requestParams completionBlock:block];
+    MSALDeviceInfoProvider *deviceInfoProvider = [MSALDeviceInfoProvider new];
+    [deviceInfoProvider deviceInfoWithRequestParameters:requestParams completionBlock:block];
 }
 
 #pragma mark - Authority validation

--- a/MSAL/src/instance/MSALAccountsProvider.h
+++ b/MSAL/src/instance/MSALAccountsProvider.h
@@ -27,6 +27,7 @@
 
 #import <Foundation/Foundation.h>
 #import "MSIDAccountMetadata.h"
+#import "MSALSSOExtensionRequestHandler.h"
 
 @class MSALAccount;
 @class MSIDDefaultTokenCacheAccessor;
@@ -40,7 +41,7 @@
 @class MSIDAccountIdentifier;
 @class MSIDRequestParameters;
 
-@interface MSALAccountsProvider : NSObject
+@interface MSALAccountsProvider : MSALSSOExtensionRequestHandler
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/MSAL/src/instance/MSALAccountsProvider.h
+++ b/MSAL/src/instance/MSALAccountsProvider.h
@@ -57,7 +57,7 @@
 
 - (void)allAccountsFromDevice:(MSALAccountEnumerationParameters *)parameters
             requestParameters:(MSIDRequestParameters *)requestParameters
-              completionBlock:(MSALAccountsCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15));
+              completionBlock:(MSALAccountsCompletionBlock)completionBlock;
 
 // Authority filtering (deprecated)
 - (void)allAccountsFilteredByAuthority:(MSALAuthority *)authority

--- a/MSAL/src/instance/MSALAccountsProvider.m
+++ b/MSAL/src/instance/MSALAccountsProvider.m
@@ -321,9 +321,16 @@
 
 - (void)allAccountsFromDevice:(MSALAccountEnumerationParameters *)parameters
             requestParameters:(MSIDRequestParameters *)requestParameters
-              completionBlock:(MSALAccountsCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15))
+              completionBlock:(MSALAccountsCompletionBlock)completionBlock
 {
-    if (![MSIDSSOExtensionGetAccountsRequest canPerformRequest] || ![requestParameters shouldUseBroker])
+    BOOL shouldCallBroker = NO;
+    
+    if (@available(iOS 13.0, *))
+    {
+        shouldCallBroker = [MSIDSSOExtensionGetAccountsRequest canPerformRequest] && [requestParameters shouldUseBroker];
+    }
+    
+    if (!shouldCallBroker)
     {
         NSError *localError;
         NSArray<MSALAccount *> *msalAccounts = [self accountsForParameters:parameters authority:nil brokerAccounts:nil error:&localError];
@@ -331,6 +338,18 @@
         return;
     }
     
+    if (@available(iOS 13.0, *))
+    {
+        [self allAccountsFromSSOExtension:parameters
+                        requestParameters:requestParameters
+                          completionBlock:completionBlock];
+    }
+}
+
+- (void)allAccountsFromSSOExtension:(MSALAccountEnumerationParameters *)parameters
+                  requestParameters:(MSIDRequestParameters *)requestParameters
+                    completionBlock:(MSALAccountsCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15))
+{
     NSError *requestError;
     MSIDSSOExtensionGetAccountsRequest *ssoExtensionRequest = [[MSIDSSOExtensionGetAccountsRequest alloc] initWithRequestParameters:requestParameters
                                                                                                          returnOnlySignedInAccounts:parameters.returnOnlySignedInAccounts

--- a/MSAL/src/instance/MSALAccountsProvider.m
+++ b/MSAL/src/instance/MSALAccountsProvider.m
@@ -325,7 +325,7 @@
 {
     BOOL shouldCallBroker = NO;
     
-    if (@available(iOS 13.0, *))
+    if (@available(iOS 13.0, macOS 10.15, *))
     {
         shouldCallBroker = [MSIDSSOExtensionGetAccountsRequest canPerformRequest] && [requestParameters shouldUseBroker];
     }
@@ -338,7 +338,7 @@
         return;
     }
     
-    if (@available(iOS 13.0, *))
+    if (@available(iOS 13.0, macOS 10.15, *))
     {
         [self allAccountsFromSSOExtension:parameters
                         requestParameters:requestParameters

--- a/MSAL/src/instance/MSALAccountsProvider.m
+++ b/MSAL/src/instance/MSALAccountsProvider.m
@@ -59,7 +59,6 @@
 @property (nullable, nonatomic) NSString *clientId;
 @property (nullable, nonatomic) MSALExternalAccountHandler *externalAccountProvider;
 @property (nullable, nonatomic) NSPredicate *homeTenantFilterPredicate;
-@property (nullable, nonatomic) MSIDSSOExtensionGetAccountsRequest *currentRequest API_AVAILABLE(ios(13.0), macos(10.15));
 
 @end
 
@@ -438,43 +437,6 @@
                                                        principalAccountId:currentAccountId
                                                                   context:nil
                                                                     error:error];
-}
-
-#pragma mark - Completion block
-
-- (BOOL)setCurrentSSOExtensionRequest:(MSIDSSOExtensionGetAccountsRequest *)request API_AVAILABLE(ios(13.0), macos(10.15))
-{
-    @synchronized (self)
-    {
-        if (self.currentRequest)
-        {
-            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Request is already executing. Please wait or cancel the request before starting it again.");
-            return NO;
-        }
-        
-        self.currentRequest = request;
-        return YES;
-    }
-    
-    return NO;
-}
-
-- (MSIDSSOExtensionGetAccountsRequest *)copyAndClearCurrentSSOExtensionRequest API_AVAILABLE(ios(13.0), macos(10.15))
-{
-    @synchronized (self)
-    {
-        if (!self.currentRequest)
-        {
-            // There's no error param because this isn't on a critical path. Just log that you are
-            // trying to clear a request when there isn't one.
-            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Trying to clear out an empty request");
-            return nil;
-        }
-        
-        MSIDSSOExtensionGetAccountsRequest *currentRequest = self.currentRequest;
-        self.currentRequest = nil;
-        return currentRequest;
-    }
 }
 
 @end

--- a/MSAL/src/instance/MSALDeviceInfoProvider.h
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.h
@@ -1,0 +1,42 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import "MSALSSOExtensionRequestHandler.h"
+
+@class MSIDRequestParameters;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALDeviceInfoProvider : MSALSSOExtensionRequestHandler
+
+- (void)deviceInfoWithRequestParameters:(MSIDRequestParameters *)requestParameters
+                        completionBlock:(MSALDeviceInformationCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/instance/MSALDeviceInfoProvider.m
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.m
@@ -37,10 +37,21 @@
 - (void)deviceInfoWithRequestParameters:(MSIDRequestParameters *)requestParameters
                         completionBlock:(MSALDeviceInformationCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15))
 {
-    if (![MSIDSSOExtensionGetDeviceInfoRequest canPerformRequest] || ![requestParameters shouldUseBroker])
+    if (![requestParameters shouldUseBroker])
     {
-        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorBrokerNotAvailable, @"Broker is either not present on this device or not available for this operation", nil, nil, nil, nil, nil, YES);
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorBrokerNotAvailable, @"Broker is not enabled for this operation. Please make sure you have enabled broker support for your application", nil, nil, nil, nil, nil, YES);
         completionBlock(nil, error);
+        return;
+    }
+    
+    
+    if (![MSIDSSOExtensionGetDeviceInfoRequest canPerformRequest])
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, requestParameters, @"Broker is not present on this device. Defaulting to personal mode");
+        
+        MSALDeviceInformation *msalDeviceInfo = [MSALDeviceInformation new];
+        msalDeviceInfo.deviceMode = MSALDeviceModeDefault;
+        completionBlock(msalDeviceInfo, nil);
         return;
     }
     

--- a/MSAL/src/instance/MSALDeviceInfoProvider.m
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.m
@@ -1,0 +1,79 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALDeviceInfoProvider.h"
+#import "MSIDRequestParameters.h"
+#import "MSALDefinitions.h"
+#import "MSIDSSOExtensionGetDeviceInfoRequest.h"
+#import "MSIDRequestParameters+Broker.h"
+#import "MSALDeviceInformation+Internal.h"
+
+@implementation MSALDeviceInfoProvider
+
+- (void)deviceInfoWithRequestParameters:(MSIDRequestParameters *)requestParameters
+                        completionBlock:(MSALDeviceInformationCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    if (![MSIDSSOExtensionGetDeviceInfoRequest canPerformRequest] || ![requestParameters shouldUseBroker])
+    {
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorBrokerNotAvailable, @"Broker is either not present on this device or not available for this operation", nil, nil, nil, nil, nil, YES);
+        completionBlock(nil, error);
+        return;
+    }
+    
+    NSError *requestError;
+    MSIDSSOExtensionGetDeviceInfoRequest *ssoExtensionRequest = [[MSIDSSOExtensionGetDeviceInfoRequest alloc] initWithRequestParameters:requestParameters
+                                                                                                                                  error:&requestError];
+    
+    if (!ssoExtensionRequest)
+    {
+        completionBlock(nil, requestError);
+        return;
+    }
+    
+    if (![self setCurrentSSOExtensionRequest:ssoExtensionRequest])
+    {
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Trying to start a get accounts request while one is already executing", nil, nil, nil, nil, nil, YES);
+        completionBlock(nil, error);
+        return;
+    }
+    
+    [ssoExtensionRequest executeRequestWithCompletion:^(MSIDDeviceInfo * _Nullable deviceInfo, NSError * _Nullable error)
+    {
+        [self copyAndClearCurrentSSOExtensionRequest];
+        
+        if (!deviceInfo)
+        {
+            completionBlock(nil, error);
+            return;
+        }
+        
+        MSALDeviceInformation *msalDeviceInfo = [[MSALDeviceInformation alloc] initWithMSIDDeviceInfo:deviceInfo];
+        completionBlock(msalDeviceInfo, nil);
+    }];
+}
+
+@end

--- a/MSAL/src/instance/MSALSSOExtensionRequestHandler.h
+++ b/MSAL/src/instance/MSALSSOExtensionRequestHandler.h
@@ -1,0 +1,39 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALSSOExtensionRequestHandler : NSObject
+
+- (BOOL)setCurrentSSOExtensionRequest:(id)request API_AVAILABLE(ios(13.0), macos(10.15));
+- (id)copyAndClearCurrentSSOExtensionRequest API_AVAILABLE(ios(13.0), macos(10.15));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/instance/MSALSSOExtensionRequestHandler.m
+++ b/MSAL/src/instance/MSALSSOExtensionRequestHandler.m
@@ -1,0 +1,75 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALSSOExtensionRequestHandler.h"
+
+@interface MSALSSOExtensionRequestHandler()
+
+@property (nullable, nonatomic) id currentRequest API_AVAILABLE(ios(13.0), macos(10.15));
+
+@end
+
+@implementation MSALSSOExtensionRequestHandler
+
+#pragma mark - Request tracking
+
+- (BOOL)setCurrentSSOExtensionRequest:(id)request API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    @synchronized (self)
+    {
+        if (self.currentRequest)
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Request is already executing. Please wait or cancel the request before starting it again.");
+            return NO;
+        }
+        
+        self.currentRequest = request;
+        return YES;
+    }
+    
+    return NO;
+}
+
+- (id)copyAndClearCurrentSSOExtensionRequest API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    @synchronized (self)
+    {
+        if (!self.currentRequest)
+        {
+            // There's no error param because this isn't on a critical path. Just log that you are
+            // trying to clear a request when there isn't one.
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Trying to clear out an empty request");
+            return nil;
+        }
+        
+        id currentRequest = self.currentRequest;
+        self.currentRequest = nil;
+        return currentRequest;
+    }
+}
+
+@end

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -82,3 +82,4 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #if TARGET_OS_IPHONE
 #import <MSAL/MSALLegacySharedAccountsProvider.h>
 #endif
+#import <MSAL/MSALDeviceInformation.h>

--- a/MSAL/src/public/MSALDefinitions.h
+++ b/MSAL/src/public/MSALDefinitions.h
@@ -30,6 +30,7 @@
 
 @class MSALResult;
 @class MSALAccount;
+@class MSALDeviceInformation;
 
 /**
  Levels of logging. Defines the priority of the logged message
@@ -138,6 +139,22 @@ typedef NS_ENUM(NSUInteger, MSALPromptType)
 };
 
 /**
+ Device mode configured by the administrator
+ */
+typedef NS_ENUM(NSUInteger, MSALDeviceMode)
+{
+    /*
+        Administrator hasn't configured this device into any specific mode.
+    */
+    MSALDeviceModeDefault,
+    
+    /*
+        This device is shared by multiple employees. Employees can sign in and access customer information quickly. When they are finished with their shift or task, they can sign out of the device and it will be immediately ready for the next employee to use.
+     */
+    MSALDeviceModeShared
+};
+
+/**
     The block that gets invoked after MSAL has finished getting a token silently or interactively.
     @param result       Represents information returned to the application after a successful interactive or silent token acquisition. See `MSALResult` for more information.
     @param error         Provides information about error that prevented MSAL from getting a token. See `MSALError` for possible errors.
@@ -158,6 +175,11 @@ typedef void (^MSALCurrentAccountCompletionBlock)(MSALAccount * _Nullable accoun
     The completion block that will be called when sign out is completed, or MSAL encountered an error.
  */
 typedef void (^MSALSignoutCompletionBlock)(BOOL success, NSError * _Nullable error);
+
+/**
+   The completion block that will be called when MSAL has finished reading device state, or MSAL encountered an error.
+*/
+typedef void (^MSALDeviceInformationCompletionBlock)(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error);
 
 /**
  The block that returns a MSAL log message.

--- a/MSAL/src/public/MSALDeviceInformation.h
+++ b/MSAL/src/public/MSALDeviceInformation.h
@@ -1,0 +1,44 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Information about the device that is applicable to MSAL scenarios. 
+*/
+@interface MSALDeviceInformation : NSObject
+
+/**
+ Device mode configured by the administrator
+*/
+@property (nonatomic, readonly) MSALDeviceMode deviceMode;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -374,4 +374,9 @@ typedef NS_ENUM(NSInteger, MSALInternalError)
      Failed to read broker application token.
      */
     MSALInternalErrorBrokerApplicationTokenReadFailed   = -42713,
+    
+    /**
+     Broker is either not found on device or not available for this configuration.
+    */
+    MSALInternalBrokerNotAvailable                      = -42714
 };

--- a/MSAL/src/public/MSALPublicClientApplication+SingleAccount.h
+++ b/MSAL/src/public/MSALPublicClientApplication+SingleAccount.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  If there're multiple accounts present, MSAL will return an ambiguous account error, and application should do account disambiguation by calling other MSAL Account enumeration APIs.
 */
 - (void)getCurrentAccountWithParameters:(nullable MSALParameters *)parameters
-                        completionBlock:(MSALCurrentAccountCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15));
+                        completionBlock:(MSALCurrentAccountCompletionBlock)completionBlock;
 
 @end
 

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -464,6 +464,6 @@
    Reads device information from the authentication broker if present on the device. 
 */
 - (void)getDeviceInformationWithParameters:(nullable MSALParameters *)parameters
-                           completionBlock:(nonnull MSALDeviceInformationCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15));;
+                           completionBlock:(nonnull MSALDeviceInformationCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15));
 
 @end

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -233,11 +233,12 @@
 
 /**
     Returns account for the given account identifying parameters including locally cached accounts and accounts from the SSO extension
+    Accounts from SSO extension are only available on iOS 13+. On earlier versions, this method will return same results as a local account query.
 
     @param  completionBlock     The completion block that will be called when accounts are loaded, or MSAL encountered an error.
 */
 - (void)accountsFromDeviceForParameters:(nonnull MSALAccountEnumerationParameters *)parameters
-                        completionBlock:(nonnull MSALAccountsCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15));
+                        completionBlock:(nonnull MSALAccountsCompletionBlock)completionBlock;
 
 #pragma mark - Handling MSAL responses
 

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -40,6 +40,7 @@
 @class MSALWebviewParameters;
 @class MSALSignoutParameters;
 @class WKWebView;
+@class MSALParameters;
 
 /**
     Representation of OAuth 2.0 Public client application. Create an instance of this class to acquire tokens.
@@ -457,5 +458,12 @@
          signoutParameters:(nonnull MSALSignoutParameters *)signoutParameters
            completionBlock:(nonnull MSALSignoutCompletionBlock)signoutCompletionBlock;
 
+#pragma mark - Device information
+
+/**
+   Reads device information from the authentication broker if present on the device. 
+*/
+- (void)getDeviceInformationWithParameters:(nullable MSALParameters *)parameters
+                           completionBlock:(nonnull MSALDeviceInformationCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15));;
 
 @end

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -1,10 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
 //
-//  MSALDeviceInfoProviderTests.m
-//  MSAL iOS Unit Tests
+// This code is licensed under the MIT License.
 //
-//  Created by Olga Dalton on 1/25/20.
-//  Copyright © 2020 Microsoft. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import <XCTest/XCTest.h>
 #import "MSALDeviceInfoProvider.h"

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -1,0 +1,197 @@
+//
+//  MSALDeviceInfoProviderTests.m
+//  MSAL iOS Unit Tests
+//
+//  Created by Olga Dalton on 1/25/20.
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "MSALDeviceInfoProvider.h"
+#import "MSIDTestSwizzle.h"
+#import "MSIDSSOExtensionGetDeviceInfoRequest.h"
+#import "MSIDTestParametersProvider.h"
+#import "MSIDDeviceInfo.h"
+#import "MSIDInteractiveTokenRequestParameters.h"
+#import "MSALDeviceInformation.h"
+
+@interface MSALDeviceInfoProviderTests : XCTestCase
+
+@end
+
+@implementation MSALDeviceInfoProviderTests
+
+#pragma mark - Get device info
+
+- (void)testGetDeviceInfo_whenCurrentSSOExtensionRequestAlreadyPresent_shouldReturnNilAndFillError API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
+                           class:[MSIDSSOExtensionGetDeviceInfoRequest class]
+                           block:(id)^(id obj)
+    {
+        return YES;
+    }];
+    
+    MSALDeviceInfoProvider *deviceInfoProvider = [MSALDeviceInfoProvider new];
+    
+    __block dispatch_semaphore_t dsem = dispatch_semaphore_create(0);
+    
+    [MSIDTestSwizzle instanceMethod:@selector(executeRequestWithCompletion:)
+                              class:[MSIDSSOExtensionGetDeviceInfoRequest  class]
+                              block:(id)^(id obj, MSIDGetDeviceInfoRequestCompletionBlock callback)
+    {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            dispatch_semaphore_wait(dsem, DISPATCH_TIME_FOREVER);
+            callback(nil, nil);
+        });
+    }];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Get device info"];
+    XCTestExpectation *failExpectation = [self expectationWithDescription:@"Failed expectation"];
+    
+    MSIDRequestParameters *requestParams = [MSIDTestParametersProvider testInteractiveParameters];
+    requestParams.validateAuthority = YES;
+    
+    [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
+                                        completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+    {
+        [expectation fulfill];
+    }];
+    
+    [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
+                                        completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+    {
+        XCTAssertNil(deviceInformation);
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+        XCTAssertEqual(error.code, MSIDErrorInternal);
+        [failExpectation fulfill];
+        dispatch_semaphore_signal(dsem);
+    }];
+    
+    [self waitForExpectations:@[expectation, failExpectation] timeout:1];
+}
+
+- (void)testGetDeviceInfo_whenSSOExtensionNotAvailable_shouldReturnBrokerUnavailableError API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
+                           class:[MSIDSSOExtensionGetDeviceInfoRequest class]
+                           block:(id)^(id obj)
+    {
+        return NO;
+    }];
+    
+    MSALDeviceInfoProvider *deviceInfoProvider = [MSALDeviceInfoProvider new];
+        
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Execute request"];
+    expectation.inverted = YES;
+    
+    [MSIDTestSwizzle instanceMethod:@selector(executeRequestWithCompletion:)
+                              class:[MSIDSSOExtensionGetDeviceInfoRequest  class]
+                              block:(id)^(id obj, MSIDGetDeviceInfoRequestCompletionBlock callback)
+    {
+        [expectation fulfill];
+    }];
+    
+    XCTestExpectation *failExpectation = [self expectationWithDescription:@"Get device info"];
+    
+    MSIDRequestParameters *requestParams = [MSIDTestParametersProvider testInteractiveParameters];
+    requestParams.validateAuthority = YES;
+    
+    [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
+                                        completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+    {
+        XCTAssertNil(deviceInformation);
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+        XCTAssertEqual(error.code, MSIDErrorBrokerNotAvailable);
+        [failExpectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation, failExpectation] timeout:1];
+}
+
+- (void)testGetDeviceInfo_whenSSOExtensionPresent_encounteredError_shouldReturnError API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
+                           class:[MSIDSSOExtensionGetDeviceInfoRequest class]
+                           block:(id)^(id obj)
+    {
+        return YES;
+    }];
+    
+    MSALDeviceInfoProvider *deviceInfoProvider = [MSALDeviceInfoProvider new];
+        
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Execute request"];
+    
+    [MSIDTestSwizzle instanceMethod:@selector(executeRequestWithCompletion:)
+                              class:[MSIDSSOExtensionGetDeviceInfoRequest  class]
+                              block:(id)^(id obj, MSIDGetDeviceInfoRequestCompletionBlock callback)
+    {
+        [expectation fulfill];
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorUnsupportedFunctionality, @"Unsupported functionality", nil, nil, nil, nil, nil, NO);
+        callback(nil, error);
+    }];
+    
+    XCTestExpectation *failExpectation = [self expectationWithDescription:@"Get device info"];
+    
+    MSIDRequestParameters *requestParams = [MSIDTestParametersProvider testInteractiveParameters];
+    requestParams.validateAuthority = YES;
+    
+    [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
+                                        completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+    {
+        XCTAssertNil(deviceInformation);
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
+        XCTAssertEqual(error.code, MSIDErrorUnsupportedFunctionality);
+        [failExpectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation, failExpectation] timeout:1];
+}
+
+- (void)testGetDeviceInfo_whenSSOExtensionPresent_andReturnedDeviceInfo_shouldReturnMSALDeviceInfo API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
+                           class:[MSIDSSOExtensionGetDeviceInfoRequest class]
+                           block:(id)^(id obj)
+    {
+        return YES;
+    }];
+    
+    MSALDeviceInfoProvider *deviceInfoProvider = [MSALDeviceInfoProvider new];
+        
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Execute request"];
+    
+    [MSIDTestSwizzle instanceMethod:@selector(executeRequestWithCompletion:)
+                              class:[MSIDSSOExtensionGetDeviceInfoRequest  class]
+                              block:(id)^(id obj, MSIDGetDeviceInfoRequestCompletionBlock callback)
+    {
+        [expectation fulfill];
+        
+        MSIDDeviceInfo *deviceInfo = [MSIDDeviceInfo new];
+        deviceInfo.brokerVersion = @"test";
+        deviceInfo.deviceMode = MSIDDeviceModeShared;
+        
+        callback(deviceInfo, nil);
+    }];
+    
+    XCTestExpectation *successExpectation = [self expectationWithDescription:@"Get device info"];
+    
+    MSIDRequestParameters *requestParams = [MSIDTestParametersProvider testInteractiveParameters];
+    requestParams.validateAuthority = YES;
+    
+    [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
+                                        completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+    {
+        XCTAssertNotNil(deviceInformation);
+        XCTAssertNil(error);
+        XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeShared);
+        [successExpectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation, successExpectation] timeout:1];
+}
+
+@end

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -87,7 +87,7 @@
     [self waitForExpectations:@[expectation, failExpectation] timeout:1];
 }
 
-- (void)testGetDeviceInfo_whenSSOExtensionNotAvailable_shouldReturnBrokerUnavailableError API_AVAILABLE(ios(13.0), macos(10.15))
+- (void)testGetDeviceInfo_whenSSOExtensionNotAvailable_shouldReturnDefaultDeviceInfo API_AVAILABLE(ios(13.0), macos(10.15))
 {
     [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
                            class:[MSIDSSOExtensionGetDeviceInfoRequest class]
@@ -116,10 +116,9 @@
     [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
                                         completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
     {
-        XCTAssertNil(deviceInformation);
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
-        XCTAssertEqual(error.code, MSIDErrorBrokerNotAvailable);
+        XCTAssertNotNil(deviceInformation);
+        XCTAssertNil(error);
+        XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeDefault);
         [failExpectation fulfill];
     }];
     

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2713,7 +2713,7 @@
     XCTAssertEqual([application allAccounts:nil].count, 0);
     
     // 5. Make sure account and FOCI tokens are still in cache
-    MSIDAccount *cachedAccount = [self.tokenCacheAccessor getAccountForIdentifier:account.accountIdentifier authority:authority context:nil error:nil];
+    MSIDAccount *cachedAccount = [self.tokenCacheAccessor getAccountForIdentifier:account.accountIdentifier authority:authority realmHint:nil context:nil error:nil];
     XCTAssertNotNil(cachedAccount);
     
     MSIDRefreshToken *fociToken = [self.tokenCacheAccessor getRefreshTokenWithAccount:account.accountIdentifier familyId:@"1" configuration:configuration context:nil error:nil];


### PR DESCRIPTION
This PR implements MSAL getDeviceInfo public API that allows retrieving whether device is in the shared mode or not. In the future, we can return more information on the device information object. 