### PR TITLE
Peter/customer settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
 * Refactor crypto code for cpp integration and add api to generate ephemeral asymmetric key pair. #1018
 * Update logger from Identity Core. (#1009)
 
+## [1.1.8] - 2020-08-20
+### Added
+* Enabled the following XCODE 11.4 recommended settings by default
+ -CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+ -CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+ -CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+ -Renamed private properties within "MSIDLastRequestTelemetry.m" to address nested dispatch call issues that arise by enabling above implicit retain self setting.
+
 ## [1.1.7] - 2020-07-31
 ### Added
 * New variable in configuration to allow user bypass redirect URI check (#1013)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ## [1.1.8] - 2020-08-20
 ### Added
-* Enabled the following XCODE 11.4 recommended settings by default
+* Enabled the following XCODE 11.4 recommended settings by default per customer request
  -CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
  -CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
  -CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;

--- a/MSAL/test/app/ios/MSALTestAppCacheViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppCacheViewController.m
@@ -83,15 +83,15 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
 @property (nonatomic) MSIDCacheConfig *cacheConfig;
 @property (nonatomic) NSString *keychainSharingGroup;
 @property (nonatomic) MSIDMetadataCache *metadataCache;
+@property (nonatomic) NSMutableDictionary *cacheSections;
+@property (nonatomic) NSMutableArray *cacheSectionTitles;
+@property (nonatomic) UITableView *cacheTableView;
 
 @end
 
 @implementation MSALTestAppCacheViewController
 {
     NSMutableDictionary<NSString *, NSMutableArray *> *_tokensPerAccount;
-    NSMutableDictionary *_cacheSections;
-    NSMutableArray *_cacheSectionTitles;
-    UITableView *_cacheTableView;
 }
 
 - (id)init
@@ -296,10 +296,10 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         
         [self setAppMetadataEntries:[self.defaultAccessor getAppMetadataEntries:nil context:nil error:nil]];
         
-        _cacheSections = [NSMutableDictionary dictionary];
+        self.cacheSections = [NSMutableDictionary dictionary];
         if ([[self appMetadataEntries] count])
         {
-            [_cacheSections setObject:[self appMetadataEntries] forKey:APP_METADATA];
+            [self.cacheSections setObject:[self appMetadataEntries] forKey:APP_METADATA];
             self.accountMetadataEntries = [NSMutableArray new];
             for (MSIDAppMetadataCacheItem *item in self.appMetadataEntries)
             {
@@ -314,13 +314,13 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
         
         if ([[self accountMetadataEntries] count])
         {
-            [_cacheSections setObject:[self accountMetadataEntries] forKey:ACCOUNT_METADATA];
+            [self.cacheSections setObject:[self accountMetadataEntries] forKey:ACCOUNT_METADATA];
         }
         
         for (MSIDAccount *account in [self accounts])
         {
-            _cacheSections[[self rowIdentifier:account.accountIdentifier]] = [NSMutableArray array];
-            [_cacheSections[[self rowIdentifier:account.accountIdentifier]] addObject:account];
+            self.cacheSections[[self rowIdentifier:account.accountIdentifier]] = [NSMutableArray array];
+            [self.cacheSections[[self rowIdentifier:account.accountIdentifier]] addObject:account];
         }
         
         NSMutableArray *allTokens = [[self.defaultAccessor allTokensWithContext:nil error:nil] mutableCopy];
@@ -339,26 +339,26 @@ static NSString *const s_defaultAuthorityUrlString = @"https://login.microsofton
                 }
             }
             
-            NSMutableArray *tokens = _cacheSections[[self rowIdentifier:token.accountIdentifier]];
+            NSMutableArray *tokens = self.cacheSections[[self rowIdentifier:token.accountIdentifier]];
             [tokens addObject:token];
         }
         
-        _cacheSectionTitles = [NSMutableArray arrayWithArray:[_cacheSections allKeys]];
+        self.cacheSectionTitles = [NSMutableArray arrayWithArray:[self.cacheSections allKeys]];
         if (isPopToken)
         {
-            MSIDAssymetricKeyPair *keyPair = [self.keyGenerator readKeyPairForAttributes:_keyPairAttributes error:nil];
+            MSIDAssymetricKeyPair *keyPair = [self.keyGenerator readKeyPairForAttributes:self.keyPairAttributes error:nil];
             if (keyPair)
             {
                 MSALTestAppAsymmetricKey *publicKey = [[MSALTestAppAsymmetricKey alloc] initWithName:self.keyPairAttributes.publicKeyIdentifier kid:keyPair.kid];
                 MSALTestAppAsymmetricKey *privateKey = [[MSALTestAppAsymmetricKey alloc] initWithName:self.keyPairAttributes.privateKeyIdentifier kid:keyPair.kid];
-                _tokenKeys = [[NSMutableArray alloc] initWithObjects:publicKey, privateKey, nil];
-                [_cacheSections setObject:_tokenKeys forKey:POP_TOKEN_KEYS];
-                [_cacheSectionTitles addObject:POP_TOKEN_KEYS];
+                self.tokenKeys = [[NSMutableArray alloc] initWithObjects:publicKey, privateKey, nil];
+                [self.cacheSections setObject:self.tokenKeys forKey:POP_TOKEN_KEYS];
+                [self.cacheSectionTitles addObject:POP_TOKEN_KEYS];
             }
         }
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            [_cacheTableView reloadData];
+            [self.cacheTableView reloadData];
             [self.refreshControl endRefreshing];
         });
     });

