### PR TITLE
Remove check if access_token is not returned for id_token only scenarios

### DIFF
--- a/MSAL/src/MSALResult.m
+++ b/MSAL/src/MSALResult.m
@@ -135,10 +135,6 @@
     }
     
     NSString *accessToken = [authScheme getClientAccessToken:tokenResult.accessToken popManager:popManager error:error];
-    if (!accessToken)
-    {
-        return nil;
-    }
     
     return [self resultWithAccessToken:accessToken
                              expiresOn:tokenResult.accessToken.expiresOn

--- a/MSAL/src/public/MSALResult.h
+++ b/MSAL/src/public/MSALResult.h
@@ -40,13 +40,13 @@
 #pragma mark - Token response
 
 /** The Access Token requested. */
-@property (readonly, nonnull) NSString *accessToken;
+@property (readonly, nullable) NSString *accessToken;
 
 /**
     The time that the access token returned in the Token property ceases to be valid.
     This value is calculated based on current UTC time measured locally and the value expiresIn returned from the service
  */
-@property (readonly, nonnull) NSDate *expiresOn;
+@property (readonly, nullable) NSDate *expiresOn;
 
 /**
     Some access tokens have extended lifetime when server is in an unavailable state.
@@ -67,7 +67,7 @@
 /**
     The scope values returned from the service.
  */
-@property (readonly, nonnull) NSArray<NSString *> *scopes;
+@property (readonly, nullable) NSArray<NSString *> *scopes;
 
 #pragma mark - Account information
 


### PR DESCRIPTION
## Proposed changes

Remove the check that treated all cases without access_token as errors, and support scenarios with only id_token (mainly Azure AD B2C).
#852

It relies on the following pull request.
https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/952

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

