### PR TITLE
Merge 1.1.3 back into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.1.3] - 2020-05-22
+
+### Added
+* Support client side telemetry in ESTS requests (#930)
+
+### Fixed
+* Add logging for enrollment id mismatch for access tokens (#932)
+* Protect legacy macOS cache when MSAL writes into ADAL cache (common core #729)
+* Fix NTLM crash when window is not key (common core #724)
+* Fixed authority validation for developer known authorities (#913)
+* Pass prompt=login for signed out accounts (#919)
+* Don't require URL scheme registration in Info.plist for app extensions (#914)
+
 ## [1.1.2] - 2020-04-17
 
 ### Added

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MSAL"
-  s.version      = "1.1.2"
+  s.version      = "1.1.3"
   s.summary      = "Microsoft Authentication Library (MSAL) Preview for iOS"
 
   s.description  = <<-DESC

--- a/MSAL/resources/ios/Info.plist
+++ b/MSAL/resources/ios/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.1.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MSAL/resources/mac/Info.plist
+++ b/MSAL/resources/mac/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.1.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/MSAL/src/MSAL_Internal.h
+++ b/MSAL/src/MSAL_Internal.h
@@ -27,7 +27,7 @@
 
 #define MSAL_VER_HIGH       1
 #define MSAL_VER_LOW        1
-#define MSAL_VER_PATCH      2
+#define MSAL_VER_PATCH      3
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)


### PR DESCRIPTION
## Proposed changes

Merging MSAL 1.1.3 release back into dev.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

