### PR TITLE
Normalize account ID for cache lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ##TBD
+* Normalize account ID for cache lookups (#1084)
 * Support forgetting cached account (#1077)
 * Add SSO Seeding call in MSAL Test MacApp 
 * Fix custom webview bug in MSAL Test MacApp


### PR DESCRIPTION
## Proposed changes

Update MSAL common core for this change: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/839

Copying change description from the main PR:

```
In current cache lookups not all account identifiers where properly normalized.
From looking at an issue reported by customer, I've noticed that Teams is passing home account id in following format "uid.UTID". This seems to happen because another Office app is writing account to external cache in this format.

What is happening is that access token lookups succeeds, but account lookup fails. Therefore, we'll always make a network call to the server and after a few calls request will be dropped with the "loop detected error". After that happens, Teams will reach out to SSO extension and that will use PRT to get new token. That will also be marked as "looping" after a few tries.

In the end of the loop, Teams will be unable to get a token.
```

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

