### PR TITLE
Support wiping external account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ##TBD
+* Support wiping external account #1085
 * Normalize account ID for cache lookups (#1084)
 * Add documentation for Proof-of-Possession for Access tokens.
 * Support forgetting cached account (#1077)

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1228,11 +1228,11 @@
 - (BOOL)removeAccount:(MSALAccount *)account
                 error:(NSError * __autoreleasing *)error
 {
-    return [self removeAccountImpl:account clearAccounts:NO error:error];
+    return [self removeAccountImpl:account wipeAccount:NO error:error];
 }
 
 - (BOOL)removeAccountImpl:(MSALAccount *)account
-            clearAccounts:(BOOL)clearAccount
+              wipeAccount:(BOOL)wipeAccount
                     error:(NSError * __autoreleasing *)error
 {
     if (!account)
@@ -1243,13 +1243,13 @@
     NSError *msidError = nil;
     
     // If developer is passing a wipeAccount flag, we want to wipe cache for any clientId
-    NSString *clientId = clearAccount ? nil : self.internalConfig.clientId;
+    NSString *clientId = wipeAccount ? nil : self.internalConfig.clientId;
 
     BOOL result = [self.tokenCache clearCacheForAccount:account.lookupAccountIdentifier
                                               authority:nil
                                                clientId:clientId
                                                familyId:nil
-                                          clearAccounts:clearAccount
+                                          clearAccounts:wipeAccount
                                                 context:nil
                                                   error:&msidError];
     if (!result)
@@ -1262,7 +1262,7 @@
     if (self.externalAccountHandler)
     {
         NSError *externalError = nil;
-        result &= [self.externalAccountHandler removeAccount:account error:&externalError];
+        result &= [self.externalAccountHandler removeAccount:account wipeAccount:wipeAccount error:&externalError];
         
         MSID_LOG_WITH_CTX(MSIDLogLevelVerbose, nil, @"External account removed with result %d", (int)result);
         
@@ -1333,7 +1333,7 @@
     }
     
     NSError *localError;
-    BOOL localRemovalResult = [self removeAccountImpl:account clearAccounts:signoutParameters.wipeAccount error:&localError];
+    BOOL localRemovalResult = [self removeAccountImpl:account wipeAccount:signoutParameters.wipeAccount error:&localError];
     
     if (!localRemovalResult)
     {

--- a/MSAL/src/configuration/external/MSALExternalAccountHandler.h
+++ b/MSAL/src/configuration/external/MSALExternalAccountHandler.h
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                     error:(NSError * _Nullable * _Nullable)error;
 
 - (BOOL)updateWithResult:(MSALResult *)result error:(NSError * _Nullable * _Nullable)error;
-- (BOOL)removeAccount:(MSALAccount *)account error:(NSError * _Nullable * _Nullable)error;
+- (BOOL)removeAccount:(MSALAccount *)account wipeAccount:(BOOL)wipeAccount error:(NSError * _Nullable * _Nullable)error;
 - (nullable NSArray<MSALAccount *> *)allExternalAccountsWithParameters:(MSALAccountEnumerationParameters *)parameters error:(NSError * _Nullable * _Nullable)error;
 
 @end

--- a/MSAL/src/configuration/external/MSALExternalAccountHandler.m
+++ b/MSAL/src/configuration/external/MSALExternalAccountHandler.m
@@ -74,7 +74,7 @@
 
 #pragma mark - Accounts
 
-- (BOOL)removeAccount:(MSALAccount *)account error:(NSError **)error
+- (BOOL)removeAccount:(MSALAccount *)account wipeAccount:(BOOL)wipeAccount error:(NSError **)error
 {
     if (!account)
     {
@@ -85,7 +85,7 @@
     for (id<MSALExternalAccountProviding> provider in self.externalAccountProviders)
     {
         NSError *removalError = nil;
-        BOOL result = [provider removeAccount:account tenantProfiles:account.tenantProfiles error:&removalError];
+        BOOL result = [provider removeAccount:account wipeAccount:wipeAccount tenantProfiles:account.tenantProfiles error:&removalError];
         
         if (!result)
         {

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccount.h
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccount.h
@@ -39,7 +39,8 @@ typedef NS_ENUM(NSInteger, MSALLegacySharedAccountVersion)
 typedef NS_ENUM(NSInteger, MSALLegacySharedAccountWriteOperation)
 {
     MSALLegacySharedAccountRemoveOperation = 0,
-    MSALLegacySharedAccountUpdateOperation
+    MSALLegacySharedAccountUpdateOperation,
+    MSALLegacySharedAccountWipeOperation
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/MSAL/src/public/configuration/publicClientApplication/cache/MSALExternalAccountProviding.h
+++ b/MSAL/src/public/configuration/publicClientApplication/cache/MSALExternalAccountProviding.h
@@ -56,6 +56,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)removeAccount:(id<MSALAccount>)account
        tenantProfiles:(nullable NSArray<MSALTenantProfile *> *)tenantProfiles
+                error:(NSError * _Nullable * _Nullable)error DEPRECATED_MSG_ATTRIBUTE("Use -removeAccount:wipeAccount:tenantProfiles:error: instead");
+
+/**
+ This is triggered when removal of an account is necessary.
+ It normally happens when the app calls removeAccount API in MSAL.
+ But it can also happen in other circumstances when MSAL needs to cleanup account.
+ If wipeAccount == YES, it means application requested full removal of the account and all related artifacts. 
+ */
+- (BOOL)removeAccount:(id<MSALAccount>)account
+          wipeAccount:(BOOL)wipeAccount
+       tenantProfiles:(nullable NSArray<MSALTenantProfile *> *)tenantProfiles
                 error:(NSError * _Nullable * _Nullable)error;
 
 /**

--- a/MSAL/test/unit/MSALExternalAccountHandlerTests.m
+++ b/MSAL/test/unit/MSALExternalAccountHandlerTests.m
@@ -36,6 +36,7 @@
 @interface MSALTestExternalAccountsProvider : NSObject<MSALExternalAccountProviding>
 
 @property (nonatomic) BOOL accountOperationResult;
+@property (nonatomic) BOOL wipeAccountValue;
 @property (nonatomic) NSError *accountOperationError;
 @property (nonatomic) NSArray *resultAccounts;
 
@@ -65,14 +66,10 @@
        tenantProfiles:(nullable NSArray<MSALTenantProfile *> *)tenantProfiles
                 error:(NSError * _Nullable * _Nullable)error
 {
-    self.removeAccountInvokedCount++;
-    
-    if (self.accountOperationError && error)
-    {
-        *error = self.accountOperationError;
-    }
-    
-    return self.accountOperationResult;
+    return [self removeAccount:account
+                   wipeAccount:NO
+                tenantProfiles:tenantProfiles
+                         error:error];
 }
 
 - (nullable NSArray<id<MSALAccount>> *)accountsWithParameters:(MSALAccountEnumerationParameters *)parameters
@@ -87,6 +84,23 @@
     
     return self.resultAccounts;
 }
+
+- (BOOL)removeAccount:(nonnull id<MSALAccount>)account
+          wipeAccount:(BOOL)wipeAccount
+       tenantProfiles:(nullable NSArray<MSALTenantProfile *> *)tenantProfiles
+                error:(NSError * _Nullable __autoreleasing * _Nullable)error
+{
+    self.removeAccountInvokedCount++;
+    self.wipeAccountValue = wipeAccount;
+    
+    if (self.accountOperationError && error)
+    {
+        *error = self.accountOperationError;
+    }
+    
+    return self.accountOperationResult;
+}
+
 
 @end
 
@@ -316,13 +330,14 @@
     
     MSALAccount *nilAccount = nil;
     NSError *removeError = nil;
-    BOOL result = [handler removeAccount:nilAccount error:&removeError];
+    BOOL result = [handler removeAccount:nilAccount wipeAccount:NO error:&removeError];
     XCTAssertFalse(result);
     XCTAssertNotNil(removeError);
     XCTAssertEqual(removeError.code, MSALErrorInternal);
     XCTAssertEqual(testProvider.removeAccountInvokedCount, 0);
+    XCTAssertFalse(testProvider.wipeAccountValue);
 }
-
+ 
 - (void)testRemoveAccount_whenFailedToRemove_shouldReturnNoAndFillError
 {
     MSALTestExternalAccountsProvider *testProvider = [MSALTestExternalAccountsProvider new];
@@ -338,12 +353,13 @@
     
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"username" homeAccountId:nil environment:@"login.microsoftonline.com" tenantProfiles:nil];
     NSError *removeError = nil;
-    BOOL result = [handler removeAccount:account error:&removeError];
+    BOOL result = [handler removeAccount:account wipeAccount:NO error:&removeError];
     XCTAssertFalse(result);
     XCTAssertNotNil(removeError);
     XCTAssertEqual(removeError.code, MSALErrorInternal);
     XCTAssertEqualObjects(removeError.userInfo[MSALErrorDescriptionKey], @"Unexpected removal error");
     XCTAssertEqual(testProvider.removeAccountInvokedCount, 1);
+    XCTAssertFalse(testProvider.wipeAccountValue);
 }
 
 - (void)testRemoveAccount_whenRemovalSucceeded_shouldReturnYesAndNilError
@@ -359,10 +375,11 @@
     
     MSALAccount *account = [[MSALAccount alloc] initWithUsername:@"username" homeAccountId:nil environment:@"login.microsoftonline.com" tenantProfiles:nil];
     NSError *removeError = nil;
-    BOOL result = [handler removeAccount:account error:&removeError];
+    BOOL result = [handler removeAccount:account wipeAccount:YES error:&removeError];
     XCTAssertTrue(result);
     XCTAssertNil(removeError);
     XCTAssertEqual(testProvider.removeAccountInvokedCount, 1);
+    XCTAssertTrue(testProvider.wipeAccountValue);
 }
 
 @end

--- a/MSAL/test/unit/MSALExternalAccountHandlerTests.m
+++ b/MSAL/test/unit/MSALExternalAccountHandlerTests.m
@@ -80,6 +80,7 @@
     if (self.accountOperationError && error)
     {
         *error = self.accountOperationError;
+        return nil;
     }
     
     return self.resultAccounts;
@@ -96,6 +97,7 @@
     if (self.accountOperationError && error)
     {
         *error = self.accountOperationError;
+        return NO;
     }
     
     return self.accountOperationResult;
@@ -362,7 +364,7 @@
     XCTAssertFalse(testProvider.wipeAccountValue);
 }
 
-- (void)testRemoveAccount_whenRemovalSucceeded_shouldReturnYesAndNilError
+- (void)testRemoveAccount_whenWipeSucceeded_shouldReturnYesAndNilError
 {
     MSALTestExternalAccountsProvider *testProvider = [MSALTestExternalAccountsProvider new];
     testProvider.accountOperationResult = YES;

--- a/MSAL/test/unit/MSALPublicClientApplicationAccountUpdateTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationAccountUpdateTests.m
@@ -50,6 +50,7 @@
 #import "MSIDTestCacheDataSource.h"
 #import "MSALOauth2ProviderFactory.h"
 #import "MSALTestCacheTokenResponse.h"
+#import "MSALSignoutParameters.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -186,6 +187,7 @@
     XCTAssertTrue(result);
     XCTAssertNil(removalError);
     XCTAssertEqual(mockExternalAccountHandler.removeAccountCount, 1);
+    XCTAssertFalse(mockExternalAccountHandler.wipeAccountValue);
 }
 
 #pragma mark - Helpers

--- a/MSAL/test/unit/mocks/MSALMockExternalAccountHandler.h
+++ b/MSAL/test/unit/mocks/MSALMockExternalAccountHandler.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) NSUInteger updateInvokedCount;
 @property (nonatomic) NSUInteger removeAccountCount;
 @property (nonatomic) NSUInteger allExternalAccountsInvokedCount;
+@property (nonatomic) BOOL wipeAccountValue;
 
 @property (nonatomic) NSError *accountOperationError;
 @property (nonatomic) BOOL accountOperationResult;

--- a/MSAL/test/unit/mocks/MSALMockExternalAccountHandler.m
+++ b/MSAL/test/unit/mocks/MSALMockExternalAccountHandler.m
@@ -51,9 +51,10 @@
     return self.accountOperationResult;
 }
 
-- (BOOL)removeAccount:(MSALAccount *)account error:(NSError * _Nullable * _Nullable)error
+- (BOOL)removeAccount:(MSALAccount *)account wipeAccount:(BOOL)wipeAccount error:(NSError * _Nullable * _Nullable)error
 {
     self.removeAccountCount++;
+    self.wipeAccountValue = wipeAccount;
     
     if (self.accountOperationError)
     {


### PR DESCRIPTION
## Proposed changes

In order to make sure user has a way to "forget" or "wipe" their account entry in cache, we need to add new API to MSAL to do so. This PR is a follow up PR for this one https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/1077, and it applies same wiping functionality to external account store. 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

