### PR TITLE
Install python only when previous tasks fail

### DIFF
--- a/azure_pipelines/automation.yml
+++ b/azure_pipelines/automation.yml
@@ -99,8 +99,10 @@ jobs:
       artifact: 'TestOutputs'
       publishLocation: 'pipeline'
   - task: UsePythonVersion@0
+    condition: failed()
     displayName: Use Python 3.x
   - bash: python3 -m pip install github3.py==2.0.0
+    condition: failed()
     displayName: Install the github3.py REST API client for Python
   - task: PythonScript@0
     displayName: Create Issue if Pipeline fails
@@ -113,7 +115,6 @@ jobs:
         import textwrap
         from pprint import pprint
         from subprocess import run, PIPE
-        import random
 
         auth_header = ""
         try:


### PR DESCRIPTION
## Proposed changes

Correcting pipeline to install py & githubpy3 in automation pipeline only when previous steps fail.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

