### PR TITLE
Save automation artifacts using pipeline Job Id

### DIFF
--- a/azure_pipelines/automation.yml
+++ b/azure_pipelines/automation.yml
@@ -82,19 +82,13 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.2' \
             -retry-tests-on-failure \
             -parallel-testing-enabled NO \
-            -resultBundlePath '$(Agent.BuildDirectory)/s/test_output/report.xcresult'
-  - task: Bash@3
-    displayName: Delete previous run results
-    inputs:
-      targetType: 'inline'
-      script: |
-        # If failed job is asked to re-run, it runs in the same pipeline and previous failed result might be present. Need to delete it to publish new results.
-        rm -f $(Agent.BuildDirectory)/s/test_output/*        
+            -resultBundlePath '$(Agent.BuildDirectory)/s/test_output/report.xcresult'       
+  # https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#q-can-i-delete-pipeline-artifacts-when-re-running-failed-jobs
   - task: PublishPipelineArtifact@1
     condition: succeededOrFailed()
     inputs:
       targetPath: '$(Agent.BuildDirectory)/s/test_output/'
-      artifact: 'TestOutputs'
+      artifactName: '$(system.JobId) - TestOutputs'
       publishLocation: 'pipeline'
   - task: UsePythonVersion@0
     condition: failed()


### PR DESCRIPTION
Add job id to published artifact name

## Proposed changes

Use workaround provided by ADO for re-running failed jobs : https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#q-can-i-delete-pipeline-artifacts-when-re-running-failed-jobs

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

