### PR TITLE
Added interface in public client app for getting AAD registered devic…

### DIFF
--- a/MSAL/src/MSALDeviceInformation+Internal.h
+++ b/MSAL/src/MSALDeviceInformation+Internal.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithMSIDDeviceInfo:(MSIDDeviceInfo *)deviceInfo;
 
-- (void) addRegisteredDeviceMetadataInformation:(NSDictionary *)deviceInfoMetadata;
+- (void)addRegisteredDeviceMetadataInformation:(NSDictionary *)deviceInfoMetadata;
 
 @end
 

--- a/MSAL/src/MSALDeviceInformation+Internal.h
+++ b/MSAL/src/MSALDeviceInformation+Internal.h
@@ -31,11 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readwrite) MSALDeviceMode deviceMode;
 
-- (instancetype)init;
-- (void) addExtraDeviceInformation:(MSIDDeviceInfo *)deviceInfo;
-- (void) addWorkPlaceJoinedUPN:(NSString *)upn;
-- (void) addWorkPlaceJoinedDeviceId:(NSString *)deviceId;
-- (void) addWorkPlaceJoinedTenantId:(NSString *)tenantId;
+- (instancetype)initWithMSIDDeviceInfo:(MSIDDeviceInfo *)deviceInfo;
+
+- (void) addRegisteredDeviceMetadataInformation:(NSDictionary *)deviceInfoMetadata;
 
 @end
 

--- a/MSAL/src/MSALDeviceInformation+Internal.h
+++ b/MSAL/src/MSALDeviceInformation+Internal.h
@@ -31,7 +31,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readwrite) MSALDeviceMode deviceMode;
 
-- (instancetype)initWithMSIDDeviceInfo:(MSIDDeviceInfo *)deviceInfo;
+- (instancetype)init;
+- (void) addExtraDeviceInformation:(MSIDDeviceInfo *)deviceInfo;
+- (void) addWorkPlaceJoinedUPN:(NSString *)upn;
+- (void) addWorkPlaceJoinedDeviceId:(NSString *)deviceId;
+- (void) addWorkPlaceJoinedTenantId:(NSString *)tenantId;
 
 @end
 

--- a/MSAL/src/MSALDeviceInformation.m
+++ b/MSAL/src/MSALDeviceInformation.m
@@ -32,20 +32,21 @@
 #import "ASAuthorizationSingleSignOnProvider+MSIDExtensions.h"
 
 NSString *const MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY = @"isSSOExtensionInFullMode";
+NSString *const MSAL_DEVICE_INFORMATION_UPN_ID_KEY = @"upnIdentifier";
+NSString *const MSAL_DEVICE_INFORMATION_AAD_DEVICE_ID_KEY = @"aadDeviceIdentifier";
+NSString *const MSAL_DEVICE_INFORMATION_AAD_TENANT_ID_KEY = @"aadTenantIdentifier";
 
 @implementation MSALDeviceInformation
 {
     NSMutableDictionary *_extraDeviceInformation;
 }
 
-- (instancetype)initWithMSIDDeviceInfo:(MSIDDeviceInfo *)deviceInfo
+- (instancetype)init
 {
     self = [super init];
     
     if (self)
     {
-        _deviceMode = [self msalDeviceModeFromMSIDMode:deviceInfo.deviceMode];
-        
         if (@available(iOS 13.0, macOS 10.15, *))
         {
             _hasAADSSOExtension = [[ASAuthorizationSingleSignOnProvider msidSharedProvider] canPerformAuthorization];
@@ -56,7 +57,6 @@ NSString *const MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY = @"isSSOExt
         }
         
         _extraDeviceInformation = [NSMutableDictionary new];
-        [self initExtraDeviceInformation:deviceInfo];
     }
     
     return self;
@@ -90,9 +90,25 @@ NSString *const MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY = @"isSSOExt
 }
 
 // For readability, both keys and values in the output dictionary are NSString
