### PR TITLE
Add Darwin notification listener to Test App for FLW testing

### DIFF
--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -59,7 +59,6 @@
 
 static NSString *const kDeviceIdClaimsValue = @"{\"access_token\":{\"deviceid\":{\"essential\":true}}}";
 
-static NSString *const kGlobalSignoutDarwinNotificationKey = @"FLWSignoutOccured";
 static NSString *const kDarwinNotificationReceivedKey = @"DarwinNotificationReceived";
 
 @interface MSALTestAppAcquireTokenViewController () <UITextFieldDelegate>
@@ -142,7 +141,8 @@ static NSString *const kDarwinNotificationReceivedKey = @"DarwinNotificationRece
     
     //Listens for Darwin notifcations coming from broker in the FLW global signout scenario
     CFNotificationCenterRef center = CFNotificationCenterGetDarwinNotifyCenter();
-    CFNotificationCenterAddObserver(center, nil, globalSignoutCallback, (CFStringRef)kGlobalSignoutDarwinNotificationKey, nil, CFNotificationSuspensionBehaviorDeliverImmediately);
+    CFNotificationCenterAddObserver(center, nil, globalSignoutCallback, (CFStringRef)MSID_SHARED_MODE_CURRENT_ACCOUNT_CHANGED_NOTIFICATION_KEY,
+                                    nil, CFNotificationSuspensionBehaviorDeliverImmediately);
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -786,7 +786,7 @@ static void sharedModeAccountChangedCallback(__unused CFNotificationCenterRef ce
 
 - (void) receivedGlobalSignoutDarwinNotification:(NSNotification *)notification
 {
-    self.resultTextView.text = @"Darwin notification received from the broker SDK indicating a global signout has occurred.";
+    self.resultTextView.text = @"Darwin notification received from the broker SDK indicating the device is in shared mode and the current account changed.";
 }
 
 @end

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -777,7 +777,7 @@ static NSString *const kDarwinNotificationReceivedKey = @"DarwinNotificationRece
 
 - (void) receivedGlobalSignoutDarwinNotification:(NSNotification *)notification
 {
-    self.resultTextView.text = @"Darwin notification received from the broker SDK indicating a global sigout has occurred.";
+    self.resultTextView.text = @"Darwin notification received from the broker SDK indicating a global signout has occurred.";
 }
 
 void globalSignoutCallback(__unused CFNotificationCenterRef center,

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -61,6 +61,15 @@ static NSString *const kDeviceIdClaimsValue = @"{\"access_token\":{\"deviceid\":
 
 static NSString *const kDarwinNotificationReceivedKey = @"DarwinNotificationReceived";
 
+void sharedModeAccountChangedCallback(__unused CFNotificationCenterRef center,
+                           __unused void * observer,
+                           __unused CFStringRef name,
+                           __unused void const * object,
+                           __unused CFDictionaryRef userInfo)
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:kDarwinNotificationReceivedKey object:nil];
+}
+
 @interface MSALTestAppAcquireTokenViewController () <UITextFieldDelegate>
 
 @property (nonatomic) IBOutlet UIButton *profileButton;
@@ -141,7 +150,7 @@ static NSString *const kDarwinNotificationReceivedKey = @"DarwinNotificationRece
     
     //Listens for Darwin notifcations coming from broker in the FLW global signout scenario
     CFNotificationCenterRef center = CFNotificationCenterGetDarwinNotifyCenter();
-    CFNotificationCenterAddObserver(center, nil, globalSignoutCallback, (CFStringRef)MSID_SHARED_MODE_CURRENT_ACCOUNT_CHANGED_NOTIFICATION_KEY,
+    CFNotificationCenterAddObserver(center, nil, sharedModeAccountChangedCallback, (CFStringRef)MSID_SHARED_MODE_CURRENT_ACCOUNT_CHANGED_NOTIFICATION_KEY,
                                     nil, CFNotificationSuspensionBehaviorDeliverImmediately);
 }
 
@@ -778,15 +787,6 @@ static NSString *const kDarwinNotificationReceivedKey = @"DarwinNotificationRece
 - (void) receivedGlobalSignoutDarwinNotification:(NSNotification *)notification
 {
     self.resultTextView.text = @"Darwin notification received from the broker SDK indicating a global signout has occurred.";
-}
-
-void globalSignoutCallback(__unused CFNotificationCenterRef center,
-                           __unused void * observer,
-                           __unused CFStringRef name,
-                           __unused void const * object,
-                           __unused CFDictionaryRef userInfo)
-{
-    [[NSNotificationCenter defaultCenter] postNotificationName:kDarwinNotificationReceivedKey object:nil];
 }
 
 @end

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -60,7 +60,7 @@
 static NSString *const kDeviceIdClaimsValue = @"{\"access_token\":{\"deviceid\":{\"essential\":true}}}";
 
 static NSString *const kGlobalSignoutDarwinNotificationKey = @"FLWSignoutOccured";
