### PR TITLE
Add isCallerAppManaged to extraDeviceInfoDict

### DIFF
--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -365,6 +365,7 @@
         NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
         extraDeviceInfoDict[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
         extraDeviceInfoDict[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
+        extraDeviceInfoDict[MSID_IS_CALLER_MANAGED_KEY] = @"1";
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
         deviceInfo.platformSSOStatus = MSIDPlatformSSOEnabledAndRegistered;
 #endif
@@ -387,6 +388,7 @@
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"isSSOExtensionInFullMode"], @"No");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY], @"mdmId");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY], @"objectId");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_IS_CALLER_MANAGED_KEY], @"1");
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
         XCTAssertEqual(deviceInformation.platformSSOStatus, MSALPlatformSSOEnabledAndRegistered);
 #endif
@@ -435,6 +437,7 @@
         XCTAssertNil(error);
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeShared);
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"isSSOExtensionInFullMode"], @"No");
+        XCTAssertNotNil(deviceInformation.extraDeviceInformation[MSID_IS_CALLER_MANAGED_KEY]);
         XCTAssertNil(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY]);
         XCTAssertNil(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY]);
         [successExpectation fulfill];

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -362,14 +362,17 @@
         deviceInfo.brokerVersion = @"test";
         deviceInfo.deviceMode = MSIDDeviceModeShared;
         deviceInfo.ssoExtensionMode = MSIDSSOExtensionModeSilentOnly;
+#if TARGET_OS_IPHONE
         NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
         extraDeviceInfoDict[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
         extraDeviceInfoDict[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
         extraDeviceInfoDict[MSID_IS_CALLER_MANAGED_KEY] = @"1";
+        deviceInfo.extraDeviceInfo = extraDeviceInfoDict;
+#endif
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
         deviceInfo.platformSSOStatus = MSIDPlatformSSOEnabledAndRegistered;
 #endif
-        deviceInfo.extraDeviceInfo = extraDeviceInfoDict;
+
         
         callback(deviceInfo, nil);
     }];
@@ -386,9 +389,11 @@
         XCTAssertNil(error);
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeShared);
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"isSSOExtensionInFullMode"], @"No");
+#if TARGET_OS_IPHONE
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY], @"mdmId");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY], @"objectId");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_IS_CALLER_MANAGED_KEY], @"1");
+#endif
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
         XCTAssertEqual(deviceInformation.platformSSOStatus, MSALPlatformSSOEnabledAndRegistered);
 #endif
@@ -421,7 +426,11 @@
         deviceInfo.brokerVersion = @"test";
         deviceInfo.deviceMode = MSIDDeviceModeShared;
         deviceInfo.ssoExtensionMode = MSIDSSOExtensionModeSilentOnly;
-        
+#if TARGET_OS_IPHONE
+        NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
+        extraDeviceInfoDict[MSID_IS_CALLER_MANAGED_KEY] = @"1";
+        deviceInfo.extraDeviceInfo = extraDeviceInfoDict;
+#endif
         callback(deviceInfo, nil);
     }];
     
@@ -437,9 +446,12 @@
         XCTAssertNil(error);
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeShared);
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[@"isSSOExtensionInFullMode"], @"No");
-        XCTAssertNotNil(deviceInformation.extraDeviceInformation[MSID_IS_CALLER_MANAGED_KEY]);
+#if TARGET_OS_IPHONE
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_IS_CALLER_MANAGED_KEY], @"1");
+#endif
         XCTAssertNil(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY]);
         XCTAssertNil(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY]);
+
         [successExpectation fulfill];
     }];
     

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -2552,9 +2552,13 @@
         
         MSIDDeviceInfo *msidDeviceInfo = [MSIDDeviceInfo new];
         msidDeviceInfo.deviceMode = MSIDDeviceModeShared;
+#if TARGET_OS_IPHONE
         NSMutableDictionary *extraDeviceInfoDict = [NSMutableDictionary new];
         extraDeviceInfoDict[MSID_BROKER_MDM_ID_KEY] = @"mdmId";
         extraDeviceInfoDict[MSID_ENROLLED_USER_OBJECT_ID_KEY] = @"objectId";
+        extraDeviceInfoDict[MSID_IS_CALLER_MANAGED_KEY] = @"0";
+#endif
+        
         msidDeviceInfo.extraDeviceInfo = extraDeviceInfoDict;
         MSALDeviceInformation *deviceInfo = [[MSALDeviceInformation alloc] initWithMSIDDeviceInfo:msidDeviceInfo];
         
@@ -2569,8 +2573,11 @@
         XCTAssertNotNil(deviceInformation);
         XCTAssertNil(error);
         XCTAssertEqual(deviceInformation.deviceMode, MSALDeviceModeShared);
+#if TARGET_OS_IPHONE
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_BROKER_MDM_ID_KEY], @"mdmId");
         XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_ENROLLED_USER_OBJECT_ID_KEY], @"objectId");
+        XCTAssertEqualObjects(deviceInformation.extraDeviceInformation[MSID_IS_CALLER_MANAGED_KEY], @"0");
+#endif
         [deviceInfoExpectation fulfill];
     }];
     
@@ -2920,8 +2927,6 @@
 
 #pragma mark - allAccountsFilteredByAuthority
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)testAllAccountsFilteredByAuthority_when2AccountExists_shouldReturnAccountsFilteredByAuthority
 {
     [self msalStoreTokenResponseInCacheWithAuthority:@"https://login.microsoftonline.com/common" uid:@"myuid"
@@ -2983,7 +2988,6 @@
     
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
-#pragma clang diagnostic pop
 
 #pragma mark - loadAccountForHomeAccountId
 


### PR DESCRIPTION
## Proposed changes

Expose is CallerApp managed in extraDeviceInfo dict for MAM sdk

## Type of change

- [x ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

