### PR TITLE
Ignore sign in status on account removal from ODSP cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ##[TBD]
 * Expose extra deviceInfo
+* Ignore sign in status on account removal from ODSP cache #1541
 
 ## [1.2.3]
 * Stop extra background tasks in the system webview case.

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -164,6 +164,10 @@
 		231CE9DC1FEC682000E95D3E /* libIdentityTest.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A206271FC50A4D00755A51 /* libIdentityTest.a */; };
 		231CE9DE1FEC684C00E95D3E /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 231CE9DD1FEC684C00E95D3E /* Security.framework */; };
 		231CE9DF1FEC7E8400E95D3E /* libIdentityTest.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A206291FC50A4D00755A51 /* libIdentityTest.a */; };
+		2328074028BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2328073F28BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h */; };
+		2328074128BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2328073F28BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h */; };
+		2328074228BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2328073F28BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h */; };
+		2328074328BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2328073F28BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h */; };
 		232D614B2248484C00260C42 /* MSALClaimsRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 232D61482248484C00260C42 /* MSALClaimsRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		232D614C2248484C00260C42 /* MSALClaimsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 232D61492248484C00260C42 /* MSALClaimsRequest.m */; };
 		232D614D2248484C00260C42 /* MSALClaimsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 232D61492248484C00260C42 /* MSALClaimsRequest.m */; };
@@ -1146,6 +1150,7 @@
 		23014D4F25672E53005E12F2 /* MSALAuthenticationSchemeBearer+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSALAuthenticationSchemeBearer+Internal.h"; sourceTree = "<group>"; };
 		231CE9DD1FEC684C00E95D3E /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		231CE9E01FECBD4600E95D3E /* unit-test-host.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "unit-test-host.entitlements"; sourceTree = "<group>"; };
+		2328073F28BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSALAccountEnumerationParameters+Private.h"; sourceTree = "<group>"; };
 		232D61482248484C00260C42 /* MSALClaimsRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALClaimsRequest.h; sourceTree = "<group>"; };
 		232D61492248484C00260C42 /* MSALClaimsRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALClaimsRequest.m; sourceTree = "<group>"; };
 		232D615A22485B4600260C42 /* MSALIndividualClaimRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALIndividualClaimRequest.h; sourceTree = "<group>"; };
@@ -2135,6 +2140,7 @@
 				96D9A5461E4AB21400674A85 /* telemetry */,
 				D673F06E1E4411960018BA91 /* util */,
 				D65A6F731E3FF3D900C69FBA /* MSAL_Internal.h */,
+				2328073F28BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h */,
 				23014D172567233A005E12F2 /* MSALAuthenticationSchemeProtocolInternal.h */,
 				1EE776BD246C98D300F7EBFC /* MSALAuthenticationSchemeBearer.m */,
 				1EE776C3246C98E700F7EBFC /* MSALAuthenticationSchemePop.m */,
@@ -2569,6 +2575,7 @@
 				04A6B5B62269370E0035C7C2 /* MSALWebviewType_Internal.h in Headers */,
 				B273D0BE226E85A5005A7BB4 /* MSALGlobalConfig+Internal.h in Headers */,
 				B2D478A6230E3E57005AE186 /* MSALTelemetryEventsObservingProxy.h in Headers */,
+				2328074328BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */,
 				B273D0A2226E8574005A7BB4 /* MSALIndividualClaimRequest+Internal.h in Headers */,
 				B2D47885230E3DC6005AE186 /* MSALB2COauth2Provider.h in Headers */,
 				B273D08E226E852F005A7BB4 /* MSALJsonSerializable.h in Headers */,
@@ -2629,6 +2636,7 @@
 				B273D08F226E8534005A7BB4 /* MSALJsonDeserializable.h in Headers */,
 				B273D077226E84DD005A7BB4 /* MSALHTTPConfig.h in Headers */,
 				B273D0CB226E85C7005A7BB4 /* MSALHTTPConfig+Internal.h in Headers */,
+				2328074228BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */,
 				B2D478B9230E3E91005AE186 /* MSALExternalAccountHandler.h in Headers */,
 				B273D06F226E84C3005A7BB4 /* MSALGlobalConfig.h in Headers */,
 				04A6B5E0226937AD0035C7C2 /* MSALAccountsProvider.h in Headers */,
@@ -2771,6 +2779,7 @@
 				1E3658A7247F2BB60044A072 /* MSALAuthenticationSchemeProtocol.h in Headers */,
 				B2AA5D6823A353F200BD47D8 /* MSALSignoutParameters.h in Headers */,
 				96CF95312268FD0500D97374 /* MSALJsonSerializable.h in Headers */,
+				2328074028BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */,
 				B273D09B226E856A005A7BB4 /* MSAL_Internal.h in Headers */,
 				96CF95162268FD0400D97374 /* MSALGlobalConfig.h in Headers */,
 				96CF951F2268FD0400D97374 /* MSALPublicClientApplication.h in Headers */,