-- (void) initExtraDeviceInformation:(MSIDDeviceInfo *)deviceInfo
+- (void) addExtraDeviceInformation:(MSIDDeviceInfo *)deviceInfo
 {
+    _deviceMode = [self msalDeviceModeFromMSIDMode:deviceInfo.deviceMode];
     [_extraDeviceInformation setValue:deviceInfo.ssoExtensionMode == MSIDSSOExtensionModeFull ? @"Yes" : @"No" forKey:MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY];
+}
+
+- (void) addWorkPlaceJoinedDeviceId:(NSString *)deviceId
+{
+    [_extraDeviceInformation setValue:deviceId forKey:MSAL_DEVICE_INFORMATION_AAD_DEVICE_ID_KEY];
+}
+
+- (void) addWorkPlaceJoinedTenantId:(NSString *)tenantID
+{
+    [_extraDeviceInformation setValue:tenantID forKey:MSAL_DEVICE_INFORMATION_AAD_TENANT_ID_KEY];
+}
+
+- (void) addWorkPlaceJoinedUPN:(NSString *)upn
+{
+    [_extraDeviceInformation setValue:upn forKey:MSAL_DEVICE_INFORMATION_UPN_ID_KEY];
 }
 
 - (NSString *)description

--- a/MSAL/src/MSALDeviceInformation.m
+++ b/MSAL/src/MSALDeviceInformation.m
@@ -110,7 +110,7 @@ NSString *const MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY = @"isSSOExt
 
 - (void) addRegisteredDeviceMetadataInformation:(NSDictionary *)deviceInfoMetadata
 {
-    [_extraDeviceInformation setDictionary:deviceInfoMetadata];
+    [_extraDeviceInformation addEntriesFromDictionary:deviceInfoMetadata];
 }
 
 - (NSString *)description

--- a/MSAL/src/instance/MSALDeviceInfoProvider.h
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MSALDeviceInfoProvider : MSALSSOExtensionRequestHandler
 
 - (void)deviceInfoWithRequestParameters:(MSIDRequestParameters *)requestParameters
-                        completionBlock:(MSALDeviceInformationCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15));
+                        completionBlock:(MSALDeviceInformationCompletionBlock)completionBlock;
 
 @end
 

--- a/MSAL/src/instance/MSALDeviceInfoProvider.m
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.m
@@ -32,59 +32,91 @@
 #import "MSIDRequestParameters+Broker.h"
 #import "MSALDeviceInformation+Internal.h"
 
+#import "MSIDWorkPlaceJoinConstants.h"
+#import "MSIDWorkPlaceJoinUtil.h"
+#import "MSIDRegistrationInformation.h"
+
 @implementation MSALDeviceInfoProvider
 
 - (void)deviceInfoWithRequestParameters:(MSIDRequestParameters *)requestParameters
