### PR TITLE
Hotfix account filtering logic when accounts are coming from broker SDK and combined by MSAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.1.10] - 2020-09-21
+* Fixed isSSOAccount flag on the MSALAccount when MSAL reads accounts from multiple sources.
+
 ## [1.1.9] - 2020-09-16
 * Ignore duplicate certificate authentication challenge in system webview.
 * Make webview parameters optional in MSALSignoutParameters #1086

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [1.1.10] - 2020-09-21
+* Fixed account filtering logic by accountId or username where accounts are queried from multiple sources.
 * Fixed isSSOAccount flag on the MSALAccount when MSAL reads accounts from multiple sources.
 
 ## [1.1.9] - 2020-09-16

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MSAL"
-  s.version      = "1.1.9"
+  s.version      = "1.1.10"
   s.summary      = "Microsoft Authentication Library (MSAL) Preview for iOS"
   s.description  = <<-DESC
                    The MSAL library preview for iOS gives your app the ability to begin using the Microsoft Cloud by supporting Microsoft Azure Active Directory and Microsoft Accounts in a converged experience using industry standard OAuth2 and OpenID Connect. The library also supports Microsoft Azure B2C for those using our hosted identity management service.

--- a/MSAL/resources/ios/Info.plist
+++ b/MSAL/resources/ios/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.9</string>
+	<string>1.1.10</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MSAL/resources/mac/Info.plist
+++ b/MSAL/resources/mac/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.9</string>
+	<string>1.1.10</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>NSPrincipalClass</key>

--- a/MSAL/src/MSAL_Internal.h
+++ b/MSAL/src/MSAL_Internal.h
@@ -27,7 +27,7 @@
 
 #define MSAL_VER_HIGH       1
 #define MSAL_VER_LOW        1
-#define MSAL_VER_PATCH      9
+#define MSAL_VER_PATCH      10
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/MSAL/src/instance/MSALAccountsProvider.m
+++ b/MSAL/src/instance/MSALAccountsProvider.m
@@ -297,6 +297,11 @@
         existingAccount.accountClaims = accountClaims;
         existingAccount.username = account.username;
     }
+    
+    if (account.isSSOAccount)
+    {
+        existingAccount.isSSOAccount = YES;
+    }
 }
 
 #pragma mark - Authority (deprecated)

--- a/MSAL/test/unit/MSALAccountsProviderTests.m
+++ b/MSAL/test/unit/MSALAccountsProviderTests.m
@@ -1012,6 +1012,7 @@
 {
     MSALAccountId *accountId = [[MSALAccountId alloc] initWithAccountIdentifier:@"uid.tid" objectId:nil tenantId:nil];
     MSALAccount *externalAccount = [[MSALAccount alloc] initWithUsername:@"user@contoso.com" homeAccountId:accountId environment:@"login.microsoftonline.com" tenantProfiles:nil];
+    externalAccount.isSSOAccount = YES;
     MSALMockExternalAccountHandler *externalAccountsHandler = [[MSALMockExternalAccountHandler alloc] initMock];
     externalAccountsHandler.externalAccountsResult = @[externalAccount];
     
@@ -1049,6 +1050,7 @@
     XCTAssertEqualObjects(allAccounts[0].tenantProfiles[0].tenantId, @"tid");
     XCTAssertTrue(allAccounts[0].tenantProfiles[0].claims.count > 0);
     XCTAssertNotNil([allAccounts[0] accountClaims]);
+    XCTAssertTrue(allAccounts[0].isSSOAccount);
 }
 
 - (void)testAllAccounts_whenLegacyAccountInCache_andDifferentExternalAccountExists_shouldReturnTwoAccounts

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2311,7 +2311,7 @@
     
     XCTestExpectation *accountsExpectation = [self expectationWithDescription:@"Accounts from device"];
     
-    MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:@"uid.utid"];
+    MSALAccountEnumerationParameters *params = [MSALAccountEnumerationParameters new];
     
     [application accountsFromDeviceForParameters:params
                                  completionBlock:^(NSArray<MSALAccount *> * _Nullable accounts, NSError * _Nullable error) {
@@ -2331,6 +2331,137 @@
     }];
     
     [self waitForExpectations:@[expectation, accountsExpectation] timeout:1];