@@ -2801,6 +2810,7 @@
 				96B5E6E12256D166002232F9 /* MSALTelemetryConfig.h in Headers */,
 				96B5E6DB2256D15A002232F9 /* MSALHTTPConfig.h in Headers */,
 				A0274CDC24B54A7000BD198D /* MSALDevicePopManagerUtil.h in Headers */,
+				2328074128BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */,
 				96B5E6E72256D174002232F9 /* MSALLoggerConfig.h in Headers */,
 				1E3658A8247F2BB60044A072 /* MSALAuthenticationSchemeProtocol.h in Headers */,
 				D65A6FA81E3FF3D900C69FBA /* MSAL.h in Headers */,

--- a/MSAL/src/MSALAccountEnumerationParameters+Private.h
+++ b/MSAL/src/MSALAccountEnumerationParameters+Private.h
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#import "MSALAccountEnumerationParameters.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALAccountEnumerationParameters ()
+
+@property (nonatomic, readwrite) BOOL ignoreSignedInStatus;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/MSALAccountEnumerationParameters.m
+++ b/MSAL/src/MSALAccountEnumerationParameters.m
@@ -25,7 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
-#import "MSALAccountEnumerationParameters.h"
+#import "MSALAccountEnumerationParameters+Private.h"
 
 @interface MSALAccountEnumerationParameters()
 

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccount.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccount.m
@@ -24,7 +24,7 @@
 #import "MSALLegacySharedAccount.h"
 #import "MSIDJsonObject.h"
 #import "NSDictionary+MSIDExtensions.h"
-#import "MSALAccountEnumerationParameters.h"
+#import "MSALAccountEnumerationParameters+Private.h"
 #import <MSAL/MSAL.h>
 
 @interface MSALLegacySharedAccount()
@@ -117,6 +117,8 @@ static NSDateFormatter *s_updateDateFormatter = nil;
 
 - (BOOL)matchesParameters:(MSALAccountEnumerationParameters *)parameters
 {
+    if (parameters.ignoreSignedInStatus) return YES;
+    
     if (parameters.returnOnlySignedInAccounts)
     {
         NSString *appIdentifier = [[NSBundle mainBundle] bundleIdentifier];

--- a/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
+++ b/MSAL/src/configuration/external/ios/MSALLegacySharedAccountsProvider.m
@@ -28,7 +28,7 @@
 #import "MSALLegacySharedAccountFactory.h"
 #import "MSIDJsonObject.h"
 #import "MSALLegacySharedAccount.h"
-#import "MSALAccountEnumerationParameters.h"
+#import "MSALAccountEnumerationParameters+Private.h"
 #import "MSIDConstants.h"
 #import "MSALErrorConverter.h"
 #import "MSALAccount.h"
@@ -300,6 +300,7 @@
     {
         MSALAccountEnumerationParameters *parameters = [MSALLegacySharedAccountFactory parametersForAccount:account
                                                                                     tenantProfileIdentifier:account.accountClaims[@"oid"]];
+        parameters.ignoreSignedInStatus = YES;
         
         if (!parameters)
         {
@@ -317,6 +318,7 @@
     {
         MSALAccountEnumerationParameters *parameters = [MSALLegacySharedAccountFactory parametersForAccount:account
                                                                                     tenantProfileIdentifier:tenantProfile.identifier];
+        parameters.ignoreSignedInStatus = YES;
         
         if (!parameters)
         {

--- a/MSAL/test/unit/ios/external-cache/MSALLegacySharedAccountTests.m
+++ b/MSAL/test/unit/ios/external-cache/MSALLegacySharedAccountTests.m
@@ -27,7 +27,7 @@
 
 #import <XCTest/XCTest.h>
 #import "MSALLegacySharedAccount.h"
-#import "MSALAccountEnumerationParameters.h"
+#import "MSALAccountEnumerationParameters+Private.h"
 #import "MSALTestConstants.h"
 #import "MSIDTestBundle.h"
 #import "MSALAccount+Internal.h"
@@ -159,6 +159,21 @@
     params.returnOnlySignedInAccounts = YES;
     BOOL result = [account matchesParameters:params];
     XCTAssertFalse(result);
+}
+
+- (void)testMatchesParameters_whenIgnoreSignedInStatus_andAppSignedOut_shouldReturnYes
+{
+    NSMutableDictionary *jsonDictionary = [[MSALLegacySharedAccountTestUtil sampleADALJSONDictionary] mutableCopy];
+    
+    NSDictionary *signinStatusDict = @{[[NSBundle mainBundle] bundleIdentifier]: @"SignedOut"};
+    jsonDictionary[@"signInStatus"] = signinStatusDict;
+    
+    MSALLegacySharedAccount *account = [[MSALLegacySharedAccount alloc] initWithJSONDictionary:jsonDictionary error:nil];
+    
+    MSALAccountEnumerationParameters *params = [MSALAccountEnumerationParameters new];
+    params.ignoreSignedInStatus = YES;
+    BOOL result = [account matchesParameters:params];
+    XCTAssertTrue(result);
 }
 
 #pragma mark - updateAccountWithMSALAccount


### PR DESCRIPTION
## Proposed changes

Remove signed-out accounts as well.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

