### PR TITLE
Revise app extension redirect uri requirements

### DIFF
--- a/MSAL/src/util/ios/MSALRedirectUriVerifier.m
+++ b/MSAL/src/util/ios/MSALRedirectUriVerifier.m
@@ -28,6 +28,7 @@
 #import "MSALRedirectUriVerifier.h"
 #import "MSALRedirectUri+Internal.h"
 #import "MSIDConstants.h"
+#import "MSIDAppExtensionUtil.h"
 
 @implementation MSALRedirectUriVerifier
 
@@ -120,6 +121,11 @@
         // HTTPS schemes don't need to be registered in the Info.plist file
         return YES;
     }
+    
+    if (([MSIDAppExtensionUtil isExecutingInAppExtension]))
+    {
+        return YES;
+    }
 
     NSArray *urlTypes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"];
 
@@ -141,6 +147,12 @@
 + (BOOL)verifyAdditionalRequiredSchemesAreRegistered:(__unused NSError **)error
 {
 #if !AD_BROKER
+    
+    if (([MSIDAppExtensionUtil isExecutingInAppExtension]))
+    {
+        return YES;
+    }
+    
     NSArray *querySchemes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"LSApplicationQueriesSchemes"];
     
     if (![querySchemes containsObject:@"msauthv2"]


### PR DESCRIPTION
## Proposed changes

App extensions never call out to legacy URL-scheme based broker, but only call out to SSO extension. Therefore, app extension doesn't need to have "broker" presence URL schemes as well as register app URL scheme in Info.plist. Hence, remove this requirement from code. 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

