### PR TITLE
Create MSAL API in PublicClientApplication for Darwin notification listener

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -110,6 +110,7 @@
 #import "MSIDAssymetricKeyLookupAttributes.h"
 #import "MSIDRequestTelemetryConstants.h"
 #import "MSALWipeCacheForAllAccountsConfig.h"
+#import "MSIDDarwinNotificationListener.h"
 
 @interface MSALPublicClientApplication()
 {
@@ -122,6 +123,7 @@
 @property (nonatomic) MSIDCacheConfig *msidCacheConfig;
 @property (nonatomic) MSIDDevicePopManager *popManager;
 @property (nonatomic) MSIDAssymetricKeyLookupAttributes *keyPairAttributes;
+@property (nonatomic) MSIDDarwinNotificationListener *darwinListener;
 
 @end
 
@@ -1649,6 +1651,22 @@
     return @MSAL_VERSION_STRING;
 }
 
+#pragma mark - Shared Device Mode
+
+- (void)createSharedDeviceModeAccountChangeListener:(MSALSimpleCallback)completionBlock
+{
+    self.darwinListener = [[MSIDDarwinNotificationListener alloc] initWithCallback:completionBlock];
+    
+    if (self.darwinListener)
+    {
+        [self.darwinListener createSharedDeviceAccountChangeListener];
+    }
+    else
+    {
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Failed to create Shared Device Mode account change listener", nil, nil, nil, nil, nil, YES);
+        completionBlock(error);
+    }
+}
 
 #pragma mark - Private
 

--- a/MSAL/src/public/MSALDefinitions.h
+++ b/MSAL/src/public/MSALDefinitions.h
@@ -203,6 +203,11 @@ typedef void (^MSALLogCallback)(MSALLogLevel level, NSString * _Nullable message
  */
 typedef void(^MSALTelemetryCallback)(NSDictionary<NSString *, NSString *> * _Nonnull event);
 
+/**
+ Simple callback style containing just error information if the requested operation resulted in an error.
+ */
+typedef void(^MSALSimpleCallback)(NSError * _Nullable error);
+
 #endif /* MSALConstants_h */
 
 typedef NS_ENUM(NSUInteger, MSALAuthScheme)

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -477,4 +477,11 @@
 */
 @property (nullable, class, readonly) NSString *sdkVersion;
 
+#pragma mark - Shared Device Mode
+
+/**
+   Creates a listener for a Darwin notification broadcast when an account change occurs in Shared Device Mode.
+*/
+- (void)createSharedDeviceModeAccountChangeListener:(nonnull MSALSimpleCallback)completionBlock;
+
 @end


### PR DESCRIPTION
## Proposed changes

In order to make it simpler to use the basic Darwin notification system that we offer for shared device mode partners, we can create an API in MSAL that will setup the notification listener. That way, partners don't have to implement it themselves. Also, we can better control how to functionality is used this way, and can make changes under the hood if necessary.

This PR opens up the API in MSAL, by adding it to the available API's in PublicClientApplication. This PR makes use of the listener code added in common core here: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1121.

An alternative design proposal for this API would be to create an entirely different public class for this functionality. My initial proposal is to open up the API in PCA because:
* Any wrapper in MSAL for the MSIDDarwinNotificationListener would add almost no new code. 
* Shared Device Mode apps need to call PCA.getCurrentAccount anyway in their shared device implementations, even calling it in the callback to the Darwin listener.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