-                        completionBlock:(MSALDeviceInformationCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15))
+                        completionBlock:(MSALDeviceInformationCompletionBlock)completionBlock
 {
-    if (![requestParameters shouldUseBroker])
+    MSALDeviceInformation *deviceInformation = [MSALDeviceInformation new];
+
+    MSIDRegistrationInformation* regInfo = [MSIDWorkPlaceJoinUtil getRegistrationInformation:nil urlChallenge:nil];
+    if (regInfo && regInfo.isWorkPlaceJoined)
     {
-        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorBrokerNotAvailable, @"Broker is not enabled for this operation. Please make sure you have enabled broker support for your application", nil, nil, nil, nil, nil, YES);
-        completionBlock(nil, error);
-        return;
-    }
-    
-    
-    if (![MSIDSSOExtensionGetDeviceInfoRequest canPerformRequest])
-    {
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, requestParameters, @"Broker is not present on this device. Defaulting to personal mode");
-        
-        MSALDeviceInformation *msalDeviceInfo = [MSALDeviceInformation new];
-        msalDeviceInfo.deviceMode = MSALDeviceModeDefault;
-        completionBlock(msalDeviceInfo, nil);
-        return;
-    }
-    
-    NSError *requestError;
-    MSIDSSOExtensionGetDeviceInfoRequest *ssoExtensionRequest = [[MSIDSSOExtensionGetDeviceInfoRequest alloc] initWithRequestParameters:requestParameters
-                                                                                                                                  error:&requestError];
-    
-    if (!ssoExtensionRequest)
-    {
-        completionBlock(nil, requestError);
-        return;
-    }
-    
-    if (![self setCurrentSSOExtensionRequest:ssoExtensionRequest])
-    {
-        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Trying to start a get accounts request while one is already executing", nil, nil, nil, nil, nil, YES);
-        completionBlock(nil, error);
-        return;
-    }
-    
-    [ssoExtensionRequest executeRequestWithCompletion:^(MSIDDeviceInfo * _Nullable deviceInfo, NSError * _Nullable error)
-    {
-        [self copyAndClearCurrentSSOExtensionRequest];
-        
-        if (!deviceInfo)
+        // Certificate subject is nothing but the AAD deviceID
+        NSString *deviceId = regInfo.certificateSubject;
+        if (deviceId)
         {
-            completionBlock(nil, error);
+            [deviceInformation addWorkPlaceJoinedDeviceId:deviceId];
+        }
+
+        NSString *upn = [MSIDWorkPlaceJoinUtil getWPJStringData:nil identifier:kMSIDUPNKeyIdentifier error:nil];
+        if (upn)
+        {
+            [deviceInformation addWorkPlaceJoinedUPN:upn];
+        }
+
+        NSString *tenantID = [MSIDWorkPlaceJoinUtil getWPJStringData:nil identifier:kMSIDTenantKeyIdentifier error:nil];
+        if (tenantID)
+        {
+            [deviceInformation addWorkPlaceJoinedTenantId:tenantID];
+        }
+    }
+
+    if (@available(iOS 13.0, macOS 10.15, *))
+    {
+        if (![requestParameters shouldUseBroker])
+        {
+            NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorBrokerNotAvailable, @"Broker is not enabled for this operation. Please make sure you have enabled broker support for your application", nil, nil, nil, nil, nil, YES);
+            completionBlock(deviceInformation, error);
             return;
         }
-        
-        MSALDeviceInformation *msalDeviceInfo = [[MSALDeviceInformation alloc] initWithMSIDDeviceInfo:deviceInfo];
-        completionBlock(msalDeviceInfo, nil);
-    }];
+
+        if (![MSIDSSOExtensionGetDeviceInfoRequest canPerformRequest])
+        {
+            MSID_LOG_WITH_CTX(MSIDLogLevelInfo, requestParameters, @"Broker is not present on this device. Defaulting to personal mode");
+
+            deviceInformation.deviceMode = MSALDeviceModeDefault;
+            completionBlock(deviceInformation, nil);
+            return;
+        }
+
+        NSError *requestError;
+        MSIDSSOExtensionGetDeviceInfoRequest *ssoExtensionRequest = [[MSIDSSOExtensionGetDeviceInfoRequest alloc] initWithRequestParameters:requestParameters
+                                                                                                                                      error:&requestError];
+
+        if (!ssoExtensionRequest)
+        {
+            completionBlock(deviceInformation, requestError);
+            return;
+        }
+
+        if (![self setCurrentSSOExtensionRequest:ssoExtensionRequest])
+        {
+            NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Trying to start a get accounts request while one is already executing", nil, nil, nil, nil, nil, YES);
+            completionBlock(deviceInformation, error);
+            return;
+        }
+
+        [ssoExtensionRequest executeRequestWithCompletion:^(MSIDDeviceInfo * _Nullable deviceInfo, NSError * _Nullable error)
+        {
+            [self copyAndClearCurrentSSOExtensionRequest];
+
+            if (!deviceInfo)
+            {
+                completionBlock(deviceInformation, error);
+                return;
+            }
+
+            [deviceInformation addExtraDeviceInformation:deviceInfo];
+            completionBlock(deviceInformation, nil);
+        }];
+    } else {
+        completionBlock(deviceInformation, nil);
+    }
 }
 
 @end

