### PR TITLE
addressed latest comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Refactor crypto code for cpp integration and add api to generate ephemeral asymmetric key pair. #1018
 * Update logger from Identity Core. (#1009)
 
-## [1.1.8] - 2020-08-20
+## [1.1.9] - 2020-08-20
 ### Added
 * Enabled the following XCODE 11.4 recommended settings by default per customer request
  -CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;


### PR DESCRIPTION
## Proposed changes

The purpose of this PR is to enable XCODE 11.4 recommended settings by default as per the customer request
(AzureAD/microsoft-authentication-library-for-objc#961)

Specifically, this PR is aimed at enabling the following three settings by default.

CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;


## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

