### PR TITLE
Add prompt = default to test app

### DIFF
--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -607,6 +607,7 @@
     if ([label isEqualToString:@"Select"]) return MSALPromptTypeSelectAccount;
     if ([label isEqualToString:@"Login"]) return MSALPromptTypeLogin;
     if ([label isEqualToString:@"Consent"]) return MSALPromptTypeConsent;
+    if ([label isEqualToString:@"Default"]) return MSALPromptTypeDefault;
     
     @throw @"Do not recognize prompt behavior";
 }

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.storyboard
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -240,6 +240,7 @@
                                                                             <segment title="Select"/>
                                                                             <segment title="Login"/>
                                                                             <segment title="Consent"/>
+                                                                            <segment title="Default"/>
                                                                         </segments>
                                                                     </segmentedControl>
                                                                 </subviews>


### PR DESCRIPTION
Add the option to set prompt=default in MSAL test app.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

