### PR TITLE
fix throttling error handling of MSIDLRUCache + add more loggings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [TBD]
+* Added more logging within common core throttling logic
+
 ## [1.1.21] - 2021-08-20
 * Update release pipeline to publish public docs (#1359)
 

--- a/build.py
+++ b/build.py
@@ -97,18 +97,18 @@ target_specifiers = [
 ]
 
 def print_operation_start(name, operation) :
-	print ColorValues.HDR + "Beginning " + name + " [" + operation + "]" + ColorValues.END
-	print "##[group]" + (name + "_" + operation).replace(" ", "_")
+	print (ColorValues.HDR + "Beginning " + name + " [" + operation + "]" + ColorValues.END)
+	print ("##[group]" + (name + "_" + operation).replace(" ", "_"))
 
 def print_operation_end(name, operation, exit_code, start_time) :
-	print "##[endgroup]" + (name + "_" + operation).replace(" ", "_")
+	print ("##[endgroup]" + (name + "_" + operation).replace(" ", "_"))
 	
 	end_time = timer()
 
 	if (exit_code == 0) :
-		print ColorValues.OK + name + " [" + operation + "] Succeeded" + ColorValues.END + " (" + "{0:.2f}".format(end_time - start_time) + " seconds)"
+		print (ColorValues.OK + name + " [" + operation + "] Succeeded" + ColorValues.END + " (" + "{0:.2f}".format(end_time - start_time) + " seconds)")
 	else :
-		print ColorValues.FAIL + name + " [" + operation + "] Failed" + ColorValues.END + " (" + "{0:.2f}".format(end_time - start_time) + " seconds)"
+		print (ColorValues.FAIL + name + " [" + operation + "] Failed" + ColorValues.END + " (" + "{0:.2f}".format(end_time - start_time) + " seconds)")
 
 class BuildTarget:
 	def __init__(self, target):
@@ -180,20 +180,20 @@ class BuildTarget:
 		if (self.build_settings != None) :
 			return self.build_settings
 		
-		print "Retrieving Build Settings for " + self.name
+		print ("Retrieving Build Settings for " + self.name)
 		if (show_build_settings) :
-			print "##[group]" + (self.name + "_settings").replace(" ", "_")
+			print ("##[group]" + (self.name + "_settings").replace(" ", "_"))
 				
 		command = self.xcodebuild_command(None, False)
 		command += " -showBuildSettings"
-		print command
+		print (command)
 		
 		start = timer()
         
 		settings_blob = subprocess.check_output(command, shell=True)
 		if (show_build_settings) :
-			print settings_blob
-			print "##[endgroup]" + (self.name + "_settings").replace(" ", "_")
+			print (settings_blob)
+			print ("##[endgroup]" + (self.name + "_settings").replace(" ", "_"))
 		
 		settings_blob = settings_blob.decode("utf-8")
 		settings_blob = settings_blob.split("\n")
@@ -213,7 +213,7 @@ class BuildTarget:
 		
 		end = timer()
 		
-		print "Retrieved Build Settings (" + "{0:.2f}".format(end - start) + " sec)"
+		print ("Retrieved Build Settings (" + "{0:.2f}".format(end - start) + " sec)")
 		
 		return settings
 		
@@ -270,18 +270,18 @@ class BuildTarget:
 		
 		profile_data_path = derived_dir + "/ProfileData/" + device_guid + "/Coverage.profdata"
 		if not os.path.isfile(profile_data_path) :
-			print ColorValues.FAIL + "Coverage data file missing! : " + profile_data_path + ColorValues.END
+			print (ColorValues.FAIL + "Coverage data file missing! : " + profile_data_path + ColorValues.END)
 			return -1
 		
 		configuration_build_dir = build_settings["CONFIGURATION_BUILD_DIR"]
 		executable_path = build_settings["EXECUTABLE_PATH"]
 		executable_file_path = configuration_build_dir + "/" + executable_path
 		if not os.path.isfile(executable_file_path) :
-			print ColorValues.FAIL + "executable file missing! : " + executable_file_path + ColorValues.END
+			print (ColorValues.FAIL + "executable file missing! : " + executable_file_path + ColorValues.END)
 			return -1
 		
 		command = "xcrun llvm-cov report -instr-profile " + profile_data_path + " -arch=\"x86_64\" -use-color " + executable_file_path
-		print command
+		print (command)
 		p = subprocess.Popen(command, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = True)
 		
 		output = p.communicate()
@@ -313,16 +313,16 @@ class BuildTarget:
 				if (operation == "build" and self.use_sonarcube == "true" and os.environ.get('TRAVIS') == "true") :
 					subprocess.call("rm -rf .sonar; rm -rf build-wrapper-output", shell = True)
 					command = "build-wrapper-macosx-x86 --out-dir build-wrapper-output " + command
-				print command
+				print (command)
 				exit_code = subprocess.call("set -o pipefail;" + command, shell = True)
 			
 			if (exit_code != 0) :
 				self.failed = True
 		except Exception as inst:
 			self.failed = True
-			print "Failed due to exception in build script"
+			print ("Failed due to exception in build script")
 			tb = traceback.format_exc()
-			print tb
+			print (tb)
 
 		print_operation_end(self.name, operation, exit_code, start_time)
 		
@@ -343,9 +343,9 @@ def requires_simulator(targets) :
 	return False
 
 def launch_simulator() :
-	print "Booting simulator..."
+	print ("Booting simulator...")
 	command = "xcrun simctl boot " + device_guids.get_ios(ios_sim_device)
-	print command
+	print (command)
 	
 	# This spawns a new process without us having to wait for it
 	subprocess.Popen(command, shell = True)
@@ -364,7 +364,7 @@ use_xcpretty = args.no_xcpretty
 show_build_settings = args.show_build_settings
 
 if (args.targets != None) :
-	print "Targets specified: " + str(args.targets)
+	print ("Targets specified: " + str(args.targets))
 
 targets = []
 
@@ -382,10 +382,10 @@ if (clean) :
 		build_dir = target.get_build_settings()["BUILD_DIR"]
 		derived_dir = os.path.normpath(build_dir + "/../..")
 		derived_folders.add(derived_dir)
-		print derived_dir
+		print (derived_dir)
 	
 	for dir in derived_folders :
-		print "Deleting " + dir
+		print ("Deleting " + dir)
 		subprocess.call("rm -rf " + dir, shell=True)
 
 for target in targets:
@@ -408,35 +408,35 @@ for target in targets:
 
 	# Add success/failure state to the build status dictionary
 	if (exit_code == 0) :
-		print ColorValues.OK + target.name + " Succeeded" + ColorValues.END
+		print (ColorValues.OK + target.name + " Succeeded" + ColorValues.END)
 	else :
-		print ColorValues.FAIL + target.name + " Failed" + ColorValues.END
+		print (ColorValues.FAIL + target.name + " Failed" + ColorValues.END)
 
 final_status = 0
 
-print "\n"
+print ("\n")
 
 code_coverage = False
 
 # Print out the final result of each operation.
 for target in targets :
 	if (target.failed) :
-		print ColorValues.FAIL + target.name + " failed." + ColorValues.END + " (" + "{0:.2f}".format(target.end_time - target.start_time) + " seconds)"
+		print (ColorValues.FAIL + target.name + " failed." + ColorValues.END + " (" + "{0:.2f}".format(target.end_time - target.start_time) + " seconds)")
 		final_status = 1
 	else :
 		if ("codecov" in target.operations) :
 			code_coverage = True
-		print ColorValues.OK + '\033[92m' + target.name + " succeeded." + ColorValues.END + " (" + "{0:.2f}".format(target.end_time - target.start_time) + " seconds)"
+		print (ColorValues.OK + '\033[92m' + target.name + " succeeded." + ColorValues.END + " (" + "{0:.2f}".format(target.end_time - target.start_time) + " seconds)")
 
 if code_coverage :
-	print "\nCode Coverage Results:"
+	print ("\nCode Coverage Results:")
 	for target in targets :
 		if (target.coverage != None) :
 			target.print_coverage(True)
 
 script_end_time = timer()
 
-print "Total running time: " + "{0:.2f}".format(script_end_time - script_start_time) + " seconds"
+print ("Total running time: " + "{0:.2f}".format(script_end_time - script_start_time) + " seconds")
 # xcodebuild seems to log in stderr instead of stdout. Catching final_status in text file to capture exit code and determine if build failed
 # Similar issue : (see https://developer.apple.com/forums/thread/663959)
 if (not os.path.exists("./build")) :

--- a/device_guids.py
+++ b/device_guids.py
@@ -24,7 +24,7 @@ def get_guid_i(device) :
 	version_regex = re.compile("([0-9]+)\\.([0-9]+)(?:\\.([0-9]+))?")
 	
 	command = "instruments -s devices"
-	print "##[group]Devices"
+	print ("##[group]Devices")
 	p = subprocess.Popen(command, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = True)
 	
 	# Sometimes the hostname comes back with the proper casing, sometimes not. Using a
@@ -35,11 +35,11 @@ def get_guid_i(device) :
 	latest_os_version = None
 	
 	for line in p.stdout :
-		sys.stdout.write(line)
-		if (dev_name_regex.match(line) == None) :
+		sys.stdout.write(line.decode('utf-8'))
+		if (dev_name_regex.match(line.decode('utf-8')) == None) :
 			continue
 		
-		match = device_regex.match(line)
+		match = device_regex.match(line.decode('utf-8'))
 		
 		# Regex won't match simulators with apple watches...
 		if (match == None) : 
@@ -58,7 +58,7 @@ def get_guid_i(device) :
 			latest_os_device = match.group(2)
 			latest_os_version = version_tuple
 	
-	print "##[endgroup]Devices"
+	print ("##[endgroup]Devices")
 	
 	return latest_os_device
 
@@ -69,7 +69,7 @@ def get_guid(device) :
 	return guid
 
 def print_failure(device) :
-	print "Failed to find GUID for device : " + device
+	print ("Failed to find GUID for device : " + device)
 	subprocess.call("instruments -s devices", shell=True)
 	raise Exception("Failed to get device GUID")
 


### PR DESCRIPTION
## Proposed changes

When a given request is has not yet been throttled, its thumbprint value would not be cached by MSIDLRUCache. when that scenario is detected, throttling logic should just log that the request is not cached / throttled yet, and hence there is no cache record.

ThrottlingModelForIncomingRequest check currently checks as below - but if error code is MSIDErrorThrottleCacheNoRecord, it won't trigger the if conditional and instead trigger the else conditional and mark it as error:

```
  if (!error.code == MSIDErrorThrottleCacheNoRecord && !error.code == MSIDErrorThrottleCacheInvalidSignature)
    {
        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, context, @"Throttling: No record in throttle cache");
        error = nil;
    }
    
    else
  {
   //error is triggered.
  }
```

but it should be 
`if (error.code == MSIDErrorThrottleCacheNoRecord || error.code == MSIDErrorThrottleCacheInvalidSignature)`

instead,

In order for the error code to be correctly handled for the scenario where the request is not throttled/cached.
## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

