### PR TITLE
Added PKeyAuth UserAgent String on MacOS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.0] - 2020-09-21
+* Enabled PKeyAuth via UserAgent String on MacOS 
+* Added a public API for both iOS and MacOS that returns a custom WKWebviewConfig object with PKeyAuth UserAgent String within MSALWebviewParameters;
+
 ## [1.1.9] - 2020-09-16
 * Ignore duplicate certificate authentication challenge in system webview.
 * Make webview parameters optional in MSALSignoutParameters #1086

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## TBD
 * Enabled PKeyAuth via UserAgent String on MacOS 
 * Added a public API for both iOS and MacOS that returns a default recommended WKWebview configuration settings. 
-  This API additionally appends "PKeyAuth/1.0" keyword to the UserAgent String to request PKeyAuth Challenge to the server on iOS.
 This API can be found in MSALWebviewParameters.h, and an example of usage has been provided in the MSAL definition header.
 * Add public interface for asymmetric key/factory for cpp djinni interface
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## TBD
 * Enabled PKeyAuth via UserAgent String on MacOS 
-* Added a public API for both iOS and MacOS that returns a custom WKWebviewConfig object with PKeyAuth UserAgent String within MSALWebviewParameters;
+* Added a public API for both iOS and MacOS that returns a default recommended WKWebview configuration settings. 
+  This API additionally appends "PKeyAuth/1.0" keyword to the UserAgent String to request PKeyAuth Challenge to the server on iOS.
+This API can be found in MSALWebviewParameters.h, and an example of usage has been provided in the MSAL definition header.
 
 ## [1.1.10] - 2020-09-21
 * Fixed account filtering logic by accountId or username where accounts are queried from multiple sources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
-<<<<<<< HEAD
 ## TBD
 * Enabled PKeyAuth via UserAgent String on MacOS 
 * Added a public API for both iOS and MacOS that returns a default recommended WKWebview configuration settings. 
   This API additionally appends "PKeyAuth/1.0" keyword to the UserAgent String to request PKeyAuth Challenge to the server on iOS.
 This API can be found in MSALWebviewParameters.h, and an example of usage has been provided in the MSAL definition header.
-=======
 * Add public interface for asymmetric key/factory for cpp djinni interface
->>>>>>> dev
+
 
 ## [1.1.10] - 2020-09-21
 * Fixed account filtering logic by accountId or username where accounts are queried from multiple sources.

--- a/MSAL/src/configuration/MSALWebviewParameters.m
+++ b/MSAL/src/configuration/MSALWebviewParameters.m
@@ -86,7 +86,7 @@
     return item;
 }
 
-+ (WKWebViewConfiguration *)defaultWKWebviewConfiguration
+- (WKWebViewConfiguration *)defaultWKWebviewConfiguration
 {
     return [MSIDWebviewUIController defaultWKWebviewConfiguration];
 }

--- a/MSAL/src/configuration/MSALWebviewParameters.m
+++ b/MSAL/src/configuration/MSALWebviewParameters.m
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 #import "MSALWebviewParameters.h"
+#import "MSIDWebviewUIController.h"
 
 @implementation MSALWebviewParameters
 
@@ -86,7 +87,7 @@
     return item;
 }
 
-- (WKWebViewConfiguration *)defaultWKWebviewConfiguration
++ (WKWebViewConfiguration *)defaultWKWebviewConfiguration
 {
     return [MSIDWebviewUIController defaultWKWebviewConfiguration];
 }

--- a/MSAL/src/configuration/MSALWebviewParameters.m
+++ b/MSAL/src/configuration/MSALWebviewParameters.m
@@ -86,4 +86,27 @@
     return item;
 }
 
+#if !MSID_EXCLUDE_WEBKIT
+
++ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent
+{
+    WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
+    webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
+
+#if TARGET_OS_IPHONE
+    if (@available(iOS 13.0, *))
+    {
+        webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
+    }
+#else
+    if (@available(macOS 10.15, *))
+    {
+        webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeDesktop;
+    }
+#endif
+    return webConfig;
+}
+
+#endif
+
 @end

--- a/MSAL/src/public/MSALDefinitions.h
+++ b/MSAL/src/public/MSALDefinitions.h
@@ -83,7 +83,12 @@ typedef NS_ENUM(NSInteger, MSALWebviewType)
     MSALWebviewTypeSafariViewController,
     
 #endif
-    /** Use WKWebView */
+    /** Use WKWebView
+     It is recommended to use the default webview configuration setting provided by a public MSAL API.
+     ex:
+     WKWebViewConfiguration *defaultWKWebConfig = [MSALWebviewParameters defaultWKWebviewConfiguration];
+     WKWebView *embeddedWebview = [[WKWebView alloc] initWithFrame:yourWebview.frame configuration:defaultWKWebConfig];
+    */
     MSALWebviewTypeWKWebView,
 };
 

