### PR TITLE
Guest account with different UPN can't find cached access token

### DIFF
--- a/MSAL/src/MSALAccount.m
+++ b/MSAL/src/MSALAccount.m
@@ -58,7 +58,17 @@
         _environment = environment;
         _homeAccountId = homeAccountId;
         _identifier = homeAccountId.identifier;
-        _lookupAccountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:username homeAccountId:homeAccountId.identifier];
+        
+        // If homeAccountId is present, displayableId is not needed for account lookup. Leaving it nil allows accounts to appear in guest
+        // tenants under a different upn and still acquire tokens silently.
+        if (homeAccountId)
+        {
+            _lookupAccountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil homeAccountId:homeAccountId.identifier];
+        }
+        else
+        {
+            _lookupAccountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:username homeAccountId:homeAccountId.identifier];
+        }
         
         [self addTenantProfiles:tenantProfiles];
     }

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -1403,7 +1403,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithUser];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
+         XCTAssertNil(params.accountIdentifier.displayableId);
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -1478,7 +1478,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithUserAndAuthority];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
+         XCTAssertNil(params.accountIdentifier.displayableId);
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -1605,7 +1605,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithUser];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
+         XCTAssertNil(params.accountIdentifier.displayableId);
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -1677,7 +1677,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithUser];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
+         XCTAssertNil(params.accountIdentifier.displayableId);
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -1738,7 +1738,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithUserAndAuthority];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
+         XCTAssertNil(params.accountIdentifier.displayableId);
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -1803,7 +1803,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithTokenParameters];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
+         XCTAssertNil(params.accountIdentifier.displayableId);
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -2947,7 +2947,7 @@
         MSIDInteractiveRequestParameters *params = [obj parameters];
         XCTAssertNotNil(params);
         
-        XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"fakeuser@contoso.com");
+        XCTAssertNil(params.accountIdentifier.displayableId);
         XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"myuid.utid");
         
         XCTAssertEqualObjects(params.authority.url.absoluteString, @"https://login.microsoftonline.com/common");


### PR DESCRIPTION
An issue came from Yammer where a developer was not able to use an access token in the cache when acquiring token silently from a guest tenant. The account had a different UPN in the guest tenant than it did in its home tenant, which caused the account to not be found when creating the access token result from cache. When looking up an account in the cache, only the homeAccountID is necessary if the account has been used with MSAL, while using username in the lookupAccountIdentifier is only necessary for ADAL and for migrating from ADAL to MSAL. The intended fix is to stop using username in the lookupAccountIdentifier if the homeAccountID is present ONLY when using MSAL.

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

