### PR TITLE
expose msal sdk version in public client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [TBD] - TBD
+* Expose MSAL SDK Version in public client (#1051)
 * Cleanup noisy SSO extension logs (#1047)
 * Mark RSA public key as extractable (#1049)
 * Cleanup main product targets from test files (#1046)

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1511,6 +1511,12 @@
                                                MSID_OAUTH2_SCOPE_OFFLINE_ACCESS_VALUE, nil];
 }
 
++ (NSString *)sdkVersion
+{
+    return [[NSBundle bundleForClass:MSALPublicClientApplication.class] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+}
+
+
 #pragma mark - Private
 
 - (MSIDRequestType)requestType

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1513,7 +1513,7 @@
 
 + (NSString *)sdkVersion
 {
-    return [[NSBundle bundleForClass:MSALPublicClientApplication.class] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    return @MSAL_VERSION_STRING;
 }
 
 

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -472,4 +472,9 @@
 */
 @property (readonly) BOOL isCompatibleAADBrokerAvailable;
 
+/**
+   A String indicates the version of current MSAL SDK
+*/
+@property (nullable, class, readonly) NSString *sdkVersion;
+
 @end

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -198,6 +198,14 @@
 #endif
 }
 
+- (void)test_non_nil_sdkVersion
+{
+    [MSIDTestBundle overrideObject:UNIT_TEST_SDK_VERSION forKey:@"CFBundleShortVersionString"];
+    NSString *version = [MSALPublicClientApplication sdkVersion];
+    XCTAssertNotNil(version);
+    XCTAssertEqualObjects(version, UNIT_TEST_SDK_VERSION);
+}
+
 - (void)testInitWithClientIdAndAuthorityAndRedirectUri_whenValidClientIdAndAuthorityAndRedirectUri_shouldReturnApplicationAndNilError
 {
     NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[@"mycustom.redirect"] } ];

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -200,10 +200,10 @@
 
 - (void)test_non_nil_sdkVersion
 {
-    [MSIDTestBundle overrideObject:UNIT_TEST_SDK_VERSION forKey:@"CFBundleShortVersionString"];
+    NSString *versionFromInfo = [[NSBundle bundleForClass:MSALPublicClientApplication.class] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     NSString *version = [MSALPublicClientApplication sdkVersion];
     XCTAssertNotNil(version);
-    XCTAssertEqualObjects(version, UNIT_TEST_SDK_VERSION);
+    XCTAssertEqualObjects(version, versionFromInfo);
 }
 
 - (void)testInitWithClientIdAndAuthorityAndRedirectUri_whenValidClientIdAndAuthorityAndRedirectUri_shouldReturnApplicationAndNilError

--- a/MSAL/test/unit/utils/MSALTestConstants.h
+++ b/MSAL/test/unit/utils/MSALTestConstants.h
@@ -38,6 +38,9 @@
 // Unit test redirect scheme : msal<clientId>
 #define UNIT_TEST_DEFAULT_REDIRECT_SCHEME   @"msal"UNIT_TEST_CLIENT_ID
 
+// Unit test MSAL SDK Version
+#define UNIT_TEST_SDK_VERSION   @"1.1.9"
+
 // Unit test redirect uri : msal<clientId>://auth
 #if TARGET_OS_IPHONE
 #define UNIT_TEST_DEFAULT_REDIRECT_URI      UNIT_TEST_DEFAULT_REDIRECT_SCHEME"://auth"

--- a/MSAL/test/unit/utils/MSALTestConstants.h
+++ b/MSAL/test/unit/utils/MSALTestConstants.h
@@ -38,9 +38,6 @@
 // Unit test redirect scheme : msal<clientId>
 #define UNIT_TEST_DEFAULT_REDIRECT_SCHEME   @"msal"UNIT_TEST_CLIENT_ID
 
-// Unit test MSAL SDK Version
-#define UNIT_TEST_SDK_VERSION   @"1.1.9"
-
 // Unit test redirect uri : msal<clientId>://auth
 #if TARGET_OS_IPHONE
 #define UNIT_TEST_DEFAULT_REDIRECT_URI      UNIT_TEST_DEFAULT_REDIRECT_SCHEME"://auth"


### PR DESCRIPTION
## Proposed changes

Add a new class variable on public client to read current SDK version.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

