### PR TITLE
Added support to return device registration details in all the cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [TBD]
+* Return device join status regardless of SSO extension error(#1403)
+
 ## [1.1.23]
 * Add helper for cross cloud B2B support in broker (#1370)
 * Add support of "create" prompt (#1384)

--- a/MSAL/src/MSALDeviceInformation.m
+++ b/MSAL/src/MSALDeviceInformation.m
@@ -46,6 +46,15 @@ NSString *const MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY = @"isSSOExt
     {
         _deviceMode = MSALDeviceModeDefault;
         _extraDeviceInformation = [NSMutableDictionary new];
+        
+        if (@available(iOS 13.0, macOS 10.15, *))
+        {
+            _hasAADSSOExtension = [[ASAuthorizationSingleSignOnProvider msidSharedProvider] canPerformAuthorization];
+        }
+        else
+        {
+            _hasAADSSOExtension = NO;
+        }
     }
 
     return self;

--- a/MSAL/src/instance/MSALDeviceInfoProvider.m
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.m
@@ -41,7 +41,7 @@
 - (void)deviceInfoWithRequestParameters:(MSIDRequestParameters *)requestParameters
                         completionBlock:(MSALDeviceInformationCompletionBlock)completionBlock
 {
-    void (^deviceInfoCompletionHandler)(MSALDeviceInformation *, NSError *) = ^void(MSALDeviceInformation *msalDeviceInfo, NSError *error)
+    void (^fillDeviceInfoCompletionBlock)(MSALDeviceInformation *, NSError *) = ^void(MSALDeviceInformation *msalDeviceInfo, NSError *error)
     {
         if (!msalDeviceInfo)
         {
@@ -74,7 +74,7 @@
     {
         MSID_LOG_WITH_CTX(MSIDLogLevelInfo, requestParameters, @"Broker is not present on this device. Defaulting to personal mode");
 
-        deviceInfoCompletionHandler(nil, nil);
+        fillDeviceInfoCompletionBlock(nil, nil);
         return;
     }
     
@@ -87,7 +87,7 @@
 
         if (!ssoExtensionRequest)
         {
-            deviceInfoCompletionHandler(nil, requestError);
+            completionBlock(nil, requestError);
             return;
         }
 
@@ -106,12 +106,12 @@
             {
                 // We are returing registration details irrespective of failures due to SSO extension request as registration details must have for few clients
                 // Once we identify and fix the intermittent SSO extension issue then we should return either deviceInfo or error
-                deviceInfoCompletionHandler(nil, error);
+                fillDeviceInfoCompletionBlock(nil, error);
                 return;
             }
 
             MSALDeviceInformation *msalDeviceInfo = [[MSALDeviceInformation alloc] initWithMSIDDeviceInfo:deviceInfo];
-            deviceInfoCompletionHandler(msalDeviceInfo, nil);
+            fillDeviceInfoCompletionBlock(msalDeviceInfo, nil);
             return;
         }];
     }

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -39,7 +39,7 @@
 
 #pragma mark - Get device info
 
-- (void)testGetDeviceInfo_whenCurrentSSOExtensionRequestAlreadyPresent_shouldReturnDefaultDeviceInfoAndFillError API_AVAILABLE(ios(13.0), macos(10.15))
+- (void)testGetDeviceInfo_whenCurrentSSOExtensionRequestAlreadyPresent_shouldReturnNilAndFillError API_AVAILABLE(ios(13.0), macos(10.15))
 {
     [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
                            class:[MSIDSSOExtensionGetDeviceInfoRequest class]
@@ -77,7 +77,7 @@
     [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
                                         completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
     {
-        XCTAssertNotNil(deviceInformation);
+        XCTAssertNil(deviceInformation);
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeDefault);
         XCTAssertEqual(deviceInformation.extraDeviceInformation.count, 0);
         XCTAssertNotNil(error);


### PR DESCRIPTION
## Proposed changes

Added support to return device registration details in all the cases.
We have seen getDeviceInfo API gets failed sometime due to SSO extension

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

