### PR TITLE
Re-arranging tasks so that final step is publishing MSAL public docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [TBD]
 * Added more logging within common core throttling logic
+* Updated release pipeline to publish public docs as last step (#1366)
 
 ## [1.1.21] - 2021-08-20
 * Update release pipeline to publish public docs (#1359)

--- a/azure_pipelines/spm-framework.yml
+++ b/azure_pipelines/spm-framework.yml
@@ -328,6 +328,17 @@ jobs:
       changeLogCompareToRelease: 'lastFullRelease'
       changeLogType: 'issueBased'
   - task: Bash@3
+    displayName: Push pod to Cocoapods
+    inputs:
+      targetType: 'inline'
+      script: |
+        # Release to CocoaPods
+        pod trunk push --use-libraries --allow-warnings MSAL.podspec
+        #pod trunk me
+      workingDirectory: '$(Build.SourcesDirectory)'
+    env:
+      COCOAPODS_TRUNK_TOKEN: $(COCOAPODS_TRUNK_TOKEN)
+  - task: Bash@3
     displayName: Build MSAL docs via Jazzy
     inputs:
       filePath: 'build_docs.sh'
@@ -336,6 +347,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
+        # NOTE : This should be the last step since it changes branch from master to $(docsRepositoryBranch)
         if [ ! -d "docs.temp" ]; then
             echo "Docs were not generated in previous step!"
         else
@@ -372,14 +384,3 @@ jobs:
       failOnStderr: false
       noProfile: false
       noRc: false
-  - task: Bash@3
-    displayName: Push pod to Cocoapods
-    inputs:
-      targetType: 'inline'
-      script: |
-        # Release to CocoaPods
-        pod trunk push --use-libraries --allow-warnings MSAL.podspec
-        #pod trunk me
-      workingDirectory: '$(Build.SourcesDirectory)'
-    env:
-      COCOAPODS_TRUNK_TOKEN: $(COCOAPODS_TRUNK_TOKEN)


### PR DESCRIPTION
## Proposed changes

Currently, in release pipeline, the task to publish MSAL public docs is placed before the task to push MSAL pod to cocoapods.
Since the task to publish MSAL public docs switches branch from master to gh-pages, the task to push MSAL pods to cocoapods fails as gh-pages does not have MSAL.podspec.

This PR aims to re-arrange the tasks so that pipeline does not fail.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [x] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

