### PR TITLE
Update automation.yml

### DIFF
--- a/azure_pipelines/automation.yml
+++ b/azure_pipelines/automation.yml
@@ -70,6 +70,7 @@ jobs:
           -derivedDataPath 'build' \
           | tee xcodebuild.log \
           | xcpretty -c
+      failOnStderr: true
   
   - task: Bash@3
     displayName: Run automations
@@ -88,7 +89,7 @@ jobs:
     condition: succeededOrFailed()
     inputs:
       targetPath: '$(Agent.BuildDirectory)/s/test_output/'
-      artifactName: '$(system.JobId) - TestOutputs'
+      artifactName: 'TestOutputs Attempt - $(System.StageAttempt)'
       publishLocation: 'pipeline'
   - task: UsePythonVersion@0
     condition: failed()


### PR DESCRIPTION
Add attempt number to test result artifact

## Proposed changes

To avoid artifact already exists error when re-running failed automation job, this PR aims to add attempt number to the artifact name so that a separate one is created for each run

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

