### PR TITLE
Adding allow warnings flag to ignore any warnings during pod validation

### DIFF
--- a/azure_pipelines/spm-framework.yml
+++ b/azure_pipelines/spm-framework.yml
@@ -304,7 +304,7 @@ jobs:
       targetType: 'inline'
       script: |
         # Release to CocoaPods
-        pod trunk push --use-libraries MSAL.podspec
+        pod trunk push --use-libraries --allow-warnings MSAL.podspec
         #pod trunk me
       workingDirectory: '$(Build.SourcesDirectory)'
     env:


### PR DESCRIPTION
## Proposed changes

Updating command to allow warning during pod push and validation.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

