### PR TITLE
Removing unused field

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -111,7 +111,6 @@
 @interface MSALPublicClientApplication()
 {
     WKWebView *_customWebview;
-    NSString *_defaultKeychainGroup;
 }
 
 @property (nonatomic) MSALPublicClientApplicationConfig *internalConfig;


### PR DESCRIPTION
Removing unused private field NSString *_defaultKeychainGroup;

## Proposed changes

Removing unused private field NSString *_defaultKeychainGroup;

Describe what this PR is trying to do.

Removing unused private field NSString *_defaultKeychainGroup;

## Type of change

Removing unused code... 

- [ ] Feature work
- [ x ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ x ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

