### PR TITLE
Update README.md for multiple accounts in the cache scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD 
+* Updated user guide to provide a sample Swift & ObjC code for querying a specific account and return token silently when multiple accounts are present in the cache. 
+
 ## [1.1.11] - 2020-10-16
 * Enabled PKeyAuth via UserAgent String on MacOS 
 * Added a public API for both iOS and MacOS that returns a default recommended WKWebview

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ let parameters = MSALAccountEnumerationParameters(identifier:accountIdentifier)
 
 var scopeArr = ["https://graph.microsoft.com/.default"]
 
-if #available(iOS 13.0, *)
+if #available(iOS 13.0, macOS 10.15, *)
 {
 	 application.accountsFromDeviceForParameters(with: parameters, completionBlock:{(accounts, error) in
          if let error = error 
@@ -451,7 +451,7 @@ if #available(iOS 13.0, *)
 
     NSArray<NSString *> *scopeArr = [[NSArray alloc] initWithObjects: @"https://graph.microsoft.com/.default",nil]; //define scope
 
-    if (@available(iOS 13.0, *)) //Currently, this public API requires iOS version 13 or greater.
+    if (@available(iOS 13.0, macOS 10.15, *)) //Currently, this public API requires iOS version 13 or greater.
     {
         [application accountsFromDeviceForParameters:parameters
                                      completionBlock:^(NSArray<MSALAccount *> * _Nullable accounts, __unused NSError * _Nullable error)

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ parameters.completionBlockQueue = dispatch_get_main_queue();
 
 MSAL also provides a public API to query multiple accounts, granted that they exist in the MSAL cache.
 
-1) Make sure the umbrella header MSAL/MSAL.h is imported 
+1) Make sure the umbrella header MSAL-umbrella.h is imported (just MSAL for Swift)
 
 2) Create config, then use it to initialize an application object 
 
@@ -426,7 +426,7 @@ if #available(iOS 13.0, macOS 10.15, *)
                          //handle error
                      }
                                        
-                     guard let resp = result else {return}
+                     guard let resp = result else {return} //process result
                                                                                              
          })                                                               
                                                                                                                                                              

--- a/README.md
+++ b/README.md
@@ -379,6 +379,113 @@ parameters.completionBlockQueue = dispatch_get_main_queue();
 }];
 ```
 
+### Multiple Accounts Mode
+
+MSAL also provides a public API to query multiple accounts, granted that they exist in the MSAL cache.
+
+1) Make sure the umbrella header MSAL/MSAL.h is imported 
+
+2) Create config, then use it to initialize an application object 
+
+3) Also initialize MSALAccountEnumerationParameters object with the account identifier. Each MSALAccount object has a parameter called "identifier", which represents the unique account identifier associated with the given MSALAccount object. We recommend using it as the primary search criterion. 
+
+4) Then invoke the API "accountsFromDeviceForParameters" from the application object using the enumeration parameter. If you have multiple accounts in MSAL cache, it will return an array containg MSALAccounts that have the account identifier you specified in the previous step. 
+
+5) Once the MSAL account is retrieved, invoke acquire token silent operation
+
+#### Swift
+
+```swift
+//import other key libraries  
+#import "MSAL.h" //Additionally, import this library 
+
+let config = MSALPublicClientApplicationConfig(clientId:clientId
+                                           	redirectUri:redirectUri
+                                            	authority:authority)
+guard let application = MSALPublicClientApplication(configuration: config) else { return }
+
+let accountIdentifier = "9f4880d8-80ba-4c40-97bc-f7a23c703084.f645ad92-e38d-4d1a-b510-d1b09a74a8ca"
+let parameters = MSALAccountEnumerationParameters(identifier:accountIdentifier)
+
+var scopeArr = ["https://graph.microsoft.com/.default"]
+
+if #available(iOS 13.0, *)
+{
+	 application.accountsFromDeviceForParameters(with: parameters, completionBlock:{(accounts, error) in
+         if let error = error 
+         {
+            //Handle error
+         }
+         
+         guard let accountObjs = accounts else {return}
+         
+         let tokenParameters = MSALSilentTokenParameters(scopes:scopeArr, account: accountObjs[0]);
+                                                                                                   
+         application.acquireTokenSilentWithParameters(with: tokenParameters, completionBlock:{(result, error) in 
+                     if let error = error
+                     {
+                         //handle error
+                     }
+                                       
+                     guard let resp = result else {return}
+                                                                                             
+         })                                                               
+                                                                                                                                                             
+   })
+  
+}
+```
+
+
+#### Objective-C
+
+```objective-c
+//import other key libraries  
+#import "MSAL-umbrella.h" //Make sure to import umbrella file 
+
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:clientId
+                                                                                             redirectUri:redirectUri
+                                                                                                  authority:authority];
+
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
+    MSALAccountEnumerationParameters *parameters = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:@"9f4880d8-80ba-4c40-97bc-f7a23c703084.f645ad92-e38d-4d1a-b510-d1b09a74a8ca"]; //init with account identifier
+
+    NSArray<NSString *> *scopeArr = [[NSArray alloc] initWithObjects: @"https://graph.microsoft.com/.default",nil]; //define scope
+
+    if (@available(iOS 13.0, *)) //Currently, this public API requires iOS version 13 or greater.
+    {
+        [application accountsFromDeviceForParameters:parameters
+                                     completionBlock:^(NSArray<MSALAccount *> * _Nullable accounts, __unused NSError * _Nullable error)
+        {
+            if (error)
+            {
+              //Log error & return 
+            }
+          
+            if (accounts)
+            {
+                NSLog(@"hi there");
+                MSALSilentTokenParameters *tokenParameters = [[MSALSilentTokenParameters alloc] initWithScopes:scopeArr account:accounts[0]];
+
+                [application acquireTokenSilentWithParameters:tokenParameters
+                                completionBlock:^(MSALResult * _Nullable result, NSError * _Nullable error)
+                 {
+                    if (error)
+                    {
+                        //Log Error & return 
+                    }
+                    if (result)
+                    {
+                        //process result
+                    }
+                }
+                 ];
+            }
+     
+        }];
+    }
+```
+
 ### Detect shared device mode
 
 Use following code to read current device configuration, including whether device is configured as shared:

--- a/README.md
+++ b/README.md
@@ -396,8 +396,7 @@ MSAL also provides a public API to query multiple accounts, granted that they ex
 #### Swift
 
 ```swift
-//import other key libraries  
-#import "MSAL.h" //Additionally, import this library 
+#import MSAL //Make sure to import MSAL  
 
 let config = MSALPublicClientApplicationConfig(clientId:clientId
                                            	redirectUri:redirectUri
@@ -444,8 +443,8 @@ if #available(iOS 13.0, *)
 #import "MSAL-umbrella.h" //Make sure to import umbrella file 
 
     MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:clientId
-                                                                                             redirectUri:redirectUri
-                                                                                                  authority:authority];
+     redirectUri:redirectUri
+       authority:authority];
 
     MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
     MSALAccountEnumerationParameters *parameters = [[MSALAccountEnumerationParameters alloc] initWithIdentifier:@"9f4880d8-80ba-4c40-97bc-f7a23c703084.f645ad92-e38d-4d1a-b510-d1b09a74a8ca"]; //init with account identifier


### PR DESCRIPTION
## Proposed changes

Added sample ObjC & Swift codes and provided description for querying a specific account when multiple accounts are present in the cache, since customers don't have sufficient information to handle such a scenario in the user guide. 

Related customer issue:
https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/923

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

