### PR TITLE
Turning off check to validate result account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [TBD] - TBD
+* Disabling check for validating result Account.
 * Fix unused parameter errors and add macOS specific test mocks.
 * Move openBroswerResponse code into its operation (#1020)
 * Include redirect uri in body when redeeming refresh token at token endpoint (#1020)

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1145,14 +1145,13 @@
     msidParams.tokenExpirationBuffer = self.internalConfig.tokenExpirationBuffer;
     msidParams.extendedLifetimeEnabled = self.internalConfig.extendedLifetimeEnabled;
     msidParams.clientCapabilities = self.internalConfig.clientApplicationCapabilities;
-    msidParams.shouldValidateResultAccount = YES;
     
     msidParams.validateAuthority = [self shouldValidateAuthorityForRequestAuthority:requestAuthority];
     msidParams.instanceAware = self.internalConfig.multipleCloudsSupported;
     msidParams.keychainAccessGroup = self.internalConfig.cacheConfig.keychainSharingGroup;
     msidParams.claimsRequest = parameters.claimsRequest.msidClaimsRequest;
     msidParams.providedAuthority = requestAuthority;
-    msidParams.shouldValidateResultAccount = YES;
+    msidParams.shouldValidateResultAccount = NO;
     msidParams.currentRequestTelemetry = [MSIDCurrentRequestTelemetry new];
     msidParams.currentRequestTelemetry.schemaVersion = 2;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -2811,10 +2811,6 @@
         // Assuming msidRequestParameters.shouldValidateAccount = NO
          XCTAssertNil(error);
          XCTAssertNotNil(result);
-//         XCTAssertEqualObjects(error.domain, MSALErrorDomain);
-//         XCTAssertEqual(error.code, MSALErrorInternal);
-//         NSInteger internalErrorCode = [error.userInfo[MSALInternalErrorCodeKey] integerValue];
-//         XCTAssertEqual(internalErrorCode, MSALInternalErrorMismatchedUser);
          
          [expectation fulfill];
      }];

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -2808,13 +2808,13 @@
                             completionBlock:^(MSALResult *rlt, NSError *error)
      {
          result = rlt;
-         
-         XCTAssertNotNil(error);
-         XCTAssertNil(result);
-         XCTAssertEqualObjects(error.domain, MSALErrorDomain);
-         XCTAssertEqual(error.code, MSALErrorInternal);
-         NSInteger internalErrorCode = [error.userInfo[MSALInternalErrorCodeKey] integerValue];
-         XCTAssertEqual(internalErrorCode, MSALInternalErrorMismatchedUser);
+        // Assuming msidRequestParameters.shouldValidateAccount = NO
+         XCTAssertNil(error);
+         XCTAssertNotNil(result);
+//         XCTAssertEqualObjects(error.domain, MSALErrorDomain);
+//         XCTAssertEqual(error.code, MSALErrorInternal);
+//         NSInteger internalErrorCode = [error.userInfo[MSALInternalErrorCodeKey] integerValue];
+//         XCTAssertEqual(internalErrorCode, MSALInternalErrorMismatchedUser);
          
          [expectation fulfill];
      }];


### PR DESCRIPTION
## Proposed changes
Setting shouldValidateResultAccount to NO so that token request's account identifier uid is not compared with tokenResult accountIdentifier uid. This is done so that MSIDErrorMismatchedAccount is not thrown when request account uid is not equal to response account uid.
Fix done to resolve case where a user's account is deleted from AAD and restored with the same UPN. The cached account uid passed during request mismatches result token account identifier and MSAL throws error.
This PR disables the above check.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

