### PR TITLE
Resolved conflict between initWithParentController API on App Store upload

### DIFF
--- a/MSAL/src/configuration/MSALWebviewParameters.m
+++ b/MSAL/src/configuration/MSALWebviewParameters.m
@@ -52,12 +52,23 @@
     return self;
 }
 
+- (instancetype)initWithAuthPresentationViewController:(MSALViewController *)parentViewController
+{
+    self = [super init];
+    if (self)
+    {
+        _parentViewController = parentViewController;
+    }
+    
+    return self;
+}
+
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(__unused NSZone *)zone
 {
     MSALWebviewParameters *item;
-    item = [[MSALWebviewParameters alloc] initWithParentViewController:_parentViewController];
+    item = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:_parentViewController];
     item.parentViewController = _parentViewController;
 
 #if TARGET_OS_IPHONE

--- a/MSAL/src/public/MSALWebviewParameters.h
+++ b/MSAL/src/public/MSALWebviewParameters.h
@@ -83,15 +83,22 @@ NS_ASSUME_NONNULL_BEGIN
     @param parentViewController The view controller to present authorization UI from.
     @note parentViewController is mandatory on iOS 13+. It is strongly recommended on macOS 10.15+ to allow correct presentation of ASWebAuthenticationSession. If parentViewController is not provided on macOS 10.15+, MSAL will use application's keyWindow for presentation
  */
-- (nonnull instancetype)initWithParentViewController:(MSALViewController *)parentViewController;
+- (nonnull instancetype)initWithParentViewController:(MSALViewController *)parentViewController DEPRECATED_MSG_ATTRIBUTE("Use -initWithAuthPresentationViewController: instead.");;
+
+/**
+   Creates an instance of MSALWebviewParameters with a provided parentViewController.
+   @param parentViewController The view controller to present authorization UI from.
+   @note parentViewController is mandatory on iOS 13+. It is strongly recommended on macOS 10.15+ to allow correct presentation of ASWebAuthenticationSession. If parentViewController is not provided on macOS 10.15+, MSAL will use application's keyWindow for presentation
+*/
+- (nonnull instancetype)initWithAuthPresentationViewController:(MSALViewController *)parentViewController;
 
 #if TARGET_OS_IPHONE
 
 #pragma mark - Unavailable initializers
 
-- (nonnull instancetype)init DEPRECATED_MSG_ATTRIBUTE("Use -initWithParentViewController: instead.");
+- (nonnull instancetype)init DEPRECATED_MSG_ATTRIBUTE("Use -initWithAuthPresentationViewController: instead.");
 
-+ (nonnull instancetype)new DEPRECATED_MSG_ATTRIBUTE("Use -initWithParentViewController: instead.");
++ (nonnull instancetype)new DEPRECATED_MSG_ATTRIBUTE("Use -initWithAuthPresentationViewController: instead.");
 
 #endif
 

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -183,7 +183,7 @@
 
 - (MSALWebviewParameters *)msalTestWebViewParameters
 {
-    MSALWebviewParameters *webviewParameters = [[MSALWebviewParameters alloc] initWithParentViewController:self];
+    MSALWebviewParameters *webviewParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:self];
     webviewParameters.webviewType = self.webviewTypeSegmentControl.selectedSegmentIndex == 0 ? MSALWebviewTypeWKWebView : MSALWebviewTypeDefault;
     
     if (webviewParameters.webviewType == MSALWebviewTypeWKWebView

--- a/MSAL/test/app/mac/MSALAcquireTokenViewController.m
+++ b/MSAL/test/app/mac/MSALAcquireTokenViewController.m
@@ -313,7 +313,7 @@ static NSString * const defaultScope = @"User.Read";
         });
     };
     
-    MSALWebviewParameters *webviewParameters = [[MSALWebviewParameters alloc] initWithParentViewController:self];
+    MSALWebviewParameters *webviewParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:self];
     if ([self passedInWebview])
     {
         webviewParameters.customWebview = self.webView;

--- a/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenAction.m
@@ -137,7 +137,7 @@
         parentController = containerController.presentedViewController;
     }
     
-    MSALWebviewParameters *webviewParameters= [[MSALWebviewParameters alloc] initWithParentViewController:parentController];
+    MSALWebviewParameters *webviewParameters= [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:parentController];
     
     MSIDWebviewType webviewSelection = testRequest.webViewType;
     

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -689,7 +689,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"acquireToken"];
     
     UIViewController *parentController = nil;
