### PR TITLE
Send redirect uri for refresh token grant flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [TBD] - TBD
+* Include redirect uri in body when redeeming refresh token at token endpoint (#1020)
 * Cleanup noisy SSO extension logs (#1047)
 * Mark RSA public key as extractable (#1049)
 * Cleanup main product targets from test files (#1046)
@@ -10,7 +11,6 @@
 * update MSAL test app for SSO Seeding flow #1021
 * update new variable in configuration to allow user by pass URI check #1013
 * Refactor crypto code for cpp integration and add api to generate ephemeral asymmetric key pair. #1018
-* Include redirect uri in body when redeeming refresh token at token endpoint (#1020)
 
 ## [1.1.7] - 2020-07-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * update MSAL test app for SSO Seeding flow #1021
 * update new variable in configuration to allow user by pass URI check #1013
 * Refactor crypto code for cpp integration and add api to generate ephemeral asymmetric key pair. #1018
+* Include redirect uri in body when redeeming refresh token at token endpoint (#1020)
 
 ## [1.1.7] - 2020-07-31
 ### Added

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -1743,6 +1743,7 @@
                                                     MSID_OAUTH2_SCOPE : @"user.read fakescope1 fakescope2 fakescope3 openid profile offline_access",
                                                     @"client_info" : @"1",
                                                     @"grant_type" : @"refresh_token",
+                                                    MSID_OAUTH2_REDIRECT_URI : UNIT_TEST_DEFAULT_REDIRECT_URI,
                                                     MSID_OAUTH2_REFRESH_TOKEN : @"i am a refresh token!" }
                                        authority:authority];
     

--- a/MSAL/test/unit/utils/MSIDTestURLResponse+MSAL.m
+++ b/MSAL/test/unit/utils/MSIDTestURLResponse+MSAL.m
@@ -157,6 +157,7 @@
     NSMutableDictionary *requestBody = [@{ MSID_OAUTH2_CLIENT_ID : UNIT_TEST_CLIENT_ID,
                                            MSID_OAUTH2_SCOPE : [scopes msidToString],
                                            MSID_OAUTH2_REFRESH_TOKEN : @"i am a refresh token!",
+                                           MSID_OAUTH2_REDIRECT_URI : UNIT_TEST_DEFAULT_REDIRECT_URI,
                                            @"client_info" : @"1",
                                            @"grant_type" : @"refresh_token" } mutableCopy];
     if (claims) [requestBody setValue:claims forKey:@"claims"];
@@ -202,6 +203,7 @@
     NSMutableDictionary *requestBody = [@{ MSID_OAUTH2_CLIENT_ID : UNIT_TEST_CLIENT_ID,
                                            MSID_OAUTH2_SCOPE : [scopes msidToString],
                                            MSID_OAUTH2_REFRESH_TOKEN : refreshToken ? refreshToken : @"i am a refresh token!",
+                                           MSID_OAUTH2_REDIRECT_URI : UNIT_TEST_DEFAULT_REDIRECT_URI,
                                            @"client_info" : @"1",
                                            @"grant_type" : @"refresh_token" } mutableCopy];
     if (claims) [requestBody setValue:claims forKey:@"claims"];


### PR DESCRIPTION
## Proposed changes

Make changes to send redirect uri to refresh token grant flow. With such parameter being sent, it helps server to identify client types (public client or confidential client) correctly. It is addressing [this issue.](https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/1020)

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

