### PR TITLE
Make webview parameters optional in MSALSignoutParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ##TBD
+* Make webview parameters optional in MSALSignoutParameters #1086
 * Support wiping external account #1085
 * Normalize account ID for cache lookups (#1084)
 * Add documentation for Proof-of-Possession for Access tokens.

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1130,8 +1130,8 @@
         block(nil, webViewParamsError, nil);
         return;
     }
-    
-    [msidParams fillWithAccount:parameters.account];
+        
+    [msidParams setAccountIdentifierFromMSALAccount:parameters.account];
     
     msidParams.promptType = MSIDPromptTypeForPromptType(parameters.promptType);
     msidParams.loginHint = parameters.loginHint;
@@ -1361,7 +1361,7 @@
         return;
     }
     
-    [msidParams fillWithAccount:account];
+    [msidParams setAccountIdentifierFromMSALAccount:account];
     
     if (signoutParameters.webviewParameters)
     {

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1121,7 +1121,6 @@
     
     NSError *webViewParamsError;
     BOOL webViewParamsResult = [msidParams fillWithWebViewParameters:parameters.webviewParameters
-                                                             account:parameters.account
                                       useWebviewTypeFromGlobalConfig:useWebviewTypeFromGlobalConfig
                                                        customWebView:_customWebview
                                                                error:&webViewParamsError];
@@ -1131,6 +1130,8 @@
         block(nil, webViewParamsError, nil);
         return;
     }
+    
+    [msidParams fillWithAccount:parameters.account];
     
     msidParams.promptType = MSIDPromptTypeForPromptType(parameters.promptType);
     msidParams.loginHint = parameters.loginHint;
@@ -1332,15 +1333,6 @@
         return;
     }
     
-    NSError *localError;
-    BOOL localRemovalResult = [self removeAccountImpl:account clearAccounts:signoutParameters.wipeAccount error:&localError];
-    
-    if (!localRemovalResult)
-    {
-        block(NO, localError, nil);
-        return;
-    }
-    
     NSError *authorityError;
     MSIDAuthority *requestAuthority = [self interactiveRequestAuthorityWithCustomAuthority:nil error:&authorityError];
     
@@ -1369,22 +1361,41 @@
         return;
     }
     
-    NSError *webViewParamsError;
-    BOOL webViewParamsResult = [msidParams fillWithWebViewParameters:signoutParameters.webviewParameters
-                                                             account:account
-                                      useWebviewTypeFromGlobalConfig:NO
-                                                       customWebView:_customWebview
-                                                               error:&webViewParamsError];
+    [msidParams fillWithAccount:account];
     
-    if (!webViewParamsResult)
+    if (signoutParameters.webviewParameters)
     {
-        block(NO, webViewParamsError, msidParams);
+        NSError *webViewParamsError;
+        BOOL webViewParamsResult = [msidParams fillWithWebViewParameters:signoutParameters.webviewParameters
+                                          useWebviewTypeFromGlobalConfig:NO
+                                                           customWebView:_customWebview
+                                                                   error:&webViewParamsError];
+        
+        if (!webViewParamsResult)
+        {
+            block(NO, webViewParamsError, msidParams);
+            return;
+        }
+    }
+    else if (signoutParameters.signoutFromBrowser)
+    {
+        NSError *browserError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"Valid MSALWebviewParameters are required if signoutFromBrowser is requested. Please use [MSALSignoutParameters initWithWebviewParameters:] initializer", nil, nil, nil, nil, nil, YES);
+        block(NO, browserError, msidParams);
         return;
     }
     
     msidParams.validateAuthority = [self shouldValidateAuthorityForRequestAuthority:requestAuthority];
     msidParams.keychainAccessGroup = self.internalConfig.cacheConfig.keychainSharingGroup;
     msidParams.providedAuthority = requestAuthority;
+    
+    NSError *localError;
+    BOOL localRemovalResult = [self removeAccountImpl:account clearAccounts:signoutParameters.wipeAccount error:&localError];
+    
+    if (!localRemovalResult)
+    {
+        block(NO, localError, nil);
+        return;
+    }
     
     NSError *controllerError;
     MSIDSignoutController *controller = [MSIDRequestControllerFactory signoutControllerForParameters:msidParams

--- a/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.h
+++ b/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDInteractiveRequestParameters (MSALRequest)
 
-- (void)fillWithAccount:(MSALAccount *)account;
+- (void)setAccountIdentifierFromMSALAccount:(MSALAccount *)account;
 
 - (BOOL)fillWithWebViewParameters:(nonnull MSALWebviewParameters *)webParameters
    useWebviewTypeFromGlobalConfig:(BOOL)useWebviewTypeFromGlobalConfig

--- a/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.h
+++ b/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.h
@@ -35,8 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MSIDInteractiveRequestParameters (MSALRequest)
 
+- (void)fillWithAccount:(MSALAccount *)account;
+
 - (BOOL)fillWithWebViewParameters:(nonnull MSALWebviewParameters *)webParameters
-                          account:(nullable MSALAccount *)account
    useWebviewTypeFromGlobalConfig:(BOOL)useWebviewTypeFromGlobalConfig
                     customWebView:(nullable WKWebView *)customWebView
                             error:(NSError * _Nullable * _Nullable)error;

--- a/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.m
+++ b/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.m
@@ -87,7 +87,7 @@
     return YES;
 }
 
