### PR TITLE
Add task to delete previous automation run results

### DIFF
--- a/azure_pipelines/automation.yml
+++ b/azure_pipelines/automation.yml
@@ -83,7 +83,13 @@ jobs:
             -retry-tests-on-failure \
             -parallel-testing-enabled NO \
             -resultBundlePath '$(Agent.BuildDirectory)/s/test_output/report.xcresult'
-            
+  - task: Bash@3
+    displayName: Delete previous run results
+    inputs:
+      targetType: 'inline'
+      script: |
+        # If failed job is asked to re-run, it runs in the same pipeline and previous failed result might be present. Need to delete it to publish new results.
+        rm -f $(Agent.BuildDirectory)/s/test_output/*        
   - task: PublishPipelineArtifact@1
     condition: succeededOrFailed()
     inputs:


### PR DESCRIPTION
## Proposed changes

The ADO task in pipeline responsible to publish test results does not have a feature to overwrite previous results and fails if previous results already exist.
If Automation job fails and is asked to re-run, it runs in the same pipeline and previous run results need to be deleted before publishing new results.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

