### PR TITLE
Veena/expose platform sso status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD
+* Updated extraDeviceInfo to include platform sso status on macOS
+
 ## [1.2.10]
 * Performed testing for CIAM behaviors in MSAL (#1668)
 

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		6077D4A922498D87001798A2 /* MSALTenantProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 6077D4A822498D87001798A2 /* MSALTenantProfile.m */; };
 		6077D4AA22498D87001798A2 /* MSALTenantProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 6077D4A822498D87001798A2 /* MSALTenantProfile.m */; };
 		609AF9332256BD0C00E2978D /* MSALAccountsProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 609AF9322256BD0C00E2978D /* MSALAccountsProviderTests.m */; };
+		6525115A29CD84A000D3B876 /* MSALPublicClientApplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D673F07C1E4AAB0D0018BA91 /* MSALPublicClientApplicationTests.m */; };
 		6577FFC829CC2E4B003235A6 /* MSALDeviceInfoProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B253153A23DD717900432133 /* MSALDeviceInfoProviderTests.m */; };
 		8893E96929B13A4C0017B148 /* MSALCIAMTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8893E96729B13A4C0017B148 /* MSALCIAMTest.m */; };
 		94E876CE1E492D6000FB96ED /* MSALAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 94E876CB1E492D6000FB96ED /* MSALAuthority.m */; };
@@ -745,7 +746,6 @@
 		B2D478C3230E3EBD005AE186 /* MSALTenantProfile+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 609AF958225B348900E2978D /* MSALTenantProfile+Internal.h */; };
 		B2D478C4230E3EC4005AE186 /* MSALAccountEnumerationParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = B27CCDF1229F9F4700CAD565 /* MSALAccountEnumerationParameters.m */; };
 		B2D478C5230E3EC5005AE186 /* MSALAccountEnumerationParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = B27CCDF1229F9F4700CAD565 /* MSALAccountEnumerationParameters.m */; };
-		B2D6672D210E766F00952595 /* MSALPublicClientApplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D673F07C1E4AAB0D0018BA91 /* MSALPublicClientApplicationTests.m */; };
 		B2E2A9422393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E2A9402393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h */; };
 		B2E2A9432393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = B2E2A9412393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.m */; };
 		B2E2A94A2393192400BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E2A9402393191D00BA2EA3 /* MSIDInteractiveRequestParameters+MSALRequest.h */; };
@@ -3975,6 +3975,7 @@
 				B2725EC622BF4865009B454A /* MSALMockExternalAccountHandler.m in Sources */,
 				A0274CBF24B432B100BD198D /* MSALAuthSchemeTests.m in Sources */,
 				D69ADB401E516F9B00952049 /* MSALTestURLSessionDataTask.m in Sources */,
+				6525115A29CD84A000D3B876 /* MSALPublicClientApplicationTests.m in Sources */,
 				D62746DA1E9B5F1E00EFCE99 /* MSALAccountTests.m in Sources */,
 				B256121C217EA44900999876 /* MSALOauth2FactoryProducerTests.m in Sources */,
 				B29A56D62283D7430023F5E6 /* MSALAADAuthorityTests.m in Sources */,
@@ -3985,7 +3986,6 @@
 				D69ADB3E1E516F9B00952049 /* MSIDTestURLSession+MSAL.m in Sources */,
 				B281B33C226BC225009619AB /* MSALPublicClientApplicationConfigTests.m in Sources */,
 				960751BC2183E82C00F2BF2F /* MSALAccountIdTests.m in Sources */,
-				B2D6672D210E766F00952595 /* MSALPublicClientApplicationTests.m in Sources */,
 				1E8FC6A4221F370C00B4D4C1 /* MSALResultTests.m in Sources */,
 				A0274CDE24B54C8900BD198D /* MSALDevicePopManagerUtil.m in Sources */,
 				58B81F7224AC5D7300E8799E /* MSALTestCacheTokenResponse.m in Sources */,

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		6077D4A922498D87001798A2 /* MSALTenantProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 6077D4A822498D87001798A2 /* MSALTenantProfile.m */; };
 		6077D4AA22498D87001798A2 /* MSALTenantProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 6077D4A822498D87001798A2 /* MSALTenantProfile.m */; };
 		609AF9332256BD0C00E2978D /* MSALAccountsProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 609AF9322256BD0C00E2978D /* MSALAccountsProviderTests.m */; };
