### PR TITLE
Cross cloud support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## TBD 
+* Added cross-cloud B2B support.
 * Fixed logic to handle links that open in new tab for embedded webview.
 * Updated user guide to provide a sample Swift & ObjC code for querying a specific account and return token silently when multiple accounts are present in the cache. 
 

--- a/MSAL/src/MSALAccount.m
+++ b/MSAL/src/MSALAccount.m
@@ -161,7 +161,7 @@
 - (NSUInteger)hash
 {
     NSUInteger hash = 0;
-    // Equality of MSALAccount is depending on either one of homeAccountId or username
+    // Equality of MSALAccount is depending on equality of homeAccountId or username
     // So we are not able to calculate a precise hash
     return hash;
 }

--- a/MSAL/src/MSALAccount.m
+++ b/MSAL/src/MSALAccount.m
@@ -161,7 +161,8 @@
 - (NSUInteger)hash
 {
     NSUInteger hash = 0;
-    hash = hash * 31 + self.environment.hash;
+    // Equality of MSALAccount is depending on either one of homeAccountId or username
+    // So we are not able to calculate a precise hash
     return hash;
 }
 
@@ -180,7 +181,6 @@
         result &= [self.username.lowercaseString isEqualToString:user.username.lowercaseString];
     }
     
-    result &= (!self.environment && !user.environment) || [self.environment isEqualToString:user.environment];
     return result;
 }
 

--- a/MSAL/test/unit/MSALAccountTests.m
+++ b/MSAL/test/unit/MSALAccountTests.m
@@ -408,4 +408,20 @@
     XCTAssertNotEqualObjects(account1, account2);
 }
 
+- (void)testEquals_whenIdentifiersEqual_environmentDifferent_shouldConsiderEqual
+{
+    MSALAccountId *accountId = [[MSALAccountId alloc] initWithAccountIdentifier:@"1.2" objectId:@"1" tenantId:@"2"];
+    MSALAccount *account1 = [[MSALAccount alloc] initWithUsername:@"displayableID"
+                                                    homeAccountId:accountId
+                                                      environment:@"login.microsoftonline.com"
+                                                   tenantProfiles:nil];
+    
+    XCTAssertNotNil(account1);
+    MSALAccount *account2 = [account1 copy];
+    account2.environment = @"login.microsoftonline.de";
+    
+    XCTAssertNotNil(account2);
+    XCTAssertEqualObjects(account1, account2);
+}
+
 @end

--- a/MSAL/test/unit/MSALPublicClientApplicationAccountUpdateTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationAccountUpdateTests.m
@@ -220,6 +220,8 @@
     
     NSError *error = nil;
     BOOL result = [MSALTestCacheTokenResponse msalStoreTokenResponseInCacheWithAuthority:@"https://login.microsoftonline.com/common"
+                                                                                     uid:@"myuid"
+                                                                                    utid:@"utid"
                                                                       tokenCacheAccessor:self.tokenCacheAccessor
                                                                                    error:&error];
     XCTAssertTrue(result);

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2054,8 +2054,10 @@
 
 - (void)testAllAccounts_when2AccountExists_shouldReturn2Accounts
 {
-    [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.microsoftonline.com/common"];
-    [self msalStoreTokenResponseInCacheWithAuthority:@"https://example.com/common"];
+    [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.microsoftonline.com/common" uid:@"myuid"
+                                                utid:@"utid"];
+    [self msalStoreTokenResponseInCacheWithAuthority:@"https://example.com/common" uid:@"myuid2"
+                                                utid:@"utid2"];
     
     __auto_type application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID error:nil];
     application.tokenCache = self.tokenCacheAccessor;
@@ -2087,9 +2089,9 @@
     
     XCTAssertEqualObjects(account2.username, @"fakeuser@contoso.com");
     XCTAssertEqualObjects(account2.environment, @"example.com");
-    XCTAssertEqualObjects(account2.homeAccountId.identifier, @"myuid.utid");
-    XCTAssertEqualObjects(account2.homeAccountId.objectId, @"myuid");
-    XCTAssertEqualObjects(account2.homeAccountId.tenantId, @"utid");
+    XCTAssertEqualObjects(account2.homeAccountId.identifier, @"myuid2.utid2");
+    XCTAssertEqualObjects(account2.homeAccountId.objectId, @"myuid2");
+    XCTAssertEqualObjects(account2.homeAccountId.tenantId, @"utid2");
 }
 
 - (void)testAllAccount_whenFociTokenExistsForOtherClient_andAppMetadataWithSameFamilyIdInCache_shouldReturnAccountNoError
