### PR TITLE
Add MSALHttpMethod to public definitions

### DIFF
--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -86,3 +86,4 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALAuthenticationSchemeBearer.h>
 #import <MSAL/MSALAuthenticationSchemePop.h>
 #import <MSAL/MSALAuthenticationSchemeProtocol.h>
+#import <MSAL/MSALHttpMethod.h>

--- a/MSAL/src/public/MSALHttpMethod.h
+++ b/MSAL/src/public/MSALHttpMethod.h
@@ -24,6 +24,5 @@
 // THE SOFTWARE.
 //
 //------------------------------------------------------------------------------
-#import "MSIDConstants.h"
 
 extern NSString *MSALParameterStringForHttpMethod(MSALHttpMethod httpMethod);


### PR DESCRIPTION
## Proposed changes

MSAL.h was missing MSALHttpMethod imports and causing compilation failures with Cocoapods.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

