### PR TITLE
Expose objectId for mam support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+##[TBD]
+* Expose extra deviceInfo
+
 ## [1.2.3]
 * Stop extra background tasks in the system webview case.
 * Minor fixes.

--- a/MSAL/src/MSALDeviceInformation.m
+++ b/MSAL/src/MSALDeviceInformation.m
@@ -116,7 +116,12 @@ NSString *const MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY = @"isSSOExt
 - (void) initExtraDeviceInformation:(MSIDDeviceInfo *)deviceInfo
 {
     [_extraDeviceInformation setValue:deviceInfo.ssoExtensionMode == MSIDSSOExtensionModeFull ? @"Yes" : @"No" forKey:MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY];
-    [_extraDeviceInformation addEntriesFromDictionary:deviceInfo.extraDeviceInfo];
+    
+    if (deviceInfo.extraDeviceInfo)
+    {
+        [_extraDeviceInformation addEntriesFromDictionary:deviceInfo.extraDeviceInfo];
+    }
+    
 }
 
 - (void) addRegisteredDeviceMetadataInformation:(NSDictionary *)deviceInfoMetadata

--- a/MSAL/src/MSALDeviceInformation.m
+++ b/MSAL/src/MSALDeviceInformation.m
@@ -116,10 +116,7 @@ NSString *const MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY = @"isSSOExt
 - (void) initExtraDeviceInformation:(MSIDDeviceInfo *)deviceInfo
 {
     [_extraDeviceInformation setValue:deviceInfo.ssoExtensionMode == MSIDSSOExtensionModeFull ? @"Yes" : @"No" forKey:MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY];
-    if (![NSString msidIsStringNilOrBlank:deviceInfo.mdmId])
-    {
-        [_extraDeviceInformation setValue:deviceInfo.mdmId forKey:MSID_BROKER_MDM_ID_KEY];
-    }
+    [_extraDeviceInformation addEntriesFromDictionary:deviceInfo.extraDeviceInfo];
 }
 
 - (void) addRegisteredDeviceMetadataInformation:(NSDictionary *)deviceInfoMetadata

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -262,7 +262,8 @@
         deviceInfo.brokerVersion = @"test";
         deviceInfo.deviceMode = MSIDDeviceModeShared;
         deviceInfo.ssoExtensionMode = MSIDSSOExtensionModeSilentOnly;
-        deviceInfo.mdmId = @"mdmId";
+        deviceInfo.extraDeviceInfo[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
+        deviceInfo.extraDeviceInfo[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
         
         callback(deviceInfo, nil);
     }];
@@ -280,11 +281,61 @@
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeShared);
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"isSSOExtensionInFullMode"], @"No");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY], @"mdmId");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY], @"objectId");
         [successExpectation fulfill];
     }];
     
     [self waitForExpectations:@[expectation, successExpectation] timeout:1];
 }
+
+- (void)testGetDeviceInfo_whenSSOExtensionPresent_notConfiguredForJIT_shouldReturnMSALDeviceInfoWithoutMdmIdAndObjectId API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
+                           class:[MSIDSSOExtensionGetDeviceInfoRequest class]
+                           block:(id)^(id obj)
+    {
+        return YES;
+    }];
+    
+    MSALDeviceInfoProvider *deviceInfoProvider = [MSALDeviceInfoProvider new];
+        
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Execute request"];
+    
+    [MSIDTestSwizzle instanceMethod:@selector(executeRequestWithCompletion:)
+                              class:[MSIDSSOExtensionGetDeviceInfoRequest  class]
+                              block:(id)^(id obj, MSIDGetDeviceInfoRequestCompletionBlock callback)
+    {
+        [expectation fulfill];
+        
+        MSIDDeviceInfo *deviceInfo = [MSIDDeviceInfo new];
+        deviceInfo.brokerVersion = @"test";
+        deviceInfo.deviceMode = MSIDDeviceModeShared;
+        deviceInfo.ssoExtensionMode = MSIDSSOExtensionModeSilentOnly;
+        
+        callback(deviceInfo, nil);
+    }];
+    
+    XCTestExpectation *successExpectation = [self expectationWithDescription:@"Get device info"];
+    
+    MSIDRequestParameters *requestParams = [MSIDTestParametersProvider testInteractiveParameters];
+    requestParams.validateAuthority = YES;
+    
+    [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
+                                        completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+    {
+        XCTAssertNotNil(deviceInformation);
+        XCTAssertNil(error);
+        XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeShared);
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"isSSOExtensionInFullMode"], @"No");
+        XCTAssertNil(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY]);
+        XCTAssertNil(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY]);
+        [successExpectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation, successExpectation] timeout:1];
+}
+
+
 
 - (void)testGetDeviceInfo_whenSSOExtensionPresent_andReturnedDeviceInfo_shouldReturnMSALDeviceInfo_withWPJRegisterationInfo API_AVAILABLE(ios(13.0), macos(10.15))
 {

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -226,7 +226,6 @@
         XCTAssertNotNil(deviceInformation);
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeDefault);
         XCTAssertEqual(deviceInformation.extraDeviceInformation.count, 3);
