### PR TITLE
Disable Metal API validation in MSAL Test App Mac

### DIFF
--- a/MSAL/MSAL.xcodeproj/xcshareddata/xcschemes/MSAL Test App (Mac).xcscheme
+++ b/MSAL/MSAL.xcodeproj/xcshareddata/xcschemes/MSAL Test App (Mac).xcscheme
@@ -50,6 +50,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">


### PR DESCRIPTION
Disable Metal API validation in MSAL Test App Mac to be able to use it inside a VM

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

No idea why the diff shows enableGPUValidationMode as "1" when the checkbox is unchecked:

![image](https://user-images.githubusercontent.com/1686668/212232463-a398e55c-3118-42f1-93a8-6c0894cbf4c6.png)