@@ -2544,8 +2546,10 @@
 
 - (void)testCurrentAccount_whenBrokerDisabled_andMultipleAccounts_shouldReturnError API_AVAILABLE(ios(13.0), macos(10.15))
 {
-    [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.microsoftonline.com/common"];
-    [self msalStoreTokenResponseInCacheWithAuthority:@"https://example.com/common"];
+    [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.microsoftonline.com/common"uid:@"myuid"
+                                                utid:@"utid"];
+    [self msalStoreTokenResponseInCacheWithAuthority:@"https://example.com/common"uid:@"myuid2"
+                                                utid:@"utid2"];
     
     NSError *error = nil;
     __auto_type authority = [@"https://login.microsoftonline.com/common" msalAuthority];
@@ -2730,8 +2734,10 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)testAllAccountsFilteredByAuthority_when2AccountExists_shouldReturnAccountsFilteredByAuthority
 {
-    [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.microsoftonline.com/common"];
-    [self msalStoreTokenResponseInCacheWithAuthority:@"https://example.com/common"];
+    [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.microsoftonline.com/common" uid:@"myuid"
+                                                utid:@"utid"];
+    [self msalStoreTokenResponseInCacheWithAuthority:@"https://example.com/common" uid:@"myuid2"
+                                                utid:@"utid2"];
     [self msalAddDiscoveryResponse];
     
     __auto_type application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID error:nil];
@@ -2759,8 +2765,10 @@
 
 - (void)testAllAccountsFilteredByAuthority_whenAccountWithAliasAuthorityExists_shouldReturnThatAccount
 {
-    [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.windows.net/common"];
-    [self msalStoreTokenResponseInCacheWithAuthority:@"https://example.com/common"];
+    [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.windows.net/common" uid:@"myuid"
+                                                utid:@"utid"];
+    [self msalStoreTokenResponseInCacheWithAuthority:@"https://example.com/common" uid:@"myuid2"
+                                                utid:@"utid2"];
     [self msalAddDiscoveryResponse];
     
     __auto_type application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID error:nil];
@@ -3532,9 +3540,13 @@
 }
 
 - (void)msalStoreTokenResponseInCacheWithAuthority:(NSString *)authorityString
+                                               uid:(NSString *)uid
+                                              utid:(NSString *)utid
 {
     NSError *error = nil;
     BOOL result = [MSALTestCacheTokenResponse msalStoreTokenResponseInCacheWithAuthority:authorityString
+                                                                                     uid:uid
+                                                                                    utid:utid
                                                                       tokenCacheAccessor:self.tokenCacheAccessor
                                                                                    error:&error];
     XCTAssertTrue(result);
@@ -3543,7 +3555,7 @@
 
 - (void)msalStoreTokenResponseInCache
 {
-    [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.microsoftonline.com/common"];
+    [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.microsoftonline.com/common" uid:@"myuid" utid:@"utid"];
 }
 
 - (void)msalStoreSecondAppTokenResponseInCache

--- a/MSAL/test/unit/utils/MSALTestCacheTokenResponse.h
+++ b/MSAL/test/unit/utils/MSALTestCacheTokenResponse.h
@@ -34,6 +34,8 @@
 @interface MSALTestCacheTokenResponse : NSObject
 
 + (BOOL)msalStoreTokenResponseInCacheWithAuthority:(NSString *)authorityString
+                                               uid:(NSString *)uid
+                                              utid:(NSString *)utid
                                tokenCacheAccessor:(MSIDDefaultTokenCacheAccessor *)tokenCacheAccessor
                                             error:(NSError **)error;
 

--- a/MSAL/test/unit/utils/MSALTestCacheTokenResponse.m
+++ b/MSAL/test/unit/utils/MSALTestCacheTokenResponse.m
@@ -38,21 +38,28 @@
 @implementation MSALTestCacheTokenResponse
 
 + (BOOL)msalStoreTokenResponseInCacheWithAuthority:(NSString *)authorityString
+                                               uid:(NSString *)uid
+                                              utid:(NSString *)utid
                                tokenCacheAccessor:(MSIDDefaultTokenCacheAccessor *)tokenCacheAccessor
                                             error:(NSError **)error
 {
     //store at & rt in cache
-    MSIDAADV2TokenResponse *msidResponse = [MSALTestCacheTokenResponse msalDefaultTokenResponseWithFamilyId:nil];
+    MSIDAADV2TokenResponse *msidResponse = [MSALTestCacheTokenResponse msalDefaultTokenResponseWithFamilyId:nil uid:uid utid:utid];
     MSIDConfiguration *configuration = [MSALTestCacheTokenResponse msalDefaultConfigurationWithAuthority:authorityString];
     
     return [tokenCacheAccessor saveTokensWithConfiguration:configuration
-                                                              response:msidResponse
-                                                               factory:[MSIDAADV2Oauth2Factory new]
-                                                               context:nil
-                                                                 error:error];
+                                                  response:msidResponse
+                                                   factory:[MSIDAADV2Oauth2Factory new]
+                                                   context:nil
+                                                     error:error];
 }
 
 + (MSIDAADV2TokenResponse *)msalDefaultTokenResponseWithFamilyId:(NSString *)familyId
+{
+    return [self msalDefaultTokenResponseWithFamilyId:familyId uid:@"myuid" utid:@"utid"];
+}
+
++ (MSIDAADV2TokenResponse *)msalDefaultTokenResponseWithFamilyId:(NSString *)familyId uid:(NSString *)uid utid:(NSString *)utid
 {
     NSDictionary *idTokenClaims = @{ @"home_oid" : @"myuid", @"preferred_username": @"fakeuser@contoso.com", @"tid": @"utid"};
     NSString *rawIdToken = [NSString stringWithFormat:@"fakeheader.%@.fakesignature",
@@ -62,8 +69,8 @@
                                                      RT:@"fakeRefreshToken"
                                                  scopes:[[NSOrderedSet alloc] initWithArray:@[@"fakescope1 fakescope2"]]
                                                 idToken:rawIdToken
-                                                    uid:@"myuid"
-                                                   utid:@"utid"
+                                                    uid:uid
+                                                   utid:utid
                                                familyId:familyId];
 }
 


### PR DESCRIPTION
## Proposed changes

The main change is to make sure we only compare `MSALAccount` based on home account id regardless of authority. Other logic to fill up the tenant profile is already in place.

Common core changes: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/892

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

