### PR TITLE
Added warning for deprecation methods for xcode 14

### DIFF
--- a/MSAL/src/configuration/MSALCacheConfig.m
+++ b/MSAL/src/configuration/MSALCacheConfig.m
@@ -102,7 +102,10 @@
     NSMutableArray *trustedApps = [NSMutableArray new];
     OSStatus status;
     SecTrustedApplicationRef myself = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     status = SecTrustedApplicationCreateFromPath(nil, &myself);
+#pragma clang diagnostic pop
     if (status != errSecSuccess)
     {
         NSError *msidError;
@@ -122,7 +125,10 @@
     for (NSString *appPath in appPaths)
     {
         SecTrustedApplicationRef app = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         status = SecTrustedApplicationCreateFromPath([appPath UTF8String], &app);
+#pragma clang diagnostic pop
         if (status != errSecSuccess)
         {
             NSError *msidError;


### PR DESCRIPTION
## Proposed changes

Adding Pragma warning for deprecated methods

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

