### PR TITLE
Adding task to create github issue when automation pipeline fails

### DIFF
--- a/azure_pipelines/automation.yml
+++ b/azure_pipelines/automation.yml
@@ -98,4 +98,50 @@ jobs:
       targetPath: '$(Agent.BuildDirectory)/s/test_output/'
       artifact: 'TestOutputs'
       publishLocation: 'pipeline'
+  - task: UsePythonVersion@0
+    displayName: Use Python 3.x
+  - bash: python3 -m pip install github3.py==2.0.0
+    displayName: Install the github3.py REST API client for Python
+  - task: PythonScript@0
+    displayName: Create Issue if Pipeline fails
+    condition: failed()
+    inputs:
+      scriptSource: inline
+      script: |
+        import github3
+        import requests
+        import textwrap
+        from pprint import pprint
+        from subprocess import run, PIPE
+        import random
+
+        auth_header = ""
+        try:
+            auth_header = run(["git", "config", "http.$(Build.Repository.URI).extraheader"], text=True, check=True, stdout=PIPE).stdout.strip()
+        except Exception as e:
+          pprint(e)
+        class HTTPHardcodedHeaderAuth(requests.auth.AuthBase):
+            def __call__(self, r):
+                r.headers['Authorization'] = auth_header.replace("AUTHORIZATION: ", "")
+                return r
+
+        github = github3.GitHub()
+        github.session.auth = HTTPHardcodedHeaderAuth()
+        github_org, repo = "$(Build.Repository.Name)".split("/")
+        
+        # Get the members of AppleIdentityTeam in AzureAD organization 
+        apple_id_team = github.organization('AzureAd').team(3752064)
+        members = list(apple_id_team.members(role="all"))
+        
+        # Pick random member from team to assign issue to
+        random_member = random.randint(0, apple_id_team.members_count)
+        lucky_member = members[random_member]
+        
+        # Prepare content for github issue
+        pipeline_uri = "https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=$(Build.BuildId)&view=logs"
+        git_commit = '$(Build.SourceVersionMessage) [$(Build.SourceVersion)] '
+        issue_title = "Automation tests failure"
+        issue_body = '''Automation failed for [$(repositoryName)]({0}) ran against {1} branch \n Pipeline URL : [{2}]({2})'''.format('$(Build.Repository.Uri)', git_commit, pipeline_uri) 
+        pprint(issue_body)
+        github.create_issue(github_org, repo, issue_title, issue_body, assignee=lucky_member.login, labels=['automation failure'])
   

--- a/azure_pipelines/automation.yml
+++ b/azure_pipelines/automation.yml
@@ -129,19 +129,10 @@ jobs:
         github.session.auth = HTTPHardcodedHeaderAuth()
         github_org, repo = "$(Build.Repository.Name)".split("/")
         
-        # Get the members of AppleIdentityTeam in AzureAD organization 
-        apple_id_team = github.organization('AzureAd').team(3752064)
-        members = list(apple_id_team.members(role="all"))
-        
-        # Pick random member from team to assign issue to
-        random_member = random.randint(0, apple_id_team.members_count)
-        lucky_member = members[random_member]
-        
         # Prepare content for github issue
         pipeline_uri = "https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=$(Build.BuildId)&view=logs"
         git_commit = '$(Build.SourceVersionMessage) [$(Build.SourceVersion)] '
         issue_title = "Automation tests failure"
-        issue_body = '''Automation failed for [$(repositoryName)]({0}) ran against {1} branch \n Pipeline URL : [{2}]({2})'''.format('$(Build.Repository.Uri)', git_commit, pipeline_uri) 
-        pprint(issue_body)
-        github.create_issue(github_org, repo, issue_title, issue_body, assignee=lucky_member.login, labels=['automation failure'])
+        issue_body = '''@AzureAD/appleidentity \nAutomation failed for [$(repositoryName)]({0}) ran against {1} branch \n Pipeline URL : [{2}]({2})'''.format('$(Build.Repository.Uri)', git_commit, pipeline_uri) 
+        github.create_issue(github_org, repo, issue_title, issue_body, labels=['automation failure'])
   


### PR DESCRIPTION
## Proposed changes

Adding a task in automation pipeline to create a Github issue in the repo when the pipeline fails.
If scheduled automation fails, an issue will be created in the git repo and can be triaged accordingly.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

