### PR TITLE
Support forgetting cached account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ##TBD
+* Support forgetting cached account (#1077)
 * Add SSO Seeding call in MSAL Test MacApp 
 * Fix custom webview bug in MSAL Test MacApp
 * Update MSIDBaseBrokerOperationRequest in common-core

--- a/MSAL/src/public/MSALSignoutParameters.h
+++ b/MSAL/src/public/MSALSignoutParameters.h
@@ -45,6 +45,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL signoutFromBrowser;
 
+/*
+  Removes account from the keychain with either com.microsoft.adalcache shared group by default or the one provided when configuring MSALPublicClientApplication.
+
+  This is a destructive action and will remove the SSO state from all apps sharing the same cache!
+  It's intended to be used only as a way to achieve GDPR compliance and make sure all user artifacts are cleaned on user sign out.
+  It's not intended to be used as a way to reset or fix token cache.
+  Please make sure end user is shown UI and/or warning before this flag gets set to YES.
+  NO by default.
+*/
+@property (nonatomic) BOOL wipeAccount;
+
 /**
  Initialize MSALSignoutParameters with web parameters.
  

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2954,9 +2954,9 @@
     MSALAccountId *accountId = [[MSALAccountId alloc] initWithAccountIdentifier:@"uid.utid" objectId:@"uid" tenantId:@"utid"];
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:nil homeAccountId:accountId environment:@"contoso.com" tenantProfiles:nil];
     
-    [MSIDTestSwizzle instanceMethod:@selector(clearCacheForAccount:authority:clientId:familyId:context:error:)
+    [MSIDTestSwizzle instanceMethod:@selector(clearCacheForAccount:authority:clientId:familyId:clearAccounts:context:error:)
                               class:[MSIDDefaultTokenCacheAccessor class]
-                              block:(id)^(id obj, id account, MSIDAuthority *authority, NSString *clientId, NSString *familyId, id<MSIDRequestContext> ctx, NSError **error)
+                              block:(id)^(id obj, id account, MSIDAuthority *authority, NSString *clientId, NSString *familyId, BOOL clearAccounts, id<MSIDRequestContext> ctx, NSError **error)
      {
          (void)authority;
          (void)account;
@@ -3063,6 +3063,7 @@
 - (void)testSignoutWithAccount_whenNonNilAccount_andSignoutFromBrowserTrue_andBrokerDisabled_shouldRemoveAccountFromBrowser
 {
     [self msalStoreTokenResponseInCache];
+    [self msalStoreSecondAppTokenResponseInCache];
     
     MSIDAccount *account = [[MSIDAADV2Oauth2Factory new] accountFromResponse:[self msalDefaultTokenResponse]
                                                                configuration:[self msalDefaultConfiguration]];
@@ -3080,12 +3081,16 @@
     XCTAssertNotNil(application);
     XCTAssertNil(error);
     
+    MSALPublicClientApplication *secondApplication = [self createSecondTestAppWithAuthority:authority];
+    XCTAssertNotNil(secondApplication);
+    
     MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:[self.class sharedViewControllerStub]];
     MSALSignoutParameters *parameters = [[MSALSignoutParameters alloc] initWithWebviewParameters:webParams];
     parameters.signoutFromBrowser = YES;
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     
     XCTAssertEqual([application allAccounts:nil].count, 1);
+    XCTAssertEqual([secondApplication allAccounts:nil].count, 1);
     
     [MSIDTestSwizzle instanceMethod:@selector(executeRequestWithCompletion:)
                              class:[MSIDSignoutController class]
@@ -3117,6 +3122,78 @@
         XCTAssertNil(error);
 
         XCTAssertEqual([application allAccounts:nil].count, 0);
+        XCTAssertEqual([secondApplication allAccounts:nil].count, 1);
+        
+        MSALAccountEnumerationParameters *accountEnumerationOptions = [MSALAccountEnumerationParameters new];
+        accountEnumerationOptions.returnOnlySignedInAccounts = NO;
+        
+        NSArray *firstAppSignedOutAccounts = [application accountsForParameters:accountEnumerationOptions error:nil];
+        XCTAssertEqual([firstAppSignedOutAccounts count], 1);
+        
+        NSArray *secondAppSignedOutAccounts = [application accountsForParameters:accountEnumerationOptions error:nil];
+        XCTAssertEqual([secondAppSignedOutAccounts count], 1);
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+}
+
+- (void)testSignoutWithAccount_whenNonNilAccount_andWipeAccountTrue_andBrokerDisabled_shouldWipeAccount
+{
+    // Save default response
+    [self msalStoreTokenResponseInCache];
+    
+    // Save tokens for the same account for a different client
+    [self msalStoreSecondAppTokenResponseInCache];
+    
+    MSIDAccount *account = [[MSIDAADV2Oauth2Factory new] accountFromResponse:[self msalDefaultTokenResponse]
+                                                               configuration:[self msalDefaultConfiguration]];
+    MSALAccount *msalAccount = [[MSALAccount alloc] initWithMSIDAccount:account createTenantProfile:NO];
+        
+    NSError *error = nil;
+    __auto_type authority = [@"https://login.microsoftonline.com/common" msalAuthority];
+    
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID
+                                                                                                redirectUri:nil
+                                                                                                  authority:authority];
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config
+                                                                                                    error:&error];
+    
+    XCTAssertNotNil(application);
+    XCTAssertNil(error);
+    
+    MSALPublicClientApplication *secondApplication = [self createSecondTestAppWithAuthority:authority];
+    XCTAssertNotNil(secondApplication);
+    
+    MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:[self.class sharedViewControllerStub]];
+    MSALSignoutParameters *parameters = [[MSALSignoutParameters alloc] initWithWebviewParameters:webParams];
+    parameters.wipeAccount = YES;
+    MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
+    
+    XCTAssertEqual([application allAccounts:nil].count, 1);
+    XCTAssertEqual([secondApplication allAccounts:nil].count, 1);
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Signout"];
+    
+    [application signoutWithAccount:msalAccount
+                  signoutParameters:parameters completionBlock:^(BOOL success, NSError * _Nullable error) {
+        
+        XCTAssertTrue(success);
+        XCTAssertNil(error);
+
+        XCTAssertEqual([application allAccounts:nil].count, 0);
+        XCTAssertEqual([secondApplication allAccounts:nil].count, 0);
+        
+        MSALAccountEnumerationParameters *accountEnumerationOptions = [MSALAccountEnumerationParameters new];
+        accountEnumerationOptions.returnOnlySignedInAccounts = NO;
+        
+        NSArray *firstAppSignedOutAccounts = [application accountsForParameters:accountEnumerationOptions error:nil];
+        XCTAssertEqual([firstAppSignedOutAccounts count], 0);
+        
+        NSArray *secondAppSignedOutAccounts = [application accountsForParameters:accountEnumerationOptions error:nil];
+        XCTAssertEqual([secondAppSignedOutAccounts count], 0);
+        
         [expectation fulfill];
     }];
     
@@ -3218,6 +3295,27 @@
 
 #pragma mark - Helpers
 
+- (MSALPublicClientApplication *)createSecondTestAppWithAuthority:(MSALAuthority *)authority
+{
+    NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[@"msauth.com.microsoft.unit-test-host"] } ];
+    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
+    
+    NSArray *schemes = @[@"msauthv2", @"msauthv3"];
+    [MSIDTestBundle overrideObject:schemes forKey:@"LSApplicationQueriesSchemes"];
+    
+    MSALPublicClientApplicationConfig *secondAppConfig = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"second_clientId"
+                                                                                                         redirectUri:nil
+                                                                                                           authority:authority];
+    
+    NSError *error = nil;
+    MSALPublicClientApplication *secondApplication = [[MSALPublicClientApplication alloc] initWithConfiguration:secondAppConfig error:&error];
+    
+    XCTAssertNotNil(secondApplication);
+    XCTAssertNil(error);
+    
+    return secondApplication;
+}
+
 - (void)msalStoreTokenResponseInCacheWithAuthority:(NSString *)authorityString
 {
     NSError *error = nil;
@@ -3231,6 +3329,20 @@
 - (void)msalStoreTokenResponseInCache
 {
     [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.microsoftonline.com/common"];
+}
+
+- (void)msalStoreSecondAppTokenResponseInCache
+{
+    // Save tokens for the same account for a different client
+    MSIDAADV2TokenResponse *msidResponse = [MSALTestCacheTokenResponse msalDefaultTokenResponseWithFamilyId:nil];
+    MSIDConfiguration *configuration = [MSALTestCacheTokenResponse msalDefaultConfigurationWithAuthority:@"https://login.microsoftonline.com/common"];
+    configuration.clientId = @"second_clientId";
+    
+    [self.tokenCacheAccessor saveTokensWithConfiguration:configuration
+                                                response:msidResponse
+                                                 factory:[MSIDAADV2Oauth2Factory new]
+                                                 context:nil
+                                                   error:nil];
 }
 
 - (void)msalAddDiscoveryResponse


### PR DESCRIPTION
## Proposed changes

In order to make sure user has a way to "forget" or "wipe" their account entry in cache, we need to add new API to MSAL to do so. This PR introduces new parameter on the "signout parameters" that allows developer to wipe their local account cache.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [x] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