+		6577FFC829CC2E4B003235A6 /* MSALDeviceInfoProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B253153A23DD717900432133 /* MSALDeviceInfoProviderTests.m */; };
 		8893E96929B13A4C0017B148 /* MSALCIAMTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8893E96729B13A4C0017B148 /* MSALCIAMTest.m */; };
 		94E876CE1E492D6000FB96ED /* MSALAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 94E876CB1E492D6000FB96ED /* MSALAuthority.m */; };
 		960751BB2183E82C00F2BF2F /* MSALAccountIdTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 960751BA2183E82C00F2BF2F /* MSALAccountIdTests.m */; };
@@ -3977,6 +3978,7 @@
 				D62746DA1E9B5F1E00EFCE99 /* MSALAccountTests.m in Sources */,
 				B256121C217EA44900999876 /* MSALOauth2FactoryProducerTests.m in Sources */,
 				B29A56D62283D7430023F5E6 /* MSALAADAuthorityTests.m in Sources */,
+				6577FFC829CC2E4B003235A6 /* MSALDeviceInfoProviderTests.m in Sources */,
 				D69ADB381E516F9B00952049 /* MSALTestCase.m in Sources */,
 				04D32CD11FD8AFF3000B123E /* MSALErrorConverterTests.m in Sources */,
 				232D6193224C53E500260C42 /* MSALClaimsRequestTests.m in Sources */,

--- a/MSAL/src/MSALDeviceInformation.m
+++ b/MSAL/src/MSALDeviceInformation.m
@@ -83,6 +83,10 @@ NSString *const MSAL_PRIMARY_REGISTRATION_CERTIFICATE_THUMBPRINT = @"primary_reg
         {
             _hasAADSSOExtension = NO;
         }
+        
+#if TARGET_OS_OSX
+        _platformSSOStatus = [self msalPlatformSSOStatusFromMSIDPlatformSSOStatus:deviceInfo.platformSSOStatus];
+#endif
 
         _extraDeviceInformation = [NSMutableDictionary new];
         [self initExtraDeviceInformation:deviceInfo];
@@ -115,6 +119,19 @@ NSString *const MSAL_PRIMARY_REGISTRATION_CERTIFICATE_THUMBPRINT = @"primary_reg
             
         default:
             return @"default";
+    }
+}
+
+- (MSALPlatformSSOStatus)msalPlatformSSOStatusFromMSIDPlatformSSOStatus:(MSIDPlatformSSOStatus)msidPlatformSSOStatus
+{
+    switch (msidPlatformSSOStatus) {
+        case MSIDPlatformSSOEnabledNotRegistered:
+            return MSALPlatformSSOEnabledNotRegistered;
+        case MSIDPlatformSSOEnabledAndRegistered:
+            return MSALPlatformSSOEnabledAndRegistered;
+            
+        default:
+            return MSALPlatformSSONotEnabled;
     }
 }
 

--- a/MSAL/src/public/MSALDefinitions.h
+++ b/MSAL/src/public/MSALDefinitions.h
@@ -168,12 +168,12 @@ typedef NS_ENUM(NSUInteger, MSALPlatformSSOStatus)
     MSALPlatformSSONotEnabled,
     
     /*
-     Administrator has configured Platform SSO in sso config. But device has not been registred with ADRS via platform SSO
+     Administrator has configured Platform SSO in sso config. But device has not been registred with AAD via platform SSO
      */
     MSALPlatformSSOEnabledNotRegistered,
     
     /*
-     Administrator has configured Platform SSO in sso config and the device is registred with ADRS via platform SSO
+     Administrator has configured Platform SSO in sso config and the device is registred with AAD via platform SSO
      */
     MSALPlatformSSOEnabledAndRegistered
 };