-- (void)fillWithAccount:(MSALAccount *)account
+- (void)setAccountIdentifierFromMSALAccount:(MSALAccount *)account
 {
     self.accountIdentifier = account.lookupAccountIdentifier;
 }

--- a/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.m
+++ b/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.m
@@ -34,14 +34,11 @@
 @implementation MSIDInteractiveRequestParameters (MSALRequest)
 
 - (BOOL)fillWithWebViewParameters:(MSALWebviewParameters *)webParameters
-                          account:(MSALAccount *)account
    useWebviewTypeFromGlobalConfig:(BOOL)useWebviewTypeFromGlobalConfig
                     customWebView:(WKWebView *)customWebView
                             error:(NSError **)error
 {
-    self.accountIdentifier = account.lookupAccountIdentifier;
-    
-    #if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE
     if (@available(iOS 13.0, *))
     {
         if (webParameters.parentViewController == nil)
@@ -88,6 +85,11 @@
     self.telemetryWebviewType = MSALStringForMSALWebviewType(webviewType);
     self.customWebview = webParameters.customWebview ?: customWebView;
     return YES;
+}
+
+- (void)fillWithAccount:(MSALAccount *)account
+{
+    self.accountIdentifier = account.lookupAccountIdentifier;
 }
 
 @end

--- a/MSAL/src/public/MSALSignoutParameters.h
+++ b/MSAL/src/public/MSALSignoutParameters.h
@@ -61,19 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param webviewParameters   User Interface configuration that MSAL uses when getting a token interactively or authorizing an end user.
  */
-- (instancetype)initWithWebviewParameters:(MSALWebviewParameters *)webviewParameters NS_DESIGNATED_INITIALIZER;
-
-#pragma mark - Unavailable initializers
-
-/**
-    Use `[MSALSignoutParameters initWithWebviewParameters:]` instead
- */
-+ (instancetype)new NS_UNAVAILABLE;
-
-/**
-   Use `[MSALSignoutParameters initWithWebviewParameters:]` instead
-*/
-- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithWebviewParameters:(MSALWebviewParameters *)webviewParameters;
 
 @end
 

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -3060,6 +3060,49 @@
     [self waitForExpectations:@[expectation] timeout:1];
 }
 
+- (void)testSignoutWithAccount_whenSignoutFromBrowserTrue_andNilWebViewParameters_shouldFailWithError_andNotRemoveAccount
+{
+    [self msalStoreTokenResponseInCache];
+    
+    MSIDAccount *account = [[MSIDAADV2Oauth2Factory new] accountFromResponse:[self msalDefaultTokenResponse]
+                                                               configuration:[self msalDefaultConfiguration]];
+    MSALAccount *msalAccount = [[MSALAccount alloc] initWithMSIDAccount:account createTenantProfile:NO];
+        
+    NSError *error = nil;
+    __auto_type authority = [@"https://login.microsoftonline.com/common" msalAuthority];
+    
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID
+                                                                                                redirectUri:nil
+                                                                                                  authority:authority];
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config
+                                                                                                    error:&error];
+    
+    XCTAssertNotNil(application);
+    XCTAssertNil(error);
+    
+    MSALSignoutParameters *parameters = [MSALSignoutParameters new];
+    parameters.signoutFromBrowser = YES;
+    MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
+    
+    XCTAssertEqual([application allAccounts:nil].count, 1);
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Signout"];
+    
+    [application signoutWithAccount:msalAccount
+                  signoutParameters:parameters completionBlock:^(BOOL success, NSError * _Nullable error) {
+        
+        XCTAssertFalse(success);
+        XCTAssertNotNil(error);
+        XCTAssertEqual(error.code, MSALErrorInternal);
+        XCTAssertEqual([error.userInfo[MSALInternalErrorCodeKey] integerValue], MSALInternalErrorInvalidParameter);
+
+        XCTAssertEqual([application allAccounts:nil].count, 1);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+}
+
 - (void)testSignoutWithAccount_whenNonNilAccount_andSignoutFromBrowserTrue_andBrokerDisabled_shouldRemoveAccountFromBrowser
 {
     [self msalStoreTokenResponseInCache];


### PR DESCRIPTION
## Proposed changes

Since most of developers call MSAL signout without requesting interactive signout from browser, it is tedious to require to provide MSALWebViewParameters in those cases.

This PR makes MSAL a bit "smarter" and makes MSALWebViewParameters mandatory only when signoutFromBrowser is requested.  

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

