### PR TITLE
Correcting release pipeline to zip with preserving symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## TBD
-
+* Fixed zipping in release pipeline to preserve symlinks in xcframework
+ 
 ## [1.2.0]
 * Multi-tenant PkeyAuth support in MSAL (#1438)
 * Add support to wipe cache for all accounts (#1426)

--- a/azure_pipelines/spm-framework.yml
+++ b/azure_pipelines/spm-framework.yml
@@ -91,16 +91,17 @@ jobs:
         -framework $(Build.binariesDirectory)/iOS.xcarchive/Products/Library/Frameworks/MSAL.framework \
         -framework $(Build.binariesDirectory)/iOS-Sim.xcarchive/Products/Library/Frameworks/MSAL.framework \
         -framework $(Build.binariesDirectory)/macOS.xcarchive/Products/Library/Frameworks/MSAL.framework \
-        -output $(Build.binariesDirectory)/MSAL.xcframework
+        -output $(Build.ArtifactStagingDirectory)/MSAL.xcframework
       failOnStderr: true
-  - task: ArchiveFiles@2
-    displayName: Zip xcframework
+  - task: Bash@3
+    displayName: Zip xcframework for codesigning
     inputs:
-      rootFolderOrFile: '$(Build.binariesDirectory)/MSAL.xcframework'
-      includeRootFolder: true
-      archiveType: 'zip'
-      archiveFile: '$(Build.ArtifactStagingDirectory)/MSAL.zip'
-      replaceExistingArchive: true
+      workingDirectory: $(Build.ArtifactStagingDirectory)
+      targetType: 'inline'
+      script: |
+        # Zipping xcframework. -y : including symlinks (Need to preserve symlinks in xcframework so that codesign validation doesn't fail) -v : verbose logging
+        zip -r $(Build.ArtifactStagingDirectory)/MSAL.zip MSAL.xcframework -y -v
+      failOnStderr: true
   - task: UseDotNet@2
     displayName: 'Install .NET Core sdk for signing'
     inputs:
@@ -132,9 +133,15 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        unzip MSAL.zip -d MSAL.xcframework
+        # Codesigning service explodes xcframework in output zip. Need to re-package contents into xcframework
+        # Extract code signature and add it into built xcframework
+        unzip MSAL.zip _CodeSignature\* -d MSAL.xcframework
+        # Delete zip file
         rm MSAL.zip
-        zip -r MSAL.zip MSAL.xcframework
+        # Delete md file created by codesigning service
+        rm *.md
+        # Zip xcframework into zip file with symlinks preserved and delete xcframework
+        zip -r MSAL.zip MSAL.xcframework -y -m
       workingDirectory: '$(Build.ArtifactStagingDirectory)'
       failOnStderr: true
   - task: Bash@3


### PR DESCRIPTION
## Proposed changes

When we build and send xcframework to the codesigning service, we need to zip it. During zip, the symlinks inside the xcframework were not preserved, instead the destinations that the links point to were being copied. As a result Xcode for macOS MSAL.xcframework fails code signing validation. See : https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/1453

Fixing this by adding flags to preserve symlinks while zipping. 

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

