### PR TITLE
Add more logs in getDeviceInfo flow due to an IcM

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1459,7 +1459,7 @@
 - (void)getDeviceInformationWithParameters:(MSALParameters *)parameters
                            completionBlock:(MSALDeviceInformationCompletionBlock)completionBlock
 {
-    MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Querying device info");
+    MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Querying device info");
     
     __auto_type block = ^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable msidError)
     {
@@ -1495,6 +1495,7 @@
     
     if (!requestParams)
     {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, nil, @"GetDeviceInfo: Error when creating requestParams: %@", requestParamsError);
         block(nil, requestParamsError);
         return;
     }

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1471,7 +1471,7 @@
         }
         else
         {
-            MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Retrieved device info %@", deviceInformation);
+            MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, nil, @"Retrieved device info %@", MSID_PII_LOG_MASKABLE(deviceInformation));
         }
         
         [MSALPublicClientApplication logOperation:@"getDeviceInformation" result:nil error:msalError context:nil];


### PR DESCRIPTION
## Proposed changes

There is a customer issue where getDeviceInfo is hanging, but no local repro yet, based on the logs, the flow stopped responding somewhere, but logs only show the staring of the whole flow. Adding more logs for debugging.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