--- a/MSAL/src/instance/MSALDeviceInfoProvider.m
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.m
@@ -56,10 +56,10 @@
 
             MSALDeviceInformation *msalDeviceInfo = [MSALDeviceInformation new];
             msalDeviceInfo.deviceMode = MSALDeviceModeDefault;
-            MSIDRegistrationInformation* regInfo = [MSIDWorkPlaceJoinUtil getRegistrationInformation:nil urlChallenge:nil];
-            if (regInfo && regInfo.isWorkPlaceJoined)
+            NSDictionary* deviceRegMetadataInfo = [MSIDWorkPlaceJoinUtil getRegisteredDeviceMetadataInformation:nil];
+            if (deviceRegMetadataInfo)
             {
-                [msalDeviceInfo addRegisteredDeviceMetadataInformation:regInfo.registeredDeviceMetadata];
+                [msalDeviceInfo addRegisteredDeviceMetadataInformation:deviceRegMetadataInfo];
             }
             completionBlock(msalDeviceInfo, nil);
             return;
@@ -93,21 +93,21 @@
             }
 
             MSALDeviceInformation *msalDeviceInfo = [[MSALDeviceInformation alloc] initWithMSIDDeviceInfo:deviceInfo];
-            MSIDRegistrationInformation* regInfo = [MSIDWorkPlaceJoinUtil getRegistrationInformation:nil urlChallenge:nil];
-            if (regInfo && regInfo.isWorkPlaceJoined)
+            NSDictionary* deviceRegMetadataInfo = [MSIDWorkPlaceJoinUtil getRegisteredDeviceMetadataInformation:nil];
+            if (deviceRegMetadataInfo)
             {
-                [msalDeviceInfo addRegisteredDeviceMetadataInformation:regInfo.registeredDeviceMetadata];
+                [msalDeviceInfo addRegisteredDeviceMetadataInformation:deviceRegMetadataInfo];
             }
             completionBlock(msalDeviceInfo, nil);
         }];
     }
     else
     {
-        MSIDRegistrationInformation *regInfo = [MSIDWorkPlaceJoinUtil getRegistrationInformation:nil urlChallenge:nil];
-        if (regInfo && regInfo.isWorkPlaceJoined)
+        MSALDeviceInformation *msalDeviceInfo = [MSALDeviceInformation new];
+        NSDictionary* deviceRegMetadataInfo = [MSIDWorkPlaceJoinUtil getRegisteredDeviceMetadataInformation:nil];
+        if (deviceRegMetadataInfo)
         {
-            MSALDeviceInformation *msalDeviceInfo = [MSALDeviceInformation new];
-            [msalDeviceInfo addRegisteredDeviceMetadataInformation:regInfo.registeredDeviceMetadata];
+            [msalDeviceInfo addRegisteredDeviceMetadataInformation:deviceRegMetadataInfo];
             completionBlock(msalDeviceInfo, nil);
         }
     }

--- a/MSAL/src/public/MSALDeviceInformation.h
+++ b/MSAL/src/public/MSALDeviceInformation.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Device mode configured by the administrator
 */
-@property (nonatomic, readonly) MSALDeviceMode deviceMode API_AVAILABLE(ios(13.0), macos(10.15));
+@property (nonatomic, readonly) MSALDeviceMode deviceMode;
 
 /**
  Specifies whether AAD SSO extension was detected on the device.

--- a/MSAL/src/public/MSALDeviceInformation.h
+++ b/MSAL/src/public/MSALDeviceInformation.h
@@ -29,11 +29,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY;
-extern NSString *const MSAL_DEVICE_INFORMATION_UPN_ID_KEY;
-extern NSString *const MSAL_DEVICE_INFORMATION_AAD_DEVICE_ID_KEY;
-extern NSString *const MSAL_DEVICE_INFORMATION_AAD_TENANT_ID_KEY;
-
 /**
  Information about the device that is applicable to MSAL scenarios. 
 */

