### PR TITLE
Add extra query parameters for the silent token acquisition

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -854,7 +854,9 @@
     msidParams.validateAuthority = shouldValidate;
     msidParams.extendedLifetimeEnabled = self.internalConfig.extendedLifetimeEnabled;
     msidParams.clientCapabilities = self.internalConfig.clientApplicationCapabilities;
-    msidParams.extraURLQueryParameters = self.internalConfig.extraQueryParameters.extraURLQueryParameters;
+    NSMutableDictionary *extraURLQueryParameters = [self.internalConfig.extraQueryParameters.extraURLQueryParameters mutableCopy];
+    [extraURLQueryParameters addEntriesFromDictionary:parameters.extraQueryParameters];
+    msidParams.extraURLQueryParameters = extraURLQueryParameters;
     msidParams.extraTokenRequestParameters = self.internalConfig.extraQueryParameters.extraTokenURLParameters;
     msidParams.tokenExpirationBuffer = self.internalConfig.tokenExpirationBuffer;
     msidParams.claimsRequest = parameters.claimsRequest.msidClaimsRequest;

--- a/MSAL/src/public/MSALSilentTokenParameters.h
+++ b/MSAL/src/public/MSALSilentTokenParameters.h
@@ -64,6 +64,13 @@ Initialize a MSALSilentTokenParameters with scopes and account.
 */
 - (instancetype)initWithScopes:(NSArray<NSString *> *)scopes NS_UNAVAILABLE;
 
+/**
+ Key-value pairs to pass to the authentication server during
+ the silent authentication flow. This should not be url-encoded value.
+ */
+@property (nonatomic, nullable) NSDictionary <NSString *, NSString *> *extraQueryParameters;
+
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Proposed changes

Add the possibility of including extra query parameters in a silent token request.
The extra query parameters can be used by custom APIs to retrieve specific information (like an ID) and return more information inside the token.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

