### PR TITLE
Add a flag to disable logger queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add swift static lib target to common core to support AES GCM.
 * Enabled XCODE 11.4 recommended settings by default per customer request.
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS.
+* Add a flag to disable logger queue.
 
 ## [1.1.8] - 2020-08-24
 * Disabling check for validating result Account.


### PR DESCRIPTION
## Proposed changes

We need to disable logger's queue when we integrate with MSAL CPP logger.


## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

