### PR TITLE
Keyed unarchiver crash hot fix on iOS 11.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [1.0.0-hotfix2] - 2020-01-27
+### Fixed
+- [Broker patch] Keyed unarchiver deserialization fix for iOS 11.2
+
 # [1.0.0-hotfix1] - 2020-01-21
 ### Fixed
 - [Broker patch] Fixed account lookups and validation with the same email (#827)


### PR DESCRIPTION
This PR fixes the problem in this line:

`NSMutableDictionary *additionalServer = [[coder decodePropertyListForKey:@"additionalServer"] mutableCopy];`

When additionalServer has NSURL type (which ADAL normally injects), this line will:
1. Fail to deserialize on any version other than iOS 11.2.x. It will also cause any line after this line to fail to deserialize so other properties wouldn't be read correctly.
2. On iOS 11.2.x only, this line will always crash:

`*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSDictionary initWithObjects:forKeys:]: count of objects (0) differs from count of keys (5)'`

This PR also moves this operation to the very end so that on non iOS 11.2.x, even if it fails, it doesn't cause other critical properties from deserializing. 

Common core PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/677