--- a/MSAL/src/public/MSALDeviceInformation.h
+++ b/MSAL/src/public/MSALDeviceInformation.h
@@ -29,6 +29,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString *const MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY;
+extern NSString *const MSAL_DEVICE_INFORMATION_UPN_ID_KEY;
+extern NSString *const MSAL_DEVICE_INFORMATION_AAD_DEVICE_ID_KEY;
+extern NSString *const MSAL_DEVICE_INFORMATION_AAD_TENANT_ID_KEY;
+
 /**
  Information about the device that is applicable to MSAL scenarios. 
 */
@@ -37,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Device mode configured by the administrator
 */
-@property (nonatomic, readonly) MSALDeviceMode deviceMode;
+@property (nonatomic, readonly) MSALDeviceMode deviceMode API_AVAILABLE(ios(13.0), macos(10.15));
 
 /**
  Specifies whether AAD SSO extension was detected on the device.

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -465,6 +465,6 @@
    Reads device information from the authentication broker if present on the device. 
 */
 - (void)getDeviceInformationWithParameters:(nullable MSALParameters *)parameters
-                           completionBlock:(nonnull MSALDeviceInformationCompletionBlock)completionBlock API_AVAILABLE(ios(13.0), macos(10.15));
+                           completionBlock:(nonnull MSALDeviceInformationCompletionBlock)completionBlock;
 
 @end

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -76,7 +76,7 @@
     [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
                                         completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
     {
-        XCTAssertNotNil(deviceInformation);
+        XCTAssertNil(deviceInformation);
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeDefault);
         XCTAssertEqual(deviceInformation.extraDeviceInformation.count, 0);
         XCTAssertNotNil(error);
@@ -158,7 +158,7 @@
     [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
                                         completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
     {
-        XCTAssertNotNil(deviceInformation);
+        XCTAssertNil(deviceInformation);
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeDefault);
         XCTAssertEqual(deviceInformation.extraDeviceInformation.count, 0);
         XCTAssertNotNil(error);

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -29,6 +29,7 @@
 #import "MSIDDeviceInfo.h"
 #import "MSIDInteractiveTokenRequestParameters.h"
 #import "MSALDeviceInformation.h"
+#import "MSIDWorkPlaceJoinUtil.h"
 
 @interface MSALDeviceInfoProviderTests : XCTestCase
 
@@ -128,6 +129,59 @@
     [self waitForExpectations:@[expectation, failExpectation] timeout:1];
 }
 
+- (void)testGetDeviceInfo_whenSSOExtensionNotAvailable_shouldReturnDefaultDeviceInfo_withWPJRegisterationInfo API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
+                           class:[MSIDSSOExtensionGetDeviceInfoRequest class]
+                           block:(id)^(id obj)
+    {
+        return NO;
+    }];
+
+    MSALDeviceInfoProvider *deviceInfoProvider = [MSALDeviceInfoProvider new];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Execute request"];
+    expectation.inverted = YES;
+
+    [MSIDTestSwizzle instanceMethod:@selector(executeRequestWithCompletion:)
+                              class:[MSIDSSOExtensionGetDeviceInfoRequest  class]
+                              block:(id)^(id obj, MSIDGetDeviceInfoRequestCompletionBlock callback)
+    {
+        [expectation fulfill];
+    }];
+
+    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:)
+                           class:[MSIDWorkPlaceJoinUtil class]
+                           block:(id<MSIDRequestContext>)^(id<MSIDRequestContext>_Nullable context)
+    {
+        NSMutableDictionary *deviceMetadata = [NSMutableDictionary new];
+        [deviceMetadata setValue:@"TestDevID" forKey:@"aadDeviceIdentifier"];
+        [deviceMetadata setValue:@"TestUPN" forKey:@"userPrincipleName"];
+        [deviceMetadata setValue:@"TestTenantID" forKey:@"aadTenantIdentifier"];
+        return deviceMetadata;
+    }];
+
+    XCTestExpectation *failExpectation = [self expectationWithDescription:@"Get device info"];
+
+    MSIDRequestParameters *requestParams = [MSIDTestParametersProvider testInteractiveParameters];
+    requestParams.validateAuthority = YES;
+
+    [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
+                                        completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+    {
+        XCTAssertNotNil(deviceInformation);
+        XCTAssertNil(error);
+        XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeDefault);
+        XCTAssertEqual(deviceInformation.extraDeviceInformation.count, 3);
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"aadDeviceIdentifier"], @"TestDevID");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"userPrincipleName"], @"TestUPN");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"aadTenantIdentifier"], @"TestTenantID");
+        [failExpectation fulfill];
+    }];
+
+    [self waitForExpectations:@[expectation, failExpectation] timeout:1];
+}
+
 - (void)testGetDeviceInfo_whenSSOExtensionPresent_encounteredError_shouldReturnError API_AVAILABLE(ios(13.0), macos(10.15))
 {
     [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
@@ -212,6 +266,65 @@
         [successExpectation fulfill];
     }];
     
