### PR TITLE
Create previous MSAL account from identifier if doesn't exist in cache

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -569,7 +569,7 @@
         MSIDAccountIdentifier *newIdentifier = newAccount.lookupAccountIdentifier ?: nil;
         
         NSError *accountUpdateError;
-        BOOL result = [request setCurrentPrincipalAccountId:newIdentifier error:&accountUpdateError];
+        BOOL result = [request setCurrentPrincipalAccountId:newIdentifier accountEnvironment:newAccount.environment error:&accountUpdateError];
         
         if (!result)
         {

--- a/MSAL/src/instance/MSALAccountsProvider.h
+++ b/MSAL/src/instance/MSALAccountsProvider.h
@@ -81,6 +81,6 @@
 #pragma mark - Principal account id
 
 - (MSALAccount *)currentPrincipalAccount:(NSError **)error;
-- (BOOL)setCurrentPrincipalAccountId:(MSIDAccountIdentifier *)currentAccountId error:(NSError **)error;
+- (BOOL)setCurrentPrincipalAccountId:(MSIDAccountIdentifier *)currentAccountId accountEnvironment:(NSString *)accountEnvironment error:(NSError **)error;
 
 @end


### PR DESCRIPTION
For scenarios where account doesn't exist in cache, but we have saved previous account for FLW purposes, we can create account from identifier and environment.