### PR TITLE
Update PKeyauth headers to variable that can change depending on pkey…

### DIFF
--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -87,6 +87,7 @@
 #import "MSALTestCacheTokenResponse.h"
 #import "MSALAuthenticationSchemePop.h"
 #import "MSALWipeCacheForAllAccountsConfig.h"
+#import "MSIDWorkPlaceJoinConstants.h"
 
 #if TARGET_OS_IPHONE
 #import "MSIDApplicationTestUtil.h"
@@ -3813,7 +3814,7 @@
     }
     
     headers[@"Accept"] = @"application/json";
-    headers[@"x-ms-PkeyAuth"] = @"1.0";
+    headers[kMSIDPKeyAuthHeader] = @"1.0";
     response->_requestHeaders = headers;
     
     NSString *endpoint = [NSString stringWithFormat:@"%@/v2.0/.well-known/openid-configuration", authority];

--- a/MSAL/test/unit/utils/MSIDTestURLResponse+MSAL.m
+++ b/MSAL/test/unit/utils/MSIDTestURLResponse+MSAL.m
@@ -35,6 +35,7 @@
 #import "MSIDVersion.h"
 #import "NSOrderedSet+MSIDExtensions.h"
 #import "MSALAccount.h"
+#import "MSIDWorkPlaceJoinConstants.h"
 
 @implementation MSIDTestURLResponse (MSAL)
 
@@ -50,7 +51,7 @@
         headers[@"Accept"] = @"application/json";
         headers[@"x-app-name"] = @"MSIDTestsHostApp";
         headers[@"x-app-ver"] = @"1.0";
-        headers[@"x-ms-PkeyAuth"] = @"1.0";
+        headers[kMSIDPKeyAuthHeader] = @"1.0";
         headers[@"X-AnchorMailbox"] = [MSIDTestIgnoreSentinel new];
 
         s_msalHeaders = [headers copy];


### PR DESCRIPTION
…auth+ feature flag

Changing hardcoded values for PKeyAuth header to defined constant. With introduction of PKeyAuth+ header, this constant can change depending on if the MSID_ENABLE_ECC_SUPPORT flag is enabled/disabled.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

