### PR TITLE
Indicate whether account is SSO account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Indicate whether SSO extension account is available for device wide SSO (#1065)
+
 ## [1.1.8] - 2020-08-24
 * Disabling check for validating result Account.
 * Fix unused parameter errors and add macOS specific test mocks.

--- a/MSAL/src/MSALAccount+Internal.h
+++ b/MSAL/src/MSALAccount+Internal.h
@@ -45,6 +45,7 @@
 @property (nonatomic) NSDictionary<NSString *, NSString *> *accountClaims;
 @property (nonatomic) NSString *identifier;
 @property (nonatomic) MSIDAccountIdentifier *lookupAccountIdentifier;
+@property (nonatomic) BOOL isSSOAccount;
 
 - (instancetype)initWithUsername:(NSString *)username
                    homeAccountId:(MSALAccountId *)homeAccountId

--- a/MSAL/src/MSALAccount.m
+++ b/MSAL/src/MSALAccount.m
@@ -89,10 +89,13 @@
                                                                            objectId:account.accountIdentifier.uid
                                                                            tenantId:account.accountIdentifier.utid];
     
-    return [self initWithUsername:account.username
-                    homeAccountId:homeAccountId
-                      environment:account.storageEnvironment ?: account.environment
-                   tenantProfiles:tenantProfiles];
+    MSALAccount *msalAccount = [self initWithUsername:account.username
+                                        homeAccountId:homeAccountId
+                                          environment:account.storageEnvironment ?: account.environment
+                                       tenantProfiles:tenantProfiles];
+    
+    msalAccount.isSSOAccount = account.isSSOAccount;
+    return msalAccount;
 }
 
 - (instancetype)initWithMSALExternalAccount:(id<MSALAccount>)externalAccount

--- a/MSAL/src/public/MSALAccount+MultiTenantAccount.h
+++ b/MSAL/src/public/MSALAccount+MultiTenantAccount.h
@@ -53,4 +53,9 @@
  */
 @property (readonly, nullable) MSALAccountId *homeAccountId;
 
+/**
+ Indicates that account is used for device wide SSO.
+*/
+@property (readonly) BOOL isSSOAccount;
+
 @end

--- a/MSAL/src/public/MSALAccount+MultiTenantAccount.h
+++ b/MSAL/src/public/MSALAccount+MultiTenantAccount.h
@@ -55,6 +55,8 @@
 
 /**
  Indicates that account is used for device wide SSO.
+ This property is only available for organizational accounts when AAD SSO plugin is present on the device.
+ It will be NO in all other cases.
 */
 @property (readonly) BOOL isSSOAccount;
 

--- a/MSAL/test/unit/MSALAccountTests.m
+++ b/MSAL/test/unit/MSALAccountTests.m
@@ -68,6 +68,7 @@
     __auto_type authority = [[MSIDAADAuthority alloc] initWithURL:authorityUrl context:nil error:nil];
     msidAccount.environment = authority.environment;
     msidAccount.realm = authority.realm;
+    msidAccount.isSSOAccount = YES;
     NSDictionary *clientInfoClaims = @{ @"uid" : @"uid",
                                         @"utid" : @"tid"
                                         };
@@ -91,6 +92,7 @@
     XCTAssertEqualObjects(account.username, @"user@contoso.com");
     XCTAssertEqualObjects(account.identifier, @"uid.tid");
     XCTAssertNil(account.accountClaims);
+    XCTAssertTrue(account.isSSOAccount);
     XCTAssertEqual(account.tenantProfiles.count, 1);
     XCTAssertEqualObjects(account.tenantProfiles[0].identifier, @"localoid");
     XCTAssertEqualObjects(account.tenantProfiles[0].tenantId, @"tid");
@@ -134,6 +136,7 @@
     XCTAssertEqualObjects(account.username, @"user@contoso.com");
     XCTAssertEqualObjects(account.identifier, @"uid.tid");
     XCTAssertNil(account.accountClaims);
+    XCTAssertFalse(account.isSSOAccount);
     XCTAssertNil(account.tenantProfiles);
 }
 


### PR DESCRIPTION
## Proposed changes

Allow SSO extension to indicate whether account is used for device wide SSO. 
Also, expose a property on MSALAccount for that. 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

