### PR TITLE
Update unit tests for removed deprecated methods in CommonCore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [TBD]
+* Remove references to deprecated APIs. (#1779)
 ## [1.2.12]
 * Support read device info when ecc is on. (#1714)
 * Add troubleshooting flow when doing Just in Time registration (#1646)

--- a/MSAL/test/unit/MSALTelemetryAggregatedTests.m
+++ b/MSAL/test/unit/MSALTelemetryAggregatedTests.m
@@ -351,7 +351,7 @@
     XCTAssertNotNil(self.receivedEvent);
     NSDictionary *eventInfo = self.receivedEvent;
 #if TARGET_OS_IPHONE
-    XCTAssertEqual(eventInfo.count, 14);
+    XCTAssertEqual(eventInfo.count, 13);
     XCTAssertNotNil(eventInfo[@"msal.x_client_dm"]);
     XCTAssertNotNil(eventInfo[@"msal.application_version"]);
 #else
@@ -368,7 +368,9 @@
     XCTAssertNotNil(eventInfo[@"msal.x_client_sku"]);
     XCTAssertNotNil(eventInfo[@"msal.x_client_ver"]);
     XCTAssertNotNil(eventInfo[@"msal.application_name"]);
+#if !TARGET_OS_IPHONE
     XCTAssertNotNil(eventInfo[@"msal.device_id"]);
+#endif
 }
 
 - (void)testFlush_whenThereIsOneBrokerEvent_shouldSendAggregatedEvent
@@ -480,7 +482,7 @@
     XCTAssertNotNil(self.receivedEvent);
     NSDictionary *eventInfo = self.receivedEvent;
 #if TARGET_OS_IPHONE
-    XCTAssertEqual(eventInfo.count, 13);
+    XCTAssertEqual(eventInfo.count, 12);
     XCTAssertNotNil(eventInfo[@"msal.x_client_dm"]);
     XCTAssertNotNil(eventInfo[@"msal.application_version"]);
 #else
@@ -496,7 +498,9 @@
     XCTAssertNotNil(eventInfo[@"msal.x_client_sku"]);
     XCTAssertNotNil(eventInfo[@"msal.x_client_ver"]);
     XCTAssertNotNil(eventInfo[@"msal.application_name"]);
+#if !TARGET_OS_IPHONE
     XCTAssertNotNil(eventInfo[@"msal.device_id"]);
+#endif
 }
 
 - (void)testFlush_whenThereIsEventAndObserverRemoved_shouldNotSendEvents


### PR DESCRIPTION
## Proposed changes

Update unit tests for removed deprecated methods in CommonCore.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