--- a/MSAL/test/app/ios/MSALTestAppLogViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppLogViewController.m
@@ -32,13 +32,12 @@
 
 @interface MSALTestAppLogViewController ()
 
+@property (nonatomic) UITextView *logView;
+@property (nonatomic) NSTextStorage *logStorage;
+
 @end
 
 @implementation MSALTestAppLogViewController
-{
-    UITextView* _logView;
-    NSTextStorage* _logStorage;
-}
 
 static NSAttributedString* s_attrNewLine = nil;
 
@@ -75,18 +74,18 @@ static NSAttributedString* s_attrNewLine = nil;
         NSAttributedString* attrLog = [[NSAttributedString alloc] initWithString:message];
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (_logView)
+            if (self.logView)
             {
-                [[_logView textStorage] appendAttributedString:attrLog];
-                [[_logView textStorage] appendAttributedString:s_attrNewLine];
+                [[self.logView textStorage] appendAttributedString:attrLog];
+                [[self.logView textStorage] appendAttributedString:s_attrNewLine];
                 
                 [self scrollToBottom];
             }
             else
             {
                 
-                [_logStorage appendAttributedString:attrLog];
-                [_logStorage appendAttributedString:s_attrNewLine];
+                [self.logStorage appendAttributedString:attrLog];
+                [self.logStorage appendAttributedString:s_attrNewLine];
             }
         });
     }];

--- a/MSAL/test/app/ios/MSALTestAppTelemetryViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppTelemetryViewController.m
@@ -31,11 +31,10 @@
 #import <MSAL/MSALGlobalConfig.h>
 #import <MSAL/MSALTelemetryConfig.h>
 
-@interface MSALTestAppTelemetryViewController ()
-{
-    NSMutableArray<NSDictionary<NSString *, NSString *> *> *_telemetryEvents;
-    NSInteger _expandedRowIndex;
-}
+@interface MSALTestAppTelemetryViewController()
+
+@property (nonatomic) NSMutableArray<NSDictionary<NSString *, NSString *> *> *telemetryEvents;
+@property (nonatomic) NSInteger expandedRowIndex;
 
 @end
 
@@ -76,7 +75,7 @@
     MSALGlobalConfig.telemetryConfig.telemetryCallback = ^(NSDictionary<NSString *, NSString *> *event)
     {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [_telemetryEvents addObject:event];
+            [self.telemetryEvents addObject:event];
             [self refresh];
         });
     };

--- a/MSAL/test/app/ios/MSALTestAppUserViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppUserViewController.m
@@ -35,13 +35,13 @@
 
 @interface MSALTestAppUserViewController ()
 
+@property (nonatomic) MSALAccount *currentAccount;
+@property (nonatomic) NSArray<MSALAccount *> *accounts;
+
 @end
 
 @implementation MSALTestAppUserViewController
-{
-    NSArray<MSALAccount *> *_accounts;
-    MSALAccount *_currentAccount;
-}
+
 
 + (instancetype)sharedController
 {
@@ -101,7 +101,7 @@
         [application getCurrentAccountWithParameters:parameters
                                      completionBlock:^(MSALAccount * _Nullable account, __unused MSALAccount * _Nullable previousAccount, __unused NSError * _Nullable error)
         {
-            _currentAccount = account;
+            self.currentAccount = account;
             
             dispatch_async(dispatch_get_main_queue(), ^{
                 [super refresh];


### PR DESCRIPTION
## Proposed changes

The purpose of this PR is to enable XCODE 11.4 recommended settings by default as per the customer request
(AzureAD/microsoft-authentication-library-for-objc#961)

Specifically, this PR is aimed at enabling the following three settings by default.

CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;

Enabling above settings also require code changes, most of which stem from enabling "CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF".
Primarily, above setting requires adding self. prefix to all properties being used within block statements.
This could alter XCODE behavior and result in invoking the wrong instance variable.

If a private property declared within an implementation file shares identical name with another private instance method, and if that private property is being used within a dispatch block, and the private instance method with identical name also uses another dispatch block, this results in nested dispatch calls, resulting in EXC_BAD_INSTRUCTION.
In order to address this issue, some private properties within MSIDLastRequestTelemetry.m have been renamed.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [x] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

