### PR TITLE
Adfs automation fix disable cba

### DIFF
--- a/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenAction.m
+++ b/MSAL/test/automation/ios/actions/MSALAutomationAcquireTokenAction.m
@@ -38,6 +38,7 @@
 #import "MSALInteractiveTokenParameters.h"
 #import "MSALClaimsRequest.h"
 #import "MSALWebviewParameters.h"
+#import "MSIDCertAuthHandler.h"
 
 @implementation MSALAutomationAcquireTokenAction
 
@@ -172,6 +173,11 @@
         webviewParameters.customWebview = containerController.passedinWebView;
         [containerController showPassedInWebViewControllerWithContext:@{@"context": application}];
         webviewParameters.parentViewController = containerController;
+    }
+    
+    if (testRequest.disableCertBasedAuth)
+    {
+        [[MSIDCertAuthHandler class] performSelector:@selector(disableCertBasedAuth)];
     }
     
     MSALInteractiveTokenParameters *parameters = [[MSALInteractiveTokenParameters alloc] initWithScopes:scopes.array

--- a/MSAL/test/automation/tests/MSALADFSBaseUITest.m
+++ b/MSAL/test/automation/tests/MSALADFSBaseUITest.m
@@ -43,6 +43,7 @@
     {
         [self aadEnterEmail:self.testApp];
     }
+    
     sleep(1);
     [self aadEnterPassword:self.testApp];
     [self acceptMSSTSConsentIfNecessary:@"Accept" embeddedWebView:request.usesEmbeddedWebView];

--- a/MSAL/test/automation/tests/MSALADFSBaseUITest.m
+++ b/MSAL/test/automation/tests/MSALADFSBaseUITest.m
@@ -43,13 +43,6 @@
     {
         [self aadEnterEmail:self.testApp];
     }
-    Class certClazz =  [NSClassFromString(@"MSIDCertAuthHandler") class];
-    XCTAssertNotNil(certClazz);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    SEL sel = NSSelectorFromString(@"disableCertBasedAuth");
-    [certClazz performSelector:sel];
-#pragma clang diagnostic pop
     sleep(1);
     [self aadEnterPassword:self.testApp];
     [self acceptMSSTSConsentIfNecessary:@"Accept" embeddedWebView:request.usesEmbeddedWebView];

--- a/MSAL/test/automation/tests/MSALADFSBaseUITest.m
+++ b/MSAL/test/automation/tests/MSALADFSBaseUITest.m
@@ -43,7 +43,13 @@
     {
         [self aadEnterEmail:self.testApp];
     }
-
+    Class certClazz =  [NSClassFromString(@"MSIDCertAuthHandler") class];
+    XCTAssertNotNil(certClazz);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    SEL sel = NSSelectorFromString(@"disableCertBasedAuth");
+    [certClazz performSelector:sel];
+#pragma clang diagnostic pop
     sleep(1);
     [self aadEnterPassword:self.testApp];
     [self acceptMSSTSConsentIfNecessary:@"Accept" embeddedWebView:request.usesEmbeddedWebView];

--- a/MSAL/test/automation/tests/interactive/MSALADFSv3FederatedTests.m
+++ b/MSAL/test/automation/tests/interactive/MSALADFSv3FederatedTests.m
@@ -45,19 +45,12 @@
     MSIDTestAutomationAppConfigurationRequest *appConfigurationRequest = [MSIDTestAutomationAppConfigurationRequest new];
     appConfigurationRequest.testAppAudience = MSIDTestAppAudienceMultipleOrgs;
     appConfigurationRequest.testAppEnvironment = self.testEnvironment;
-    
     [self loadTestApp:appConfigurationRequest];
     MSIDTestAutomationAccountConfigurationRequest *accountConfigurationRequest = [MSIDTestAutomationAccountConfigurationRequest new];
     accountConfigurationRequest.environmentType = self.testEnvironment;
     accountConfigurationRequest.accountType = MSIDTestAccountTypeFederated;
     accountConfigurationRequest.federationProviderType = MSIDTestAccountFederationProviderTypeADFSV3;
-    [self disableCertBasedAuth];
     [self loadTestAccount:accountConfigurationRequest];
-}
-
-- (void)disableCertBasedAuth
-{
-    [[NSClassFromString(@"MSIDCertAuthHandler") class] performSelector:@selector(disableCertBasedAuth)];
 }
 
 #pragma mark - Tests
@@ -108,6 +101,7 @@
     request.testAccount = self.primaryAccount;
     request.webViewType = MSIDWebviewTypeWKWebView;
     request.loginHint = self.primaryAccount.upn;
+    request.disableCertBasedAuth = YES;
 
     // Do interactive login
     NSString *homeAccountId = [self runSharedADFSInteractiveLoginWithRequest:request];

--- a/MSAL/test/automation/tests/interactive/MSALADFSv3FederatedTests.m
+++ b/MSAL/test/automation/tests/interactive/MSALADFSv3FederatedTests.m
@@ -47,13 +47,17 @@
     appConfigurationRequest.testAppEnvironment = self.testEnvironment;
     
     [self loadTestApp:appConfigurationRequest];
-    
     MSIDTestAutomationAccountConfigurationRequest *accountConfigurationRequest = [MSIDTestAutomationAccountConfigurationRequest new];
     accountConfigurationRequest.environmentType = self.testEnvironment;
     accountConfigurationRequest.accountType = MSIDTestAccountTypeFederated;
     accountConfigurationRequest.federationProviderType = MSIDTestAccountFederationProviderTypeADFSV3;
-    
+    [self disableCertBasedAuth];
     [self loadTestAccount:accountConfigurationRequest];
+}
+
+- (void)disableCertBasedAuth
+{
+    [[NSClassFromString(@"MSIDCertAuthHandler") class] performSelector:@selector(disableCertBasedAuth)];
 }
 
 #pragma mark - Tests

--- a/MSAL/test/automation/tests/interactive/MSALADFSv3FederatedTests.m
+++ b/MSAL/test/automation/tests/interactive/MSALADFSv3FederatedTests.m
@@ -45,11 +45,13 @@
     MSIDTestAutomationAppConfigurationRequest *appConfigurationRequest = [MSIDTestAutomationAppConfigurationRequest new];
     appConfigurationRequest.testAppAudience = MSIDTestAppAudienceMultipleOrgs;
     appConfigurationRequest.testAppEnvironment = self.testEnvironment;
+    
     [self loadTestApp:appConfigurationRequest];
     MSIDTestAutomationAccountConfigurationRequest *accountConfigurationRequest = [MSIDTestAutomationAccountConfigurationRequest new];
     accountConfigurationRequest.environmentType = self.testEnvironment;
     accountConfigurationRequest.accountType = MSIDTestAccountTypeFederated;
     accountConfigurationRequest.federationProviderType = MSIDTestAccountFederationProviderTypeADFSV3;
+    
     [self loadTestAccount:accountConfigurationRequest];
 }
 


### PR DESCRIPTION
## Proposed changes

Disabling CBA for ADFS tests in MSAL automation

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

