### PR TITLE
Mask EUII logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD
+* Mask EUII in logs (#1206)
+
 ## [1.1.14] - 2020-01-19
 * Removed identity core classes from public api (#1158).
 * Fixed possible deadlock caused by thread explosion (#1175)

--- a/MSAL/src/MSALAccountEnumerationParameters.m
+++ b/MSAL/src/MSALAccountEnumerationParameters.m
@@ -94,7 +94,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"Account identifier %@, username %@, tenant profile identifier %@, return only signed in accounts %d", self.identifier, self.username, self.tenantProfileIdentifier, self.returnOnlySignedInAccounts];
+    return [NSString stringWithFormat:@"Account identifier %@, username %@, tenant profile identifier %@, return only signed in accounts %d", self.identifier, MSID_PII_LOG_EMAIL(self.username), self.tenantProfileIdentifier, self.returnOnlySignedInAccounts];
 }
 
 @end

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -421,7 +421,7 @@
 - (NSArray<MSALAccount *> *)accountsForParameters:(MSALAccountEnumerationParameters *)parameters
                                             error:(NSError **)error
 {
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Querying MSAL accounts with parameters (identifier=%@, tenantProfileId=%@, username=%@, return only signed in accounts %d)", MSID_PII_LOG_MASKABLE(parameters.identifier), MSID_PII_LOG_MASKABLE(parameters.tenantProfileIdentifier), MSID_PII_LOG_EMAIL(parameters.username), parameters.returnOnlySignedInAccounts);
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Querying MSAL accounts with parameters (identifier=%@, tenantProfileId=%@, username=%@, return only signed in accounts %d)", MSID_PII_LOG_TRACKABLE(parameters.identifier), MSID_PII_LOG_MASKABLE(parameters.tenantProfileIdentifier), MSID_PII_LOG_EMAIL(parameters.username), parameters.returnOnlySignedInAccounts);
     
     MSALAccountsProvider *request = [[MSALAccountsProvider alloc] initWithTokenCache:self.tokenCache
                                                                 accountMetadataCache:self.accountMetadataCache
@@ -1206,7 +1206,7 @@
                           "                                            claimsRequest:%@]",
                           parameters.scopes,
                           parameters.extraScopesToConsent,
-                          MSID_PII_LOG_MASKABLE(parameters.account.homeAccountId),
+                          MSID_PII_LOG_TRACKABLE(parameters.account.homeAccountId),
                           MSID_PII_LOG_EMAIL(parameters.loginHint),
                           MSALStringForPromptType(parameters.promptType),
                           parameters.extraQueryParameters,

--- a/MSAL/src/configuration/MSALLoggerConfig.m
+++ b/MSAL/src/configuration/MSALLoggerConfig.m
@@ -79,22 +79,28 @@
 
 - (void)setPiiEnabled:(BOOL)piiEnabled
 {
-    [MSIDLogger sharedLogger].piiLoggingEnabled = piiEnabled;
+    [MSIDLogger sharedLogger].logMaskingLevel = piiEnabled ? MSIDLogMaskingSettingsMaskSecretsOnly : MSIDLogMaskingSettingsMaskAllPII;
 }
 
 - (BOOL)piiEnabled
 {
-    return [MSIDLogger sharedLogger].piiLoggingEnabled;
+    switch ([MSIDLogger sharedLogger].logMaskingLevel) {
+        case MSIDLogMaskingSettingsMaskAllPII:
+            return NO;
+            
+        default:
+            return YES;
+    }
 }
 
-- (void)setMaskEUII:(BOOL)maskEUII
+- (MSALLogMaskingLevel)logMaskingLevel
 {
-    [MSIDLogger sharedLogger].euiiMaskingEnabled = maskEUII;
+    return (MSALLogMaskingLevel)[MSIDLogger sharedLogger].logMaskingLevel;
 }
 
-- (BOOL)maskEUII
+- (void)setLogMaskingLevel:(MSALLogMaskingLevel)logMaskingLevel
 {
-    return [MSIDLogger sharedLogger].euiiMaskingEnabled;
+    [MSIDLogger sharedLogger].logMaskingLevel = (MSIDLogMaskingLevel)logMaskingLevel;
 }
 
 @end

--- a/MSAL/src/configuration/MSALLoggerConfig.m
+++ b/MSAL/src/configuration/MSALLoggerConfig.m
@@ -87,4 +87,14 @@
     return [MSIDLogger sharedLogger].piiLoggingEnabled;
 }
 
+- (void)setMaskEUII:(BOOL)maskEUII
+{
+    [MSIDLogger sharedLogger].euiiMaskingEnabled = maskEUII;
+}
+
+- (BOOL)maskEUII
+{
+    return [MSIDLogger sharedLogger].euiiMaskingEnabled;
+}
+
 @end

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedADALAccount.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedADALAccount.m
@@ -132,7 +132,7 @@ static NSString *kADALAccountType = @"ADAL";
         _username = [jsonDictionary msidStringObjectForKey:@"username"];
         _accountClaims = claims;
         
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Created external ADAL account with identifier %@, object Id %@, tenant Id %@, name %@, username %@, claims %@", MSID_PII_LOG_TRACKABLE(_identifier), MSID_PII_LOG_MASKABLE(_objectId), _tenantId, MSID_PII_LOG_MASKABLE(displayName), MSID_PII_LOG_EMAIL(_username), MSID_PII_LOG_MASKABLE(_accountClaims));
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Created external ADAL account with identifier %@, object Id %@, tenant Id %@, name %@, username %@, claims %@", MSID_PII_LOG_TRACKABLE(_identifier), MSID_PII_LOG_TRACKABLE(_objectId), _tenantId, MSID_EUII_ONLY_LOG_MASKABLE(displayName), MSID_PII_LOG_EMAIL(_username), MSID_EUII_ONLY_LOG_MASKABLE(_accountClaims));
     }
     
     return self;

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccount.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccount.m
@@ -64,7 +64,7 @@ static NSDateFormatter *s_updateDateFormatter = nil;
         }
         
         _signinStatusDictionary = [jsonDictionary msidObjectForKey:@"signInStatus" ofClass:[NSDictionary class]];
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Created sign in status dictionary %@", MSID_PII_LOG_MASKABLE(_signinStatusDictionary));
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Created sign in status dictionary %@", MSID_EUII_ONLY_LOG_MASKABLE(_signinStatusDictionary));
     }
     
     return self;

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
@@ -182,7 +182,7 @@
 
 - (BOOL)updateAccount:(id<MSALAccount>)account idTokenClaims:(NSDictionary *)idTokenClaims error:(__unused NSError **)error
 {
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Updating account %@", MSID_PII_LOG_MASKABLE(account));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Updating account %@", MSID_EUII_ONLY_LOG_MASKABLE(account));
     
     [self updateAccountAsync:account
                idTokenClaims:idTokenClaims
@@ -248,7 +248,7 @@
        tenantProfiles:(nullable NSArray<MSALTenantProfile *> *)tenantProfiles
                 error:(NSError * _Nullable * _Nullable)error
 {
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Removing account %@", MSID_PII_LOG_MASKABLE(account));
+    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Removing account %@", MSID_EUII_ONLY_LOG_MASKABLE(account));
     
     __block BOOL result = YES;
     __block NSError *removeError;
@@ -416,7 +416,7 @@
             return NO;
         }
         
-        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Updating accounts %@", MSID_PII_LOG_MASKABLE(accounts));
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Updating accounts %@", MSID_EUII_ONLY_LOG_MASKABLE(accounts));
         
         NSError *saveError = nil;
         BOOL saveResult = [self saveUpdatedAccount:account
@@ -450,7 +450,7 @@
     NSString *versionIdentifier = [self accountVersionIdentifier:version];
     NSMutableDictionary *resultDictionary = jsonObject ? [[jsonObject jsonDictionary] mutableCopy] : [NSMutableDictionary new];
     
-    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Updating accounts %@", MSID_PII_LOG_MASKABLE(accounts));
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Updating accounts %@", MSID_EUII_ONLY_LOG_MASKABLE(accounts));
     
     for (MSALLegacySharedAccount *sharedAccount in accounts)
     {

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedMSAAccount.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedMSAAccount.m
@@ -87,7 +87,7 @@ static NSString *kDefaultCacheAuthority = @"https://login.windows.net/common";
         _accountClaims = @{@"tid": MSID_DEFAULT_MSA_TENANTID,
                            @"oid": uid};
         
-        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Created external MSA account with identifier %@, object Id %@, tenant Id %@, username %@, claims %@", MSID_PII_LOG_TRACKABLE(_identifier), MSID_PII_LOG_MASKABLE(cid), MSID_DEFAULT_MSA_TENANTID, MSID_PII_LOG_EMAIL(_username), MSID_PII_LOG_MASKABLE(_accountClaims));
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Created external MSA account with identifier %@, object Id %@, tenant Id %@, username %@, claims %@", MSID_PII_LOG_TRACKABLE(_identifier), MSID_PII_LOG_TRACKABLE(cid), MSID_DEFAULT_MSA_TENANTID, MSID_PII_LOG_EMAIL(_username), MSID_EUII_ONLY_LOG_MASKABLE(_accountClaims));
     }
     
     return self;

--- a/MSAL/src/public/configuration/global/MSALLoggerConfig.h
+++ b/MSAL/src/public/configuration/global/MSALLoggerConfig.h
@@ -28,6 +28,20 @@
 #import <Foundation/Foundation.h>
 #import "MSALDefinitions.h"
 
+/*! Levels of log masking */
+typedef NS_ENUM(NSInteger, MSALLogMaskingLevel)
+{
+    /** MSAL will not return any messages with any user or organizational information. This includes EUII and EUPI. This is the default level. */
+    MSALLogMaskingSettingsMaskAllPII,
+    
+    /** MSAL logs will still include OII (organization identifiable information), and EUPI (end user pseudonymous identifiers), but MSAL will try to exclude and/or mask any EUII (end user identifiable information) like UPN, username, email from its logs. */
+    
+    MSALLogMaskingSettingsMaskEUIIOnly, //
+    
+    /** MSAL logs will still include OII (organization identifiable information),  EUPI (end user pseudonymous identifiers), and EUII (end user identifiable information) like UPN, username, email from its logs. MSAL will still hide all secrets like tokens from its logs */
+    MSALLogMaskingSettingsMaskSecretsOnly
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -45,15 +59,16 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  MSAL provides logging callbacks that assist in diagnostics. There is a boolean value in the logging callback that indicates whether the message contains user information. If piiEnabled is set to NO, the callback will not be triggered for log messages that contain any user information. By default the library will not return any messages with user information in them.
  */
-@property (atomic) BOOL piiEnabled;
+@property (atomic) BOOL piiEnabled DEPRECATED_MSG_ATTRIBUTE("Use logMaskingLevel instead");
 
 /**
  MSAL provides logging callbacks that assist in diagnostics. By default the library will not return any messages with any user or organizational information. However, this might make diagnosing issues difficult.
+ logMaskingLevel property can be used to adjust level of MSAL masking.
  When both piiEnabled is set to YES, and maskEUII is set to YES, MSAL logs will still include OII (organization identifiable information), and EUPI (end user pseudonymous identifiers), but MSAL will try to exclude and/or mask any EUII (end user identifiable information) like UPN, username, email from its logs.
  This flag has no effect when piiEnabled is set to NO.
  Default value is NO.
 */
-@property (atomic) BOOL maskEUII;
+@property (atomic) MSALLogMaskingLevel logMaskingLevel;
 
 #pragma mark - Setting up the logging callback
 

--- a/MSAL/src/public/configuration/global/MSALLoggerConfig.h
+++ b/MSAL/src/public/configuration/global/MSALLoggerConfig.h
@@ -59,14 +59,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  MSAL provides logging callbacks that assist in diagnostics. There is a boolean value in the logging callback that indicates whether the message contains user information. If piiEnabled is set to NO, the callback will not be triggered for log messages that contain any user information. By default the library will not return any messages with user information in them.
  */
-@property (atomic) BOOL piiEnabled DEPRECATED_MSG_ATTRIBUTE("Use logMaskingLevel instead");
+@property (nonatomic) BOOL piiEnabled DEPRECATED_MSG_ATTRIBUTE("Use logMaskingLevel instead");
 
 /**
  MSAL provides logging callbacks that assist in diagnostics. By default the library will not return any messages with any user or organizational information. However, this might make diagnosing issues difficult.
  logMaskingLevel property can be used to adjust level of MSAL masking.
  Default value is MSALLogMaskingSettingsMaskAllPII.
 */
-@property (atomic) MSALLogMaskingLevel logMaskingLevel;
+@property (nonatomic) MSALLogMaskingLevel logMaskingLevel;
 
 #pragma mark - Setting up the logging callback
 

--- a/MSAL/src/public/configuration/global/MSALLoggerConfig.h
+++ b/MSAL/src/public/configuration/global/MSALLoggerConfig.h
@@ -47,6 +47,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (atomic) BOOL piiEnabled;
 
+/**
+ MSAL provides logging callbacks that assist in diagnostics. By default the library will not return any messages with any user or organizational information. However, this might make diagnosing issues difficult.
+ When both piiEnabled is set to YES, and maskEUII is set to YES, MSAL logs will still include OII (organization identifiable information), and EUPI (end user pseudonymous identifiers), but MSAL will try to exclude and/or mask any EUII (end user identifiable information) like UPN, username, email from its logs.
+ This flag has no effect when piiEnabled is set to NO.
+ Default value is NO.
+*/
+@property (atomic) BOOL maskEUII;
+
 #pragma mark - Setting up the logging callback
 
 /**

--- a/MSAL/src/public/configuration/global/MSALLoggerConfig.h
+++ b/MSAL/src/public/configuration/global/MSALLoggerConfig.h
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSInteger, MSALLogMaskingLevel)
     
     /** MSAL logs will still include OII (organization identifiable information), and EUPI (end user pseudonymous identifiers), but MSAL will try to exclude and/or mask any EUII (end user identifiable information) like UPN, username, email from its logs. */
     
-    MSALLogMaskingSettingsMaskEUIIOnly, //
+    MSALLogMaskingSettingsMaskEUIIOnly,
     
     /** MSAL logs will still include OII (organization identifiable information),  EUPI (end user pseudonymous identifiers), and EUII (end user identifiable information) like UPN, username, email from its logs. MSAL will still hide all secrets like tokens from its logs */
     MSALLogMaskingSettingsMaskSecretsOnly
@@ -64,9 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  MSAL provides logging callbacks that assist in diagnostics. By default the library will not return any messages with any user or organizational information. However, this might make diagnosing issues difficult.
  logMaskingLevel property can be used to adjust level of MSAL masking.
- When both piiEnabled is set to YES, and maskEUII is set to YES, MSAL logs will still include OII (organization identifiable information), and EUPI (end user pseudonymous identifiers), but MSAL will try to exclude and/or mask any EUII (end user identifiable information) like UPN, username, email from its logs.
- This flag has no effect when piiEnabled is set to NO.
- Default value is NO.
+ Default value is MSALLogMaskingSettingsMaskAllPII.
 */
 @property (atomic) MSALLogMaskingLevel logMaskingLevel;
 

--- a/MSAL/test/app/ios/MSALTestAppLogViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppLogViewController.m
@@ -60,7 +60,7 @@ static NSAttributedString* s_attrNewLine = nil;
     
     [self setEdgesForExtendedLayout:UIRectEdgeNone];
     
-    MSALGlobalConfig.loggerConfig.piiEnabled = YES;
+    MSALGlobalConfig.loggerConfig.logMaskingLevel = MSALLogMaskingSettingsMaskEUIIOnly;
     [MSALGlobalConfig.loggerConfig setLogCallback:^(MSALLogLevel level, NSString * _Nullable message, __unused BOOL containsPII)
     {
         (void)level;


### PR DESCRIPTION
## Proposed changes

MSAL and broker provide logging callbacks that assist in diagnostics. By default the library will not return any messages with any user or organizational information. However, this might make diagnosing issues difficult.

The most sensitive information is EUII (things like upn, name, email etc). 
This PR introduces a new logger flag and macro that allows masking only EUII, while keeping EUPI and OII intact. 

When both piiEnabled is set to YES, and maskEUII is set to YES, MSAL logs will still include OII (organization identifiable information), and EUPI (end user pseudonymous identifiers), but MSAL will try to exclude and/or mask any EUII (end user identifiable information) like UPN, username, email from its logs.

This flag has no effect when piiEnabled is set to NO.
Default value is NO.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information