### PR TITLE
Veena/refresh in telemetry

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -861,9 +861,10 @@
     msidParams.instanceAware = self.internalConfig.multipleCloudsSupported;
     msidParams.keychainAccessGroup = self.internalConfig.cacheConfig.keychainSharingGroup;
     msidParams.currentRequestTelemetry = [MSIDCurrentRequestTelemetry new];
-    msidParams.currentRequestTelemetry.schemaVersion = 2;
+    msidParams.currentRequestTelemetry.schemaVersion = 4;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
-    msidParams.currentRequestTelemetry.forceRefresh = parameters.forceRefresh; 
+    msidParams.currentRequestTelemetry.tokenCacheRefresh = parameters.forceRefresh ? ForceRefresh : NoCacheLookupInvolved;
+     
     
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, msidParams,
                  @"-[MSALPublicClientApplication acquireTokenSilentForScopes:%@\n"
@@ -1182,7 +1183,7 @@
     msidParams.currentRequestTelemetry = [MSIDCurrentRequestTelemetry new];
     msidParams.currentRequestTelemetry.schemaVersion = 2;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
-    msidParams.currentRequestTelemetry.forceRefresh = NO;
+    msidParams.currentRequestTelemetry.tokenCacheRefresh = NoCacheLookupInvolved;
     
     MSIDAccountMetadataState signInState = [self accountStateForParameters:msidParams error:nil];
     

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -863,7 +863,7 @@
     msidParams.currentRequestTelemetry = [MSIDCurrentRequestTelemetry new];
     msidParams.currentRequestTelemetry.schemaVersion = 4;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
-    msidParams.currentRequestTelemetry.tokenCacheRefresh = parameters.forceRefresh ? TokenCacheRefreshTypeForceRefresh : TokenCacheRefreshTypeNoCacheLookupInvolved;
+    msidParams.currentRequestTelemetry.tokenCacheRefreshType = parameters.forceRefresh ? TokenCacheRefreshTypeForceRefresh : TokenCacheRefreshTypeNoCacheLookupInvolved;
      
     
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, msidParams,
@@ -1183,7 +1183,7 @@
     msidParams.currentRequestTelemetry = [MSIDCurrentRequestTelemetry new];
     msidParams.currentRequestTelemetry.schemaVersion = 2;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
-    msidParams.currentRequestTelemetry.tokenCacheRefresh = TokenCacheRefreshTypeNoCacheLookupInvolved;
+    msidParams.currentRequestTelemetry.tokenCacheRefreshType = TokenCacheRefreshTypeNoCacheLookupInvolved;
     
     MSIDAccountMetadataState signInState = [self accountStateForParameters:msidParams error:nil];
     

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -863,7 +863,7 @@
     msidParams.currentRequestTelemetry = [MSIDCurrentRequestTelemetry new];
     msidParams.currentRequestTelemetry.schemaVersion = 4;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
-    msidParams.currentRequestTelemetry.tokenCacheRefresh = parameters.forceRefresh ? ForceRefresh : NoCacheLookupInvolved;
+    msidParams.currentRequestTelemetry.tokenCacheRefresh = parameters.forceRefresh ? TokenCacheRefreshTypeForceRefresh : TokenCacheRefreshTypeNoCacheLookupInvolved;
      
     
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, msidParams,
@@ -1183,7 +1183,7 @@
     msidParams.currentRequestTelemetry = [MSIDCurrentRequestTelemetry new];
     msidParams.currentRequestTelemetry.schemaVersion = 2;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
-    msidParams.currentRequestTelemetry.tokenCacheRefresh = NoCacheLookupInvolved;
+    msidParams.currentRequestTelemetry.tokenCacheRefresh = TokenCacheRefreshTypeNoCacheLookupInvolved;
     
     MSIDAccountMetadataState signInState = [self accountStateForParameters:msidParams error:nil];
     

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -108,6 +108,7 @@
 #import "MSIDCacheConfig.h"
 #import "MSIDDevicePopManager.h"
 #import "MSIDAssymetricKeyLookupAttributes.h"
+#import "MSIDRequestTelemetryConstants.h"
 
 @interface MSALPublicClientApplication()
 {
@@ -861,7 +862,7 @@
     msidParams.instanceAware = self.internalConfig.multipleCloudsSupported;
     msidParams.keychainAccessGroup = self.internalConfig.cacheConfig.keychainSharingGroup;
     msidParams.currentRequestTelemetry = [MSIDCurrentRequestTelemetry new];
-    msidParams.currentRequestTelemetry.schemaVersion = 4;
+    msidParams.currentRequestTelemetry.schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
     msidParams.currentRequestTelemetry.tokenCacheRefreshType = parameters.forceRefresh ? TokenCacheRefreshTypeForceRefresh : TokenCacheRefreshTypeNoCacheLookupInvolved;
      
@@ -1181,7 +1182,7 @@
     msidParams.providedAuthority = requestAuthority;
     msidParams.shouldValidateResultAccount = NO;
     msidParams.currentRequestTelemetry = [MSIDCurrentRequestTelemetry new];
-    msidParams.currentRequestTelemetry.schemaVersion = 4;
+    msidParams.currentRequestTelemetry.schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
     msidParams.currentRequestTelemetry.tokenCacheRefreshType = TokenCacheRefreshTypeNoCacheLookupInvolved;
     

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1181,7 +1181,7 @@
     msidParams.providedAuthority = requestAuthority;
     msidParams.shouldValidateResultAccount = NO;
     msidParams.currentRequestTelemetry = [MSIDCurrentRequestTelemetry new];
-    msidParams.currentRequestTelemetry.schemaVersion = 2;
+    msidParams.currentRequestTelemetry.schemaVersion = 4;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
     msidParams.currentRequestTelemetry.tokenCacheRefreshType = TokenCacheRefreshTypeNoCacheLookupInvolved;
     


### PR DESCRIPTION
## Proposed changes
Update server telemetry (Current Request Telemetry) to follow schema version 4. Replace existing field for force refresh with below values
->InteractiveNoCacheLookupInvolved = 0, request goes to ESTS for interactive call for which there is no cache look-up involved (N/A for S2S).
-> ForcedTokenRefresh = 1, request goes to ESTS because caller requested to forcefully refresh the cache.
-> CacheMiss = 2, request goes to ESTS because cache entry for the requested token does NOT exist.
-> CachedTokenExpired = 3, request goes to ESTS because cache entry for the requested token does exist but token has expired.
-> ProactiveTokenRefresh = 4, request goes to ESTS because refresh_in was used and existing non-expired token needs to be refreshed proactively.
-> CachingMechanismNotImplemented = 5, request goes to ESTS because client (for Non-MSAL client specifically for now) has not implemented any caching mechanism.
• BLANK, if client is not aware of the LLT policy and its telemetry update and doesn’t update their code to send us this telemetry signal yet.


Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

