### PR TITLE
Publish public docs to repository pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## TBD
-* Updating release pipeline to publish public docs(#1359)
+* Updating release pipeline to publish public docs (#1359)
 
 ## [1.1.20] - 2021-07-19
 * Migrated PR validation pipeline from Travis to Azure DevOps.(#1333)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD
+* Updating release pipeline to publish public docs(#1359)
+
 ## [1.1.20] - 2021-07-19
 * Migrated PR validation pipeline from Travis to Azure DevOps.(#1333)
 

--- a/azure_pipelines/spm-framework.yml
+++ b/azure_pipelines/spm-framework.yml
@@ -339,28 +339,34 @@ jobs:
         if [ ! -d "docs.temp" ]; then
             echo "Docs were not generated in previous step!"
         else
+            authorName=$(git log -1 --pretty=format:'%an')
+            authorEmail=$(git log -1 --pretty=format:'%ae')
+            git config --global user.email "${authorEmail}"
+            git config --global user.name "${authorName}"
+
             author=$(git log -1 --pretty=format:'%an <%ae>')
             # Create a temp branch to cherry pick doc changes
-            git checkout -b update-docs-for-release-$(releaseVersion) -q
-            git add docs.temp/docs/* -q
-            git commit -m 'adding docs for release' -q --author="${author}"
+            git checkout -b 'update-docs-for-release-$(releaseVersion)'
+            git add docs.temp/docs/*
+            git commit -m 'adding docs for release' --author="${author}" --status
             
             # Cleanup
             rm -rf docs.temp
-            git checkout $(docsRepositoryBranch) -q
+            git fetch origin $(docsRepositoryBranch)
+            git checkout FETCH_HEAD
+            git checkout $(docsRepositoryBranch)
             git clean -fd
             
             # Get previously commited changes for docs
-            git cherry-pick update-docs-for-release-$(releaseVersion) -q
+            git cherry-pick "update-docs-for-release-$(releaseVersion)"
             
             # Copy files in docs.temp folder to root
             \cp -r docs.temp/docs/* .
-
+        
             # Push changes to docsRepositoryBranch branch
-            git commit -m 'Update docs for release $(releaseVersion)' -q
-            git push origin $(docsRepositoryBranch) -q
-
-            git branch -d update-docs-for-$(releaseVersion) -q
+            git add -A
+            git commit -m 'Update docs for release $(releaseVersion)' --status  --author="${author}"
+            git push origin $(docsRepositoryBranch)
         fi
       workingDirectory: '$(Build.SourcesDirectory)'
       failOnStderr: false

--- a/azure_pipelines/spm-framework.yml
+++ b/azure_pipelines/spm-framework.yml
@@ -11,6 +11,8 @@ variables:
     value: 'master'
   - name: 'GithubServiceConnection' # Service connection name used to connect Github repository
     value: 'MSAL ObjC Service Connection'
+  - name: 'docsRepositoryBranch' # Name of the branch where public reference docs will be pushed for github page
+    value: 'gh-pages'
 
 trigger:
   branches:
@@ -329,6 +331,41 @@ jobs:
     displayName: Build MSAL docs via Jazzy
     inputs:
       filePath: 'build_docs.sh'
+  - task: Bash@3
+    displayName: Push docs to github page for repository 
+    inputs:
+      targetType: 'inline'
+      script: |
+        if [ ! -d "docs.temp" ]; then
+            echo "Docs were not generated in previous step!"
+        else
+            author=$(git log -1 --pretty=format:'%an <%ae>')
+            # Create a temp branch to cherry pick doc changes
+            git checkout -b update-docs-for-release-$(releaseVersion) -q
+            git add docs.temp/docs/* -q
+            git commit -m 'adding docs for release' -q --author="${author}"
+            
+            # Cleanup
+            rm -rf docs.temp
+            git checkout $(docsRepositoryBranch) -q
+            git clean -fd
+            
+            # Get previously commited changes for docs
+            git cherry-pick update-docs-for-release-$(releaseVersion) -q
+            
+            # Copy files in docs.temp folder to root
+            \cp -r docs.temp/docs/* .
+
+            # Push changes to docsRepositoryBranch branch
+            git commit -m 'Update docs for release $(releaseVersion)' -q
+            git push origin $(docsRepositoryBranch) -q
+
+            git branch -d update-docs-for-$(releaseVersion) -q
+        fi
+      workingDirectory: '$(Build.SourcesDirectory)'
+      failOnStderr: false
+      noProfile: false
+      noRc: false
   - task: Bash@3
     displayName: Push pod to Cocoapods
     inputs:


### PR DESCRIPTION
## Proposed changes

MSAL public docs reference : https://azuread.github.io/microsoft-authentication-library-for-objc/index.html is stored in branch 'gh-pages'.
The documentation files are generated by running build_docs.sh, which uses MSAL public classes and comments. The script generates files in a folder docs.temp.
This PR aims to push these doc files after running build_docs.sh to gh-pages branch so that post release documentation is automatically updated.

Since gh-pages and master branch don't have any common ancestor/origin, the logic in PR is to : 
- Generate docs by running script on master branch.
- Commit docs.temp to a temporary branch
- Switch to gh-pages and cherry-pick changes from temporary branch.


## Type of change

- [ ] Feature work
- [ ] Bug fix
- [x] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