--- a/MSAL/src/public/MSALDefinitions.h
+++ b/MSAL/src/public/MSALDefinitions.h
@@ -158,6 +158,27 @@ typedef NS_ENUM(NSUInteger, MSALDeviceMode)
 };
 
 /**
+ Platform SSO status on macOS device
+ */
+typedef NS_ENUM(NSUInteger, MSALPlatformSSOStatus)
+{
+    /*
+        Administrator hasn't configured Platform SSO in sso config.
+    */
+    MSALPlatformSSONotEnabled,
+    
+    /*
+     Administrator has configured Platform SSO in sso config. But device has not been registred with ADRS via platform SSO
+     */
+    MSALPlatformSSOEnabledNotRegistered,
+    
+    /*
+     Administrator has configured Platform SSO in sso config and the device is registred with ADRS via platform SSO
+     */
+    MSALPlatformSSOEnabledAndRegistered
+};
+
+/**
     The block that gets invoked after MSAL has finished getting a token silently or interactively.
     @param result       Represents information returned to the application after a successful interactive or silent token acquisition. See `MSALResult` for more information.
     @param error         Provides information about error that prevented MSAL from getting a token. See `MSALError` for possible errors.

--- a/MSAL/src/public/MSALDeviceInformation.h
+++ b/MSAL/src/public/MSALDeviceInformation.h
@@ -79,6 +79,14 @@ NS_ASSUME_NONNULL_BEGIN
 */
 @property (nonatomic, readonly) NSDictionary *extraDeviceInformation;
 
+#if TARGET_OS_OSX
+/**
+ Platform SSO status on macOS device
+*/
+@property (nonatomic, readonly) MSALPlatformSSOStatus platformSSOStatus;
+
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -367,7 +367,7 @@
         extraDeviceInfoDict[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
         extraDeviceInfoDict[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
-        extraDeviceInfoDict[MSID_PLATFORM_SSO_STATUS] = @"MSIDPlatformSSOEnabledAndRegistered";
+        deviceInfo.platformSSOStatus = MSIDPlatformSSOEnabledAndRegistered;
 #endif
         deviceInfo.extraDeviceInfo = extraDeviceInfoDict;
         
@@ -389,10 +389,10 @@
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY], @"mdmId");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY], @"objectId");
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
-        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_PLATFORM_SSO_STATUS], @"MSIDPlatformSSOEnabledAndRegistered");
+        XCTAssertEqual(deviceInformation.platformSSOStatus, MSALPlatformSSOEnabledAndRegistered);
 #endif
 #if TARGET_OS_IPHONE
-        XCTAssertNil(deviceInformation.extraDeviceInformation[MSID_PLATFORM_SSO_STATUS]);
+        XCTAssertNil(deviceInformation.platformSSOStatus);
 #endif
         [successExpectation fulfill];
     }];
@@ -469,8 +469,8 @@
         MSIDDeviceInfo *deviceInfo = [MSIDDeviceInfo new];
         deviceInfo.brokerVersion = @"test";
         deviceInfo.deviceMode = MSIDDeviceModeShared;
+        deviceInfo.platformSSOStatus = MSIDPlatformSSONotEnabled;
         NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
-        extraDeviceInfoDict[MSID_PLATFORM_SSO_STATUS] = @"MSIDPlatformSSONotEnabled";
         deviceInfo.extraDeviceInfo = extraDeviceInfoDict;
         callback(deviceInfo, nil);
     }];