+    [self waitForExpectations:@[expectation, successExpectation] timeout:1];
+}
+
+- (void)testGetDeviceInfo_whenSSOExtensionPresent_andReturnedDeviceInfo_shouldReturnMSALDeviceInfo_withWPJRegisterationInfo API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
+                           class:[MSIDSSOExtensionGetDeviceInfoRequest class]
+                           block:(id)^(id obj)
+    {
+        return YES;
+    }];
+
+    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:)
+                           class:[MSIDWorkPlaceJoinUtil class]
+                           block:(id<MSIDRequestContext>)^(id<MSIDRequestContext>_Nullable context)
+    {
+        NSMutableDictionary *deviceMetadata = [NSMutableDictionary new];
+        [deviceMetadata setValue:@"TestDevID" forKey:@"aadDeviceIdentifier"];
+        [deviceMetadata setValue:@"TestUPN" forKey:@"userPrincipleName"];
+        [deviceMetadata setValue:@"TestTenantID" forKey:@"aadTenantIdentifier"];
+        return deviceMetadata;
+    }];
+
+    MSALDeviceInfoProvider *deviceInfoProvider = [MSALDeviceInfoProvider new];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Execute request"];
+
+    [MSIDTestSwizzle instanceMethod:@selector(executeRequestWithCompletion:)
+                              class:[MSIDSSOExtensionGetDeviceInfoRequest  class]
+                              block:(id)^(id obj, MSIDGetDeviceInfoRequestCompletionBlock callback)
+    {
+        [expectation fulfill];
+
+        MSIDDeviceInfo *deviceInfo = [MSIDDeviceInfo new];
+        deviceInfo.brokerVersion = @"test";
+        deviceInfo.deviceMode = MSIDDeviceModeShared;
+        deviceInfo.ssoExtensionMode = MSIDSSOExtensionModeSilentOnly;
+
+        callback(deviceInfo, nil);
+    }];
+
+    XCTestExpectation *successExpectation = [self expectationWithDescription:@"Get device info"];
+
+    MSIDRequestParameters *requestParams = [MSIDTestParametersProvider testInteractiveParameters];
+    requestParams.validateAuthority = YES;
+
+    [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
+                                        completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+    {
+        XCTAssertNotNil(deviceInformation);
+        XCTAssertNil(error);
+        XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeShared);
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"isSSOExtensionInFullMode"], @"No");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"aadDeviceIdentifier"], @"TestDevID");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"userPrincipleName"], @"TestUPN");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"aadTenantIdentifier"], @"TestTenantID");
+        [successExpectation fulfill];
+    }];
+
     [self waitForExpectations:@[expectation, successExpectation] timeout:1];
 }
 

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -76,7 +76,9 @@
     [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
                                         completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
     {
-        XCTAssertNil(deviceInformation);
+        XCTAssertNotNil(deviceInformation);
+        XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeDefault);
+        XCTAssertEqual(deviceInformation.extraDeviceInformation.count, 0);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
         XCTAssertEqual(error.code, MSIDErrorInternal);
@@ -156,7 +158,9 @@
     [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
                                         completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
     {
-        XCTAssertNil(deviceInformation);
+        XCTAssertNotNil(deviceInformation);
+        XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeDefault);
+        XCTAssertEqual(deviceInformation.extraDeviceInformation.count, 0);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.domain, MSIDErrorDomain);
         XCTAssertEqual(error.code, MSIDErrorUnsupportedFunctionality);

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -156,7 +156,7 @@
     {
         NSMutableDictionary *deviceMetadata = [NSMutableDictionary new];
         [deviceMetadata setValue:@"TestDevID" forKey:@"aadDeviceIdentifier"];
-        [deviceMetadata setValue:@"TestUPN" forKey:@"userPrincipleName"];
+        [deviceMetadata setValue:@"TestUPN" forKey:@"userPrincipalName"];
         [deviceMetadata setValue:@"TestTenantID" forKey:@"aadTenantIdentifier"];
         return deviceMetadata;
     }];