--- a/MSAL/src/public/MSALWebviewParameters.h
+++ b/MSAL/src/public/MSALWebviewParameters.h
@@ -26,7 +26,7 @@
 //------------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
-#import "MSIDWebviewUIController.h"
+#import <WebKit/WebKit.h>
 
 #if TARGET_OS_IPHONE
 typedef UIViewController    MSALViewController;
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nonnull instancetype)initWithAuthPresentationViewController:(MSALViewController *)parentViewController;
 
 
-@property (nonatomic, readonly) WKWebViewConfiguration *defaultWKWebviewConfiguration;
+@property (class, nonatomic, readonly) WKWebViewConfiguration *defaultWKWebviewConfiguration;
 
 
 #if TARGET_OS_IPHONE

--- a/MSAL/src/public/MSALWebviewParameters.h
+++ b/MSAL/src/public/MSALWebviewParameters.h
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nonnull instancetype)initWithAuthPresentationViewController:(MSALViewController *)parentViewController;
 
 
-+ (WKWebViewConfiguration *)defaultWKWebviewConfiguration;
+@property (nonatomic, readonly) WKWebViewConfiguration *defaultWKWebviewConfiguration;
 
 
 #if TARGET_OS_IPHONE

--- a/MSAL/src/public/MSALWebviewParameters.h
+++ b/MSAL/src/public/MSALWebviewParameters.h
@@ -95,11 +95,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nonnull instancetype)initWithAuthPresentationViewController:(MSALViewController *)parentViewController;
 
 
-#if !MSID_EXCLUDE_WEBKIT
-
 + (WKWebViewConfiguration *)defaultWKWebviewConfiguration;
 
-#endif
 
 #if TARGET_OS_IPHONE
 

--- a/MSAL/src/public/MSALWebviewParameters.h
+++ b/MSAL/src/public/MSALWebviewParameters.h
@@ -27,6 +27,7 @@
 
 #import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
+#import "MSIDWorkPlaceJoinConstants.h"
 
 #if TARGET_OS_IPHONE
 typedef UIViewController    MSALViewController;
@@ -93,6 +94,13 @@ NS_ASSUME_NONNULL_BEGIN
    @note parentViewController is mandatory on iOS 13+. It is strongly recommended on macOS 10.15+ to allow correct presentation of ASWebAuthenticationSession. If parentViewController is not provided on macOS 10.15+, MSAL will use application's keyWindow for presentation
 */
 - (nonnull instancetype)initWithAuthPresentationViewController:(MSALViewController *)parentViewController;
+
+
+#if !MSID_EXCLUDE_WEBKIT
+
++ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent;
+
+#endif
 
 #if TARGET_OS_IPHONE
 

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -105,7 +105,9 @@
 {
     [super viewDidLoad];
     
-    self.customWebview = [WKWebView new];
+    WKWebViewConfiguration *defaultWKWebConfig = [MSALWebviewParameters defaultWKWebviewConfiguration];
+    self.customWebview = [[WKWebView alloc] initWithFrame:self.wkWebViewContainer.frame configuration:defaultWKWebConfig];
+
     [self.wkWebViewContainer addSubview:self.customWebview];
     self.customWebview.translatesAutoresizingMaskIntoConstraints = NO;
     [self.customWebview.leftAnchor constraintEqualToAnchor:self.wkWebViewContainer.leftAnchor].active = YES;

--- a/MSAL/test/app/mac/MSALAcquireTokenViewController.m
+++ b/MSAL/test/app/mac/MSALAcquireTokenViewController.m
@@ -74,7 +74,8 @@ static NSString * const defaultScope = @"User.Read";
     [super viewDidLoad];
     //TODO: MSAL MacOS test app doesn't support embedded webview mode
     //Also, webView is initialized from the storyboard.
-    //Need to create it programmatically in order to be able to initialize it with a default config setting.
+    //Need to create it programmatically in order to be able to initialize it with a default recommended config setting,
+    //which can be created by using WKWebViewConfiguration *defaultWKWebConfig = [MSALWebviewParameters defaultWKWebviewConfiguration];
     
     self.settings = [MSALTestAppSettings settings];
     [self populateProfiles];

--- a/MSAL/test/app/mac/MSALAcquireTokenViewController.m
+++ b/MSAL/test/app/mac/MSALAcquireTokenViewController.m
@@ -72,6 +72,9 @@ static NSString * const defaultScope = @"User.Read";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    //TODO: MSAL MacOS test app doesn't support embedded webview mode
+    //Also, webView is initialized from the storyboard.
+    //Need to create it programmatically in order to be able to initialize it with a default config setting.
     
     self.settings = [MSALTestAppSettings settings];
     [self populateProfiles];


### PR DESCRIPTION
## Proposed changes

Enabled PKeyAuth support via UserAgent String on MacOS
Added an API within MSALWebviewParameters to return a custom WKWebViewConfig object with PKeyAuth UserAgent String.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

