### PR TITLE
Fixed MSAL error converter when description is provided in user info

### DIFF
--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -200,14 +200,11 @@ static NSSet *s_recoverableErrorCode;
         msalUserInfo[mappedKey] = userInfo[key];
     }
 
-    msalUserInfo[MSALErrorDescriptionKey] = errorDescription;
-    msalUserInfo[MSALOAuthErrorKey] = oauthError;
-    msalUserInfo[MSALOAuthSubErrorKey] = subError;
+    if (errorDescription) msalUserInfo[MSALErrorDescriptionKey] = errorDescription;
+    if (oauthError) msalUserInfo[MSALOAuthErrorKey] = oauthError;
+    if (subError) msalUserInfo[MSALOAuthSubErrorKey] = subError;
     
-    if (underlyingError)
-    {
-        msalUserInfo[NSUnderlyingErrorKey] = [MSALErrorConverter msalErrorFromMsidError:underlyingError];
-    }
+    if (underlyingError) msalUserInfo[NSUnderlyingErrorKey] = [MSALErrorConverter msalErrorFromMsidError:underlyingError];
     
     msalUserInfo[MSALInternalErrorCodeKey] = internalCode;
 

--- a/MSAL/test/unit/MSALErrorConverterTests.m
+++ b/MSAL/test/unit/MSALErrorConverterTests.m
@@ -144,6 +144,34 @@
     XCTAssertEqualObjects(msalError.userInfo[MSALInternalErrorCodeKey], @(-42400));
 }
 
+- (void)testErrorConversion_whenUnclassifiedInternalMSALErrorPassed_andErrorDescriptionPassedInDictionary_shouldMapToInternal_andPreserveErrorDescription
+{
+    NSInteger errorCode = -42400;
+    NSString *errorDescription = @"a fake error description.";
+    NSString *oauthError = @"a fake oauth error message.";
+    NSString *subError = @"a fake suberror";
+    
+    NSError *msalError = [MSALErrorConverter errorWithDomain:MSALErrorDomain
+                                                        code:errorCode
+                                            errorDescription:nil
+                                                  oauthError:oauthError
+                                                    subError:subError
+                                             underlyingError:nil
+                                               correlationId:nil
+                                                    userInfo:@{MSALErrorDescriptionKey : errorDescription}
+                                              classifyErrors:YES
+                                          msalOauth2Provider:nil];
+    
+    NSString *expectedErrorDomain = MSALErrorDomain;
+    XCTAssertNotNil(msalError);
+    XCTAssertEqualObjects(msalError.domain, expectedErrorDomain);
+    XCTAssertEqual(msalError.code, MSALErrorInternal);
+    XCTAssertEqualObjects(msalError.userInfo[MSALErrorDescriptionKey], errorDescription);
+    XCTAssertEqualObjects(msalError.userInfo[MSALOAuthErrorKey], oauthError);
+    XCTAssertEqualObjects(msalError.userInfo[MSALOAuthSubErrorKey], subError);
+    XCTAssertEqualObjects(msalError.userInfo[MSALInternalErrorCodeKey], @(-42400));
+}
+
 - (void)testErrorConversion_whenUnclassifiedRecoverableErrorPassed_shouldMapToRecoverable
 {
     NSInteger errorCode = MSALErrorUserCanceled;


### PR DESCRIPTION
**Issue:**
When description, oauth error, or sub error are passed as part of the user info and not a parameter, resulting error would be missing them. 

**Symptoms:**
All MSAL errors returned from SSO extension would have no description