### PR TITLE
Support read device info when ecc is on.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+TBD
+* Support read device info when ecc is on. (#1714)
+
 ## [1.2.11]
 * Updated extraDeviceInfo to include platform sso status on macOS
 * Created CIAM authority for MSAL (#1682)

--- a/MSAL/src/instance/MSALDeviceInfoProvider.m
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.m
@@ -132,7 +132,7 @@
 {
     MSALWPJMetaData *wpjMetaData = [MSALWPJMetaData new];
     
-    NSDictionary *deviceRegMetaDataInfo = [MSIDWorkPlaceJoinUtil getRegisteredDeviceMetadataInformation:requestParameters tenantId:tenantId];
+    NSDictionary *deviceRegMetaDataInfo = [MSIDWorkPlaceJoinUtil getRegisteredDeviceMetadataInformation:requestParameters tenantId:tenantId usePrimaryFormat:NO];
     if (deviceRegMetaDataInfo)
     {
         [wpjMetaData addRegisteredDeviceMetadataInformation:deviceRegMetaDataInfo];

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -485,3 +485,5 @@
 @property (nullable, class, readonly) NSString *sdkVersion;
 
 @end
+
+

--- a/MSAL/test/app/mac/MSALMacTestApp.entitlements
+++ b/MSAL/test/app/mac/MSALMacTestApp.entitlements
@@ -13,6 +13,7 @@
 		<string>$(AppIdentifierPrefix)com.microsoft.MSALMacTestApp</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.identity.universalstorage</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.ssoseeding</string>
+		<string>$(AppIdentifierPrefix)com.microsoft.workplacejoin.v2</string>
 	</array>
 </dict>
 </plist>

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -93,7 +93,7 @@
 
 - (void)testWPJMetaDataDeviceInfoWithRequestParameters_tenantIdNil API_AVAILABLE(ios(13.0), macos(10.15))
 {
-    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:)
+    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:usePrimaryFormat:)
                            class:[MSIDWorkPlaceJoinUtil class]
                            block:(id<MSIDRequestContext>)^(id<MSIDRequestContext>_Nullable context)
     {
@@ -130,7 +130,7 @@
 - (void)testWPJMetaDataDeviceInfoWithRequestParameters_tenantIdNil_noRegisterationInformation API_AVAILABLE(ios(13.0), macos(10.15))
 {
     
-    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:)
+    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:usePrimaryFormat:)
                            class:[MSIDWorkPlaceJoinUtil class]
                            block:(id<MSIDRequestContext>)^(id<MSIDRequestContext>_Nullable context)
     {
@@ -160,7 +160,7 @@
 
 - (void)testWPJMetaDataDeviceInfoWithRequestParameters_tenantIdNonNil API_AVAILABLE(ios(13.0), macos(10.15))
 {
-    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:)
+    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:usePrimaryFormat:)
                            class:[MSIDWorkPlaceJoinUtil class]
                            block:(id<MSIDRequestContext>)^(id<MSIDRequestContext>_Nullable context)
     {
@@ -224,7 +224,6 @@
         XCTAssertNotNil(deviceInformation);
         XCTAssertNil(error);
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeDefault);
-        XCTAssertEqual(deviceInformation.extraDeviceInformation.count, 0);
         [failExpectation fulfill];
     }];
     

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2579,7 +2579,7 @@
 
 - (void)testGetWPJMetaDataDeviceWithParameters_whenTenantIdNil API_AVAILABLE(ios(13.0), macos(10.15))
 {
-    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:)
+    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:usePrimaryFormat:)
                            class:[MSIDWorkPlaceJoinUtil class]
                            block:(id<MSIDRequestContext>)^(id<MSIDRequestContext>_Nullable context)
     {
@@ -2621,7 +2621,7 @@
 
 - (void)testGetWPJMetaDataDeviceWithParameters_whenTenantIdNonNil API_AVAILABLE(ios(13.0), macos(10.15))
 {
-    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:)
+    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:usePrimaryFormat:)
                            class:[MSIDWorkPlaceJoinUtil class]
                            block:(id<MSIDRequestContext>)^(id<MSIDRequestContext>_Nullable context)
     {
@@ -2663,7 +2663,7 @@
 
 - (void)testGetWPJMetaDataDeviceWithParameters_whenTenantIdNonNil_wpjMetaDatanil API_AVAILABLE(ios(13.0), macos(10.15))
 {
-    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:)
+    [MSIDTestSwizzle classMethod:@selector(getRegisteredDeviceMetadataInformation:tenantId:usePrimaryFormat:)
                            class:[MSIDWorkPlaceJoinUtil class]
                            block:(id<MSIDRequestContext>)^(id<MSIDRequestContext>_Nullable context)
     {


### PR DESCRIPTION
## Proposed changes

Support read device info when ecc is on.
Unify the api (return same response as SSO ext returns for primary registration call)

Core PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1240

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