@@ -485,7 +485,7 @@
     {
         XCTAssertNotNil(deviceInformation);
         XCTAssertNil(error);
-        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_PLATFORM_SSO_STATUS], @"MSIDPlatformSSONotEnabled");
+        XCTAssertEqual(deviceInformation.platformSSOStatus, MSALPlatformSSONotEnabled);
         [successExpectation fulfill];
     }];
     

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -366,6 +366,9 @@
         NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
         extraDeviceInfoDict[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
         extraDeviceInfoDict[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+        extraDeviceInfoDict[MSID_PLATFORM_SSO_STATUS] = @"MSIDPlatformSSOEnabledAndRegistered";
+#endif
         deviceInfo.extraDeviceInfo = extraDeviceInfoDict;
         
         callback(deviceInfo, nil);
@@ -385,6 +388,12 @@
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"isSSOExtensionInFullMode"], @"No");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY], @"mdmId");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY], @"objectId");
+#if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_PLATFORM_SSO_STATUS], @"MSIDPlatformSSOEnabledAndRegistered");
+#endif
+#if TARGET_OS_IPHONE
+        XCTAssertNil(deviceInformation.extraDeviceInformation[MSID_PLATFORM_SSO_STATUS]);
+#endif
         [successExpectation fulfill];
     }];
     
@@ -437,7 +446,53 @@
     
     [self waitForExpectations:@[expectation, successExpectation] timeout:1];
 }
+#if TARGET_OS_OSX
+- (void)testGetDeviceInfo_whenSSOExtensionPresent_platformSSONotEnabled_shouldReturnPlatformSSONotEnabled API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    [MSIDTestSwizzle classMethod:@selector(canPerformRequest)
+                           class:[MSIDSSOExtensionGetDeviceInfoRequest class]
+                           block:(id)^(id obj)
+    {
+        return YES;
+    }];
+    
+    MSALDeviceInfoProvider *deviceInfoProvider = [MSALDeviceInfoProvider new];
+        
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Execute request"];
+    
+    [MSIDTestSwizzle instanceMethod:@selector(executeRequestWithCompletion:)
+                              class:[MSIDSSOExtensionGetDeviceInfoRequest  class]
+                              block:(id)^(id obj, MSIDGetDeviceInfoRequestCompletionBlock callback)
+    {
+        [expectation fulfill];
+        
+        MSIDDeviceInfo *deviceInfo = [MSIDDeviceInfo new];
+        deviceInfo.brokerVersion = @"test";
+        deviceInfo.deviceMode = MSIDDeviceModeShared;
+        NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
+        extraDeviceInfoDict[MSID_PLATFORM_SSO_STATUS] = @"MSIDPlatformSSONotEnabled";
+        deviceInfo.extraDeviceInfo = extraDeviceInfoDict;
+        callback(deviceInfo, nil);
+    }];
+    
+    XCTestExpectation *successExpectation = [self expectationWithDescription:@"Get device info"];
+    
+    MSIDRequestParameters *requestParams = [MSIDTestParametersProvider testInteractiveParameters];
+    requestParams.validateAuthority = YES;
+    
+    [deviceInfoProvider deviceInfoWithRequestParameters:requestParams
+                                        completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+    {
+        XCTAssertNotNil(deviceInformation);
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_PLATFORM_SSO_STATUS], @"MSIDPlatformSSONotEnabled");
+        [successExpectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation, successExpectation] timeout:1];
+}
 
+#endif
 - (void)testGetDeviceInfo_whenSSOExtensionPresent_andReturnedDeviceInfo_shouldReturnMSALDeviceInfo_withWPJRegisterationInfo API_AVAILABLE(ios(13.0), macos(10.15))
 {
     [MSIDTestSwizzle classMethod:@selector(canPerformRequest)

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -391,9 +391,6 @@
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
         XCTAssertEqual(deviceInformation.platformSSOStatus, MSALPlatformSSOEnabledAndRegistered);
 #endif
-#if TARGET_OS_IPHONE
-        XCTAssertNil(deviceInformation.platformSSOStatus);
-#endif
         [successExpectation fulfill];
     }];
     

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2016,7 +2016,7 @@
                 XCTAssertNotNil(error);
     }];    
 }
