### PR TITLE
Fix out of bound error in stress test multi accs

### DIFF
--- a/MSAL/test/app/MSALStressTestHelper.m
+++ b/MSAL/test/app/MSALStressTestHelper.m
@@ -88,15 +88,15 @@ static BOOL s_runningTest = NO;
             dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
 
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-
-                MSALAccount *account = accounts[userIndex];
-                account = [application accountForIdentifier:account.identifier error:nil];
                 
                 if (multipleUsers)
                 {
                     userIndex = ++userIndex >= [accounts count] ? 0 : userIndex;
                 }
                 
+                MSALAccount *account = accounts[userIndex];
+                account = [application accountForIdentifier:account.identifier error:nil];
+
                 __auto_type scopes = [[MSALTestAppSettings settings].scopes allObjects];
                 MSALSilentTokenParameters *parameters = [[MSALSilentTokenParameters alloc] initWithScopes:scopes account:account];
                 


### PR DESCRIPTION
## Proposed changes
Fix the crash in stress test multi-accounts case.
Possible cause: 
In the 'for' loop, the userIndex is populated for the next loop call. If the accounts array for any reason changed size, the userIndex might be greater than the size-1 and creates out of bound error. 
To fix: move the code that calculated userIndex to the beginning of the loop to avoid any latency issue with the accounts array.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