@@ -174,7 +174,7 @@
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeDefault);
         XCTAssertEqual(deviceInformation.extraDeviceInformation.count, 3);
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"aadDeviceIdentifier"], @"TestDevID");
-        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"userPrincipleName"], @"TestUPN");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"userPrincipalName"], @"TestUPN");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"aadTenantIdentifier"], @"TestTenantID");
         [failExpectation fulfill];
     }];
@@ -284,7 +284,7 @@
     {
         NSMutableDictionary *deviceMetadata = [NSMutableDictionary new];
         [deviceMetadata setValue:@"TestDevID" forKey:@"aadDeviceIdentifier"];
-        [deviceMetadata setValue:@"TestUPN" forKey:@"userPrincipleName"];
+        [deviceMetadata setValue:@"TestUPN" forKey:@"userPrincipalName"];
         [deviceMetadata setValue:@"TestTenantID" forKey:@"aadTenantIdentifier"];
         return deviceMetadata;
     }];
@@ -320,7 +320,7 @@
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeShared);
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"isSSOExtensionInFullMode"], @"No");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"aadDeviceIdentifier"], @"TestDevID");
-        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"userPrincipleName"], @"TestUPN");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"userPrincipalName"], @"TestUPN");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"aadTenantIdentifier"], @"TestTenantID");
         [successExpectation fulfill];
     }];

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2209,9 +2209,7 @@
         
         MSIDDeviceInfo *msidDeviceInfo = [MSIDDeviceInfo new];
         msidDeviceInfo.deviceMode = MSIDDeviceModeShared;
-        MSALDeviceInformation *deviceInfo = [MSALDeviceInformation new];
-        [deviceInfo addExtraDeviceInformation:msidDeviceInfo];
-
+        MSALDeviceInformation *deviceInfo = [[MSALDeviceInformation alloc] initWithMSIDDeviceInfo:msidDeviceInfo];
         callback(deviceInfo, nil);
     }];
     

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2209,7 +2209,9 @@
         
         MSIDDeviceInfo *msidDeviceInfo = [MSIDDeviceInfo new];
         msidDeviceInfo.deviceMode = MSIDDeviceModeShared;
-        MSALDeviceInformation *deviceInfo = [[MSALDeviceInformation alloc] initWithMSIDDeviceInfo:msidDeviceInfo];
+        MSALDeviceInformation *deviceInfo = [MSALDeviceInformation new];
+        [deviceInfo addExtraDeviceInformation:msidDeviceInfo];
+
         callback(deviceInfo, nil);
     }];
     


### PR DESCRIPTION
Requirement was to get AAD deviceID, tenantID and UPN when device is registered or WorkGroupJoined.
Added interface in MSALPublicClientApplication to returns device registration info.
To return these details, leveraging existing API "MSALPublicClientApplication ::getDeviceInformationWithParameters::extraDeviceInformation"

We are getting only TenantID and UPN from WPJ stored keychain identifiers and returning AAD DeviceID with the help of Certificate.

Added interface in IdentityCore's WPJ util to return device info to MSAL.

Tested on physical iOS and Mac device .

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

