### PR TITLE
Revert "Guest account with different UPN can't find cached access token"

### DIFF
--- a/MSAL/src/MSALAccount.m
+++ b/MSAL/src/MSALAccount.m
@@ -58,17 +58,7 @@
         _environment = environment;
         _homeAccountId = homeAccountId;
         _identifier = homeAccountId.identifier;
-        
-        // If homeAccountId is present, displayableId is not needed for account lookup. Leaving it nil allows accounts to appear in guest
-        // tenants under a different upn and still acquire tokens silently.
-        if (homeAccountId)
-        {
-            _lookupAccountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil homeAccountId:homeAccountId.identifier];
-        }
-        else
-        {
-            _lookupAccountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:username homeAccountId:homeAccountId.identifier];
-        }
+        _lookupAccountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:username homeAccountId:homeAccountId.identifier];
         
         [self addTenantProfiles:tenantProfiles];
     }

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -1541,7 +1541,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithUser];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertNil(params.accountIdentifier.displayableId);
+         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -1616,7 +1616,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithUserAndAuthority];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertNil(params.accountIdentifier.displayableId);
+         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -1743,7 +1743,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithUser];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertNil(params.accountIdentifier.displayableId);
+         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -1815,7 +1815,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithUser];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertNil(params.accountIdentifier.displayableId);
+         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -1876,7 +1876,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithUserAndAuthority];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertNil(params.accountIdentifier.displayableId);
+         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -1941,7 +1941,7 @@
          
          NSString *expectedApiId = [NSString stringWithFormat:@"%ld", (long)MSALTelemetryApiIdAcquireSilentWithTokenParameters];
          XCTAssertEqualObjects(params.telemetryApiId, expectedApiId);
-         XCTAssertNil(params.accountIdentifier.displayableId);
+         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"user@contoso.com");
          XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"1.1234-5678-90abcdefg");
          XCTAssertEqualObjects(params.extraURLQueryParameters, (@{ @"slice" : @"slice", @"dc" : @"dc" }));
          
@@ -3085,7 +3085,7 @@
         MSIDInteractiveRequestParameters *params = [obj parameters];
         XCTAssertNotNil(params);
         
-        XCTAssertNil(params.accountIdentifier.displayableId);
+        XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"fakeuser@contoso.com");
         XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"myuid.utid");
         
         XCTAssertEqualObjects(params.authority.url.absoluteString, @"https://login.microsoftonline.com/common");


### PR DESCRIPTION
UI tests during July release testing revealed that this change regresses brokered WPJ scenarios and legacy ADAL coexistence scenarios. A different fix will follow.