### PR TITLE
update Mac build settings to not ignore warning

### DIFF
--- a/build.py
+++ b/build.py
@@ -39,6 +39,7 @@ ios_sim_device = "iPhone 8"
 ios_sim_dest = "-destination 'platform=iOS Simulator,name=" + ios_sim_device + ",OS=latest'"
 ios_sim_flags = "-sdk iphonesimulator CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
 
+mac_sim_flags = "GCC_TREAT_WARNINGS_AS_ERRORS=YES"
 default_workspace = "MSAL.xcworkspace"
 default_config = "Debug"
 
@@ -158,6 +159,9 @@ class BuildTarget:
 
 		if (self.platform == "iOS") :
 			command += " " + ios_sim_flags + " " + ios_sim_dest
+		
+		if (self.platform == "Mac") :
+			command += " " + mac_sim_flags
 		
 		if (xcpretty) :
 			command += " | xcpretty"


### PR DESCRIPTION
## Proposed changes

Update build script on Mac to not ignore warnings
## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

