### PR TITLE
Add Tenant and Resource for easy cross-cloud testing

### DIFF
--- a/MSAL/test/app/MSALTestAppSettings.m
+++ b/MSAL/test/app/MSALTestAppSettings.m
@@ -80,7 +80,8 @@ static NSDictionary *s_currentProfile = nil;
     
     for (NSString *host in trustedHosts)
     {
-        __auto_type tenants = @[@"common", @"organizations", @"consumers"];
+        __auto_type tenants = @[@"common", @"organizations", @"consumers", @"f645ad92-e38d-4d1a-b510-d1b09a74a8ca"];
+
         
         for (NSString *tenant in tenants)
         {
@@ -91,7 +92,8 @@ static NSDictionary *s_currentProfile = nil;
     
     s_authorities = authorities;
     
-    s_scopes_available = @[MSAL_APP_SCOPE_USER_READ, @"Tasks.Read", @"https://graph.microsoft.com/.default",@"https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read", @"TASKS.read", @"https://outlook.office365.com/.default"];
+    s_scopes_available = @[MSAL_APP_SCOPE_USER_READ, @"Tasks.Read", @"https://graph.microsoft.com/.default",@"https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read", @"TASKS.read", @"https://outlook.office365.com/.default", @"https://microsoftgraph.chinacloudapi.cn/.default"];
+
     
     __auto_type signinPolicyAuthority = @"https://login.microsoftonline.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_SignInPolicy";
     __auto_type signupPolicyAuthority = @"https://login.microsoftonline.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_SignUpPolicy";


### PR DESCRIPTION
## Proposed changes

Added cross cloud testing tenant as well as China cloud resource, such that it will be easier to test cross cloud case.

Besides, Outlook profile is not added to avoid change conflict with Kai's profile change.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

