### PR TITLE
enable XCODE 11.4 customer recommended settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [1.1.9] - 2020-08-28
-* Enabled the following XCODE 11.4 recommended settings by default per customer request (#1004)
+* Enabled the following XCODE 11.4 recommended settings by default per customer request (#1070)
  -CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
  -CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
  -CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
-## [1.1.9] - 2020-08-28
-* Enabled the following XCODE 11.4 recommended settings by default per customer request (#1070)
- -CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
- -CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
- -CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+## [TBD] - TBD
+* Add swift static lib target to common core to support AES GCM.
+* Enable XCODE 11.4 recommended settings by default. (#1070)
 
 ## [1.1.8] - 2020-08-24
 * Disabling check for validating result Account.
@@ -22,6 +20,14 @@
 * update new variable in configuration to allow user by pass URI check #1013
 * Refactor crypto code for cpp integration and add api to generate ephemeral asymmetric key pair. #1018
 * Update logger from Identity Core. (#1009)
+
+## [1.1.9] - 2020-08-20
+### Added
+* Enabled the following XCODE 11.4 recommended settings by default per customer request
+ -CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+ -CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+ -CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+ -Renamed private properties within "MSIDLastRequestTelemetry.m" to address nested dispatch call issues that arise by enabling above implicit retain self setting.
 
 ## [1.1.7] - 2020-07-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.1.9] - 2020-08-28
+* Enabled the following XCODE 11.4 recommended settings by default per customer request (#1004)
+ -CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+ -CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+ -CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+
 ## [1.1.8] - 2020-08-24
 * Disabling check for validating result Account.
 * Fix unused parameter errors and add macOS specific test mocks.
@@ -16,14 +22,6 @@
 * update new variable in configuration to allow user by pass URI check #1013
 * Refactor crypto code for cpp integration and add api to generate ephemeral asymmetric key pair. #1018
 * Update logger from Identity Core. (#1009)
-
-## [1.1.9] - 2020-08-20
-### Added
-* Enabled the following XCODE 11.4 recommended settings by default per customer request
- -CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
- -CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
- -CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
- -Renamed private properties within "MSIDLastRequestTelemetry.m" to address nested dispatch call issues that arise by enabling above implicit retain self setting.
 
 ## [1.1.7] - 2020-07-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [TBD] - TBD
 * Add swift static lib target to common core to support AES GCM.
-* Enable XCODE 11.4 recommended settings by default. (#1070)
+* Enable XCODE 11.4 recommended settings by default (#1070)
 
 ## [1.1.8] - 2020-08-24
 * Disabling check for validating result Account.


### PR DESCRIPTION
## Proposed changes

The purpose of this PR is to enable XCODE 11.4 recommended settings by default as per the customer request
(AzureAD/microsoft-authentication-library-for-objc#961)

Specifically, this PR is aimed at enabling the following three settings by default.

CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;

Enabling above settings also require code changes, most of which stem from enabling "CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF".
Primarily, above setting requires adding self. prefix or self->_ to all properties & ivars being used within block statements.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