-static NSString *const kGlobalSignoutOccuredNotificationKey = @"GlobalSignoutOccured";
+static NSString *const kDarwinNotificationReceivedKey = @"DarwinNotificationReceived";
 
 @interface MSALTestAppAcquireTokenViewController () <UITextFieldDelegate>
 
@@ -137,7 +137,7 @@ static NSString *const kGlobalSignoutOccuredNotificationKey = @"GlobalSignoutOcc
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(receivedGlobalSignoutDarwinNotification:)
-                                                 name:kGlobalSignoutOccuredNotificationKey
+                                                 name:kDarwinNotificationReceivedKey
                                                object:nil];
     
     //Listens for Darwin notifcations coming from broker in the FLW global signout scenario
@@ -786,7 +786,7 @@ void globalSignoutCallback(__unused CFNotificationCenterRef center,
                            __unused void const * object,
                            __unused CFDictionaryRef userInfo)
 {
-    [[NSNotificationCenter defaultCenter] postNotificationName:kGlobalSignoutOccuredNotificationKey object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:kDarwinNotificationReceivedKey object:nil];
 }
 
 @end

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -61,11 +61,11 @@ static NSString *const kDeviceIdClaimsValue = @"{\"access_token\":{\"deviceid\":
 
 static NSString *const kDarwinNotificationReceivedKey = @"DarwinNotificationReceived";
 
-void sharedModeAccountChangedCallback(__unused CFNotificationCenterRef center,
-                           __unused void * observer,
-                           __unused CFStringRef name,
-                           __unused void const * object,
-                           __unused CFDictionaryRef userInfo)
+static void sharedModeAccountChangedCallback(__unused CFNotificationCenterRef center,
+                                             __unused void * observer,
+                                             __unused CFStringRef name,
+                                             __unused void const * object,
+                                             __unused CFDictionaryRef userInfo)
 {
     [[NSNotificationCenter defaultCenter] postNotificationName:kDarwinNotificationReceivedKey object:nil];
 }

--- a/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
+++ b/MSAL/test/app/ios/MSALTestAppAcquireTokenViewController.m
@@ -59,6 +59,9 @@
 
 static NSString *const kDeviceIdClaimsValue = @"{\"access_token\":{\"deviceid\":{\"essential\":true}}}";
 
+static NSString *const kGlobalSignoutDarwinNotificationKey = @"FLWSignoutOccured";
+static NSString *const kGlobalSignoutOccuredNotificationKey = @"GlobalSignoutOccured";
+
 @interface MSALTestAppAcquireTokenViewController () <UITextFieldDelegate>
 
 @property (nonatomic) IBOutlet UIButton *profileButton;
@@ -131,6 +134,15 @@ static NSString *const kDeviceIdClaimsValue = @"{\"access_token\":{\"deviceid\":
                                              selector:@selector(onKeyboardWillHide:)
                                                  name:UIKeyboardWillHideNotification
                                                object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(receivedGlobalSignoutDarwinNotification:)
+                                                 name:kGlobalSignoutOccuredNotificationKey
+                                               object:nil];
+    
+    //Listens for Darwin notifcations coming from broker in the FLW global signout scenario
+    CFNotificationCenterRef center = CFNotificationCenterGetDarwinNotifyCenter();
+    CFNotificationCenterAddObserver(center, nil, globalSignoutCallback, (CFStringRef)kGlobalSignoutDarwinNotificationKey, nil, CFNotificationSuspensionBehaviorDeliverImmediately);
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -761,6 +773,20 @@ static NSString *const kDeviceIdClaimsValue = @"{\"access_token\":{\"deviceid\":
        [self.customWebview loadHTMLString:@"<html><head></head></html>" baseURL:nil];
        self.customWebviewContainer.hidden = YES;
     }
+}
+
+- (void) receivedGlobalSignoutDarwinNotification:(NSNotification *)notification
+{
+    self.resultTextView.text = @"Darwin notification received from the broker SDK indicating a global sigout has occurred.";
+}
+
+void globalSignoutCallback(__unused CFNotificationCenterRef center,
+                           __unused void * observer,
+                           __unused CFStringRef name,
+                           __unused void const * object,
+                           __unused CFDictionaryRef userInfo)
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:kGlobalSignoutOccuredNotificationKey object:nil];
 }
 
 @end


### PR DESCRIPTION
## Proposed changes

As part of FLW signout, the broker will send a system-wide broadcast to notify any listeners that the signout occurred. This PR adds a test listener to the MSAL test app to log when this broadcast reaches the app.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

