### PR TITLE
Add new allowGettingAccessTokenWithRefreshToken in MSALSilentTokenPar…

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -872,6 +872,7 @@
     msidParams.currentRequestTelemetry.schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
     msidParams.currentRequestTelemetry.tokenCacheRefreshType = parameters.forceRefresh ? TokenCacheRefreshTypeForceRefresh : TokenCacheRefreshTypeNoCacheLookupInvolved;
+    msidParams.allowGettingAccessTokenWithRefreshToken = parameters.allowGettingAccessTokenWithRefreshToken;
      
     
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, msidParams,

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -872,7 +872,7 @@
     msidParams.currentRequestTelemetry.schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
     msidParams.currentRequestTelemetry.tokenCacheRefreshType = parameters.forceRefresh ? TokenCacheRefreshTypeForceRefresh : TokenCacheRefreshTypeNoCacheLookupInvolved;
-    msidParams.allowGettingAccessTokenWithRefreshToken = parameters.allowGettingAccessTokenWithRefreshToken;
+    msidParams.allowUsingLocalCachedRtWhenSsoExtFailed = parameters.allowUsingLocalCachedRtWhenSsoExtFailed;
      
     
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, msidParams,

--- a/MSAL/src/MSALSilentTokenParameters.m
+++ b/MSAL/src/MSALSilentTokenParameters.m
@@ -40,6 +40,7 @@
     {
         self.account = account;
         self.telemetryApiId = MSALTelemetryApiIdAcquireSilentWithTokenParameters;
+        self.allowUsingLocalCachedRtWhenSsoExtFailed = YES;
     }
     return self;
 }

--- a/MSAL/src/public/MSALSilentTokenParameters.h
+++ b/MSAL/src/public/MSALSilentTokenParameters.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  2. When Sso Extension is not presenting on the device
     This parameter is ignored, and tries with existing refresh token in the cache.
  */
-@property (nonatomic) BOOL allowGettingAccessTokenWithRefreshToken;
+@property (nonatomic) BOOL allowUsingLocalCachedRtWhenSsoExtFailed;
 
 #pragma mark - Constructing MSALSilentTokenParameters
 

--- a/MSAL/src/public/MSALSilentTokenParameters.h
+++ b/MSAL/src/public/MSALSilentTokenParameters.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  1. When broker is presenting on the device
-    Default is false. when broker failed to return a (new) access token, ignores existing refresh token in local cahce, and return broker error.
+    Default is false. when broker failed to return a (new) access token, ignores existing refresh token in local cache, and return broker error.
     If set to true, when broker failed to return a (new) access token, tries with existing refresh token in the cache, and return results.
  2. When broker is not presenting on the device
     This parameter is ignored, and tries with existing refresh token in the cache.

--- a/MSAL/src/public/MSALSilentTokenParameters.h
+++ b/MSAL/src/public/MSALSilentTokenParameters.h
@@ -44,8 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  1. When Sso Extension is presenting on the device
-    Default is false. when Sso Extension failed to return a (new) access token, ignores existing refresh token in local cahce, and return Sso Extension error.
-    If set to true, when Sso Extension failed to return a (new) access token, tries with existing refresh token in the cache, and return results.
+    Default is YES. when Sso Extension failed to return a (new) access token, tries with existing refresh token in the cache, and return results.
+    If set to NO, when Sso Extension failed to return a (new) access token, ignores existing refresh token in local cahce, and return Sso Extension error.
  2. When Sso Extension is not presenting on the device
     This parameter is ignored, and tries with existing refresh token in the cache.
  */

--- a/MSAL/src/public/MSALSilentTokenParameters.h
+++ b/MSAL/src/public/MSALSilentTokenParameters.h
@@ -43,10 +43,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL forceRefresh;
 
 /**
- 1. When broker is presenting on the device
-    Default is false. when broker failed to return a (new) access token, ignores existing refresh token in local cache, and return broker error.
-    If set to true, when broker failed to return a (new) access token, tries with existing refresh token in the cache, and return results.
- 2. When broker is not presenting on the device
+ 1. When Sso Extension is presenting on the device
+    Default is false. when Sso Extension failed to return a (new) access token, ignores existing refresh token in local cahce, and return Sso Extension error.
+    If set to true, when Sso Extension failed to return a (new) access token, tries with existing refresh token in the cache, and return results.
+ 2. When Sso Extension is not presenting on the device
     This parameter is ignored, and tries with existing refresh token in the cache.
  */
 @property (nonatomic) BOOL allowGettingAccessTokenWithRefreshToken;

--- a/MSAL/src/public/MSALSilentTokenParameters.h
+++ b/MSAL/src/public/MSALSilentTokenParameters.h
@@ -42,6 +42,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL forceRefresh;
 
+/**
+ 1. When broker is presenting on the device
+    Default is false. when broker failed to return a (new) access token, ignores existing refresh token in local cahce, and return broker error.
+    If set to true, when broker failed to return a (new) access token, tries with existing refresh token in the cache, and return results.
+ 2. When broker is not presenting on the device
+    This parameter is ignored, and tries with existing refresh token in the cache.
+ */
+@property (nonatomic) BOOL allowGettingAccessTokenWithRefreshToken;
+
 #pragma mark - Constructing MSALSilentTokenParameters
 
 /**


### PR DESCRIPTION
…ameters public API

## Proposed changes

Add new property in MSALSilentTokenParameters public API to allow using local RT as fallback if broker fails

[CommonCore change can be found here](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1160)

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