-        XCTAssertEqual(deviceInformation.extraDeviceInformation.count, 3);
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"aadDeviceIdentifier"], @"TestDevID");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"userPrincipalName"], @"TestUPN");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"aadTenantIdentifier"], @"TestTenantID");
@@ -265,7 +264,7 @@
         NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
         extraDeviceInfoDict[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
         extraDeviceInfoDict[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
-        deviceInfo.extraDeviceInfo = [extraDeviceInfoDict mutableCopy];
+        deviceInfo.extraDeviceInfo = extraDeviceInfoDict;
         
         callback(deviceInfo, nil);
     }];
@@ -393,6 +392,7 @@
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"userPrincipalName"], @"TestUPN");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"aadTenantIdentifier"], @"TestTenantID");
         XCTAssertNil(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY]);
+        XCTAssertNil(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY]);
         [successExpectation fulfill];
     }];
 

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -262,8 +262,10 @@
         deviceInfo.brokerVersion = @"test";
         deviceInfo.deviceMode = MSIDDeviceModeShared;
         deviceInfo.ssoExtensionMode = MSIDSSOExtensionModeSilentOnly;
-        deviceInfo.extraDeviceInfo[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
-        deviceInfo.extraDeviceInfo[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
+        NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
+        extraDeviceInfoDict[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
+        extraDeviceInfoDict[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
+        deviceInfo.extraDeviceInfo = [extraDeviceInfoDict mutableCopy];
         
         callback(deviceInfo, nil);
     }];

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2499,7 +2499,7 @@
         NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
         extraDeviceInfoDict[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
         extraDeviceInfoDict[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
-        msidDeviceInfo.extraDeviceInfo = [extraDeviceInfoDict mutableCopy];
+        msidDeviceInfo.extraDeviceInfo = extraDeviceInfoDict;
         MSALDeviceInformation *deviceInfo = [[MSALDeviceInformation alloc] initWithMSIDDeviceInfo:msidDeviceInfo];
         
         callback(deviceInfo, nil);

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2496,8 +2496,10 @@
         
         MSIDDeviceInfo *msidDeviceInfo = [MSIDDeviceInfo new];
         msidDeviceInfo.deviceMode = MSIDDeviceModeShared;
-        msidDeviceInfo.extraDeviceInfo[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
-        msidDeviceInfo.extraDeviceInfo[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
+        NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
+        extraDeviceInfoDict[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
+        extraDeviceInfoDict[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
+        msidDeviceInfo.extraDeviceInfo = [extraDeviceInfoDict mutableCopy];
         MSALDeviceInformation *deviceInfo = [[MSALDeviceInformation alloc] initWithMSIDDeviceInfo:msidDeviceInfo];
         
         callback(deviceInfo, nil);

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2496,8 +2496,10 @@
         
         MSIDDeviceInfo *msidDeviceInfo = [MSIDDeviceInfo new];
         msidDeviceInfo.deviceMode = MSIDDeviceModeShared;
-        msidDeviceInfo.mdmId = @"mdmId";
+        msidDeviceInfo.extraDeviceInfo[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
+        msidDeviceInfo.extraDeviceInfo[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
         MSALDeviceInformation *deviceInfo = [[MSALDeviceInformation alloc] initWithMSIDDeviceInfo:msidDeviceInfo];
+        
         callback(deviceInfo, nil);
     }];
     
@@ -2510,6 +2512,7 @@
         XCTAssertNil(error);
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeShared);
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY], @"mdmId");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY], @"objectId");
         [deviceInfoExpectation fulfill];
     }];
     


### PR DESCRIPTION
## Proposed changes

Expose mdmId and objectId via extraDeviceInfo for MAM SDK , as mdmId and objectId wont be available via CP after JIT is rolled out

## Type of change

- [ x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