-    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithParentViewController:parentController];
+    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:parentController];
     webParameters.webviewType = MSALWebviewTypeWKWebView;
     MSALInteractiveTokenParameters *parameters = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"fakescopes"]
                                                                                       webviewParameters:webParameters];

--- a/MSAL/test/unit/MSALB2CPolicyTests.m
+++ b/MSAL/test/unit/MSALB2CPolicyTests.m
@@ -145,7 +145,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Acquire Token."];
     
     UIViewController *parentController = nil;
-    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithParentViewController:parentController];
+    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:parentController];
     webParameters.webviewType = MSALWebviewTypeWKWebView;
     
     __auto_type parameters = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"fakeb2cscopes"] webviewParameters:webParameters];

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -512,7 +512,7 @@
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     
     UIViewController *controller = nil;
-    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithParentViewController:controller];
+    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:controller];
     params = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"fakescope1", @"fakescope2"] webviewParameters:webParams];
     params.parentViewController = [self.class sharedViewControllerStub];
 #else
@@ -559,7 +559,7 @@
     MSALInteractiveTokenParameters *params = nil;
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     UIViewController *controller = nil;
-    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithParentViewController:controller];
+    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:controller];
     params = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"fakescope1", @"fakescope2"] webviewParameters:webParams];
     params.completionBlockQueue = dispatch_queue_create([@"test.queue" cStringUsingEncoding:NSASCIIStringEncoding], DISPATCH_QUEUE_CONCURRENT);
     const char *l1 = dispatch_queue_get_label(params.completionBlockQueue);
@@ -603,7 +603,7 @@
         controller = [UIViewController new];
     });
     
-    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithParentViewController:controller];
+    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:controller];
     params = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"fakescope1", @"fakescope2"] webviewParameters:webParams];
     params.parentViewController = controller;
     params.parentViewController.view = nil;
@@ -645,7 +645,7 @@
         MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
         
         UIViewController *controller = nil;
-        MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithParentViewController:controller];
+        MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:controller];
         params = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"profile"] webviewParameters:webParams];
         params.parentViewController = [self.class sharedViewControllerStub];
     #else
@@ -774,7 +774,7 @@
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     
     UIViewController *controller = nil;
-    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithParentViewController:controller];
+    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:controller];
     params = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"fakescope1", @"fakescope2"] webviewParameters:webParams];
 #else
     params = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"fakescope1", @"fakescope2"]];
@@ -1029,7 +1029,7 @@
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     
     UIViewController *parentController = nil;
-    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithParentViewController:parentController];
+    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:parentController];
     webParameters.webviewType = MSALWebviewTypeWKWebView;
 #else
     MSALWebviewParameters *webParameters = [MSALWebviewParameters new];
@@ -1097,7 +1097,7 @@
 #if TARGET_OS_IPHONE
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     UIViewController *parentController = nil;
-    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithParentViewController:parentController];
+    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:parentController];
     webParameters.webviewType = MSALWebviewTypeWKWebView;
 #else
     MSALWebviewParameters *webParameters = [MSALWebviewParameters new];
@@ -1240,7 +1240,7 @@
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     
     UIViewController *parentController = nil;
-    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithParentViewController:parentController];
+    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:parentController];
     webParameters.webviewType = MSALWebviewTypeWKWebView;
 #else
     MSALWebviewParameters *webParameters = [MSALWebviewParameters new];
@@ -1317,7 +1317,7 @@
 #if TARGET_OS_IPHONE
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     UIViewController *parentController = nil;
-    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithParentViewController:parentController];
+    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:parentController];
     webParameters.webviewType = MSALWebviewTypeWKWebView;
 #else
     MSALWebviewParameters *webParameters = [MSALWebviewParameters new];
@@ -2819,7 +2819,7 @@
     XCTAssertNil(error);
     
 #if TARGET_OS_IPHONE
-    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithParentViewController:[self.class sharedViewControllerStub]];
+    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:[self.class sharedViewControllerStub]];
 #else
     MSALWebviewParameters *webParams = [MSALWebviewParameters new];
 #endif
@@ -2863,7 +2863,7 @@
     XCTAssertNotNil(application);
     XCTAssertNil(error);
     
-    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithParentViewController:[self.class sharedViewControllerStub]];
+    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:[self.class sharedViewControllerStub]];
     MSALSignoutParameters *parameters = [[MSALSignoutParameters alloc] initWithWebviewParameters:webParams];
     parameters.signoutFromBrowser = NO;
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
@@ -2905,7 +2905,7 @@
     XCTAssertNotNil(application);
     XCTAssertNil(error);
     
