### PR TITLE
append PKeyAuth/1.0 keyword to the user agent string as an alternative PKeyAuth mechanism.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Indicate whether SSO extension account is available for device wide SSO (#1065)
 * Add swift static lib target to common core to support AES GCM.
 * Enable XCODE 11.4 recommended settings by default (#1070)
-* Append 'PkeyAuth/1.0' keyword to the User Agent String
+* Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS.
 
 ## [1.1.8] - 2020-08-24
 * Disabling check for validating result Account.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Indicate whether SSO extension account is available for device wide SSO (#1065)
 * Add swift static lib target to common core to support AES GCM.
 * Enable XCODE 11.4 recommended settings by default (#1070)
+* Append 'PkeyAuth/1.0' keyword to the User Agent String
 
 ## [1.1.8] - 2020-08-24
 * Disabling check for validating result Account.


### PR DESCRIPTION
## Proposed changes

On iOS, passing in the x-ms-PkeyAuth field in the HTTP header doesn't work for the scenario where the user is first directed to Microsoft sign-in page and then redirected to another adfs sign in page.
ex:

User opens ADAL test app and then attempts to acquire token using OneDrive or Office profile.
user is redirected to Office356 login page (login.microsoft.com)
3)user types in the user id - test@unisys.com
4)user is then redirected to (adfs.unisys.com)
Embedded webview is initialized during step 1, and "x-ms-PkeyAuth" field is added to the HTTP request header.
However, when the user makes it to step 4, "x-ms-PkeyAuth" field is lost in the HTTP header from the server side by then.

This issue can be addressed by appending "PKeyAuth/1.0" keyword to the User Agent string in the HTTP header during the embedded webview initialization/configuration stage. This complies with the PKeyAuth spec and also has been shown to retain the keyword in the User-Agent string field from step 1 through step 4. I have also verified that having the keyword in the User Agent string triggers PKeyAuth challenge using a test account that has device proof CA policy.



## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

