### PR TITLE
Fixed authority validation for developer known AAD authorities

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -750,8 +750,9 @@
     }
     
     BOOL shouldValidate = _validateAuthority;
+    BOOL isDeveloperKnownAuthority = [self shouldExcludeValidationForAuthority:requestAuthority];
     
-    if (shouldValidate && [self shouldExcludeValidationForAuthority:requestAuthority])
+    if (shouldValidate && isDeveloperKnownAuthority)
     {
         shouldValidate = NO;
     }
@@ -775,6 +776,8 @@
         
         return;
     }
+    
+    requestAuthority.isDeveloperKnown = isDeveloperKnownAuthority;
     
     NSError *msidError = nil;
     
@@ -1013,6 +1016,8 @@
         block(nil, authorityError, nil);
         return;
     }
+    
+    requestAuthority.isDeveloperKnown = [self shouldExcludeValidationForAuthority:requestAuthority];
     
     NSError *msidError = nil;
     
@@ -1395,9 +1400,6 @@
         for (MSALAuthority *knownAuthority in self.internalConfig.knownAuthorities)
         {
             if ([authority isKindOfClass:knownAuthority.msidAuthority.class]
-                // Treat  AAD authorities differently, since they should always succeed validation
-                // Therefore, even if they are added to known authorities, still do validation
-                && ![authority isKindOfClass:[MSIDAADAuthority class]]
                 && [knownAuthority.url isEqual:authority.url])
             {
                 return YES;

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -446,7 +446,7 @@
 
 #pragma mark - Known authorities
 
-- (void)testAcquireToken_whenKnownAADAuthority_shouldValidate
+- (void)testAcquireToken_whenKnownAADAuthority_shouldNotForceValidation
 {
     __auto_type authority = [@"https://login.microsoftonline.com/common" msalAuthority];
     
@@ -468,7 +468,7 @@
          MSIDInteractiveTokenRequestParameters *params = [obj interactiveRequestParamaters];
          XCTAssertNotNil(params);
          
-         XCTAssertTrue(params.validateAuthority);
+         XCTAssertFalse(params.validateAuthority);
          completionBlock(nil, nil);
      }];
     
@@ -485,7 +485,7 @@
      }];
 }
 
-- (void)testAcquireToken_whenKnownCustomAADAuthority_shouldValidate
+- (void)testAcquireToken_whenKnownCustomAADAuthority_shouldNotForceValidation
 {
     __auto_type authority = [@"https://login.custom.microsoftonline.com/common" msalAuthority];
     
@@ -507,8 +507,8 @@
          MSIDInteractiveTokenRequestParameters *params = [obj interactiveRequestParamaters];
          XCTAssertNotNil(params);
          
-         XCTAssertTrue(params.validateAuthority);
-            XCTAssertTrue(params.authority.isDeveloperKnown);
+         XCTAssertFalse(params.validateAuthority);
+         XCTAssertTrue(params.authority.isDeveloperKnown);
          completionBlock(nil, nil);
      }];
     


### PR DESCRIPTION
## Proposed changes

There's currently a problem when developer declares a custom AAD authority, because it would still go to login.microsoftonline.com to download the aliases instead of using actual authority host. If login.microsoftonline.com is unavailable, this would cause failures for validation.
Since developer explicitly declared authority as known and trusted, it is fine to go to actual authority for validation.

For now this only fixes this for local MSAL auth. Things are a little more complex for broker since we don't want broker to talk to fake AAD even if developer says they trust it. Therefore, broker will continue enforcing an authority whitelist for now.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
Common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/722
