### PR TITLE
Removed default urn redirect uri dependency

### DIFF
--- a/MSAL/src/util/ios/MSALRedirectUriVerifier.m
+++ b/MSAL/src/util/ios/MSALRedirectUriVerifier.m
@@ -36,8 +36,8 @@
                                             error:(NSError * __autoreleasing *)error
 {
 #if AD_BROKER
-    // Allow the broker app to use a special redirect URI when acquiring tokens
-    if ([customRedirectUri isEqualToString:MSID_AUTHENTICATOR_REDIRECT_URI])
+    // Allow the broker app to use any non-empty redirect URI when acquiring tokens
+    if (![NSString msidIsStringNilOrBlank:customRedirectUri])
     {
         return [[MSALRedirectUri alloc] initWithRedirectUri:[NSURL URLWithString:customRedirectUri]
                                               brokerCapable:YES];


### PR DESCRIPTION
## Proposed changes

Allow Authenticator app to use any Redirect URI, since Authenticator app will be moving away from the default urn:... Redirect URI. 

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

