### PR TITLE
Support bypassing macOS redirectUri validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Support bypassing redirect uri validation on macOS (#1076)
 * Indicate whether SSO extension account is available for device wide SSO (#1065)
 * Add swift static lib target to common core to support AES GCM.
 * Enable XCODE 11.4 recommended settings by default (#1070)

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -3123,6 +3123,8 @@
     [self waitForExpectations:@[expectation] timeout:1];
 }
 
+#endif
+
 - (void)testInitWithConfiguration_WhenBypassRedirectURIIsDefault_ShouldBlockInvalidURI
 {
     MSALPublicClientApplicationConfig *pcaConfig = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"test_client_id"
@@ -3145,8 +3147,6 @@
     XCTAssertTrue(application);
     XCTAssertNil(error);
 }
-
-#endif
 
 #pragma mark - Broker Availability
 


### PR DESCRIPTION
## Proposed changes

Allow bypassing redirect uri on macOS. This is needed to allow macOS CP app to add account for SSO.
This flag is already in use by iOS.
Actual changes in this PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/829

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

