### PR TITLE
Set default signout from browser to NO

### DIFF
--- a/MSAL/src/MSALSignoutParameters.m
+++ b/MSAL/src/MSALSignoutParameters.m
@@ -36,7 +36,7 @@
     if (self)
     {
         _webviewParameters = [webviewParameters copy];
-        _signoutFromBrowser = YES;
+        _signoutFromBrowser = NO;
     }
     return self;
 }

--- a/MSAL/src/public/MSALSignoutParameters.h
+++ b/MSAL/src/public/MSALSignoutParameters.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
   Specifies whether signout should also open the browser and send a network request to the end_session_endpoint.
-  YES by default.
+  NO by default.
  */
 @property (nonatomic) BOOL signoutFromBrowser;
 


### PR DESCRIPTION
We don't want to encourage developers to signout from browser. Therefore, setting default option for "signoutFromBrowser" to NO. If developer wants to sign out from browser explicitly, they'll need to set it to YES. 