### PR TITLE
Add fix to check nil before assigning error

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -442,8 +442,12 @@
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Querying MSAL account for username %@", MSID_PII_LOG_EMAIL(username));
     if ([NSString msidIsStringNilOrBlank:username])
     {
+        if (error)
+        {
+            *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter, @"No username is provided", nil, nil, nil, nil, nil, YES);
+        }
+     
         MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"username is nil or empty which is unexpected");
-        *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidInternalParameter, @"No username is provided", nil, nil, nil, nil, nil, YES);;
         return nil;
     }
     

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2978,6 +2978,20 @@
     XCTAssertNil(account);
 }
 
+- (void)testFetchAccountWithNilUsernameAndNilErrorPointer_shouldNotCrash
+{
+    [self msalStoreTokenResponseInCache];
+    
+    NSString *clientId = UNIT_TEST_CLIENT_ID;
+    __auto_type application = [[MSALPublicClientApplication alloc] initWithClientId:clientId error:nil];
+    application.tokenCache = self.tokenCacheAccessor;
+    
+    NSString *username = nil;
+    
+    __auto_type account = [application accountForUsername:username error:nil];
+    XCTAssertNil(account);
+}
+
 
 #pragma mark - removeAccount
 


### PR DESCRIPTION
## Proposed changes

As a developer, I should check if the passed-in pointer is nil or not before assign the error, otherwise, it will cause crashes

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