-    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithParentViewController:[self.class sharedViewControllerStub]];
+    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:[self.class sharedViewControllerStub]];
     MSALSignoutParameters *parameters = [[MSALSignoutParameters alloc] initWithWebviewParameters:webParams];
     parameters.signoutFromBrowser = YES;
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ if let application = try? MSALPublicClientApplication(configuration: config) {
             
 	#if os(iOS)
 	let viewController = ... // Pass a reference to the view controller that should be used when getting a token interactively
-	let webviewParameters = MSALWebviewParameters(parentViewController: viewController)
+	let webviewParameters = MSALWebviewParameters(authPresentationViewController: viewController)
 	#else
 	let webviewParameters = MSALWebviewParameters()
 	#endif
@@ -55,7 +55,7 @@ MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] 
     
 #if TARGET_OS_IPHONE
     UIViewController *viewController = ...; // Pass a reference to the view controller that should be used when getting a token interactively
-    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithParentViewController:viewController];
+    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:viewController];
 #else
     MSALWebviewParameters *webParameters = [MSALWebviewParameters new];
 #endif
@@ -226,7 +226,7 @@ MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] 
 ```swift
 #if os(iOS)
 	let viewController = ... // Pass a reference to the view controller that should be used when getting a token interactively
-	let webviewParameters = MSALWebviewParameters(parentViewController: viewController)
+	let webviewParameters = MSALWebviewParameters(authPresentationViewController: viewController)
 #else
 	let webviewParameters = MSALWebviewParameters()
 #endif
@@ -250,7 +250,7 @@ application.acquireToken(with: interactiveParameters, completionBlock: { (result
 ```obj-c
 #if TARGET_OS_IPHONE
     UIViewController *viewController = ...; // Pass a reference to the view controller that should be used when getting a token interactively
-    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithParentViewController:viewController];
+    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:viewController];
 #else
     MSALWebviewParameters *webParameters = [MSALWebviewParameters new];
 #endif 

--- a/Samples/ios/SampleApp/SampleAppiOS/SampleMSALUtil.m
+++ b/Samples/ios/SampleApp/SampleAppiOS/SampleMSALUtil.m
@@ -146,7 +146,7 @@
     // want to use so the service can request consent for them up front and minimize
     // how much users are interrupted for interactive auth.
     
-    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithParentViewController:controller];
+    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:controller];
     MSALInteractiveTokenParameters *parameters = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"User.Read", @"Calendars.Read"] webviewParameters:webParameters];
     [application acquireTokenWithParameters:parameters completionBlock:^(MSALResult *result, NSError *error)
     {
@@ -209,7 +209,7 @@
         return;
     }
     
-    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithParentViewController:controller];
+    MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:controller];
     MSALInteractiveTokenParameters *parameters = [[MSALInteractiveTokenParameters alloc] initWithScopes:scopes webviewParameters:webParameters];
     parameters.account = currentAccount;
     parameters.promptType = MSALPromptTypeDefault;

--- a/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SampleMSALAuthentication.swift
+++ b/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SampleMSALAuthentication.swift
@@ -130,7 +130,7 @@ extension SampleMSALAuthentication {
         do {
             let clientApplication = try createClientApplication()
             
-            let webParameters = MSALWebviewParameters(parentViewController: parentController)
+            let webParameters = MSALWebviewParameters(authPresentationViewController: parentController)
             let parameters = MSALInteractiveTokenParameters(scopes: [GraphScopes.UserRead.rawValue, GraphScopes.CalendarsRead.rawValue], webviewParameters: webParameters)
             clientApplication.acquireToken(with: parameters) {
                 (result: MSALResult?, error: Error?) in
@@ -185,7 +185,7 @@ extension SampleMSALAuthentication {
             let application = try createClientApplication()
             let account = try currentAccount()
             
-            let webParameters = MSALWebviewParameters(parentViewController: parentController)
+            let webParameters = MSALWebviewParameters(authPresentationViewController: parentController)
             let parameters = MSALInteractiveTokenParameters(scopes: scopes, webviewParameters: webParameters)
             parameters.account = account
             parameters.promptType = .default


### PR DESCRIPTION
## Proposed changes

Deprecate initWithParentViewController initializer that is causing issues and replace if with another initializer that has a non-conflicting name.
See details for the issue here: https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/856

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
Additional PRs:
- iOS sample: https://github.com/Azure-Samples/ms-identity-mobile-apple-swift-objc/pull/64
- Docs: https://github.com/MicrosoftDocs/azure-docs-pr/pull/110295
