### PR TITLE
Return additional metadata about primary registration in SSO extension getDeviceInfo call

### DIFF
--- a/MSAL/src/MSALDeviceInformation.m
+++ b/MSAL/src/MSALDeviceInformation.m
@@ -33,6 +33,10 @@
 #import "MSIDBrokerConstants.h"
 
 NSString *const MSAL_DEVICE_INFORMATION_SSO_EXTENSION_FULL_MODE_KEY = @"isSSOExtensionInFullMode";
+NSString *const MSAL_PRIMARY_REGISTRATION_UPN = @"primary_registration_metadata_upn";
+NSString *const MSAL_PRIMARY_REGISTRATION_DEVICE_ID = @"primary_registration_metadata_device_id";
+NSString *const MSAL_PRIMARY_REGISTRATION_TENANT_ID = @"primary_registration_metadata_tenant_id";
+NSString *const MSAL_PRIMARY_REGISTRATION_CLOUD = @"primary_registration_metadata_cloud_host";
 
 @implementation MSALDeviceInformation
 {

--- a/MSAL/src/public/MSALDeviceInformation.h
+++ b/MSAL/src/public/MSALDeviceInformation.h
@@ -27,6 +27,30 @@
 
 #import <Foundation/Foundation.h>
 
+/*
+ Key to read the UPN of the registeredOwner of the AAD device from the extraDeviceInformation property
+ If device has multiple registrations, this will be the primary registration.
+ */
+extern NSString * _Nonnull const MSAL_PRIMARY_REGISTRATION_UPN;
+
+/*
+ Key to read the identifier of the AAD device from the extraDeviceInformation property
+ If device has multiple registrations, this will be the primary registration.
+ */
+extern NSString * _Nonnull const MSAL_PRIMARY_REGISTRATION_DEVICE_ID;
+
+/*
+ Key to read the tenant identifier of the AAD device from the extraDeviceInformation property
+ If device has multiple registrations, this will be the primary registration.
+ */
+extern NSString * _Nonnull const MSAL_PRIMARY_REGISTRATION_TENANT_ID;
+
+/*
+ Key to read the host of the AAD cloud for the AAD device from the extraDeviceInformation property
+ If device has multiple registrations, this will be the primary registration.
+ */
+extern NSString * _Nonnull const MSAL_PRIMARY_REGISTRATION_CLOUD;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**


### PR DESCRIPTION
## Proposed changes

GetDeviceInfo API will now return additional metadata about primary AAD device registration.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

