### PR TITLE
Added a map to server_error

### DIFF
--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -114,6 +114,7 @@ static NSSet *s_recoverableErrorCode;
                                    @(MSIDErrorServerInvalidRequest) :@(MSALInternalErrorInvalidRequest),
                                    @(MSIDErrorServerInvalidClient) : @(MSALInternalErrorInvalidClient),
                                    @(MSIDErrorServerInvalidGrant) : @(MSALInternalErrorInvalidGrant),
+                                   @(MSIDErrorServerError) : @(MSALErrorServerError),
                                    @(MSIDErrorServerInvalidScope) : @(MSALInternalErrorInvalidScope),
                                    @(MSIDErrorServerUnauthorizedClient): @(MSALInternalErrorUnauthorizedClient),
                                    @(MSIDErrorServerAccessDenied): @(MSALErrorUserCanceled),

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -172,6 +172,11 @@ typedef NS_ENUM(NSInteger, MSALError)
      Handling of this error is optional.
      */
     MSALErrorUserCanceled                        = -50005,
+    
+    /**
+    The server error happens when server returns server_error
+     */
+    MSALErrorServerError                         = -50006,
 };
 
 /**

--- a/MSAL/test/unit/MSALErrorConverterTests.m
+++ b/MSAL/test/unit/MSALErrorConverterTests.m
@@ -188,7 +188,7 @@
     NSInteger errorCode = MSALErrorUserCanceled;
     NSString *errorDescription = @"a fake error description.";
     NSString *oauthError = @"a fake oauth error message.";
-    NSString *subError = @"a fake suberror";
+    NSString *subError = @"a fake suberror.";
     
     NSError *msalError = [MSALErrorConverter errorWithDomain:MSALErrorDomain
                                                         code:errorCode


### PR DESCRIPTION
Added a new MSALErrorServerError to map it to common library

## Proposed changes

Added a new error MSALErrorServerError 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

Added a new Error from common library for objc 
Error : MSALErrorServerError