### PR TITLE
Updated Readme to use auto Bundle Id replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can also use Git Submodule or check out the latest release and use as framew
 1. Register your app in the [Azure portal](https://aka.ms/MobileAppReg)
 2. Make sure you register a redirect URI for your application. It should be in the following format: 
 
- `msauth.[BUNDLE_ID]://auth`
+ `msauth.$(PRODUCT_BUNDLE_IDENTIFIER)://auth`
 
 3. Add a new keychain group to your project Capabilities. Keychain group should be  `com.microsoft.adalcache` on iOS and `com.microsoft.identity.universalstorage` on macOS. 
 
@@ -136,7 +136,7 @@ See more information about [keychain groups](https://docs.microsoft.com/en-us/az
 
 #### iOS only steps:
 
-1. Add your application's redirect URI scheme to your `Info.plist` file, it will be in the format of `msauth.[BUNDLE_ID]`
+1. Add your application's redirect URI scheme to your `Info.plist` file
 
 ```xml
 <key>CFBundleURLTypes</key>
@@ -144,7 +144,7 @@ See more information about [keychain groups](https://docs.microsoft.com/en-us/az
     <dict>
         <key>CFBundleURLSchemes</key>
         <array>
-            <string>msauth.[BUNDLE_ID]</string>
+            <string>msauth.$(PRODUCT_BUNDLE_IDENTIFIER)</string>
         </array>
     </dict>
 </array>


### PR DESCRIPTION
This makes this more consistent with intune integration where $(PRODUCT_BUNDLE_IDENTIFIER) is used
 and simpler on the user as Bundle Id is auto replaced. This is also helpful for apps that get resigned with a new Bundle ID

## Proposed changes

Dhanged [BUINDEL_ID] to $(PRODUCT_BUNDLE_IDENTIFIER) so it automatically gets replaced

## Type of change

Documentation

## Risk

No issues are expected.
Documentation changes where tested on our intune app the app continue to function as expected