+}
+
+- (void)testAllAccountsFromDevice_whenBrokerEnabled_andFoundAccounts_andAccountEnumerationParametersProvided_shouldReturnFilteredAccounts API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    NSString *scheme = [NSString stringWithFormat:@"msauth.%@", [[NSBundle mainBundle] bundleIdentifier]];
+    NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[scheme] } ];
+    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
+    
+    NSArray *querySchemes = @[@"myotherscheme", @"msauthv2", @"msauthv3"];
+    [MSIDTestBundle overrideObject:querySchemes forKey:@"LSApplicationQueriesSchemes"];
+    
+    NSError *error = nil;
+    __auto_type authority = [@"https://login.microsoftonline.com/common" msalAuthority];
+    
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID
+                                                                                                redirectUri:nil
+                                                                                                  authority:authority];
+    
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config
+                                                                                                    error:&error];
+    
+    XCTAssertNotNil(application);
+    XCTAssertNil(error);
+    MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityAuto;
+    
+    XCTAssertEqual([application allAccounts:nil].count, 0);
+    
+    [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
+                           class:[MSIDSSOExtensionGetAccountsRequest class]
+                           block:(id)^(id obj)
+    {
+        return YES;
+    }];
+          
+    [MSIDTestSwizzle instanceMethod:@selector(executeRequestWithCompletion:)
+                              class:[MSIDSSOExtensionGetAccountsRequest  class]
+                              block:(id)^(id obj, MSIDGetAccountsRequestCompletionBlock callback)
+    {
+        MSIDAccount *account2 = [MSIDAccount new];
+        account2.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user@contoso.com" homeAccountId:@"uid.tid"];
+        account2.environment = @"login.windows.net";
+        account2.localAccountId = @"local.oid";
+        
+        MSIDAccount *account3 = [MSIDAccount new];
+        account3.accountIdentifier = [[MSIDAccountIdentifier alloc] initWithDisplayableId:@"user2@contoso.com" homeAccountId:@"uid2.utid"];
+        account3.environment = @"login.windows.net";
+        account3.localAccountId = @"local.oid2";
+        
+        callback(@[account2, account3], NO, nil);
+    }];
+    
+    XCTestExpectation *accountIdExpectation = [self expectationWithDescription:@"Accounts from device filtered by identifier"];
+    
+    // 1. Filter by home account id
+    MSALAccountEnumerationParameters *params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:@"uid2.utid"];
+    
+    [application accountsFromDeviceForParameters:params
+                                 completionBlock:^(NSArray<MSALAccount *> * _Nullable accounts, NSError * _Nullable error) {
+        
+        XCTAssertNotNil(accounts);
+        XCTAssertEqual([accounts count], 1);
+        
+        MSALAccount *firstAccount = accounts[0];
+        XCTAssertEqualObjects(firstAccount.identifier, @"uid2.utid");
+        
+        XCTAssertNil(error);
+        [accountIdExpectation fulfill];
+        
+    }];
+    
+    [self waitForExpectations:@[accountIdExpectation] timeout:1];
+    
+    XCTestExpectation *usernameExpectation = [self expectationWithDescription:@"Accounts from device filtered by username"];
+    
+    // 2. Filter by username
+    params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:nil username:@"user2@contoso.com"];
+    
+    [application accountsFromDeviceForParameters:params
+                                 completionBlock:^(NSArray<MSALAccount *> * _Nullable accounts, NSError * _Nullable error) {
+        
+        XCTAssertNotNil(accounts);
+        XCTAssertEqual([accounts count], 1);
+        
+        MSALAccount *firstAccount = accounts[0];
+        XCTAssertEqualObjects(firstAccount.identifier, @"uid2.utid");
+        
+        XCTAssertNil(error);
+        [usernameExpectation fulfill];
+        
+    }];
+    
+    [self waitForExpectations:@[usernameExpectation] timeout:1];
+    
+    XCTestExpectation *localAccountIdExpectation = [self expectationWithDescription:@"Accounts from device filtered by tenant profile identifier"];
+    
+    // 3. Filter by local id
+    params = [[MSALAccountEnumerationParameters alloc] initWithTenantProfileIdentifier:@"local.oid2"];
+    
+    [application accountsFromDeviceForParameters:params
+                                 completionBlock:^(NSArray<MSALAccount *> * _Nullable accounts, NSError * _Nullable error) {
+        
+        XCTAssertNotNil(accounts);
+        XCTAssertEqual([accounts count], 1);
+        
+        MSALAccount *firstAccount = accounts[0];
+        XCTAssertEqualObjects(firstAccount.identifier, @"uid2.utid");
+        
+        XCTAssertNil(error);
+        [localAccountIdExpectation fulfill];
+        
+    }];
+    
+    [self waitForExpectations:@[localAccountIdExpectation] timeout:1];
+    
+    XCTestExpectation *combinedExpectation = [self expectationWithDescription:@"Accounts from device filtered by username and account id"];
+    
+    // 4. Filter by both accountId and username
+    params = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:@"uid2.utid" username:@"nonexistent@contoso.com"];
+    
+    [application accountsFromDeviceForParameters:params
+                                 completionBlock:^(NSArray<MSALAccount *> * _Nullable accounts, NSError * _Nullable error) {
+        
+        XCTAssertNotNil(accounts);
+        XCTAssertEqual([accounts count], 0);
+        
+        XCTAssertNil(error);
+        [combinedExpectation fulfill];
+        
+    }];
+    
+    [self waitForExpectations:@[combinedExpectation] timeout:1];
 }
 
 #pragma mark - Get device info


### PR DESCRIPTION
## Proposed changes

When accounts are combined from multiple sources and MSAL developer requests filtering by either username or accountIdentifier, MSAL bypasses filtering and returns all accounts from broker SDK. 

This causes incorrect account being returned by MSAL. 

Previous logic would only filter by tenantProfileId (and it would crash if developer would set it, which indicates that nobody is using filtering by tenantProfileId). 

I also added additional unit tests to prevent this issue in the future.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
Verified that there's no regression to broker or MSAL automation test pass. 