### PR TITLE
Support external SSO keys in PkeyAuth handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,6 @@ let package = Package(
           targets: ["MSAL"]),
   ],
   targets: [
-      .binaryTarget(name: "MSAL", url: "https://github.com/AzureAD/microsoft-authentication-library-for-objc/releases/download/1.2.8/MSAL.zip", checksum: "e2b4a2fab811b2646bbb91b60df3bdcc0a0310b5f03c7b3bdc1d957b57538b34")
+      .binaryTarget(name: "MSAL", url: "https://github.com/AzureAD/microsoft-authentication-library-for-objc/releases/download/1.2.9/MSAL.zip", checksum: "5fe144133a3094d2bf5c8932641c3a2935412f41059e52d6b7e3361c617ec59a")
   ]
 )


### PR DESCRIPTION
## Proposed changes

Support external SSO extension context in PkeyAuth calls. This is needed if device keys are supplied externally by the SSO extension.
There're a lot of changes here, but majority of them are simply passing the ssoContext between all layers. 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