-
+#if TARGET_OS_OSX
 - (void)testGetDeviceInfo_whenBrokerEnabled_andFoundDeviceInfo_shouldReturnDeviceInfoWithPlatformSSOStatus API_AVAILABLE(ios(13.0), macos(10.15))
 {
     NSString *scheme = [NSString stringWithFormat:@"msauth.%@", [[NSBundle mainBundle] bundleIdentifier]];
@@ -2040,7 +2040,9 @@
         
         MSIDDeviceInfo *msidDeviceInfo = [MSIDDeviceInfo new];
         msidDeviceInfo.deviceMode = MSIDDeviceModeShared;
+
         msidDeviceInfo.platformSSOStatus = MSIDPlatformSSOEnabledAndRegistered;
+        
         NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
         extraDeviceInfoDict[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
         extraDeviceInfoDict[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
@@ -2066,6 +2068,7 @@
     
     [self waitForExpectations:@[expectation, deviceInfoExpectation] timeout:1];
 }
+#endif
 
 #if TARGET_OS_IPHONE
 

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2017,6 +2017,56 @@
     }];    
 }
 
+- (void)testGetDeviceInfo_whenBrokerEnabled_andFoundDeviceInfo_shouldReturnDeviceInfoWithPlatformSSOStatus API_AVAILABLE(ios(13.0), macos(10.15))
+{
+    NSString *scheme = [NSString stringWithFormat:@"msauth.%@", [[NSBundle mainBundle] bundleIdentifier]];
+    NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[scheme] } ];
+    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
+    
+    NSArray *querySchemes = @[@"msauthv2", @"msauthv3"];
+    [MSIDTestBundle overrideObject:querySchemes forKey:@"LSApplicationQueriesSchemes"];
+    
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID error:nil];
+    
+    XCTAssertNotNil(application);
+      
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Execute request"];
+    
+    [MSIDTestSwizzle instanceMethod:@selector(deviceInfoWithRequestParameters:completionBlock:)
+                              class:[MSALDeviceInfoProvider  class]
+                              block:(id)^(id obj, MSIDRequestParameters *requestParameters, MSALDeviceInformationCompletionBlock callback)
+    {
+        [expectation fulfill];
+        
+        MSIDDeviceInfo *msidDeviceInfo = [MSIDDeviceInfo new];
+        msidDeviceInfo.deviceMode = MSIDDeviceModeShared;
+        msidDeviceInfo.platformSSOStatus = MSIDPlatformSSOEnabledAndRegistered;
+        NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
+        extraDeviceInfoDict[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
+        extraDeviceInfoDict[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
+        msidDeviceInfo.extraDeviceInfo = extraDeviceInfoDict;
+        MSALDeviceInformation *deviceInfo = [[MSALDeviceInformation alloc] initWithMSIDDeviceInfo:msidDeviceInfo];
+        
+        callback(deviceInfo, nil);
+    }];
+    
+    XCTestExpectation *deviceInfoExpectation = [self expectationWithDescription:@"Get device info"];
+    
+    [application getDeviceInformationWithParameters:nil
+                                    completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+    {
+        XCTAssertNotNil(deviceInformation);
+        XCTAssertNil(error);
+        XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeShared);
+        XCTAssertEqual(deviceInformation.platformSSOStatus, MSALPlatformSSOEnabledAndRegistered);
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY], @"mdmId");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY], @"objectId");
+        [deviceInfoExpectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation, deviceInfoExpectation] timeout:1];
+}
+
 #if TARGET_OS_IPHONE
 
 #pragma mark - allAccounts

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,6 @@ let package = Package(
           targets: ["MSAL"]),
   ],
   targets: [
-      .binaryTarget(name: "MSAL", url: "https://github.com/AzureAD/microsoft-authentication-library-for-objc/releases/download/1.2.9/MSAL.zip", checksum: "5fe144133a3094d2bf5c8932641c3a2935412f41059e52d6b7e3361c617ec59a")
+      .binaryTarget(name: "MSAL", url: "https://github.com/AzureAD/microsoft-authentication-library-for-objc/releases/download/1.2.10/MSAL.zip", checksum: "3a9dbe5f1cf562076d1bee99297f0cbf6a4b8013769614d5ddeace86ef808ca4")
   ]
 )


### PR DESCRIPTION
## Proposed changes

Update get DeviceInfo public api to expose platform sso status which tells if enabled in sso config, if device is registered with ADRS via platform sso . CP , 1P apps and 3P can consume this to check platform sso status

## Type of change

- [ x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

