### PR TITLE
changed build settings per customer requeset

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -4232,6 +4232,7 @@
 				DEVELOPMENT_TEAM = UBF8T346G9;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = "$(SRCROOT)/test/automation/ios/resources/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSALAutomationApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4249,6 +4250,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = UBF8T346G9;
 				INFOPLIST_FILE = "$(SRCROOT)/test/automation/ios/resources/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSALAutomationApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4650,7 +4652,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = UBF8T346G9;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSALTestApp;
 				PROVISIONING_PROFILE = "";
@@ -4667,7 +4669,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = UBF8T346G9;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSALTestApp;
 				PROVISIONING_PROFILE = "";
@@ -4683,7 +4685,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = "";
 				GCC_OPTIMIZATION_LEVEL = 0;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				USER_HEADER_SEARCH_PATHS = "$(inherited) $IDCORE_PATH/src/**";
 			};
 			name = Debug;
@@ -4695,7 +4697,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				USER_HEADER_SEARCH_PATHS = "$(inherited) $IDCORE_PATH/src/**";
 			};
 			name = Release;
@@ -4786,6 +4788,7 @@
 				CODE_SIGN_ENTITLEMENTS = "unit-test-host.entitlements";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
@@ -4797,6 +4800,7 @@
 				CODE_SIGN_ENTITLEMENTS = "unit-test-host.entitlements";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
@@ -4805,10 +4809,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D65A6FF01E4026B900C69FBA /* msal__debug.xcconfig */;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 			};
 			name = Debug;
 		};
@@ -4816,6 +4824,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D65A6FF11E4026C000C69FBA /* msal__release.xcconfig */;
 			buildSettings = {
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 			};
 			name = Release;
 		};

--- a/MSAL/test/app/ios/MSALTestAppLogViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppLogViewController.m
@@ -32,13 +32,12 @@
 
 @interface MSALTestAppLogViewController ()
 
+@property (nonatomic) UITextView *logView;
+@property (nonatomic) NSTextStorage *logStorage;
+
 @end
 
 @implementation MSALTestAppLogViewController
-{
-    UITextView* _logView;
-    NSTextStorage* _logStorage;
-}
 
 static NSAttributedString* s_attrNewLine = nil;
 
@@ -75,18 +74,18 @@ static NSAttributedString* s_attrNewLine = nil;
         NSAttributedString* attrLog = [[NSAttributedString alloc] initWithString:message];
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (_logView)
+            if (self.logView)
             {
-                [[_logView textStorage] appendAttributedString:attrLog];
-                [[_logView textStorage] appendAttributedString:s_attrNewLine];
+                [[self.logView textStorage] appendAttributedString:attrLog];
+                [[self.logView textStorage] appendAttributedString:s_attrNewLine];
                 
                 [self scrollToBottom];
             }
             else
             {
                 
-                [_logStorage appendAttributedString:attrLog];
-                [_logStorage appendAttributedString:s_attrNewLine];
+                [self.logStorage appendAttributedString:attrLog];
+                [self.logStorage appendAttributedString:s_attrNewLine];
             }
         });
     }];

--- a/MSAL/test/app/ios/MSALTestAppTelemetryViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppTelemetryViewController.m
@@ -32,10 +32,9 @@
 #import <MSAL/MSALTelemetryConfig.h>
 
 @interface MSALTestAppTelemetryViewController ()
-{
-    NSMutableArray<NSDictionary<NSString *, NSString *> *> *_telemetryEvents;
-    NSInteger _expandedRowIndex;
-}
+
+@property (nonatomic) NSMutableArray<NSDictionary<NSString *, NSString *> *> *telemetryEvents;
+@property (nonatomic) NSInteger expandedRowIndex;
 
 @end
 
@@ -76,7 +75,7 @@
     MSALGlobalConfig.telemetryConfig.telemetryCallback = ^(NSDictionary<NSString *, NSString *> *event)
     {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [_telemetryEvents addObject:event];
+            [self.telemetryEvents addObject:event];
             [self refresh];
         });
     };

--- a/MSAL/test/app/ios/MSALTestAppUserViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppUserViewController.m
@@ -35,13 +35,13 @@
 
 @interface MSALTestAppUserViewController ()
 
+@property (nonatomic) NSArray<MSALAccount *> *accounts;
+@property (nonatomic) MSALAccount *currentAccount;
+
 @end
 
 @implementation MSALTestAppUserViewController
-{
-    NSArray<MSALAccount *> *_accounts;
-    MSALAccount *_currentAccount;
-}
+
 
 + (instancetype)sharedController
 {
@@ -101,7 +101,7 @@
         [application getCurrentAccountWithParameters:parameters
                                      completionBlock:^(MSALAccount * _Nullable account, __unused MSALAccount * _Nullable previousAccount, __unused NSError * _Nullable error)
         {
-            _currentAccount = account;
+            self.currentAccount = account;
             
             dispatch_async(dispatch_get_main_queue(), ^{
                 [super refresh];

--- a/MSAL/test/unit/ios/unit-test-host/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/MSAL/test/unit/ios/unit-test-host/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,92 +2,97 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "60x60"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "60x60"
     },
     {
       "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "76x76"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "76x76"
     },
     {
       "idiom" : "ipad",
-      "size" : "83.5x83.5",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }


### PR DESCRIPTION
## Proposed changes

This PR will enable the following settings by default.
By enabling some of these settings, it also generated additional build errors that had to be addressed by changing private variables to properties and adding self. prefix to areas where these properties are used within block statements.

CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES; 
CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES; 
CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

