### PR TITLE
Native Auth Sign Up + base/generic code

### DIFF
--- a/MSAL/src/native_auth/MSALNativeAuthInternalError.swift
+++ b/MSAL/src/native_auth/MSALNativeAuthInternalError.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+enum MSALNativeAuthInternalError: Error, Equatable {
+    case invalidInput
+    case validationError
+    case tokenResultNotPresent
+    case serverProtectionPoliciesRequired(homeAccountId: String?)
+    case headerNotSerialized
+    case invalidAuthority
+    case invalidUrl
+    case missingResponseSerializer
+    case responseSerializationError
+    case invalidResponse
+    case invalidRequest
+    case generalError
+    case invalidAttributes
+}

--- a/MSAL/src/native_auth/cache/MSALNativeAuthCacheAccessor.swift
+++ b/MSAL/src/native_auth/cache/MSALNativeAuthCacheAccessor.swift
@@ -1,0 +1,181 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthCacheAccessor: MSALNativeAuthCacheInterface {
+
+    private let tokenCacheAccessor: MSIDDefaultTokenCacheAccessor = {
+        let dataSource = MSIDKeychainTokenCache()
+        return MSIDDefaultTokenCacheAccessor(dataSource: dataSource, otherCacheAccessors: [])
+    }()
+
+    private let accountMetadataCache: MSIDAccountMetadataCacheAccessor = MSIDAccountMetadataCacheAccessor(dataSource: MSIDKeychainTokenCache())
+    private let externalAccountProvider: MSALExternalAccountHandler = MSALExternalAccountHandler()
+    private let validator = MSIDTokenResponseValidator()
+
+    func getTokens(
+        account: MSALAccount,
+        configuration: MSIDConfiguration,
+        context: MSIDRequestContext) throws -> MSALNativeAuthTokens {
+            let accountConfiguration = try getAccountConfiguration(configuration: configuration, account: account)
+            let idToken = try tokenCacheAccessor.getIDToken(
+                forAccount: account.lookupAccountIdentifier,
+                configuration: accountConfiguration,
+                idTokenType: MSIDCredentialType.MSIDIDTokenType,
+                context: context)
+            let refreshToken = try tokenCacheAccessor.getRefreshToken(
+                withAccount: account.lookupAccountIdentifier,
+                familyId: nil,
+                configuration: accountConfiguration,
+                context: context)
+            let accessToken = try tokenCacheAccessor.getAccessToken(
+                forAccount: account.lookupAccountIdentifier,
+                configuration: accountConfiguration,
+                context: context)
+            return MSALNativeAuthTokens(accessToken: accessToken, refreshToken: refreshToken, rawIdToken: idToken.rawIdToken)
+        }
+
+    func getAccount(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        context: MSIDRequestContext) throws -> MSIDAccount? {
+            return try tokenCacheAccessor.getAccountFor(
+                accountIdentifier,
+                authority: authority,
+                realmHint: nil,
+                context: context)
+        }
+
+    func getAllAccounts(configuration: MSIDConfiguration) throws -> [MSALAccount] {
+        let request = MSALAccountsProvider(tokenCache: tokenCacheAccessor,
+                                           accountMetadataCache: accountMetadataCache,
+                                           clientId: configuration.clientId,
+                                           externalAccountProvider: externalAccountProvider)
+        return try request?.allAccounts() ?? []
+    }
+
+    func validateAndSaveTokensAndAccount(
+        tokenResponse: MSIDTokenResponse,
+        configuration: MSIDConfiguration,
+        context: MSIDRequestContext) throws -> MSIDTokenResult? {
+            let ciamOauth2Provider = getCIAMOauth2Provider(clientId: configuration.clientId)
+            return try? validator.validateAndSave(tokenResponse,
+                                                  oauthFactory: ciamOauth2Provider.msidOauth2Factory,
+                                                  tokenCache: tokenCacheAccessor,
+                                                  accountMetadataCache: accountMetadataCache,
+                                                  requestParameters: getRequestParameters(tokenResponse: tokenResponse,
+                                                                                          configuration: configuration,
+                                                                                          context: context),
+                                                  saveSSOStateOnly: false)
+        }
+
+    // Here we create the MSIDRequestParameters required by the validateAndSave method
+    private func getRequestParameters(
+        tokenResponse: MSIDTokenResponse,
+        configuration: MSIDConfiguration,
+        context: MSIDRequestContext
+    ) -> MSIDRequestParameters {
+
+        // We are creating the default MSIDRequestParameters to prevent unintended functionality changes.
+        // If the method `validateAndSaveTokenResponse` from `MSIDTokenResponseValidator` changes
+        // the implementation here also needs to change to match the properties needed by the method
+        // Currently only the required and used parameters are set
+        let parameters = MSIDRequestParameters()
+        // MSIDRequestParameters has to follow MSIDRequestContext protocol
+        parameters.correlationId = context.correlationId()
+        parameters.logComponent = context.logComponent()
+        parameters.telemetryRequestId = context.telemetryRequestId()
+        parameters.appRequestMetadata = context.appRequestMetadata()
+
+        parameters.msidConfiguration = configuration
+        parameters.clientId = configuration.clientId
+
+        let displayableId = tokenResponse.idTokenObj?.username()
+        let homeAccountId = tokenResponse.idTokenObj?.userId
+
+        let  accountIdentifier = MSIDAccountIdentifier(displayableId: displayableId, homeAccountId: homeAccountId)
+        parameters.accountIdentifier = accountIdentifier
+        parameters.authority = configuration.authority
+        parameters.instanceAware = false
+        let defaultOIDCScopesArray = MSALPublicClientApplication.defaultOIDCScopes().array as? [String]
+        parameters.oidcScope = defaultOIDCScopesArray?.joinScopes()
+        return parameters
+    }
+
+    func removeTokens(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        clientId: String,
+        context: MSIDRequestContext) throws {
+            try tokenCacheAccessor.clearCache(
+                forAccount: accountIdentifier,
+                authority: authority,
+                clientId: clientId,
+                familyId: nil,
+                clearAccounts: false,
+                context: context)
+        }
+
+    func clearCache(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        clientId: String,
+        context: MSIDRequestContext) throws {
+            try tokenCacheAccessor.clearCache(
+                forAccount: accountIdentifier,
+                authority: authority,
+                clientId: clientId,
+                familyId: nil,
+                clearAccounts: true,
+                context: context)
+        }
+
+    private func getCIAMOauth2Provider(clientId: String) -> MSALCIAMOauth2Provider {
+        return MSALCIAMOauth2Provider(clientId: clientId,
+                               tokenCache: tokenCacheAccessor,
+                               accountMetadataCache: accountMetadataCache)
+
+    }
+
+    private func getAccountConfiguration(configuration: MSIDConfiguration,
+                                         account: MSALAccount) throws -> MSIDConfiguration? {
+        // When retrieving tokens from the cache, we first have to get the
+        // Tenant Id from the AccountMetadataCache. Because in NativeAuth
+        // We use only CIAM authorities, we retrieve using its provider
+        let ciamOauth2Provider = getCIAMOauth2Provider(clientId: configuration.clientId)
+        let accountConfiguration = configuration.copy() as? MSIDConfiguration
+        let errorPointer: NSErrorPointer = nil
+        let requestAuthority = ciamOauth2Provider.issuerAuthority(with: account,
+                                                                      request: configuration.authority,
+                                                                      instanceAware: false,
+                                                                      error: errorPointer)
+        if let errorPointer = errorPointer, let error = errorPointer.pointee {
+            throw error
+        }
+        accountConfiguration?.authority = requestAuthority
+        return accountConfiguration
+    }
+}

--- a/MSAL/src/native_auth/cache/MSALNativeAuthCacheInterface.swift
+++ b/MSAL/src/native_auth/cache/MSALNativeAuthCacheInterface.swift
@@ -1,0 +1,57 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthCacheInterface {
+    func getTokens(
+        account: MSALAccount,
+        configuration: MSIDConfiguration,
+        context: MSIDRequestContext) throws -> MSALNativeAuthTokens
+
+    func getAccount(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        context: MSIDRequestContext) throws -> MSIDAccount?
+
+    func getAllAccounts(configuration: MSIDConfiguration) throws -> [MSALAccount]
+
+    func validateAndSaveTokensAndAccount(
+        tokenResponse: MSIDTokenResponse,
+        configuration: MSIDConfiguration,
+        context: MSIDRequestContext) throws -> MSIDTokenResult?
+
+    func removeTokens(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        clientId: String,
+        context: MSIDRequestContext) throws
+
+    func clearCache(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        clientId: String,
+        context: MSIDRequestContext) throws
+}

--- a/MSAL/src/native_auth/cache/MSALNativeAuthTokens.swift
+++ b/MSAL/src/native_auth/cache/MSALNativeAuthTokens.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthTokens {
+    let accessToken: MSIDAccessToken?
+    let refreshToken: MSIDRefreshToken?
+    let rawIdToken: String?
+
+    init(accessToken: MSIDAccessToken?, refreshToken: MSIDRefreshToken?, rawIdToken: String?) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.rawIdToken = rawIdToken
+    }
+}

--- a/MSAL/src/native_auth/configuration/MSALNativeAuthConfiguration.swift
+++ b/MSAL/src/native_auth/configuration/MSALNativeAuthConfiguration.swift
@@ -1,0 +1,49 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthConfiguration {
+    var challengeTypesString: String {
+        return challengeTypes.map { $0.rawValue }.joined(separator: " ")
+    }
+
+    let clientId: String
+    let authority: MSIDCIAMAuthority
+    let challengeTypes: [MSALNativeAuthInternalChallengeType]
+    var sliceConfig: MSALSliceConfig?
+
+    init(
+        clientId: String,
+        authority: MSALCIAMAuthority,
+        challengeTypes: [MSALNativeAuthInternalChallengeType]) throws {
+        self.clientId = clientId
+        self.authority = try MSIDCIAMAuthority(
+            url: authority.url,
+            validateFormat: false,
+            context: MSALNativeAuthRequestContext()
+        )
+        self.challengeTypes = challengeTypes
+    }
+}

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
@@ -1,0 +1,143 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthBaseController {
+
+    typealias TelemetryInfo = (event: MSIDTelemetryAPIEvent?, context: MSALNativeAuthRequestContext)
+    let clientId: String
+
+    init(
+        clientId: String
+    ) {
+        self.clientId = clientId
+    }
+
+    func makeAndStartTelemetryEvent(
+        id: MSALNativeAuthTelemetryApiId,
+        context: MSIDRequestContext
+    ) -> MSIDTelemetryAPIEvent? {
+        let event = makeLocalTelemetryApiEvent(
+            name: MSID_TELEMETRY_EVENT_API_EVENT,
+            telemetryApiId: id,
+            context: context
+        )
+
+        startTelemetryEvent(event, context: context)
+
+        return event
+    }
+
+    func makeLocalTelemetryApiEvent(
+        name: String,
+        telemetryApiId: MSALNativeAuthTelemetryApiId,
+        context: MSIDRequestContext
+    ) -> MSIDTelemetryAPIEvent? {
+        let event = MSIDTelemetryAPIEvent(
+            name: name,
+            context: context
+        )
+
+        event?.setApiId(String(telemetryApiId.rawValue))
+        event?.setCorrelationId(context.correlationId())
+        event?.setClientId(clientId)
+
+        return event
+    }
+
+    func startTelemetryEvent(_ localEvent: MSIDTelemetryAPIEvent?, context: MSIDRequestContext) {
+        guard let eventName = localEvent?.property(withName: MSID_TELEMETRY_KEY_EVENT_NAME) else {
+            return MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Telemetry event nil not expected"
+            )
+        }
+
+        MSIDTelemetry.sharedInstance().startEvent(
+            context.telemetryRequestId(),
+            eventName: eventName
+        )
+    }
+
+    func stopTelemetryEvent(_ telemetryInfo: TelemetryInfo, error: Error? = nil) {
+        stopTelemetryEvent(telemetryInfo.event, context: telemetryInfo.context, error: error)
+    }
+
+    func stopTelemetryEvent(_ localEvent: MSIDTelemetryAPIEvent?, context: MSIDRequestContext, error: Error? = nil) {
+        guard let event = localEvent else {
+            return MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Telemetry event nil not expected"
+            )
+        }
+
+        if let error = error as? NSError {
+
+            if let key = MSIDErrorConverter.defaultErrorConverter?.oauthErrorKey(),
+                let oauthErrorCode = error.userInfo[key] as? String {
+                event.setOauthErrorCode(oauthErrorCode)
+            }
+
+            event.setErrorCodeString(String(error.code))
+            event.setErrorDomain(error.domain)
+            event.setResultStatus(MSID_TELEMETRY_VALUE_FAILED)
+            event.setIsSuccessfulStatus(MSID_TELEMETRY_VALUE_NO)
+        } else {
+            event.setResultStatus(MSID_TELEMETRY_VALUE_SUCCEEDED)
+            event.setIsSuccessfulStatus(MSID_TELEMETRY_VALUE_YES)
+        }
+
+        MSIDTelemetry.sharedInstance().stopEvent(context.telemetryRequestId(), event: event)
+        MSIDTelemetry.sharedInstance().flush(context.telemetryRequestId())
+    }
+
+    func complete<T>(
+        _ telemetryEvent: MSIDTelemetryAPIEvent?,
+        response: T? = nil,
+        error: Error? = nil,
+        context: MSIDRequestContext,
+        completion: @escaping (T?, Error?) -> Void
+    ) {
+        stopTelemetryEvent(telemetryEvent, context: context, error: error)
+        completion(response, error)
+    }
+
+    func performRequest<T>(_ request: MSIDHttpRequest, context: MSIDRequestContext) async -> Result<T, Error> {
+        return await withCheckedContinuation { continuation in
+            request.send { result, error in
+                if let error = error {
+                    continuation.resume(returning: .failure(error))
+                } else if let response = result as? T {
+                    continuation.resume(returning: .success(response))
+                } else {
+                    MSALLogger.log(level: .error, context: context, format: "Error request - Both result and error are nil")
+                    continuation.resume(returning: .failure(MSALNativeAuthInternalError.invalidResponse))
+                }
+            }
+        }
+    }
+}

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthControllerTelemetryWrapper.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthControllerTelemetryWrapper.swift
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/// The Controller sends this model to the public interface, which uses the `result` value to return to the user.
+/// The `telemetryUpdate` gets called from the public interface, if it needs to tell the controller to update the telemetry
+/// (ex: an optional delegate method not implemented by the external developer).
+struct MSALNativeAuthControllerTelemetryWrapper<R> {
+    let result: R
+    let telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?
+
+    init(_ result: R, telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)? = nil) {
+        self.result = result
+        self.telemetryUpdate = telemetryUpdate
+    }
+}

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
@@ -1,0 +1,226 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+import Foundation
+
+class MSALNativeAuthTokenController: MSALNativeAuthBaseController {
+
+    // MARK: - Variables
+
+    let factory: MSALNativeAuthResultBuildable
+    private let requestProvider: MSALNativeAuthTokenRequestProviding
+    private let responseValidator: MSALNativeAuthTokenResponseValidating
+    private let cacheAccessor: MSALNativeAuthCacheInterface
+
+    init(
+        clientId: String,
+        requestProvider: MSALNativeAuthTokenRequestProviding,
+        cacheAccessor: MSALNativeAuthCacheInterface,
+        factory: MSALNativeAuthResultBuildable,
+        responseValidator: MSALNativeAuthTokenResponseValidating
+    ) {
+        self.requestProvider = requestProvider
+        self.factory = factory
+        self.responseValidator = responseValidator
+        self.cacheAccessor = cacheAccessor
+        super.init(
+            clientId: clientId
+        )
+    }
+
+    func performAndValidateTokenRequest(
+        _ request: MSIDHttpRequest,
+        config: MSIDConfiguration,
+        context: MSALNativeAuthRequestContext) async -> MSALNativeAuthTokenValidatedResponse {
+            let ciamTokenResponse: Result<MSIDCIAMTokenResponse, Error> = await performTokenRequest(request, context: context)
+            return responseValidator.validate(
+                context: context,
+                msidConfiguration: config,
+                result: ciamTokenResponse
+            )
+        }
+
+    func joinScopes(_ scopes: [String]?) -> [String] {
+        let defaultOIDCScopes = MSALPublicClientApplication.defaultOIDCScopes().array
+        guard let scopes = scopes else {
+            return defaultOIDCScopes as? [String] ?? []
+        }
+        let joinedScopes = NSMutableOrderedSet(array: scopes)
+        joinedScopes.addObjects(from: defaultOIDCScopes)
+        return joinedScopes.array as? [String] ?? []
+    }
+
+    func createTokenRequest(
+        username: String? = nil,
+        password: String? = nil,
+        scopes: [String],
+        credentialToken: String? = nil,
+        oobCode: String? = nil,
+        signInSLT: String? = nil,
+        grantType: MSALNativeAuthGrantType,
+        includeChallengeType: Bool = true,
+        context: MSIDRequestContext) -> MSIDHttpRequest? {
+            do {
+                let params = MSALNativeAuthTokenRequestParameters(
+                    context: context,
+                    username: username,
+                    credentialToken: credentialToken,
+                    signInSLT: signInSLT,
+                    grantType: grantType,
+                    scope: scopes.joinScopes(),
+                    password: password,
+                    oobCode: oobCode,
+                    includeChallengeType: includeChallengeType,
+                    refreshToken: nil)
+                return try requestProvider.signInWithPassword(parameters: params, context: context)
+            } catch {
+                MSALLogger.log(level: .error, context: context, format: "Error creating SignIn Token Request: \(error)")
+                return nil
+            }
+        }
+
+    func createRefreshTokenRequest(
+        scopes: [String],
+        refreshToken: String?,
+        context: MSIDRequestContext) -> MSIDHttpRequest? {
+            guard let refreshToken = refreshToken else {
+                MSALLogger.log(level: .error, context: context, format: "Error creating Refresh Token Request, refresh token is nil!")
+                return nil
+            }
+            do {
+                let params = MSALNativeAuthTokenRequestParameters(
+                    context: context,
+                    username: nil,
+                    credentialToken: nil,
+                    signInSLT: nil,
+                    grantType: .refreshToken,
+                    scope: scopes.joinScopes(),
+                    password: nil,
+                    oobCode: nil,
+                    includeChallengeType: false,
+                    refreshToken: refreshToken)
+                return try requestProvider.refreshToken(parameters: params, context: context)
+            } catch {
+                MSALLogger.log(level: .error, context: context, format: "Error creating Refresh Token Request: \(error)")
+                return nil
+            }
+        }
+
+    func cacheTokenResponse(
+        _ tokenResponse: MSIDTokenResponse,
+        context: MSALNativeAuthRequestContext,
+        msidConfiguration: MSIDConfiguration
+    ) throws -> MSIDTokenResult {
+        let displayableId = tokenResponse.idTokenObj?.username()
+        let homeAccountId = tokenResponse.idTokenObj?.userId
+
+        guard let accountIdentifier = MSIDAccountIdentifier(displayableId: displayableId, homeAccountId: homeAccountId) else {
+            MSALLogger.log(level: .error, context: context, format: "Error creating account identifier")
+            throw MSALNativeAuthInternalError.invalidResponse
+        }
+
+        guard let result = cacheTokenResponseRetrieveTokenResult(tokenResponse,
+                                                                 context: context,
+                                                                 msidConfiguration: msidConfiguration) else {
+            MSALLogger.log(level: .error, context: context, format: "Error caching token response")
+            throw MSALNativeAuthInternalError.invalidResponse
+        }
+
+        guard try responseValidator.validateAccount(with: result,
+                                                    context: context,
+                                                    accountIdentifier: accountIdentifier) else {
+            MSALLogger.log(level: .error, context: context, format: "Error validating account")
+            throw MSALNativeAuthInternalError.invalidResponse
+        }
+
+        return result
+    }
+
+    private func cacheTokenResponseRetrieveTokenResult(
+        _ tokenResponse: MSIDTokenResponse,
+        context: MSALNativeAuthRequestContext,
+        msidConfiguration: MSIDConfiguration
+    ) -> MSIDTokenResult? {
+        do {
+            // If there is an account existing already in the cache, we remove it
+            try clearAccount(msidConfiguration: msidConfiguration, context: context)
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error clearing account \(error) (ignoring)")
+        }
+        do {
+            let result = try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse,
+                                                                           configuration: msidConfiguration,
+                                                                           context: context)
+            return result
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error caching response: \(error) (ignoring)")
+        }
+        return nil
+    }
+
+    private func clearAccount(msidConfiguration: MSIDConfiguration, context: MSALNativeAuthRequestContext) throws {
+        do {
+            let accounts = try cacheAccessor.getAllAccounts(configuration: msidConfiguration)
+            if let account = accounts.first {
+                if let identifier = MSIDAccountIdentifier(displayableId: account.username, homeAccountId: account.identifier) {
+                    try cacheAccessor.clearCache(accountIdentifier: identifier,
+                                                  authority: msidConfiguration.authority,
+                                                  clientId: msidConfiguration.clientId,
+                                                  context: context)
+                }
+            } else {
+                MSALLogger.log(level: .error,
+                               context: context,
+                               format: "Error creating MSIDAccountIdentifier out of MSALAccount (ignoring)")
+            }
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error clearing previous account (ignoring)")
+        }
+    }
+
+    private func performTokenRequest(_ request: MSIDHttpRequest, context: MSIDRequestContext) async -> Result<MSIDCIAMTokenResponse, Error> {
+        return await withCheckedContinuation { continuation in
+            request.send { response, error in
+                if let error = error {
+                    continuation.resume(returning: .failure(error))
+                    return
+                }
+                guard let responseDict = response as? [AnyHashable: Any] else {
+                    continuation.resume(returning: .failure(MSALNativeAuthInternalError.invalidResponse))
+                    return
+                }
+                do {
+                    let tokenResponse = try MSIDCIAMTokenResponse(jsonDictionary: responseDict)
+                    tokenResponse.correlationId = request.context?.correlationId().uuidString
+                    continuation.resume(returning: .success(tokenResponse))
+                } catch {
+                    MSALLogger.log(level: .error, context: context, format: "Error token request - Both result and error are nil")
+                    continuation.resume(returning: .failure(MSALNativeAuthInternalError.invalidResponse))
+                }
+            }
+        }
+    }
+}

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -1,0 +1,192 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, MSALNativeAuthCredentialsControlling {
+
+    // MARK: - Variables
+
+    private let cacheAccessor: MSALNativeAuthCacheInterface
+
+    // MARK: - Init
+
+    override init(
+        clientId: String,
+        requestProvider: MSALNativeAuthTokenRequestProviding,
+        cacheAccessor: MSALNativeAuthCacheInterface,
+        factory: MSALNativeAuthResultBuildable,
+        responseValidator: MSALNativeAuthTokenResponseValidating
+    ) {
+        self.cacheAccessor = cacheAccessor
+        super.init(
+            clientId: clientId,
+            requestProvider: requestProvider,
+            cacheAccessor: cacheAccessor,
+            factory: factory,
+            responseValidator: responseValidator
+        )
+    }
+
+    convenience init(config: MSALNativeAuthConfiguration) {
+        let factory = MSALNativeAuthResultFactory(config: config)
+        self.init(
+            clientId: config.clientId,
+            requestProvider: MSALNativeAuthTokenRequestProvider(
+                requestConfigurator: MSALNativeAuthRequestConfigurator(config: config)),
+            cacheAccessor: MSALNativeAuthCacheAccessor(),
+            factory: factory,
+            responseValidator: MSALNativeAuthTokenResponseValidator(factory: factory,
+                                                                    msidValidator: MSIDTokenResponseValidator())
+        )
+    }
+
+    // MARK: Internal
+
+    func retrieveUserAccountResult(context: MSALNativeAuthRequestContext) -> MSALNativeAuthUserAccountResult? {
+        let accounts = self.allAccounts()
+        if let account = accounts.first {
+            // We pass an empty array of scopes because that will return all tokens for that account identifier
+            // Because we expect to be only one access token per account at this point, it's ok for the array to be empty
+            guard let tokens = retrieveTokens(account: account,
+                                              scopes: [],
+                                              context: context) else {
+                MSALLogger.log(level: .verbose, context: nil, format: "No tokens found")
+                return nil
+            }
+            return factory.makeUserAccountResult(account: account, authTokens: tokens)
+        } else {
+            MSALLogger.log(level: .verbose, context: nil, format: "No account found")
+        }
+        return nil
+    }
+
+    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> Result<String, RetrieveAccessTokenError> {
+        MSALLogger.log(level: .verbose, context: context, format: "Refresh started")
+        let telemetryEvent = makeAndStartTelemetryEvent(id: .telemetryApiIdRefreshToken, context: context)
+        let scopes = authTokens.accessToken?.scopes.array as? [String] ?? []
+        guard let request = createRefreshTokenRequest(
+            scopes: scopes,
+            refreshToken: authTokens.refreshToken?.refreshToken,
+            context: context
+        ) else {
+            stopTelemetryEvent(telemetryEvent, context: context, error: MSALNativeAuthInternalError.invalidRequest)
+            return .failure(RetrieveAccessTokenError(type: .generalError))
+        }
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        let response = await performAndValidateTokenRequest(request, config: config, context: context)
+        return handleTokenResponse(
+            response,
+            scopes: scopes,
+            context: context,
+            telemetryEvent: telemetryEvent
+        )
+    }
+
+    // MARK: - Private
+
+    private func allAccounts() -> [MSALAccount] {
+        do {
+            // We pass an empty array of scopes because that will return all accounts
+            // that have been saved for the current Client Id. We expect only one account to exist at this point per Client Id
+            let config = factory.makeMSIDConfiguration(scopes: [])
+            return try cacheAccessor.getAllAccounts(configuration: config)
+        } catch {
+            MSALLogger.log(
+                level: .error,
+                context: nil,
+                format: "Error retrieving accounts \(error)")
+        }
+        return []
+    }
+
+    private func retrieveTokens(
+        account: MSALAccount,
+        scopes: [String],
+        context: MSALNativeAuthRequestContext
+    ) -> MSALNativeAuthTokens? {
+        do {
+            let config = factory.makeMSIDConfiguration(scopes: scopes)
+            return try cacheAccessor.getTokens(account: account, configuration: config, context: context)
+        } catch {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Error retrieving tokens: \(error)"
+            )
+        }
+        return nil
+    }
+
+    private func handleTokenResponse(
+        _ response: MSALNativeAuthTokenValidatedResponse,
+        scopes: [String],
+        context: MSALNativeAuthRequestContext,
+        telemetryEvent: MSIDTelemetryAPIEvent?
+    ) -> Result<String, RetrieveAccessTokenError> {
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        switch response {
+        case .success(let tokenResponse):
+            return handleMSIDTokenResponse(
+                tokenResponse: tokenResponse,
+                telemetryEvent: telemetryEvent,
+                context: context,
+                config: config
+            )
+        case .error(let errorType):
+            let error = errorType.convertToRetrieveAccessTokenError()
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Refresh Token completed with error: \(error.errorDescription ?? "No error description")")
+            stopTelemetryEvent(telemetryEvent, context: context, error: error)
+            return .failure(error)
+        }
+    }
+
+    private func handleMSIDTokenResponse(
+        tokenResponse: MSIDTokenResponse,
+        telemetryEvent: MSIDTelemetryAPIEvent?,
+        context: MSALNativeAuthRequestContext,
+        config: MSIDConfiguration
+    ) -> Result<String, RetrieveAccessTokenError> {
+        do {
+            let tokenResult = try cacheTokenResponse(tokenResponse, context: context, msidConfiguration: config)
+            telemetryEvent?.setUserInformation(tokenResult.account)
+            stopTelemetryEvent(telemetryEvent, context: context)
+            MSALLogger.log(
+                level: .verbose,
+                context: context,
+                format: "Refresh Token completed successfully")
+            return .success(tokenResult.accessToken.accessToken)
+        } catch {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Token Result was not created properly error - \(error)")
+            return .failure(RetrieveAccessTokenError(type: .generalError))
+        }
+    }
+}

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+protocol MSALNativeAuthCredentialsControlling {
+    func retrieveUserAccountResult(context: MSALNativeAuthRequestContext) -> MSALNativeAuthUserAccountResult?
+    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> Result<String, RetrieveAccessTokenError>
+}

--- a/MSAL/src/native_auth/controllers/factories/MSALNativeAuthControllerFactory.swift
+++ b/MSAL/src/native_auth/controllers/factories/MSALNativeAuthControllerFactory.swift
@@ -1,0 +1,54 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+protocol MSALNativeAuthControllerBuildable {
+    func makeSignUpController() -> MSALNativeAuthSignUpControlling
+    func makeSignInController() -> MSALNativeAuthSignInControlling
+    func makeResetPasswordController() -> MSALNativeAuthResetPasswordControlling
+    func makeCredentialsController() -> MSALNativeAuthCredentialsControlling
+}
+
+final class MSALNativeAuthControllerFactory: MSALNativeAuthControllerBuildable {
+    private let config: MSALNativeAuthConfiguration
+
+    init(config: MSALNativeAuthConfiguration) {
+        self.config = config
+    }
+
+    func makeSignUpController() -> MSALNativeAuthSignUpControlling {
+        return MSALNativeAuthSignUpController(config: config)
+    }
+
+    func makeSignInController() -> MSALNativeAuthSignInControlling {
+        return MSALNativeAuthSignInController(config: config)
+    }
+
+    func makeResetPasswordController() -> MSALNativeAuthResetPasswordControlling {
+        return MSALNativeAuthResetPasswordController(config: config)
+    }
+
+    func makeCredentialsController() -> MSALNativeAuthCredentialsControlling {
+        return MSALNativeAuthCredentialsController(config: config)
+    }
+}

--- a/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
+++ b/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
@@ -1,0 +1,79 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthResultBuildable {
+
+    var config: MSALNativeAuthConfiguration {get}
+
+    func makeUserAccountResult(tokenResult: MSIDTokenResult, context: MSIDRequestContext) -> MSALNativeAuthUserAccountResult?
+
+    func makeUserAccountResult(account: MSALAccount, authTokens: MSALNativeAuthTokens) -> MSALNativeAuthUserAccountResult?
+
+    func makeMSIDConfiguration(scopes: [String]) -> MSIDConfiguration
+}
+
+final class MSALNativeAuthResultFactory: MSALNativeAuthResultBuildable {
+
+    let config: MSALNativeAuthConfiguration
+
+    init(config: MSALNativeAuthConfiguration) {
+        self.config = config
+    }
+
+    func makeUserAccountResult(tokenResult: MSIDTokenResult, context: MSIDRequestContext) -> MSALNativeAuthUserAccountResult? {
+        guard let account = MSALAccount.init(msidAccount: tokenResult.account, createTenantProfile: false) else {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Account could not be created")
+            return nil
+        }
+        guard let refreshToken = tokenResult.refreshToken as? MSIDRefreshToken else {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Refresh token invalid, account result could not be created")
+            return nil
+        }
+        let authTokens = MSALNativeAuthTokens(accessToken: tokenResult.accessToken,
+                                              refreshToken: refreshToken,
+                                              rawIdToken: tokenResult.rawIdToken)
+        return .init(account: account, authTokens: authTokens, configuration: config, cacheAccessor: MSALNativeAuthCacheAccessor())
+    }
+
+    func makeUserAccountResult(account: MSALAccount, authTokens: MSALNativeAuthTokens) -> MSALNativeAuthUserAccountResult? {
+        return .init(account: account, authTokens: authTokens, configuration: config, cacheAccessor: MSALNativeAuthCacheAccessor())
+    }
+
+    func makeMSIDConfiguration(scopes: [String]) -> MSIDConfiguration {
+        return .init(
+            authority: config.authority,
+            redirectUri: nil,
+            clientId: config.clientId,
+            target: scopes.joinScopes()
+        )
+    }
+}

--- a/MSAL/src/native_auth/controllers/responses/CodeRequiredGenericResult.swift
+++ b/MSAL/src/native_auth/controllers/responses/CodeRequiredGenericResult.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/// Result type that contains information about the code sent, the next state of the reset password process and possible errors.
+enum CodeRequiredGenericResult<State: MSALNativeAuthBaseState, Error: MSALNativeAuthError> {
+    /// Returned if a user has received an email with code.
+    ///
+    /// - newState: An object representing the new state of the flow with follow on methods.
+    /// - sentTo: The email/phone number that the code was sent to.
+    /// - channelTargetType: The channel (email/phone) the code was sent through.
+    /// - codeLength: The length of the code required.
+    case codeRequired(newState: State, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
+
+    /// An error object indicating why the operation failed.
+    case error(error: Error, newState: State?)
+}

--- a/MSAL/src/native_auth/controllers/responses/SignUpResults.swift
+++ b/MSAL/src/native_auth/controllers/responses/SignUpResults.swift
@@ -1,0 +1,113 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum SignUpPasswordStartResult {
+    /// Returned if a user has received an email with code.
+    ///
+    /// - newState: An object representing the new state of the flow with follow on methods.
+    /// - sentTo: The email/phone number that the code was sent to.
+    /// - channelTargetType: The channel (email/phone) the code was sent through.
+    /// - codeLength: The length of the code required.
+    case codeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
+
+    /// Returned when the attributes sent are invalid.
+    case attributesInvalid([String])
+
+    /// An error object indicating why the operation failed.
+    case error(SignUpPasswordStartError)
+}
+
+enum SignUpStartResult {
+    /// Returned if a user has received an email with code.
+    ///
+    /// - newState: An object representing the new state of the flow with follow on methods.
+    /// - sentTo: The email/phone number that the code was sent to.
+    /// - channelTargetType: The channel (email/phone) the code was sent through.
+    /// - codeLength: The length of the code required.
+    case codeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
+
+    /// Returned when the attributes sent are invalid.
+    case attributesInvalid([String])
+
+    /// An error object indicating why the operation failed.
+    case error(SignUpStartError)
+}
+
+/// An object of this type is returned after a user submits the code sent to their email/phone.
+/// It contains the next state of the flow with follow on methods, depending on the server's response.
+enum SignUpVerifyCodeResult {
+    /// Returned after the sign up operation completed successfully.
+    case completed(SignInAfterSignUpState)
+
+    /// Returned when a password is required.
+    case passwordRequired(SignUpPasswordRequiredState)
+
+    /// Returned when attributes are required.
+    case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+
+    /// An error object indicating why the operation failed.
+    case error(error: VerifyCodeError, newState: SignUpCodeRequiredState?)
+}
+
+enum SignUpResendCodeResult {
+    /// Returned if a user has received an email with code.
+    ///
+    /// - newState: An object representing the new state of the flow with follow on methods.
+    /// - sentTo: The email/phone number that the code was sent to.
+    /// - channelTargetType: The channel (email/phone) the code was sent through.
+    /// - codeLength: The length of the code required.
+    case codeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
+
+    /// An error object indicating why the operation failed.
+    case error(ResendCodeError)
+}
+
+/// An object of this type is returned after a user submits their password.
+/// It contains the next state of the flow with follow on methods, depending on the server's response.
+enum SignUpPasswordRequiredResult {
+    /// Returned after the sign up operation completed successfully.
+    case completed(SignInAfterSignUpState)
+
+    /// Returned when attributes are required.
+    case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+
+    /// An error object indicating why the operation failed.
+    case error(error: PasswordRequiredError, newState: SignUpPasswordRequiredState?)
+}
+
+enum SignUpAttributesRequiredResult {
+    /// Returned after the sign up operation completed successfully.
+    case completed(SignInAfterSignUpState)
+
+    /// Returned when attributes are required.
+    case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], state: SignUpAttributesRequiredState)
+
+    /// Returned when the attributes sent are invalid.
+    case attributesInvalid(attributes: [String], newState: SignUpAttributesRequiredState)
+
+    /// An error object indicating why the operation failed.
+    case error(error: AttributesRequiredError)
+}

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -1,0 +1,664 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
+final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNativeAuthSignUpControlling {
+
+    // MARK: - Variables
+
+    private let requestProvider: MSALNativeAuthSignUpRequestProviding
+    private let responseValidator: MSALNativeAuthSignUpResponseValidating
+    private let signInController: MSALNativeAuthSignInControlling
+
+    // MARK: - Init
+
+    init(
+        config: MSALNativeAuthConfiguration,
+        requestProvider: MSALNativeAuthSignUpRequestProviding,
+        responseValidator: MSALNativeAuthSignUpResponseValidating,
+        signInController: MSALNativeAuthSignInControlling
+    ) {
+        self.requestProvider = requestProvider
+        self.responseValidator = responseValidator
+        self.signInController = signInController
+        super.init(clientId: config.clientId)
+    }
+
+    convenience init(config: MSALNativeAuthConfiguration) {
+        self.init(
+            config: config,
+            requestProvider: MSALNativeAuthSignUpRequestProvider(
+                requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+                telemetryProvider: MSALNativeAuthTelemetryProvider()
+            ),
+            responseValidator: MSALNativeAuthSignUpResponseValidator(),
+            signInController: MSALNativeAuthSignInController(config: config)
+        )
+    }
+
+    // MARK: - Internal
+
+    func signUpStartPassword(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartPasswordControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpPasswordStart, context: parameters.context)
+        let result = await performAndValidateStartRequest(parameters: parameters)
+        return await handleSignUpStartPasswordResult(result, username: parameters.username, event: event, context: parameters.context)
+    }
+
+    func signUpStartCode(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartCodeControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpCodeStart, context: parameters.context)
+        let result = await performAndValidateStartRequest(parameters: parameters)
+        return await handleSignUpStartCodeResult(result, username: parameters.username, event: event, context: parameters.context)
+    }
+
+    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpResendCode, context: context)
+        let challengeResult = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+        return handleResendCodeResult(challengeResult, username: username, event: event, context: context)
+    }
+
+    func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitCode, context: context)
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(grantType: .oobCode, signUpToken: signUpToken, oobCode: code, context: context)
+
+        let result = await performAndValidateContinueRequest(parameters: params)
+        return await handleSubmitCodeResult(result, username: username, signUpToken: signUpToken, event: event, context: context)
+    }
+
+    func submitPassword(
+        _ password: String,
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpSubmitPasswordControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitPassword, context: context)
+
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: signUpToken,
+            password: password,
+            context: context
+        )
+        let continueRequestResult = await performAndValidateContinueRequest(parameters: params)
+        return handleSubmitPasswordResult(continueRequestResult, username: username, signUpToken: signUpToken, event: event, context: context)
+    }
+
+    func submitAttributes(
+        _ attributes: [String: Any],
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpAttributesRequiredResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitAttributes, context: context)
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .attributes,
+            signUpToken: signUpToken,
+            attributes: attributes,
+            context: context
+        )
+
+        let result = await performAndValidateContinueRequest(parameters: params)
+        return handleSubmitAttributesResult(result, username: username, signUpToken: signUpToken, event: event, context: context)
+    }
+
+    // MARK: - Start Request handling
+
+    private func performAndValidateStartRequest(
+        parameters: MSALNativeAuthSignUpStartRequestProviderParameters
+    ) async -> MSALNativeAuthSignUpStartValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.start(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error while creating Start Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing signup/start request")
+
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(response, with: parameters.context)
+    }
+
+    // swiftlint:disable:next function_body_length
+    private func handleSignUpStartPasswordResult(
+        _ result: MSALNativeAuthSignUpStartValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> SignUpStartPasswordControllerResponse {
+        switch result {
+        case .verificationRequired(let signUpToken, let attributes):
+            MSALLogger.log(
+                level: .info,
+                context: context,
+                format: "verification_required received from signup/start with password request for attributes: \(attributes)"
+            )
+            let challengeResult = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+            return handleSignUpPasswordChallengeResult(challengeResult, username: username, event: event, context: context)
+        case .attributeValidationFailed(let invalidAttributes):
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "attribute_validation_failed received from signup/start with password request for attributes: \(invalidAttributes)"
+            )
+            let message = String(format: MSALNativeAuthErrorMessage.attributeValidationFailedSignUpStart, invalidAttributes.description)
+            let error = SignUpPasswordStartError(type: .generalError, message: message)
+            return .init(.attributesInvalid(invalidAttributes), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                case .failure(let error):
+                    MSALLogger.log(
+                        level: .error,
+                        context: context,
+                        format: "SignUp with password error: \(error.errorDescription ?? "No error description")"
+                    )
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .redirect:
+            let error = SignUpPasswordStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "redirect error in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .error(let apiError):
+            let error = apiError.toSignUpStartPasswordPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidUsername(let apiError):
+            let error = SignUpPasswordStartError(type: .invalidUsername, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "InvalidUsername in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidClientId(let apiError):
+            let error = SignUpPasswordStartError(type: .generalError, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Invalid Client Id in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError:
+            let error = SignUpPasswordStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    private func handleSignUpStartCodeResult(
+        _ result: MSALNativeAuthSignUpStartValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> SignUpStartCodeControllerResponse {
+        switch result {
+        case .verificationRequired(let signUpToken, let unverifiedAttributes):
+            MSALLogger.log(
+                level: .info,
+                context: context,
+                format: "verification_required received from signup/start request for attributes: \(unverifiedAttributes)"
+            )
+            let challengeResult = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+            return handleSignUpCodeChallengeResult(challengeResult, username: username, event: event, context: context)
+        case .attributeValidationFailed(let invalidAttributes):
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "attribute_validation_failed received from signup/start request for attributes: \(invalidAttributes)"
+            )
+            let message = String(format: MSALNativeAuthErrorMessage.attributeValidationFailedSignUpStart, invalidAttributes.description)
+            let error = SignUpStartError(type: .generalError, message: message)
+            return .init(.attributesInvalid(invalidAttributes), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .redirect:
+            let error = SignUpStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .error(let apiError):
+            let error = apiError.toSignUpStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidUsername(let apiError):
+            let error = SignUpStartError(type: .invalidUsername, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "InvalidUsername in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidClientId(let apiError):
+            let error = SignUpStartError(type: .generalError, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Invalid Client Id in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError:
+            let error = SignUpStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    // MARK: - Challenge Request handling
+
+    private func performAndValidateChallengeRequest(
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.challenge(token: signUpToken, context: context)
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error while creating Challenge Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: context, format: "Performing signup/challenge request")
+
+        let result: Result<MSALNativeAuthSignUpChallengeResponse, Error> = await performRequest(request, context: context)
+        return responseValidator.validate(result, with: context)
+    }
+
+    private func handleSignUpPasswordChallengeResult(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpStartPasswordControllerResponse {
+        switch result {
+        case .codeRequired(let sentTo, let challengeType, let codeLength, let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge password request")
+            stopTelemetryEvent(event, context: context)
+            return SignUpStartPasswordControllerResponse(
+                .codeRequired(
+                    newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                    sentTo: sentTo,
+                    channelTargetType: challengeType,
+                    codeLength: codeLength
+                )
+            )
+        case .error(let apiError):
+            let error = apiError.toSignUpPasswordStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/challenge password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .redirect:
+            let error = SignUpPasswordStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/challenge password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError,
+             .passwordRequired:
+            let error = SignUpPasswordStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    private func handleSignUpCodeChallengeResult(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpStartCodeControllerResponse {
+        switch result {
+        case .codeRequired(let sentTo, let challengeType, let codeLength, let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge request")
+            stopTelemetryEvent(event, context: context)
+            return SignUpStartCodeControllerResponse(
+                .codeRequired(
+                    newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                    sentTo: sentTo,
+                    channelTargetType: challengeType,
+                    codeLength: codeLength
+                )
+            )
+        case .error(let apiError):
+            let error = apiError.toSignUpStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .redirect:
+            let error = SignUpStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError,
+             .passwordRequired:
+            let error = SignUpStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    private func handleResendCodeResult(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpResendCodeResult {
+        switch result {
+        case .codeRequired(let sentTo, let challengeType, let codeLength, let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge resendCode request")
+            stopTelemetryEvent(event, context: context)
+            return .codeRequired(
+                newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                sentTo: sentTo,
+                channelTargetType: challengeType,
+                codeLength: codeLength
+            )
+        case .error(let apiError):
+            let error = apiError.toResendCodePublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/challenge resendCode request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        case .redirect,
+             .unexpectedError,
+             .passwordRequired:
+            let error = ResendCodeError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge resendCode request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        }
+    }
+
+    /// This method handles the /challenge response after receiving a "credential_required" error
+    private func handlePerformChallengeAfterContinueRequest(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpSubmitCodeControllerResponse {
+        switch result {
+        case .passwordRequired(let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge request after credential_required")
+
+            let state = SignUpPasswordRequiredState(controller: self, username: username, flowToken: signUpToken)
+
+            return .init(.passwordRequired(state), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .redirect:
+            let error = VerifyCodeError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        case .error,
+             .codeRequired,
+             .unexpectedError:
+            let error = VerifyCodeError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        }
+    }
+
+    // MARK: - Continue Request handling
+
+    private func performAndValidateContinueRequest(
+        parameters: MSALNativeAuthSignUpContinueRequestProviderParams
+    ) async -> MSALNativeAuthSignUpContinueValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.continue(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error while creating Continue Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing signup/continue request")
+
+        let result: Result<MSALNativeAuthSignUpContinueResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(result, with: parameters.context)
+    }
+
+    private func handleSubmitCodeResult(
+        _ result: MSALNativeAuthSignUpContinueValidatedResponse,
+        username: String,
+        signUpToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> SignUpSubmitCodeControllerResponse {
+        switch result {
+        case .success(let slt):
+            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+            return .init(.completed(state))
+        case .invalidUserInput:
+            MSALLogger.log(level: .error, context: context, format: "invalid_user_input error in signup/continue request")
+
+            let error = VerifyCodeError(type: .invalidCode)
+            stopTelemetryEvent(event, context: context, error: error)
+            let state = SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .init(.error(error: error, newState: state))
+        case .credentialRequired(let signUpToken):
+            MSALLogger.log(level: .verbose, context: context, format: "credential_required received in signup/continue request")
+
+            let result = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+            return handlePerformChallengeAfterContinueRequest(result, username: username, event: event, context: context)
+        case .attributesRequired(let signUpToken, let attributes):
+            MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .init(.attributesRequired(attributes: attributes, newState: state), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .error(let apiError):
+            let error = apiError.toVerifyCodePublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/continue request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        case .attributeValidationFailed,
+             .unexpectedError:
+            let error = VerifyCodeError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        }
+    }
+
+    private func handleSubmitPasswordResult(
+        _ result: MSALNativeAuthSignUpContinueValidatedResponse,
+        username: String,
+        signUpToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpSubmitPasswordControllerResponse {
+        switch result {
+        case .success(let slt):
+            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+            return .init(.completed(state))
+        case .invalidUserInput(let error):
+            let error = error.toPasswordRequiredPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "invalid_user_input error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")"
+            )
+
+            let state = SignUpPasswordRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .init(.error(error: error, newState: state))
+        case .attributesRequired(let signUpToken, let attributes):
+            MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+
+            return .init(.attributesRequired(attributes: attributes, newState: state), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .error(let apiError):
+            let error = apiError.toPasswordRequiredPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        case .attributeValidationFailed,
+             .credentialRequired,
+             .unexpectedError:
+            let error = PasswordRequiredError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        }
+    }
+
+    private func handleSubmitAttributesResult(
+        _ result: MSALNativeAuthSignUpContinueValidatedResponse,
+        username: String,
+        signUpToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpAttributesRequiredResult {
+        switch result {
+        case .success(let slt):
+            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+            return .completed(state)
+        case .attributesRequired(let signUpToken, let attributes):
+            let error = AttributesRequiredError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "attributes_required received in signup/continue submitAttributes request: \(attributes)")
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .attributesRequired(attributes: attributes, state: state)
+        case .attributeValidationFailed(let signUpToken, let invalidAttributes):
+            let message = "attribute_validation_failed from signup/continue submitAttributes request. Make sure these attributes are correct: \(invalidAttributes)" // swiftlint:disable:this line_length
+            MSALLogger.log(level: .error, context: context, format: message)
+
+            let errorMessage = String(format: MSALNativeAuthErrorMessage.attributeValidationFailed, invalidAttributes.description)
+            let error = AttributesRequiredError(message: errorMessage)
+            stopTelemetryEvent(event, context: context, error: error)
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .attributesInvalid(attributes: invalidAttributes, newState: state)
+        case .error(let apiError):
+            let error = apiError.toAttributesRequiredPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/continue submitAttributes request \(error.errorDescription ?? "No error description")")
+            return .error(error: error)
+        case .credentialRequired,
+             .unexpectedError,
+             .invalidUserInput:
+            let error = AttributesRequiredError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue submitAttributes request \(error.errorDescription ?? "No error description")")
+            return .error(error: error)
+        }
+    }
+
+    private func createSignInAfterSignUpStateUsingSLT(
+        _ slt: String?,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignInAfterSignUpState {
+        MSALLogger.log(level: .info, context: context, format: "SignUp completed successfully")
+        stopTelemetryEvent(event, context: context)
+        return SignInAfterSignUpState(controller: signInController, username: username, slt: slt)
+    }
+}

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
@@ -1,0 +1,55 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignUpControlling: AnyObject {
+
+    typealias SignUpStartPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpPasswordStartResult>
+    typealias SignUpStartCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpStartResult>
+    typealias SignUpSubmitCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpVerifyCodeResult>
+    typealias SignUpSubmitPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpPasswordRequiredResult>
+
+    func signUpStartPassword(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartPasswordControllerResponse
+
+    func signUpStartCode(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartCodeControllerResponse
+
+    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeResult
+
+    func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse
+
+    func submitPassword(
+        _ password: String,
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpSubmitPasswordControllerResponse
+
+    func submitAttributes(
+        _ attributes: [String: Any],
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpAttributesRequiredResult
+}

--- a/MSAL/src/native_auth/extension/Array+joinScopes.swift
+++ b/MSAL/src/native_auth/extension/Array+joinScopes.swift
@@ -1,0 +1,31 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import Foundation
+
+extension Array where Element: StringProtocol {
+    func joinScopes() -> String {
+        return self.joined(separator: " ")
+    }
+}

--- a/MSAL/src/native_auth/input_validator/MSALNativeAuthInputValidator.swift
+++ b/MSAL/src/native_auth/input_validator/MSALNativeAuthInputValidator.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+protocol MSALNativeAuthInputValidating {
+    func isInputValid(_ input: String) -> Bool
+}
+
+final class MSALNativeAuthInputValidator: MSALNativeAuthInputValidating {
+    func isInputValid(_ input: String) -> Bool {
+        return !input.isEmpty
+    }
+}

--- a/MSAL/src/native_auth/logger/MSALLogMask.h
+++ b/MSAL/src/native_auth/logger/MSALLogMask.h
@@ -1,0 +1,55 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALLogMask : NSObject
+
+/// Terms used in to clasify data:
+/// - PII - Personally identifiable Information
+/// - EUII - End User identifiable Information such as UPN, username, email
+/// - EUPII - End User Pseudonymous Identifiers
+/// - OII - Organization Identifiable Information
+
+/// Used for masking any PII (Personally identifiable Information) including EUII and EUPI as long as log level is MSIDLogMaskingSettingsMaskAllPII
+/// - Parameter parameter: Any object that needs to be masked
++ (MSIDMaskedLogParameter*) maskPII:(nullable id) parameter;
+
+/// Used for masking any EUII (End User identifiable Information) such as UPN, username, email as long as log level is MSIDLogMaskingSettingsMaskEUIIOnly or below
+/// - Parameter parameter: Any object that needs to be masked
++ (MSIDMaskedLogParameter*) maskEUII:(nullable id) parameter;
+
+/// Used for masking any Trackable User Information such as Accounts or URLs that should be hashed as long as log level is MSIDLogMaskingSettingsMaskAllPII
+/// - Parameter parameter: Any object that needs to be masked via hashing
++ (MSIDMaskedHashableLogParameter*) maskTrackablePII:(nullable id) parameter;
+
+/// Used for masking any Username (email, id, account identifier) that should be hashed as long as log level is MSIDLogMaskingSettingsMaskEUIIOnly or below
+/// - Parameter parameter: Any Username that needs to be masked via hashing
++ (MSIDMaskedUsernameLogParameter*) maskUsername:(nullable id) parameter;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/native_auth/logger/MSALLogMask.m
+++ b/MSAL/src/native_auth/logger/MSALLogMask.m
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSALLogMask.h"
+
+@implementation MSALLogMask
+
++ (MSIDMaskedLogParameter*) maskPII:(nullable id) parameter {
+    return MSID_PII_LOG_MASKABLE(parameter);
+}
+
++ (MSIDMaskedLogParameter*) maskEUII:(nullable id) parameter {
+    return MSID_EUII_ONLY_LOG_MASKABLE(parameter);
+}
+
++ (MSIDMaskedHashableLogParameter*) maskTrackablePII:(nullable id) parameter {
+    return MSID_PII_LOG_TRACKABLE(parameter);
+}
+
++ (MSIDMaskedUsernameLogParameter*) maskUsername:(nullable id) parameter {
+    return MSID_PII_LOG_EMAIL(parameter);
+}
+
+@end

--- a/MSAL/src/native_auth/logger/MSALNativeAuthLogging.swift
+++ b/MSAL/src/native_auth/logger/MSALNativeAuthLogging.swift
@@ -1,0 +1,150 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALLogging {
+    static func log(
+        level: MSIDLogLevel,
+        context: MSIDRequestContext?,
+        filename: String,
+        lineNumber: Int,
+        function: String,
+        format: String,
+        _ args: CVarArg...)
+    static func logPII(
+        level: MSIDLogLevel,
+        context: MSIDRequestContext?,
+        filename: String,
+        lineNumber: Int,
+        function: String,
+        format: String,
+        _ args: CVarArg...)
+    static func log(
+        level: MSIDLogLevel,
+        correlationId: UUID?,
+        filename: String,
+        lineNumber: Int,
+        function: String,
+        format: String,
+        _ args: CVarArg...)
+    static func logPII(
+        level: MSIDLogLevel,
+        correlationId: UUID?,
+        filename: String,
+        lineNumber: Int,
+        function: String,
+        format: String,
+        _ args: CVarArg...)
+}
+
+extension MSALLogger: MSALLogging {
+    private static func logCommon(level: MSIDLogLevel,
+                                  context: MSIDRequestContext? = nil,
+                                  correlationId: UUID? = nil,
+                                  containsPII: Bool,
+                                  filename: String = #fileID,
+                                  lineNumber: Int = #line,
+                                  function: String = #function,
+                                  format: String,
+                                  _ args: CVaListPointer) {
+        MSIDLogger.shared().log(with: level,
+                                context: context,
+                                correlationId: correlationId,
+                                containsPII: containsPII,
+                                filename: filename,
+                                lineNumber: UInt(lineNumber),
+                                function: function,
+                                format: format,
+                                formatArgs: args)
+    }
+
+    static func log(level: MSIDLogLevel,
+                    context: MSIDRequestContext?,
+                    filename: String = #fileID,
+                    lineNumber: Int = #line,
+                    function: String = #function,
+                    format: String,
+                    _ args: CVarArg...) {
+        logCommon(level: level,
+                  context: context,
+                  containsPII: false,
+                  filename: filename,
+                  lineNumber: lineNumber,
+                  function: function,
+                  format: format,
+                  getVaList(args))
+    }
+
+    static func logPII(level: MSIDLogLevel,
+                       context: MSIDRequestContext?,
+                       filename: String = #fileID,
+                       lineNumber: Int = #line,
+                       function: String = #function,
+                       format: String,
+                       _ args: CVarArg...) {
+        logCommon(level: level,
+                  context: context,
+                  containsPII: true,
+                  filename: filename,
+                  lineNumber: lineNumber,
+                  function: function,
+                  format: format,
+                  getVaList(args))
+    }
+
+    static func log(level: MSIDLogLevel,
+                    correlationId: UUID?,
+                    filename: String = #fileID,
+                    lineNumber: Int = #line,
+                    function: String = #function,
+                    format: String,
+                    _ args: CVarArg...) {
+        logCommon(level: level,
+                  correlationId: correlationId,
+                  containsPII: false,
+                  filename: filename,
+                  lineNumber: lineNumber,
+                  function: function,
+                  format: format,
+                  getVaList(args))
+    }
+
+    static func logPII(level: MSIDLogLevel,
+                       correlationId: UUID?,
+                       filename: String = #fileID,
+                       lineNumber: Int = #line,
+                       function: String = #function,
+                       format: String,
+                       _ args: CVarArg...) {
+        logCommon(level: level,
+                  correlationId: correlationId,
+                  containsPII: true,
+                  filename: filename,
+                  lineNumber: lineNumber,
+                  function: function,
+                  format: format,
+                  getVaList(args))
+    }
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthEndpoint.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthEndpoint.swift
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+enum MSALNativeAuthEndpoint: String, CaseIterable {
+    case signUpStart = "/signup/v1.0/start"
+    case signUpChallenge = "/signup/v1.0/challenge"
+    case signUpContinue = "/signup/v1.0/continue"
+    case signInInitiate = "/oauth2/v2.0/initiate"
+    case signInChallenge = "/oauth2/v2.0/challenge"
+    case token = "/oauth2/v2.0/token"
+    case resetPasswordStart = "/resetpassword/v1.0/start"
+    case resetPasswordChallenge = "/resetpassword/v1.0/challenge"
+    case resetPasswordContinue = "/resetpassword/v1.0/continue"
+    case resetPasswordComplete = "/resetpassword/v1.0/complete"
+    case resetPasswordSubmit = "/resetpassword/v1.0/submit"
+    case resetpasswordPollCompletion = "/resetpassword/v1.0/poll_completion"
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthGrantType.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthGrantType.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+enum MSALNativeAuthGrantType: String {
+    case password
+    case otp = "passwordless_otp"
+    case oobCode = "oob"
+    case refreshToken = "refresh_token"
+    case slt
+    case attributes
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthInternalChallengeType.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthInternalChallengeType.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+enum MSALNativeAuthInternalChallengeType: String, Decodable {
+    case oob
+    case password
+    case otp
+    case redirect
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthInternalChannelType.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthInternalChannelType.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+enum MSALNativeAuthInternalChannelType: String, Decodable {
+    case phone
+    case email
+
+    func toPublicChannelType() -> MSALNativeAuthChannelType {
+        switch self {
+        case .phone:
+            return .phone
+        case .email:
+            return .email
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthRequestConfigurator.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthRequestConfigurator.swift
@@ -1,0 +1,271 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@_implementationOnly import MSAL_Private
+
+enum MSALNativeAuthRequestConfiguratorType {
+    enum SignUp {
+        case start(MSALNativeAuthSignUpStartRequestParameters)
+        case challenge(MSALNativeAuthSignUpChallengeRequestParameters)
+        case `continue`(MSALNativeAuthSignUpContinueRequestParameters)
+    }
+
+    enum SignIn {
+        case initiate(MSALNativeAuthSignInInitiateRequestParameters)
+        case challenge(MSALNativeAuthSignInChallengeRequestParameters)
+    }
+
+    enum ResetPassword {
+        case start(MSALNativeAuthResetPasswordStartRequestParameters)
+        case challenge(MSALNativeAuthResetPasswordChallengeRequestParameters)
+        case `continue`(MSALNativeAuthResetPasswordContinueRequestParameters)
+        case submit(MSALNativeAuthResetPasswordSubmitRequestParameters)
+        case pollCompletion(MSALNativeAuthResetPasswordPollCompletionRequestParameters)
+    }
+
+    enum Token {
+        case signInWithPassword(MSALNativeAuthTokenRequestParameters)
+        case refreshToken(MSALNativeAuthTokenRequestParameters)
+    }
+
+    case signUp(SignUp)
+    case signIn(SignIn)
+    case resetPassword(ResetPassword)
+    case token(Token)
+}
+
+class MSALNativeAuthRequestConfigurator: MSIDAADRequestConfigurator {
+    let config: MSALNativeAuthConfiguration
+
+    init(config: MSALNativeAuthConfiguration) {
+        self.config = config
+    }
+
+    func configure(configuratorType: MSALNativeAuthRequestConfiguratorType,
+                   request: MSIDHttpRequest,
+                   telemetryProvider: MSALNativeAuthTelemetryProviding) throws {
+        switch configuratorType {
+        case .signUp(let subType):
+            try signUpConfigure(subType, request, telemetryProvider)
+        case .signIn(let subType):
+            try signInConfigure(subType, request, telemetryProvider)
+        case .resetPassword(let subType):
+            try resetPasswordConfigure(subType, request, telemetryProvider)
+        case .token(let subType):
+            try tokenConfigure(subType, request, telemetryProvider)
+        }
+    }
+
+    private func signUpConfigure(_ subType: MSALNativeAuthRequestConfiguratorType.SignUp,
+                                 _ request: MSIDHttpRequest,
+                                 _ telemetryProvider: MSALNativeAuthTelemetryProviding) throws {
+        switch subType {
+        case .start(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignUpStartResponse>()
+            let telemetry = telemetryProvider.telemetryForSignUp(type: .signUpStart)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignUpStartResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .challenge(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignUpChallengeResponse>()
+            let telemetry = telemetryProvider.telemetryForSignUp(type: .signUpChallenge)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignUpChallengeResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .continue(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignUpContinueResponse>()
+            let telemetry = telemetryProvider.telemetryForSignUp(type: .signUpContinue)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignUpContinueResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        }
+    }
+
+    private func signInConfigure(_ subType: MSALNativeAuthRequestConfiguratorType.SignIn,
+                                 _ request: MSIDHttpRequest,
+                                 _ telemetryProvider: MSALNativeAuthTelemetryProviding) throws {
+        switch subType {
+        case .initiate(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignInInitiateResponse>()
+            let telemetry = telemetryProvider.telemetryForSignIn(type: .signInInitiate)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInInitiateResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .challenge(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignInChallengeResponse>()
+            let telemetry = telemetryProvider.telemetryForSignIn(type: .signInChallenge)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInChallengeResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        }
+    }
+
+    private func resetPasswordConfigure(_ subType: MSALNativeAuthRequestConfiguratorType.ResetPassword,
+                                        _ request: MSIDHttpRequest,
+                                        _ telemetryProvider: MSALNativeAuthTelemetryProviding) throws {
+        switch subType {
+        case .start(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthResetPasswordStartResponse>()
+            let telemetry = telemetryProvider.telemetryForResetPassword(type: .resetPasswordStart)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthResetPasswordStartResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .challenge(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthResetPasswordChallengeResponse>()
+            let telemetry = telemetryProvider.telemetryForResetPassword(type: .resetPasswordChallenge)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthResetPasswordChallengeResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .continue(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthResetPasswordContinueResponse>()
+            let telemetry = telemetryProvider.telemetryForResetPassword(type: .resetPasswordContinue)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthResetPasswordContinueResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .submit(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthResetPasswordSubmitResponse>()
+            let telemetry = telemetryProvider.telemetryForResetPassword(type: .resetPasswordSubmit)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthResetPasswordSubmitResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .pollCompletion(let parameters):
+            let responseSerializer =
+            MSALNativeAuthResponseSerializer<MSALNativeAuthResetPasswordPollCompletionResponse>()
+            let telemetry = telemetryProvider.telemetryForResetPassword(type: .resetPasswordPollCompletion)
+            let errorHandler =
+            MSALNativeAuthResponseErrorHandler<MSALNativeAuthResetPasswordPollCompletionResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        }
+    }
+
+    private func tokenConfigure(_ subType: MSALNativeAuthRequestConfiguratorType.Token,
+                                _ request: MSIDHttpRequest,
+                                _ telemetryProvider: MSALNativeAuthTelemetryProviding) throws {
+        switch subType {
+        case .signInWithPassword(let parameters):
+            let telemetry = telemetryProvider.telemetryForToken(type: .signInWithPassword)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthTokenResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .refreshToken(let parameters):
+            let telemetry = telemetryProvider.telemetryForToken(type: .refreshToken)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthTokenResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        }
+    }
+
+    private func configure<R: Decodable, E: Decodable & Error>(
+        request: MSIDHttpRequest,
+        parameters: MSALNativeAuthRequestable,
+        responseSerializer: MSALNativeAuthResponseSerializer<R>,
+        telemetry: MSALNativeAuthCurrentRequestTelemetry,
+        errorHandler: MSALNativeAuthResponseErrorHandler<E>
+    ) throws {
+        try configure(request: request,
+                      parameters: parameters,
+                      telemetry: telemetry,
+                      errorHandler: errorHandler)
+        request.responseSerializer = responseSerializer
+    }
+
+    // For the SignInToken endpoint the Response serialiser should not be set
+    // Because we cannot have optional Generic Types parameters at call time
+    // especially with Decodable we have to have another method name
+    // This might be removed in the future if the response from the /token endpoint changes
+    private func configure<E: Decodable & Error>(
+        request: MSIDHttpRequest,
+        parameters: MSALNativeAuthRequestable,
+        telemetry: MSALNativeAuthCurrentRequestTelemetry,
+        errorHandler: MSALNativeAuthResponseErrorHandler<E>
+    ) throws {
+        try configureAllRequests(request: request, parameters: parameters)
+        request.requestSerializer = MSALNativeAuthUrlRequestSerializer(
+            context: parameters.context,
+            encoding: .wwwFormUrlEncoded
+        )
+        request.serverTelemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetry,
+            context: parameters.context
+        )
+        request.errorHandler = errorHandler
+    }
+
+    private func configureAllRequests(request: MSIDHttpRequest,
+                                      parameters: MSALNativeAuthRequestable) throws {
+        request.context = parameters.context
+        request.parameters = parameters.makeRequestBody(config: config)
+
+        do {
+            let endpointUrl = try parameters.makeEndpointUrl(config: config)
+            request.urlRequest = URLRequest(url: endpointUrl)
+            request.urlRequest?.httpMethod = MSALParameterStringForHttpMethod(.POST)
+        } catch {
+            MSALLogger.log(
+                level: .error,
+                context: parameters.context,
+                format: "Endpoint could not be created: \(error)"
+            )
+            throw MSALNativeAuthInternalError.invalidRequest
+        }
+        configure(request)
+    }
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthRequestParametersKey.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthRequestParametersKey.swift
@@ -1,0 +1,48 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthRequestParametersKey: String {
+    case clientId = "client_id"
+    case challengeType = "challenge_type"
+    case grantType = "grant_type"
+    case username
+    case email
+    case password
+    case scope
+    case credentialToken = "credential_token"
+    case flowToken
+    case oobCode = "oob"
+    case otp
+    case customAttributes
+    case signInSLT = "signin_slt"
+    case attributes
+    case signUpToken = "signup_token"
+    case passwordResetToken = "password_reset_token"
+    case passwordSubmitToken = "password_submit_token"
+    case newPassword = "new_password"
+    case clientInfo = "client_info"
+    case refreshToken = "refresh_token"
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseErrorHandler.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseErrorHandler.swift
@@ -1,0 +1,193 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResponseErrorHandler<T: Decodable & Error>: NSObject, MSIDHttpRequestErrorHandling {
+    private var customError: T?
+
+    // swiftlint:disable:next function_parameter_count
+    func handleError(
+        _ error: Error?,
+        httpResponse: HTTPURLResponse?,
+        data: Data?,
+        httpRequest: MSIDHttpRequestProtocol?,
+        responseSerializer: MSIDResponseSerialization?,
+        externalSSOContext ssoContext: MSIDExternalSSOContext?,
+        context: MSIDRequestContext?,
+        completionBlock: MSIDHttpRequestDidCompleteBlock?
+    ) {
+        guard let httpResponse = httpResponse else {
+            completionBlock?(nil, error)
+            return
+        }
+
+        if shouldRetry(httpResponse: httpResponse, httpRequest: httpRequest) {
+            retryRequest(httpRequest: httpRequest,
+                         context: context,
+                         completionBlock: completionBlock)
+            return
+        }
+
+        if httpResponse.statusCode == 400 || httpResponse.statusCode == 401 {
+            // PKeyAuth challenge
+            if let authValue = wwwAuthValue(httpResponse: httpResponse) {
+                handleAuthenticateHeader(wwwAuthValue: authValue,
+                                         httpRequest: httpRequest,
+                                         context: context,
+                                         ssoContext: ssoContext,
+                                         completionBlock: completionBlock)
+                return
+            }
+
+            handleAPIError(data: data, completionBlock: completionBlock)
+            return
+        }
+
+        handleHTTPError(httpResponse: httpResponse,
+                        context: context,
+                        completionBlock: completionBlock)
+    }
+
+    private func shouldRetry(httpResponse: HTTPURLResponse,
+                             httpRequest: MSIDHttpRequestProtocol?) -> Bool {
+        guard let httpRequest = httpRequest, httpRequest.retryCounter > 0 else {
+            return false
+        }
+        return httpResponse.statusCode >= 500 && httpResponse.statusCode <= 599
+    }
+
+    private func retryRequest(
+        httpRequest: MSIDHttpRequestProtocol?,
+        context: MSIDRequestContext?,
+        completionBlock: MSIDHttpRequestDidCompleteBlock?
+    ) {
+        httpRequest?.retryCounter -= 1
+        if let context = context {
+            MSALLogger.log(level: .verbose,
+                           context: context,
+                           format: "Retrying network request, retryCounter: %d", httpRequest?.retryCounter ?? 0)
+        }
+        let deadline = DispatchTime.now() + Double(UInt64(httpRequest?.retryInterval ?? 0) * NSEC_PER_SEC )
+        DispatchQueue.global().asyncAfter(deadline: deadline) {
+            httpRequest?.send(completionBlock)
+        }
+    }
+
+    private func wwwAuthValue(httpResponse: HTTPURLResponse) -> String? {
+        let wwwAuthKey = httpResponse.allHeaderFields.keys.first(where: {
+            if let keyNameUppercased = ($0 as? String)?.uppercased() {
+                return keyNameUppercased == kMSIDWwwAuthenticateHeader.uppercased()
+            }
+            return false
+        })
+        let wwwAuthValue = httpResponse
+                            .allHeaderFields[wwwAuthKey ?? "" as Dictionary<AnyHashable, Any>.Keys.Element] as? String
+
+        if !NSString.msidIsStringNilOrBlank(wwwAuthValue),
+            let wwwAuthValue = wwwAuthValue,
+            wwwAuthValue.contains(kMSIDPKeyAuthName) {
+            return wwwAuthValue
+        }
+        return nil
+    }
+
+    private func handleAuthenticateHeader(
+        wwwAuthValue: String,
+        httpRequest: MSIDHttpRequestProtocol?,
+        context: MSIDRequestContext?,
+        ssoContext: MSIDExternalSSOContext?,
+        completionBlock: MSIDHttpRequestDidCompleteBlock?
+    ) {
+        MSIDPKeyAuthHandler.handleWwwAuthenticateHeader(
+            wwwAuthValue,
+            request: httpRequest?.urlRequest.url,
+            externalSSOContext: ssoContext,
+            context: context) { authHeader, completionError in
+            if !NSString.msidIsStringNilOrBlank(authHeader) {
+                // Append Auth Header
+                if var newRequest = httpRequest?.urlRequest {
+                    newRequest.setValue(authHeader, forHTTPHeaderField: "Authorization")
+                    httpRequest?.urlRequest = newRequest as URLRequest
+
+                    DispatchQueue.global().async {
+                        httpRequest?.send(completionBlock)
+                    }
+                }
+                return
+            }
+            completionBlock?(nil, completionError)
+        }
+    }
+
+    private func handleAPIError(
+        data: Data?,
+        completionBlock: MSIDHttpRequestDidCompleteBlock?
+    ) {
+        do {
+            customError = try JSONDecoder().decode(T.self, from: data ?? Data())
+            completionBlock?(nil, customError)
+        } catch {
+            completionBlock?(nil, error)
+        }
+    }
+
+    private func handleHTTPError(
+        httpResponse: HTTPURLResponse,
+        context: MSIDRequestContext?,
+        completionBlock: MSIDHttpRequestDidCompleteBlock?
+    ) {
+        let statusCode = httpResponse.statusCode
+        let errorDescription = HTTPURLResponse.localizedString(forStatusCode: statusCode)
+        if let context = context {
+            MSALLogger.log(level: .warning,
+                           context: context,
+                           format: "HTTP error raised. HTTP Code: %d Description %@", statusCode,
+                           MSALLogMask.maskPII(errorDescription))
+        }
+
+        var additionalInfo = [AnyHashable: Any]()
+        additionalInfo[MSIDHTTPHeadersKey] = httpResponse.allHeaderFields
+        additionalInfo[MSIDHTTPResponseCodeKey] = String(httpResponse.statusCode)
+
+        if statusCode >= 500 && statusCode <= 599 {
+            additionalInfo[MSIDServerUnavailableStatusKey] = NSNumber(value: 1)
+        }
+
+        if let context = context {
+            let httpError  = MSIDCreateError(MSIDHttpErrorCodeDomain,
+                                             MSIDErrorCode.serverUnhandledResponse.rawValue,
+                                             errorDescription,
+                                             nil,
+                                             nil,
+                                             nil,
+                                             context.correlationId(),
+                                             additionalInfo,
+                                             true)
+            completionBlock?(nil, httpError)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseSerializer.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResponseSerializer<T: Decodable>: NSObject, MSIDResponseSerialization {
+
+    func responseObject(for httpResponse: HTTPURLResponse?, data: Data?, context: MSIDRequestContext?) throws -> Any {
+        guard let data = data else {
+            throw MSALNativeAuthInternalError.responseSerializationError
+        }
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        return try decoder.decode(T.self, from: data)
+    }
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthUrlRequestSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthUrlRequestSerializer.swift
@@ -1,0 +1,94 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+enum MSALNativeAuthUrlRequestEncoding: String {
+    case wwwFormUrlEncoded = "application/x-www-form-urlencoded"
+    case json = "application/json"
+}
+
+final class MSALNativeAuthUrlRequestSerializer: NSObject, MSIDRequestSerialization {
+
+    private let context: MSIDRequestContext
+    private let encoding: MSALNativeAuthUrlRequestEncoding
+
+    init(context: MSIDRequestContext, encoding: MSALNativeAuthUrlRequestEncoding) {
+        self.context = context
+        self.encoding = encoding
+    }
+
+    func serialize(
+        with request: URLRequest,
+        parameters: [AnyHashable: Any],
+        headers: [AnyHashable: Any]
+    ) -> URLRequest {
+
+        var request = request
+        var requestHeaders: [String: String] = [:]
+
+        // Convert entries from `headers` to a dictionary [String: String]
+
+        headers.forEach {
+            if let key = $0.key as? String, let value = $0.value as? String {
+                requestHeaders[key] = value
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Header serialization failed")
+            }
+        }
+
+        if encoding == .json {
+            if JSONSerialization.isValidJSONObject(parameters) {
+                do {
+                    let jsonData = try JSONSerialization.data(withJSONObject: parameters)
+                    request.httpBody = jsonData
+                } catch {
+                    MSALLogger.log(
+                        level: .error,
+                        context: context,
+                        format: "HTTP body request serialization failed with error: \(error.localizedDescription)"
+                    )
+                }
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "HTTP body request serialization failed")
+            }
+        } else {
+            let encodedBody = formUrlEncode(parameters)
+            request.httpBody = encodedBody.data(using: .utf8)
+        }
+
+        requestHeaders["Content-Type"] = encoding.rawValue
+        request.allHTTPHeaderFields = requestHeaders
+
+        return request
+    }
+
+    private func formUrlEncode(_ parameters: [AnyHashable: Any]) -> String {
+        parameters.map {
+            let encodedKey = (($0.key as? String) ?? "").msidWWWFormURLEncode() ?? ""
+            let encodedValue = (($0.value as? String) ?? "").msidWWWFormURLEncode() ?? ""
+            return "\(encodedKey)=\(encodedValue)"
+        }.joined(separator: "&")
+    }
+}

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorCodes.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorCodes.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// This enum contains all the handled error cases from eSTS in error_codes
+enum MSALNativeAuthESTSApiErrorCodes: Int {
+    case userNotFound = 50034
+    case invalidCredentials = 50126
+    case invalidOTP = 50181
+    case incorrectOTP = 501811
+    case OTPNoCacheEntryForUser = 50184
+    case strongAuthRequired = 50076
+    case userNotHaveAPassword = 500222
+    case invalidRequestParameter = 90100
+}

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorDescriptions.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorDescriptions.swift
@@ -1,0 +1,31 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+// This enum contains all the handled error cases from eSTS in error_descriptions
+enum MSALNativeAuthESTSApiErrorDescriptions: String, CaseIterable {
+    case usernameParameterIsEmptyOrNotValid = "username parameter is empty or not valid"
+    case clientIdParameterIsEmptyOrNotValid = "client_id parameter is empty or not valid"
+}

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// swiftlint:disable line_length
+enum MSALNativeAuthErrorMessage {
+    static let invalidScope = "Invalid scope"
+    static let delegateNotImplemented = "MSALNativeAuth has called an optional delegate method that has not been implemented"
+    static let unsupportedMFA = "MFA currently not supported. Use the browser instead"
+    static let browserRequired = "Browser required. Use acquireTokenInteractively instead"
+    static let userDoesNotHavePassword = "User does not have password associated with account"
+    static let invalidServerResponse = "Invalid server response"
+    static let userNotFound = "User does not exist"
+    static let attributeValidationFailedSignUpStart = "Check the invalid attributes and start the sign-up process again. Invalid attributes: %@"
+    static let attributeValidationFailed = "Invalid attributes: %@"
+    static let signInNotAvailable = "Sign In is not available at this point, please use the standalone sign in methods"
+    static let passwordRequiredNotImplemented = "Implementation of onSignInPasswordRequired required"
+    static let codeRequiredNotImplemented = "Implementation of onSignInCodeRequired required"
+    static let codeRequiredForPasswordUserLog = "This user does not have a password associated with their account. SDK will call `delegate.onSignInCodeRequired()` and the entered password will be ignored"
+}
+
+// swiftlint:enable line_length

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthInnerError.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthInnerError.swift
@@ -1,0 +1,34 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthInnerError: Decodable, Equatable {
+    let error: String
+    let errorDescription: String?
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+    }
+}

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthResponseError.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+protocol MSALNativeAuthResponseError: Error, Decodable, Equatable {
+    associatedtype ErrorCode: RawRepresentable where ErrorCode.RawValue == String
+
+    var error: ErrorCode { get }
+    var errorDescription: String? { get }
+    var errorCodes: [Int]? { get }
+    var errorURI: String? { get }
+    var innerErrors: [MSALNativeAuthInnerError]? { get }
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthErrorBasicAttributes.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthErrorBasicAttributes.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+class MSALNativeAuthErrorBasicAttributes: NSObject, Decodable {
+    let name: String
+
+    init(name: String) {
+        self.name = name
+    }
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthRequiredAttributeOptions.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthRequiredAttributeOptions.swift
@@ -1,0 +1,29 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+class MSALNativeAuthRequiredAttributeOptions: Decodable {
+    let regex: String?
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthRequiredAttributesInternal.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthRequiredAttributesInternal.swift
@@ -1,0 +1,47 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+class MSALNativeAuthRequiredAttributesInternal: NSObject, Decodable {
+    let name: String
+    let type: String
+    let required: Bool
+    let options: MSALNativeAuthRequiredAttributeOptions?
+
+    init(name: String, type: String, required: Bool, options: MSALNativeAuthRequiredAttributeOptions? = nil) {
+        self.name = name
+        self.type = type
+        self.required = required
+        self.options = options
+    }
+
+    override var description: String {
+        return "\(name)"
+    }
+
+    func toRequiredAttributesPublic() -> MSALNativeAuthRequiredAttributes {
+        MSALNativeAuthRequiredAttributes(name: name, type: type, required: required, regex: options?.regex)
+    }
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCode.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthSignUpChallengeOauth2ErrorCode: String, Decodable, CaseIterable {
+    case invalidRequest = "invalid_request"
+    case unauthorizedClient = "unauthorized_client"
+    case unsupportedChallengeType = "unsupported_challenge_type"
+    case expiredToken = "expired_token"
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
@@ -1,0 +1,84 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
+    let error: MSALNativeAuthSignUpChallengeOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+    }
+}
+
+extension MSALNativeAuthSignUpChallengeResponseError {
+
+    func toSignUpPasswordStartPublicError() -> SignUpPasswordStartError {
+        switch error {
+        case .unauthorizedClient,
+             .unsupportedChallengeType,
+             .expiredToken,
+             .invalidRequest:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+
+    func toSignUpStartPublicError() -> SignUpStartError {
+        switch error {
+        case .unauthorizedClient,
+             .unsupportedChallengeType,
+             .expiredToken,
+             .invalidRequest:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+
+    func toResendCodePublicError() -> ResendCodeError {
+        switch error {
+        case .unauthorizedClient,
+             .unsupportedChallengeType,
+             .expiredToken,
+             .invalidRequest:
+            return .init(message: errorDescription)
+        }
+    }
+
+    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+        switch error {
+        case .unauthorizedClient,
+             .unsupportedChallengeType,
+             .expiredToken,
+             .invalidRequest:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCode.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthSignUpContinueOauth2ErrorCode: String, Decodable, CaseIterable {
+    case invalidRequest = "invalid_request"
+    case unauthorizedClient = "unauthorized_client"
+    case invalidGrant = "invalid_grant"
+    case expiredToken = "expired_token"
+    case passwordTooWeak = "password_too_weak"
+    case passwordTooShort = "password_too_short"
+    case passwordTooLong = "password_too_long"
+    case passwordRecentlyUsed = "password_recently_used"
+    case passwordBanned = "password_banned"
+    case userAlreadyExists = "user_already_exists"
+    case attributesRequired = "attributes_required"
+    case verificationRequired = "verification_required"
+    case attributeValidationFailed = "attribute_validation_failed"
+    case credentialRequired = "credential_required"
+    case invalidOOBValue = "invalid_oob_value"
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
@@ -1,0 +1,100 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
+    let error: MSALNativeAuthSignUpContinueOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+    let signUpToken: String?
+    let requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]?
+    let unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]?
+    let invalidAttributes: [MSALNativeAuthErrorBasicAttributes]?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+        case signUpToken = "signup_token"
+        case requiredAttributes = "required_attributes"
+        case unverifiedAttributes = "unverified_attributes"
+        case invalidAttributes = "invalid_attributes"
+    }
+}
+
+extension MSALNativeAuthSignUpContinueResponseError {
+
+    func toVerifyCodePublicError() -> VerifyCodeError {
+        switch error {
+        case .invalidOOBValue:
+            return .init(type: .invalidCode, message: errorDescription)
+        case .unauthorizedClient,
+             .expiredToken,
+             .invalidRequest,
+             .invalidGrant,
+             .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned,
+             .userAlreadyExists,
+             .attributesRequired,
+             .verificationRequired,
+             .credentialRequired,
+             .attributeValidationFailed:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+
+    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+        switch error {
+        case .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .init(type: .invalidPassword, message: errorDescription)
+        case .unauthorizedClient,
+             .expiredToken,
+             .invalidRequest,
+             .invalidGrant,
+             .userAlreadyExists,
+             .attributesRequired,
+             .verificationRequired,
+             .credentialRequired,
+             .attributeValidationFailed,
+             .invalidOOBValue:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+
+    func toAttributesRequiredPublicError() -> AttributesRequiredError {
+        return AttributesRequiredError(message: errorDescription)
+    }
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCode.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthSignUpStartOauth2ErrorCode: String, Decodable, CaseIterable, Equatable {
+    case invalidRequest = "invalid_request"
+    case unauthorizedClient = "unauthorized_client"
+    case unsupportedChallengeType = "unsupported_challenge_type"
+    case passwordTooWeak = "password_too_weak"
+    case passwordTooShort = "password_too_short"
+    case passwordTooLong = "password_too_long"
+    case passwordRecentlyUsed = "password_recently_used"
+    case passwordBanned = "password_banned"
+    case userAlreadyExists = "user_already_exists"
+    case attributesRequired = "attributes_required"
+    case verificationRequired = "verification_required"
+    case unsupportedAuthMethod = "unsupported_auth_method"
+    case attributeValidationFailed = "attribute_validation_failed"
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
@@ -1,0 +1,92 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
+
+    let error: MSALNativeAuthSignUpStartOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+    let signUpToken: String?
+    let unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]?
+    let invalidAttributes: [MSALNativeAuthErrorBasicAttributes]?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+        case signUpToken = "signup_token"
+        case unverifiedAttributes = "unverified_attributes"
+        case invalidAttributes = "invalid_attributes"
+    }
+}
+
+extension MSALNativeAuthSignUpStartResponseError {
+
+    func toSignUpStartPasswordPublicError() -> SignUpPasswordStartError {
+        switch error {
+        case .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .init(type: .invalidPassword, message: errorDescription)
+        case .userAlreadyExists:
+            return .init(type: .userAlreadyExists, message: errorDescription)
+        case .attributeValidationFailed,
+             .attributesRequired,
+             .unauthorizedClient,
+             .unsupportedChallengeType,
+             .unsupportedAuthMethod,
+             .invalidRequest,
+             .verificationRequired: /// .verificationRequired is not supported by the API team yet. We treat it as an unexpectedError in the validator
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+
+    func toSignUpStartPublicError() -> SignUpStartError {
+        switch error {
+        case .userAlreadyExists:
+            return .init(type: .userAlreadyExists, message: errorDescription)
+        case .attributeValidationFailed,
+             .attributesRequired,
+             .unauthorizedClient,
+             .invalidRequest,
+             .passwordTooWeak, /// password errors should not occur when signing up code
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned,
+             .unsupportedAuthMethod,
+             .unsupportedChallengeType,
+             .verificationRequired: /// .verificationRequired is not supported by the API team yet. We treat it as an unexpectedError in the validator
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenOauth2ErrorCode.swift
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthTokenOauth2ErrorCode: String, Decodable {
+    case invalidRequest = "invalid_request"
+    case unauthorizedClient = "unauthorized_client"
+    case invalidClient = "invalid_client"
+    case invalidGrant = "invalid_grant"
+    case expiredToken = "expired_token"
+    case expiredRefreshToken = "expired_refresh_token"
+    case unsupportedChallengeType = "unsupported_challenge_type"
+    case invalidScope = "invalid_scope"
+    case authorizationPending = "authorization_pending"
+    case slowDown = "slow_down"
+}

--- a/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
@@ -1,0 +1,44 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthTokenResponseError: MSALNativeAuthResponseError {
+
+    let error: MSALNativeAuthTokenOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+    let credentialToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+        case credentialToken = "credential_token"
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestContext.swift
+++ b/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestContext.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthRequestContext: MSIDRequestContext {
+
+    private let _correlationId: UUID
+    private let _telemetryRequestId: String = MSIDTelemetry.sharedInstance().generateRequestId()
+
+    init(correlationId: UUID? = nil) {
+        _correlationId = correlationId ?? UUID()
+    }
+
+    func correlationId() -> UUID {
+        _correlationId
+    }
+
+    func logComponent() -> String {
+        MSIDVersion.sdkName()
+    }
+
+    func telemetryRequestId() -> String {
+        _telemetryRequestId
+    }
+
+    func appRequestMetadata() -> [AnyHashable: Any] {
+        guard let metadata = Bundle.main.infoDictionary else {
+            return [:]
+        }
+
+        let appName = metadata["CFBundleDisplayName"] ?? (metadata["CFBundleName"] ?? "")
+        let appVersion = metadata["CFBundleShortVersionString"] ?? ""
+
+        return [
+            MSID_VERSION_KEY: MSIDVersion.sdkVersion() ?? "",
+            MSID_APP_NAME_KEY: appName,
+            MSID_APP_VER_KEY: appVersion
+        ]
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestable.swift
+++ b/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestable.swift
@@ -1,0 +1,51 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthRequestable {
+    var endpoint: MSALNativeAuthEndpoint { get }
+    var context: MSIDRequestContext { get }
+
+    func makeEndpointUrl(config: MSALNativeAuthConfiguration) throws -> URL
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String]
+}
+
+extension MSALNativeAuthRequestable {
+
+    func makeEndpointUrl(config: MSALNativeAuthConfiguration) throws -> URL {
+        var components = URLComponents(url: config.authority.url, resolvingAgainstBaseURL: true)
+        components?.path += endpoint.rawValue
+
+        if let dataCenter = config.sliceConfig?.dc {
+            components?.queryItems = [URLQueryItem(name: "dc", value: dataCenter)]
+        }
+
+        guard let url = components?.url else {
+            throw MSALNativeAuthInternalError.invalidUrl
+        }
+
+        return url
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParameters.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthSignUpChallengeRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .signUpChallenge
+    let signUpToken: String
+    let context: MSIDRequestContext
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.signUpToken.rawValue: signUpToken,
+            Key.challengeType.rawValue: config.challengeTypesString
+        ].compactMapValues { $0 }
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParameters.swift
@@ -1,0 +1,48 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthSignUpContinueRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .signUpContinue
+    let grantType: MSALNativeAuthGrantType
+    let signUpToken: String
+    let password: String?
+    let oobCode: String?
+    let attributes: String?
+    let context: MSIDRequestContext
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.grantType.rawValue: grantType.rawValue,
+            Key.signUpToken.rawValue: signUpToken,
+            Key.password.rawValue: password,
+            Key.oobCode.rawValue: oobCode,
+            Key.attributes.rawValue: attributes
+        ].compactMapValues { $0 }
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParameters.swift
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthSignUpStartRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .signUpStart
+    let username: String
+    let password: String?
+    let attributes: String?
+    let context: MSIDRequestContext
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.username.rawValue: username,
+            Key.password.rawValue: password,
+            Key.attributes.rawValue: attributes,
+            Key.challengeType.rawValue: config.challengeTypesString
+        ].compactMapValues { $0 }
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParameters.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthTokenRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .token
+    let context: MSIDRequestContext
+    let username: String?
+    let credentialToken: String?
+    let signInSLT: String?
+    let grantType: MSALNativeAuthGrantType
+    let scope: String?
+    let password: String?
+    let oobCode: String?
+    let includeChallengeType: Bool
+    let clientInfo = true
+    let refreshToken: String?
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+        var parameters = [
+            Key.clientId.rawValue: config.clientId,
+            Key.username.rawValue: username,
+            Key.credentialToken.rawValue: credentialToken,
+            Key.signInSLT.rawValue: signInSLT,
+            Key.grantType.rawValue: grantType.rawValue,
+            Key.scope.rawValue: scope,
+            Key.password.rawValue: password,
+            Key.oobCode.rawValue: oobCode,
+            Key.clientInfo.rawValue: clientInfo.description,
+            Key.refreshToken.rawValue: refreshToken
+        ]
+
+        if includeChallengeType {
+            parameters[Key.challengeType.rawValue] = config.challengeTypesString
+        }
+
+        return parameters.compactMapValues { $0 }
+    }
+}

--- a/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
+++ b/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResendCodeRequestResponse: Decodable {
+
+    // MARK: - Variables
+    let credentialToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case credentialToken = "flowToken"
+    }
+}

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpChallengeResponse: Decodable {
+    let challengeType: MSALNativeAuthInternalChallengeType?
+    let bindingMethod: String?
+    let interval: Int?
+    let challengeTargetLabel: String?
+    let challengeChannel: MSALNativeAuthInternalChannelType?
+    let signUpToken: String?
+    let codeLength: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case challengeType, bindingMethod, interval, challengeTargetLabel, challengeChannel, codeLength
+        // API returns signup_token not sign_up_token
+        case signUpToken = "signupToken"
+    }
+}

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpContinueResponse: Decodable {
+    let signinSLT: String?
+    let expiresIn: Int?
+    let signupToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case expiresIn, signupToken
+        // API returns signin_slt not sign_in_slt
+        case signinSLT = "signinSlt"
+    }
+}

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpStartResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpStartResponse.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpStartResponse: Decodable {
+    let signupToken: String?
+    let challengeType: MSALNativeAuthInternalChallengeType?
+}

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -1,0 +1,274 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignUpResponseValidating {
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpStartResponse, Error>, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpStartValidatedResponse
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpChallengeResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpChallengeValidatedResponse
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpContinueResponse, Error>, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpContinueValidatedResponse
+}
+
+final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseValidating {
+
+    // MARK: - Start Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpStartResponse, Error>, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpStartValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleStartSuccess(response, with: context)
+        case .failure(let error):
+            return handleStartFailed(error, with: context)
+        }
+    }
+
+    private func handleStartSuccess(
+        _ response: MSALNativeAuthSignUpStartResponse, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpStartValidatedResponse {
+        if response.challengeType == .redirect {
+            return .redirect
+        } else {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Unexpected response in signup/start. SDK expects only 200 with redirect challenge_type"
+            )
+            return .unexpectedError
+        }
+    }
+
+    private func handleStartFailed(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpStartValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthSignUpStartResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "Error type not expected")
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .verificationRequired:
+            if let signUpToken = apiError.signUpToken, let unverifiedAttributes = apiError.unverifiedAttributes, !unverifiedAttributes.isEmpty {
+                return .verificationRequired(signUpToken: signUpToken, unverifiedAttributes: extractAttributeNames(from: unverifiedAttributes))
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/start for verification_required error")
+                return .unexpectedError
+            }
+        case .attributeValidationFailed:
+            if let invalidAttributes = apiError.invalidAttributes, !invalidAttributes.isEmpty {
+                return .attributeValidationFailed(invalidAttributes: extractAttributeNames(from: invalidAttributes))
+            } else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "Missing expected fields in signup/start for attribute_validation_failed error"
+                )
+                return .unexpectedError
+            }
+        case .invalidRequest where isSignUpStartInvalidRequestParameter(
+            apiError,
+            knownErrorDescription: MSALNativeAuthESTSApiErrorDescriptions.usernameParameterIsEmptyOrNotValid.rawValue):
+            return .invalidUsername(apiError)
+        case .invalidRequest where isSignUpStartInvalidRequestParameter(
+            apiError,
+            knownErrorDescription: MSALNativeAuthESTSApiErrorDescriptions.clientIdParameterIsEmptyOrNotValid.rawValue):
+            return .invalidClientId(apiError)
+        default:
+            return .error(apiError)
+        }
+    }
+
+    // MARK: - Challenge Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpChallengeResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleChallengeSuccess(response, with: context)
+        case .failure(let error):
+            return handleChallengeError(error, with: context)
+        }
+    }
+
+    private func handleChallengeSuccess(
+        _ response: MSALNativeAuthSignUpChallengeResponse,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        guard let challengeTypeIssued = response.challengeType else {
+            MSALLogger.log(level: .error, context: context, format: "Missing ChallengeType from backend in signup/challenge response")
+            return .unexpectedError
+        }
+
+        switch challengeTypeIssued {
+        case .redirect:
+            return .redirect
+        case .oob:
+            if let sentTo = response.challengeTargetLabel,
+               let channelType = response.challengeChannel?.toPublicChannelType(),
+               let codeLength = response.codeLength,
+               let signUpChallengeToken = response.signUpToken {
+                return .codeRequired(sentTo, channelType, codeLength, signUpChallengeToken)
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/challenge with challenge_type = oob")
+                return .unexpectedError
+            }
+        case .password:
+            if let signUpToken = response.signUpToken {
+                return .passwordRequired(signUpToken)
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/challenge with challenge_type = password")
+                return .unexpectedError
+            }
+        case .otp:
+            MSALLogger.log(level: .error, context: context, format: "ChallengeType OTP not expected for signup/challenge")
+            return .unexpectedError
+        }
+    }
+
+    private func handleChallengeError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthSignUpChallengeResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "Error type not expected")
+            return .unexpectedError
+        }
+
+        return .error(apiError)
+    }
+
+    // MARK: - Continue Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpContinueResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        switch result {
+        case .success(let response):
+            // Even if the `signInSLT` is nil, the signUp flow is considered successfully completed
+            return .success(response.signinSLT)
+        case .failure(let error):
+            return handleContinueError(error, with: context)
+        }
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private func handleContinueError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthSignUpContinueResponseError else {
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .invalidOOBValue,
+             .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .invalidUserInput(apiError)
+        case .attributeValidationFailed:
+            if let signUpToken = apiError.signUpToken, let invalidAttributes = apiError.invalidAttributes, !invalidAttributes.isEmpty {
+                return .attributeValidationFailed(signUpToken: signUpToken, invalidAttributes: extractAttributeNames(from: invalidAttributes))
+            } else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "Missing expected fields in signup/continue for attribute_validation_failed error"
+                )
+                return .unexpectedError
+            }
+        case .credentialRequired:
+            if let signUpToken = apiError.signUpToken {
+                return .credentialRequired(signUpToken: signUpToken)
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/continue for credential_required error")
+                return .unexpectedError
+            }
+        case .attributesRequired:
+            if let signUpToken = apiError.signUpToken, let requiredAttributes = apiError.requiredAttributes, !requiredAttributes.isEmpty {
+                return .attributesRequired(signUpToken: signUpToken, requiredAttributes: requiredAttributes.map { $0.toRequiredAttributesPublic() })
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/continue for attributes_required error")
+                return .unexpectedError
+            }
+        // TODO: .verificationRequired is not supported by the API team yet. We treat it as an unexpectedError
+        case .verificationRequired:
+            MSALLogger.log(level: .error, context: context, format: "verificationRequired is not supported yet")
+            return .unexpectedError
+        case .unauthorizedClient,
+             .invalidGrant,
+             .expiredToken,
+             .userAlreadyExists:
+            return .error(apiError)
+        case .invalidRequest:
+            return handleInvalidRequestError(apiError)
+        }
+    }
+
+    private func handleInvalidRequestError(_ error: MSALNativeAuthSignUpContinueResponseError) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        guard let errorCode = error.errorCodes?.first, let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: errorCode) else {
+            return .error(error)
+        }
+        switch knownErrorCode {
+        case .invalidOTP,
+            .incorrectOTP,
+            .OTPNoCacheEntryForUser:
+            return .invalidUserInput(
+                MSALNativeAuthSignUpContinueResponseError(
+                    error: .invalidOOBValue,
+                    errorDescription: error.errorDescription,
+                    errorCodes: error.errorCodes,
+                    errorURI: error.errorURI,
+                    innerErrors: error.innerErrors,
+                    signUpToken: error.signUpToken,
+                    requiredAttributes: error.requiredAttributes,
+                    unverifiedAttributes: error.unverifiedAttributes,
+                    invalidAttributes: error.invalidAttributes))
+        case .userNotFound,
+            .invalidCredentials,
+            .strongAuthRequired,
+            .userNotHaveAPassword,
+            .invalidRequestParameter:
+            return .error(error)
+        }
+    }
+
+    private func isSignUpStartInvalidRequestParameter(_ apiError: MSALNativeAuthSignUpStartResponseError, knownErrorDescription: String) -> Bool {
+        guard let errorCode = apiError.errorCodes?.first,
+              let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: errorCode),
+              let errorDescription = apiError.errorDescription else {
+            return false
+        }
+        return knownErrorCode == .invalidRequestParameter && errorDescription.contains(knownErrorDescription)
+    }
+
+    private func extractAttributeNames(from attributes: [MSALNativeAuthErrorBasicAttributes]) -> [String] {
+        return attributes.map { $0.name }
+    }
+}

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
@@ -1,0 +1,53 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+enum MSALNativeAuthSignUpStartValidatedResponse: Equatable {
+    case verificationRequired(signUpToken: String, unverifiedAttributes: [String])
+    case attributeValidationFailed(invalidAttributes: [String])
+    case redirect
+    case error(MSALNativeAuthSignUpStartResponseError)
+    // TODO: Special errors handled separately. Remove after refactor validated error handling
+    case invalidUsername(MSALNativeAuthSignUpStartResponseError)
+    case invalidClientId(MSALNativeAuthSignUpStartResponseError)
+    case unexpectedError
+}
+
+enum MSALNativeAuthSignUpChallengeValidatedResponse: Equatable {
+    case codeRequired(_ sentTo: String, _ channelType: MSALNativeAuthChannelType, _ codeLength: Int, _ signUpChallengeToken: String)
+    case passwordRequired(_ signUpChallengeToken: String)
+    case redirect
+    case error(MSALNativeAuthSignUpChallengeResponseError)
+    case unexpectedError
+}
+
+enum MSALNativeAuthSignUpContinueValidatedResponse: Equatable {
+    case success(_ signInSLT: String?)
+    /// error that represents invalidOOB or invalidPassword, depending on which State the input comes from.
+    case invalidUserInput(_ error: MSALNativeAuthSignUpContinueResponseError)
+    case credentialRequired(signUpToken: String)
+    case attributesRequired(signUpToken: String, requiredAttributes: [MSALNativeAuthRequiredAttributes])
+    case attributeValidationFailed(signUpToken: String, invalidAttributes: [String])
+    case error(MSALNativeAuthSignUpContinueResponseError)
+    case unexpectedError
+}

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -1,0 +1,222 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthTokenResponseValidating {
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        msidConfiguration: MSIDConfiguration,
+        result: Result<MSIDCIAMTokenResponse, Error>
+    ) -> MSALNativeAuthTokenValidatedResponse
+
+    func validateAccount(
+        with tokenResult: MSIDTokenResult,
+        context: MSIDRequestContext,
+        accountIdentifier: MSIDAccountIdentifier
+    ) throws -> Bool
+}
+
+final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseValidating {
+    private let factory: MSALNativeAuthResultBuildable
+    private let msidValidator: MSIDTokenResponseValidator
+
+    init(
+        factory: MSALNativeAuthResultBuildable,
+        msidValidator: MSIDTokenResponseValidator
+    ) {
+        self.factory = factory
+        self.msidValidator = msidValidator
+    }
+
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        msidConfiguration: MSIDConfiguration,
+        result: Result<MSIDCIAMTokenResponse, Error>
+    ) -> MSALNativeAuthTokenValidatedResponse {
+        switch result {
+        case .success(let tokenResponse):
+            return .success(tokenResponse)
+        case .failure(let tokenResponseError):
+            guard let tokenResponseError =
+                    tokenResponseError as? MSALNativeAuthTokenResponseError else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "Token: Error type not expected, error: \(tokenResponseError)")
+                return .error(.invalidServerResponse)
+            }
+            return handleFailedTokenResult(context, tokenResponseError)
+        }
+    }
+
+    func validateAccount(
+        with tokenResult: MSIDTokenResult,
+        context: MSIDRequestContext,
+        accountIdentifier: MSIDAccountIdentifier
+    ) throws -> Bool {
+        var error: NSError?
+        let validAccount = msidValidator.validateAccount(
+            accountIdentifier,
+            tokenResult: tokenResult,
+            correlationID: context.correlationId(),
+            error: &error
+        )
+        if let error = error {
+            throw error
+        }
+        return validAccount
+    }
+
+    private func handleFailedTokenResult(
+        _ context: MSALNativeAuthRequestContext,
+        _ responseError: MSALNativeAuthTokenResponseError) -> MSALNativeAuthTokenValidatedResponse {
+            switch responseError.error {
+            case .invalidRequest:
+                return handleInvalidRequestErrorCodes(responseError.errorCodes, errorDescription: responseError.errorDescription, context: context)
+            case .invalidClient,
+                .unauthorizedClient:
+                return .error(.invalidClient(message: responseError.errorDescription))
+            case .invalidGrant:
+                return handleInvalidGrantErrorCodes(responseError.errorCodes, errorDescription: responseError.errorDescription, context: context)
+            case .expiredToken:
+                return .error(.expiredToken(message: responseError.errorDescription))
+            case .expiredRefreshToken:
+                return .error(.expiredRefreshToken(message: responseError.errorDescription))
+            case .unsupportedChallengeType:
+                return .error(.unsupportedChallengeType(message: responseError.errorDescription))
+            case .invalidScope:
+                return .error(.invalidScope(message: responseError.errorDescription))
+            case .authorizationPending:
+                return .error(.authorizationPending(message: responseError.errorDescription))
+            case .slowDown:
+                return .error(.slowDown(message: responseError.errorDescription))
+            }
+        }
+
+    private func handleInvalidRequestErrorCodes(
+        _ errorCodes: [Int]?,
+        errorDescription: String?,
+        context: MSALNativeAuthRequestContext
+    ) -> MSALNativeAuthTokenValidatedResponse {
+        return handleInvalidResponseErrorCodes(
+            errorCodes,
+            errorDescription: errorDescription,
+            context: context,
+            useInvalidRequestAsDefaultResult: true,
+            errorCodesConverterFunction: convertInvalidRequestErrorCodeToErrorType
+        )
+    }
+
+    private func handleInvalidGrantErrorCodes(
+        _ errorCodes: [Int]?,
+        errorDescription: String?,
+        context: MSALNativeAuthRequestContext
+    ) -> MSALNativeAuthTokenValidatedResponse {
+        return handleInvalidResponseErrorCodes(
+            errorCodes,
+            errorDescription: errorDescription,
+            context: context,
+            errorCodesConverterFunction: convertInvalidGrantErrorCodeToErrorType
+        )
+    }
+
+    private func handleInvalidResponseErrorCodes(
+        _ errorCodes: [Int]?,
+        errorDescription: String?,
+        context: MSALNativeAuthRequestContext,
+        useInvalidRequestAsDefaultResult: Bool = false,
+        errorCodesConverterFunction: (MSALNativeAuthESTSApiErrorCodes, String?) -> MSALNativeAuthTokenValidatedErrorType
+    ) -> MSALNativeAuthTokenValidatedResponse {
+        guard var errorCodes = errorCodes, !errorCodes.isEmpty else {
+            MSALLogger.log(level: .error, context: context, format: "/token error - Empty error_codes received")
+            return useInvalidRequestAsDefaultResult ? .error(.invalidRequest(message: errorDescription)) : .error(.generalError)
+        }
+
+        let validatedResponse: MSALNativeAuthTokenValidatedResponse
+        let firstErrorCode = errorCodes.removeFirst()
+
+        if let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: firstErrorCode) {
+            validatedResponse = .error(errorCodesConverterFunction(knownErrorCode, errorDescription))
+        } else {
+            MSALLogger.log(level: .error, context: context, format: "/token error - Unknown code received in error_codes: \(firstErrorCode)")
+            validatedResponse = useInvalidRequestAsDefaultResult ? .error(.invalidRequest(message: errorDescription)) : .error(.generalError)
+        }
+
+        // Log the rest of error_codes
+
+        errorCodes.forEach { errorCode in
+            let errorMessage: String
+
+            if let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: errorCode) {
+                errorMessage = "/token error - ESTS error received in error_codes: \(knownErrorCode) (ignoring)"
+            } else {
+                errorMessage = "/token error - Unknown ESTS received in error_codes with code: \(errorCode) (ignoring)"
+            }
+
+            MSALLogger.log(level: .verbose, context: context, format: errorMessage)
+        }
+
+        return validatedResponse
+    }
+
+    private func convertInvalidGrantErrorCodeToErrorType(
+        _ errorCode: MSALNativeAuthESTSApiErrorCodes,
+        errorDescription: String?
+    ) -> MSALNativeAuthTokenValidatedErrorType {
+        switch errorCode {
+        case .userNotFound:
+            return .userNotFound(message: errorDescription)
+        case .invalidCredentials:
+            return .invalidPassword(message: errorDescription)
+        case .invalidOTP,
+            .incorrectOTP,
+            .OTPNoCacheEntryForUser:
+            return .invalidOOBCode(message: errorDescription)
+        case .strongAuthRequired:
+            return .strongAuthRequired(message: errorDescription)
+        case .userNotHaveAPassword,
+             .invalidRequestParameter:
+            return .generalError
+        }
+    }
+
+    private func convertInvalidRequestErrorCodeToErrorType(
+        _ errorCode: MSALNativeAuthESTSApiErrorCodes,
+        errorDescription: String?
+    ) -> MSALNativeAuthTokenValidatedErrorType {
+        switch errorCode {
+        case .invalidOTP,
+            .incorrectOTP,
+            .OTPNoCacheEntryForUser:
+            return .invalidOOBCode(message: errorDescription)
+        case .userNotFound,
+            .invalidCredentials,
+            .strongAuthRequired,
+            .userNotHaveAPassword,
+            .invalidRequestParameter:
+            return .invalidRequest(message: errorDescription)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
@@ -1,0 +1,128 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+enum MSALNativeAuthTokenValidatedResponse {
+    case success(MSIDTokenResponse)
+    case error(MSALNativeAuthTokenValidatedErrorType)
+}
+
+enum MSALNativeAuthTokenValidatedErrorType: Error {
+    case generalError
+    case expiredToken(message: String?)
+    case expiredRefreshToken(message: String?)
+    case invalidClient(message: String?)
+    case invalidRequest(message: String?)
+    case invalidServerResponse
+    case userNotFound(message: String?)
+    case invalidPassword(message: String?)
+    case invalidOOBCode(message: String?)
+    case unsupportedChallengeType(message: String?)
+    case strongAuthRequired(message: String?)
+    case invalidScope(message: String?)
+    case authorizationPending(message: String?)
+    case slowDown(message: String?)
+
+    func convertToSignInPasswordStartError() -> SignInPasswordStartError {
+        switch self {
+        case .expiredToken(let message),
+             .authorizationPending(let message),
+             .slowDown(let message),
+             .invalidRequest(let message),
+             .invalidOOBCode(let message),
+             .invalidClient(let message),
+             .unsupportedChallengeType(let message),
+             .invalidScope(let message):
+            return SignInPasswordStartError(type: .generalError, message: message)
+        case .generalError:
+            return SignInPasswordStartError(type: .generalError)
+        case .invalidServerResponse:
+            return SignInPasswordStartError(type: .generalError, message: MSALNativeAuthErrorMessage.invalidServerResponse)
+        case .userNotFound(let message):
+            return SignInPasswordStartError(type: .userNotFound, message: message)
+        case .invalidPassword(let message):
+            return SignInPasswordStartError(type: .invalidPassword, message: message)
+        case .strongAuthRequired(let message):
+            return SignInPasswordStartError(type: .browserRequired, message: message)
+        case .expiredRefreshToken(let message):
+            MSALLogger.log(level: .error, context: nil, format: "Error not treated - \(self))")
+            return SignInPasswordStartError(type: .generalError, message: message)
+        }
+    }
+
+    func convertToRetrieveAccessTokenError() -> RetrieveAccessTokenError {
+        switch self {
+        case .expiredToken(let message),
+             .authorizationPending(let message),
+             .slowDown(let message),
+             .invalidRequest(let message),
+             .invalidClient(let message),
+             .unsupportedChallengeType(let message),
+             .invalidScope(let message):
+            return RetrieveAccessTokenError(type: .generalError, message: message)
+        case .generalError:
+            return RetrieveAccessTokenError(type: .generalError)
+        case .invalidServerResponse:
+            return RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.invalidServerResponse)
+        case .expiredRefreshToken:
+            return RetrieveAccessTokenError(type: .refreshTokenExpired)
+        case .strongAuthRequired(let message):
+            return RetrieveAccessTokenError(type: .browserRequired, message: message)
+        case .userNotFound(let message),
+             .invalidPassword(let message),
+             .invalidOOBCode(let message):
+            MSALLogger.log(level: .error, context: nil, format: "Error not treated - \(self))")
+            return RetrieveAccessTokenError(type: .generalError, message: message)
+        }
+    }
+
+    func convertToVerifyCodeError() -> VerifyCodeError {
+        switch self {
+        case .invalidOOBCode(let message):
+            return VerifyCodeError(type: .invalidCode, message: message)
+        case .strongAuthRequired(let message):
+            return VerifyCodeError(type: .browserRequired, message: message)
+        case .expiredToken(let message),
+             .authorizationPending(let message),
+             .slowDown(let message),
+             .invalidRequest(let message),
+             .invalidClient(let message),
+             .unsupportedChallengeType(let message),
+             .invalidScope(let message),
+             .expiredRefreshToken(let message),
+             .userNotFound(let message),
+             .invalidPassword(let message):
+            return VerifyCodeError(type: .generalError, message: message)
+        case .generalError:
+            return VerifyCodeError(type: .generalError)
+        case .invalidServerResponse:
+            return VerifyCodeError(type: .generalError, message: MSALNativeAuthErrorMessage.invalidServerResponse)
+        }
+    }
+
+    func convertToPasswordRequiredError() -> PasswordRequiredError {
+        return PasswordRequiredError(signInPasswordError: convertToSignInPasswordStartError())
+    }
+}

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpContinueRequestProviderParams.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpContinueRequestProviderParams.swift
@@ -1,0 +1,50 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthSignUpContinueRequestProviderParams {
+    let grantType: MSALNativeAuthGrantType
+    let signUpToken: String
+    let password: String?
+    let oobCode: String?
+    let attributes: [String: Any]?
+    let context: MSIDRequestContext
+
+    init(
+        grantType: MSALNativeAuthGrantType,
+        signUpToken: String,
+        password: String? = nil,
+        oobCode: String? = nil,
+        attributes: [String: Any]? = nil,
+        context: MSIDRequestContext
+    ) {
+        self.grantType = grantType
+        self.signUpToken = signUpToken
+        self.password = password
+        self.oobCode = oobCode
+        self.attributes = attributes
+        self.context = context
+    }
+}

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
@@ -1,0 +1,99 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignUpRequestProviding {
+    func start(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) throws -> MSIDHttpRequest
+    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest
+    func `continue`(parameters: MSALNativeAuthSignUpContinueRequestProviderParams) throws -> MSIDHttpRequest
+}
+
+final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProviding {
+
+    private let requestConfigurator: MSALNativeAuthRequestConfigurator
+    private let telemetryProvider: MSALNativeAuthTelemetryProviding
+
+    init(requestConfigurator: MSALNativeAuthRequestConfigurator,
+         telemetryProvider: MSALNativeAuthTelemetryProviding) {
+        self.requestConfigurator = requestConfigurator
+        self.telemetryProvider = telemetryProvider
+    }
+
+    func start(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) throws -> MSIDHttpRequest {
+        guard let attributes = try formatAttributes(parameters.attributes) else {
+            throw MSALNativeAuthInternalError.invalidAttributes
+        }
+
+        let params = MSALNativeAuthSignUpStartRequestParameters(
+            username: parameters.username,
+            password: parameters.password,
+            attributes: attributes,
+            context: parameters.context
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signUp(.start(params)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        let params = MSALNativeAuthSignUpChallengeRequestParameters(
+            signUpToken: token,
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signUp(.challenge(params)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    func `continue`(parameters: MSALNativeAuthSignUpContinueRequestProviderParams) throws -> MSIDHttpRequest {
+        let attributesFormatted = try parameters.attributes.map { try formatAttributes($0) } ?? nil
+
+        let params = MSALNativeAuthSignUpContinueRequestParameters(
+            grantType: parameters.grantType,
+            signUpToken: parameters.signUpToken,
+            password: parameters.password,
+            oobCode: parameters.oobCode,
+            attributes: attributesFormatted,
+            context: parameters.context
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signUp(.continue(params)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    private func formatAttributes(_ attributes: [String: Any]) throws -> String? {
+        let data = try JSONSerialization.data(withJSONObject: attributes)
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpStartRequestProviderParameters.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpStartRequestProviderParameters.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+struct MSALNativeAuthSignUpStartRequestProviderParameters {
+    let username: String
+    let password: String?
+    let attributes: [String: Any]
+    let context: MSALNativeAuthRequestContext
+}

--- a/MSAL/src/native_auth/network/token/MSALNativeAuthTokenRequestProvider.swift
+++ b/MSAL/src/native_auth/network/token/MSALNativeAuthTokenRequestProvider.swift
@@ -1,0 +1,80 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthTokenRequestProviding {
+    func signInWithPassword(
+        parameters: MSALNativeAuthTokenRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest
+
+    func refreshToken(
+        parameters: MSALNativeAuthTokenRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest
+}
+
+final class MSALNativeAuthTokenRequestProvider: MSALNativeAuthTokenRequestProviding {
+
+    // MARK: - Variables
+    private let requestConfigurator: MSALNativeAuthRequestConfigurator
+    private let telemetryProvider: MSALNativeAuthTelemetryProviding
+
+    // MARK: - Init
+
+    init(
+        requestConfigurator: MSALNativeAuthRequestConfigurator,
+        telemetryProvider: MSALNativeAuthTelemetryProviding = MSALNativeAuthTelemetryProvider()
+    ) {
+        self.requestConfigurator = requestConfigurator
+        self.telemetryProvider = telemetryProvider
+    }
+
+    // MARK: - Token
+
+    func signInWithPassword(
+        parameters: MSALNativeAuthTokenRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .token(.signInWithPassword(parameters)),
+                                          request: request,
+                                          telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    func refreshToken(
+        parameters: MSALNativeAuthTokenRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .token(.refreshToken(parameters)),
+                                          request: request,
+                                          telemetryProvider: telemetryProvider)
+        return request
+    }
+}

--- a/MSAL/src/native_auth/public/MSALNativeAuthChallengeTypes.h
+++ b/MSAL/src/native_auth/public/MSALNativeAuthChallengeTypes.h
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MSALNativeAuthChallengeTypes_h
+#define MSALNativeAuthChallengeTypes_h
+
+/// The set of capabilities that an application wishes to support for Native Auth operations.
+///
+/// Valid options are:
+/// * OOB: The application can support asking a user to supply a verification code that is sent by email.
+/// * Password: The application can support asking a user to supply a password
+typedef NS_OPTIONS(NSInteger, MSALNativeAuthChallengeTypes) {
+    MSALNativeAuthChallengeTypeOOB          = 1 << 0,
+    MSALNativeAuthChallengeTypePassword     = 1 << 1
+};
+
+#endif /* MSALNativeAuthChallengeTypes_h */

--- a/MSAL/src/native_auth/public/MSALNativeAuthChannelType.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthChannelType.swift
@@ -1,0 +1,31 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public enum MSALNativeAuthChannelType: Int {
+    case email
+    case phone
+}

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -1,0 +1,152 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+extension MSALNativeAuthPublicClientApplication {
+
+    func signUpUsingPasswordInternal(
+        username: String,
+        password: String,
+        attributes: [String: Any]?,
+        correlationId: UUID?
+    ) async -> MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse {
+        guard inputValidator.isInputValid(username) else {
+            return .init(.error(SignUpPasswordStartError(type: .invalidUsername)))
+        }
+        guard inputValidator.isInputValid(password) else {
+            return .init(.error(SignUpPasswordStartError(type: .invalidPassword)))
+        }
+
+        let controller = controllerFactory.makeSignUpController()
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
+            username: username,
+            password: password,
+            attributes: attributes ?? [:],
+            context: context
+        )
+
+        return await controller.signUpStartPassword(parameters: parameters)
+    }
+
+    func signUpInternal(
+        username: String,
+        attributes: [String: Any]?,
+        correlationId: UUID?
+    ) async -> MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse {
+        guard inputValidator.isInputValid(username) else {
+            return .init(.error(SignUpStartError(type: .invalidUsername)))
+        }
+
+        let controller = controllerFactory.makeSignUpController()
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
+            username: username,
+            password: nil,
+            attributes: attributes ?? [:],
+            context: context
+        )
+
+        return await controller.signUpStartCode(parameters: parameters)
+    }
+
+    func signInUsingPasswordInternal(
+        username: String,
+        password: String,
+        scopes: [String]?,
+        correlationId: UUID?
+    ) async -> MSALNativeAuthSignInControlling.SignInPasswordControllerResponse {
+        guard inputValidator.isInputValid(username) else {
+            return .init(.error(SignInPasswordStartError(type: .invalidUsername)))
+        }
+
+        guard inputValidator.isInputValid(password) else {
+            return .init(.error(SignInPasswordStartError(type: .invalidPassword)))
+        }
+
+        let controller = controllerFactory.makeSignInController()
+
+        let params = MSALNativeAuthSignInWithPasswordParameters(
+            username: username,
+            password: password,
+            context: MSALNativeAuthRequestContext(correlationId: correlationId),
+            scopes: scopes
+        )
+
+        return await controller.signIn(params: params)
+    }
+
+    func signInInternal(
+        username: String,
+        scopes: [String]?,
+        correlationId: UUID?
+    ) async -> MSALNativeAuthSignInControlling.SignInCodeControllerResponse {
+        guard inputValidator.isInputValid(username) else {
+            return .init(.error(SignInStartError(type: .invalidUsername)))
+        }
+        let controller = controllerFactory.makeSignInController()
+        let params = MSALNativeAuthSignInWithCodeParameters(
+            username: username,
+            context: MSALNativeAuthRequestContext(correlationId: correlationId),
+            scopes: scopes
+        )
+        return await controller.signIn(params: params)
+    }
+
+    func resetPasswordInternal(username: String, correlationId: UUID?) async -> ResetPasswordStartResult {
+        guard inputValidator.isInputValid(username) else {
+            return .error(ResetPasswordStartError(type: .invalidUsername))
+        }
+
+        let controller = controllerFactory.makeResetPasswordController()
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        return await controller.resetPassword(
+            parameters: .init(
+                username: username,
+                context: context
+            )
+        )
+    }
+
+    static func getInternalChallengeTypes(
+        _ challengeTypes: MSALNativeAuthChallengeTypes
+    ) -> [MSALNativeAuthInternalChallengeType] {
+        var internalChallengeTypes = [MSALNativeAuthInternalChallengeType]()
+
+        if challengeTypes.contains(.OOB) {
+            internalChallengeTypes.append(.oob)
+        }
+
+        if challengeTypes.contains(.password) {
+            internalChallengeTypes.append(.password)
+        }
+
+        internalChallengeTypes.append(.redirect)
+        return internalChallengeTypes
+    }
+}

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -1,0 +1,312 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers
+public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplication {
+
+    let controllerFactory: MSALNativeAuthControllerBuildable
+    let inputValidator: MSALNativeAuthInputValidating
+    private let internalChallengeTypes: [MSALNativeAuthInternalChallengeType]
+
+    /// Initialize a MSALNativePublicClientApplication with a given configuration and challenge types
+    /// - Parameters:
+    ///   - config: Configuration for PublicClientApplication
+    ///   - challengeTypes: The set of capabilities that this application can support as an ``MSALNativeAuthChallengeTypes`` optionset
+    /// - Throws: An error that occurred creating the application object
+    public init(
+        configuration config: MSALPublicClientApplicationConfig,
+        challengeTypes: MSALNativeAuthChallengeTypes) throws {
+        guard let ciamAuthority = config.authority as? MSALCIAMAuthority else {
+            throw MSALNativeAuthInternalError.invalidAuthority
+        }
+
+        self.internalChallengeTypes =
+            MSALNativeAuthPublicClientApplication.getInternalChallengeTypes(challengeTypes)
+
+        var nativeConfiguration = try MSALNativeAuthConfiguration(
+            clientId: config.clientId,
+            authority: ciamAuthority,
+            challengeTypes: internalChallengeTypes
+        )
+        nativeConfiguration.sliceConfig = config.sliceConfig
+
+        self.controllerFactory = MSALNativeAuthControllerFactory(config: nativeConfiguration)
+        self.inputValidator = MSALNativeAuthInputValidator()
+
+        try super.init(configuration: config)
+    }
+
+    /// Initialize a MSALNativePublicClientApplication.
+    /// - Parameters:
+    ///   - clientId: The client ID of the application, this should come from the app developer portal.
+    ///   - tenantSubdomain: The subdomain of the tenant, this should come from the app developer portal.
+    ///   - challengeTypes: The set of capabilities that this application can support as an ``MSALNativeAuthChallengeTypes`` optionset
+    ///   - redirectUri: Optional. The redirect URI for the application, this should come from the app developer portal. 
+    /// - Throws: An error that occurred creating the application object
+    public init(
+        clientId: String,
+        tenantSubdomain: String,
+        challengeTypes: MSALNativeAuthChallengeTypes,
+        redirectUri: String? = nil) throws {
+        let ciamAuthority = try MSALNativeAuthAuthorityProvider()
+                .authority(rawTenant: tenantSubdomain)
+
+        self.internalChallengeTypes = MSALNativeAuthPublicClientApplication.getInternalChallengeTypes(challengeTypes)
+        let nativeConfiguration = try MSALNativeAuthConfiguration(
+            clientId: clientId,
+            authority: ciamAuthority,
+            challengeTypes: internalChallengeTypes
+        )
+
+        self.controllerFactory = MSALNativeAuthControllerFactory(config: nativeConfiguration)
+        self.inputValidator = MSALNativeAuthInputValidator()
+
+        let configuration = MSALPublicClientApplicationConfig(
+            clientId: clientId,
+            redirectUri: redirectUri,
+            authority: ciamAuthority
+        )
+
+        // we need to bypass redirect URI validation because we don't need a redirect URI for Native Auth scenarios
+        configuration.bypassRedirectURIValidation = redirectUri == nil
+        let defaultRedirectUri = String(format: "msauth.%@://auth", Bundle.main.bundleIdentifier ?? "<bundle_id>")
+        // we need to set a default redirect URI value to ensure IdentityCore checks the bypassRedirectURIValidation flag
+        configuration.redirectUri = redirectUri ?? defaultRedirectUri
+
+        try super.init(configuration: configuration)
+    }
+
+    init(
+        controllerFactory: MSALNativeAuthControllerBuildable,
+        inputValidator: MSALNativeAuthInputValidating,
+        internalChallengeTypes: [MSALNativeAuthInternalChallengeType]
+    ) {
+        self.controllerFactory = controllerFactory
+        self.inputValidator = inputValidator
+        self.internalChallengeTypes = internalChallengeTypes
+
+        super.init()
+    }
+
+    // MARK: delegate methods
+
+    /// Sign up a user with a given username and password.
+    /// - Parameters:
+    ///   - username: Username for the new account.
+    ///   - password: Password to be used for the new account.
+    ///   - attributes: Optional. User attributes to be used during account creation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Sign Up flow.
+    public func signUpUsingPassword(
+        username: String,
+        password: String,
+        attributes: [String: Any]? = nil,
+        correlationId: UUID? = nil,
+        delegate: SignUpPasswordStartDelegate
+    ) {
+        Task {
+            let controllerResponse = await signUpUsingPasswordInternal(
+                username: username,
+                password: password,
+                attributes: attributes,
+                correlationId: correlationId
+            )
+
+            switch controllerResponse.result {
+            case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
+                await delegate.onSignUpCodeRequired(
+                    newState: newState,
+                    sentTo: sentTo,
+                    channelTargetType: channelTargetType,
+                    codeLength: codeLength
+                )
+            case .attributesInvalid(let attributes):
+                if let signUpAttributesMethod = delegate.onSignUpAttributesInvalid {
+                    controllerResponse.telemetryUpdate?(.success(()))
+                    await signUpAttributesMethod(attributes)
+                } else {
+                    let error = SignUpPasswordStartError(type: .generalError, message: MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
+                    controllerResponse.telemetryUpdate?(.failure(error))
+                    await delegate.onSignUpPasswordError(error: error)
+                }
+            case .error(let error):
+                await delegate.onSignUpPasswordError(error: error)
+            }
+        }
+    }
+
+    /// Sign up a user with a given username.
+    /// - Parameters:
+    ///   - username: Username for the new account.
+    ///   - attributes: Optional. User attributes to be used during account creation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Sign Up flow.
+    public func signUp(
+        username: String,
+        attributes: [String: Any]? = nil,
+        correlationId: UUID? = nil,
+        delegate: SignUpStartDelegate
+    ) {
+        Task {
+            let controllerResponse = await signUpInternal(username: username, attributes: attributes, correlationId: correlationId)
+
+            switch controllerResponse.result {
+            case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
+                await delegate.onSignUpCodeRequired(
+                    newState: newState,
+                    sentTo: sentTo,
+                    channelTargetType: channelTargetType,
+                    codeLength: codeLength
+                )
+            case .attributesInvalid(let attributes):
+                if let signUpAttributesMethod = delegate.onSignUpAttributesInvalid {
+                    controllerResponse.telemetryUpdate?(.success(()))
+                    await signUpAttributesMethod(attributes)
+                } else {
+                    let error = SignUpStartError(type: .generalError, message: MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
+                    controllerResponse.telemetryUpdate?(.failure(error))
+                    await delegate.onSignUpError(error: error)
+                }
+            case .error(let error):
+                await delegate.onSignUpError(error: error)
+            }
+        }
+    }
+
+    /// Sign in a user with a given username and password.
+    /// - Parameters:
+    ///   - username: Username for the account.
+    ///   - password: Password for the account.
+    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Sign In flow.
+    public func signInUsingPassword(
+        username: String,
+        password: String,
+        scopes: [String]? = nil,
+        correlationId: UUID? = nil,
+        delegate: SignInPasswordStartDelegate
+    ) {
+        Task {
+            let controllerResponse = await signInUsingPasswordInternal(
+                username: username,
+                password: password,
+                scopes: scopes,
+                correlationId: correlationId
+            )
+
+            switch controllerResponse.result {
+            case .completed(let result):
+                await delegate.onSignInCompleted(result: result)
+            case .codeRequired(let newState, let sentTo, let channelType, let codeLength):
+                if let codeRequiredMethod = delegate.onSignInCodeRequired {
+                    controllerResponse.telemetryUpdate?(.success(()))
+                    await codeRequiredMethod(newState, sentTo, channelType, codeLength)
+                } else {
+                    let error = SignInPasswordStartError(type: .generalError, message: MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
+                    controllerResponse.telemetryUpdate?(.failure(error))
+                    await delegate.onSignInPasswordError(error: error)
+                }
+            case .error(let error):
+                await delegate.onSignInPasswordError(error: error)
+            }
+        }
+    }
+
+    /// Sign in a user with a given username.
+    /// - Parameters:
+    ///   - username: Username for the account
+    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Sign In flow.
+    public func signIn(
+        username: String,
+        scopes: [String]? = nil,
+        correlationId: UUID? = nil,
+        delegate: SignInStartDelegate
+    ) {
+        Task {
+            let controllerResponse = await signInInternal(
+                username: username,
+                scopes: scopes,
+                correlationId: correlationId
+            )
+
+            switch controllerResponse.result {
+            case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
+                await delegate.onSignInCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength)
+            case .passwordRequired(let newState):
+                if let passwordRequiredMethod = delegate.onSignInPasswordRequired {
+                    controllerResponse.telemetryUpdate?(.success(()))
+                    await passwordRequiredMethod(newState)
+                } else {
+                    let error = SignInStartError(type: .generalError, message: MSALNativeAuthErrorMessage.passwordRequiredNotImplemented)
+                    controllerResponse.telemetryUpdate?(.failure(error))
+                    await delegate.onSignInError(error: error)
+                }
+            case .error(let error):
+                await delegate.onSignInError(error: error)
+            }
+        }
+    }
+
+    /// Reset the password for a given username.
+    /// - Parameters:
+    ///   - username: Username for the account.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Reset Password flow.
+    public func resetPassword(
+        username: String,
+        correlationId: UUID? = nil,
+        delegate: ResetPasswordStartDelegate
+    ) {
+        Task {
+            let result = await resetPasswordInternal(username: username, correlationId: correlationId)
+
+            switch result {
+            case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
+                await delegate.onResetPasswordCodeRequired(
+                    newState: newState,
+                    sentTo: sentTo,
+                    channelTargetType: channelTargetType,
+                    codeLength: codeLength
+                )
+            case .error(let error):
+                await delegate.onResetPasswordError(error: error)
+            }
+        }
+    }
+
+    /// Retrieve the current signed in account from the cache.
+    /// - Parameter correlationId: Optional. UUID to correlate this request with the server for debugging.
+    /// - Returns: An object representing the account information if present in the local cache.
+    public func getNativeAuthUserAccount(correlationId: UUID? = nil) -> MSALNativeAuthUserAccountResult? {
+        let controller = controllerFactory.makeCredentialsController()
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        return controller.retrieveUserAccountResult(context: context)
+    }
+}

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+extension MSALNativeAuthUserAccountResult {
+
+    func getAccessTokenInternal(forceRefresh: Bool, correlationId: UUID?) async -> Result<String, RetrieveAccessTokenError> {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        if let accessToken = self.authTokens.accessToken {
+            if forceRefresh || accessToken.isExpired() {
+                let controllerFactory = MSALNativeAuthControllerFactory(config: configuration)
+                let credentialsController = controllerFactory.makeCredentialsController()
+                return await credentialsController.refreshToken(context: context, authTokens: authTokens)
+            } else {
+                return .success(accessToken.accessToken)
+            }
+        } else {
+            MSALLogger.log(level: .error, context: context, format: "Retrieve Access Token: Existing token not found")
+            return .failure(RetrieveAccessTokenError(type: .tokenNotFound))
+        }
+    }
+}

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -1,0 +1,100 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/// Class that groups account and token information.
+@objc public class MSALNativeAuthUserAccountResult: NSObject {
+    /// The account object that holds account information.
+    @objc public let account: MSALAccount
+
+    let authTokens: MSALNativeAuthTokens
+    let configuration: MSALNativeAuthConfiguration
+    private let cacheAccessor: MSALNativeAuthCacheInterface
+
+    /// Get the ID token for the account.
+    @objc public var idToken: String? {
+        authTokens.rawIdToken
+    }
+
+    /// Get the list of permissions for the access token for the account if present.
+    @objc public var scopes: [String] {
+        authTokens.accessToken?.scopes.array as? [String] ?? []
+    }
+
+    /// Get the expiration date for the access token for the account if present.
+    @objc public var expiresOn: Date? {
+        authTokens.accessToken?.expiresOn
+    }
+
+    init(
+        account: MSALAccount,
+        authTokens: MSALNativeAuthTokens,
+        configuration: MSALNativeAuthConfiguration,
+        cacheAccessor: MSALNativeAuthCacheInterface
+    ) {
+        self.account = account
+        self.authTokens = authTokens
+        self.configuration = configuration
+        self.cacheAccessor = cacheAccessor
+    }
+
+    /// Removes all the data from the cache.
+    @objc public func signOut() {
+        let context = MSALNativeAuthRequestContext()
+
+        do {
+            try cacheAccessor.clearCache(
+                accountIdentifier: account.lookupAccountIdentifier,
+                authority: configuration.authority,
+                clientId: configuration.clientId,
+                context: context
+            )
+        } catch {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Clearing MSAL token cache for the current account failed with error %@: \(error)"
+            )
+        }
+    }
+
+    /// Retrieves an access token for the account.
+    /// - Parameters:
+    ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
+    ///   - forceRefresh: Ignore any existing access token in the cache and force MSAL to get a new access token from the service.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    @objc public func getAccessToken(delegate: CredentialsDelegate, forceRefresh: Bool = false, correlationId: UUID? = nil) {
+        Task {
+            let controllerResponse = await getAccessTokenInternal(forceRefresh: forceRefresh, correlationId: correlationId)
+
+            switch controllerResponse {
+            case .success(let accessToken):
+                await delegate.onAccessTokenRetrieveCompleted(accessToken: accessToken)
+            case .failure(let error):
+                await delegate.onAccessTokenRetrieveError(error: error)
+            }
+        }
+    }
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthParameters.swift
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers
+public class MSALNativeAuthParameters: NSObject {
+
+    /**
+     UUID to correlate this request with the server.
+     */
+    public let correlationId: UUID?
+
+    init(correlationId: UUID? = nil) {
+        self.correlationId = correlationId
+    }
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthResendCodeParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthResendCodeParameters.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers
+final public class MSALNativeAuthResendCodeParameters: MSALNativeAuthParameters {
+
+    public let credentialToken: String
+
+    public init(credentialToken: String,
+                correlationId: UUID? = nil) {
+        self.credentialToken = credentialToken
+        super.init(correlationId: correlationId)
+    }
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInOTPParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInOTPParameters.swift
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers
+final public class MSALNativeAuthSignInOTPParameters: MSALNativeAuthParameters {
+
+    public let email: String
+    public let scopes: [String]
+
+    public init(email: String, scopes: [String] = [], correlationId: UUID? = nil) {
+        self.email = email
+        self.scopes = scopes
+        super.init(correlationId: correlationId)
+    }
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers
+final public class MSALNativeAuthSignInParameters: MSALNativeAuthParameters {
+
+    public let email: String
+    public let password: String
+    public let scopes: [String]
+
+    public init(email: String,
+                password: String,
+                scopes: [String] = [],
+                correlationId: UUID? = nil) {
+        self.email = email
+        self.password = password
+        self.scopes = scopes
+        super.init(correlationId: correlationId)
+    }
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthVerifyCodeParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthVerifyCodeParameters.swift
@@ -1,0 +1,40 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers
+final public class MSALNativeAuthVerifyCodeParameters: MSALNativeAuthParameters {
+
+    public let credentialToken: String
+    public let otp: String
+
+    public init(credentialToken: String,
+                otp: String,
+                correlationId: UUID? = nil) {
+        self.credentialToken = credentialToken
+        self.otp = otp
+        super.init(correlationId: correlationId)
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/MSALNativeAuthRequiredAttributes.swift
+++ b/MSAL/src/native_auth/public/state_machine/MSALNativeAuthRequiredAttributes.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class MSALNativeAuthRequiredAttributes: NSObject {
+    public let name: String
+    public let type: String
+    public let required: Bool
+    public let regex: String?
+
+    init(name: String, type: String, required: Bool, regex: String? = nil) {
+        self.name = name
+        self.type = type
+        self.required = required
+        self.regex = regex
+        super.init()
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/delegate/CredentialsDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/CredentialsDelegates.swift
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public protocol CredentialsDelegate {
+    /// Notifies the delegate that the operation completed successfully.
+    /// - Parameter accessToken: The access token string.
+    @MainActor func onAccessTokenRetrieveCompleted(accessToken: String)
+
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onAccessTokenRetrieveError(error: RetrieveAccessTokenError)
+}

--- a/MSAL/src/native_auth/public/state_machine/delegate/SignUpDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/SignUpDelegates.swift
@@ -1,0 +1,155 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public protocol SignUpPasswordStartDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignUpPasswordError(error: SignUpPasswordStartError)
+
+    /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Parameters:
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    ///   - sentTo: The email/phone number that the code was sent to.
+    ///   - channelTargetType: The channel (email/phone) the code was sent through.
+    ///   - codeLength: The length of the code required.
+    @MainActor func onSignUpCodeRequired(newState: SignUpCodeRequiredState,
+                                         sentTo: String,
+                                         channelTargetType: MSALNativeAuthChannelType,
+                                         codeLength: Int)
+
+    /// Notifies the delegate that invalid attributes were sent.
+    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpPasswordError(error)`` will be called.
+    /// - Parameter attributeNames: List of attribute names that failed validation.
+    @MainActor @objc optional func onSignUpAttributesInvalid(attributeNames: [String])
+}
+
+@objc
+public protocol SignUpStartDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignUpError(error: SignUpStartError)
+
+    /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Parameters:
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    ///   - sentTo: The email/phone number that the code was sent to.
+    ///   - channelTargetType: The channel (email/phone) the code was sent through.
+    ///   - codeLength: The length of the code required.
+    @MainActor func onSignUpCodeRequired(newState: SignUpCodeRequiredState,
+                                         sentTo: String,
+                                         channelTargetType: MSALNativeAuthChannelType,
+                                         codeLength: Int)
+
+    /// Notifies the delegate that invalid attributes were sent.
+    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpError(error)`` will be called.
+    /// - Parameter attributeNames: List of attribute names that failed validation.
+    @MainActor @objc optional func onSignUpAttributesInvalid(attributeNames: [String])
+}
+
+@objc
+public protocol SignUpVerifyCodeDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameters:
+    ///   - error: An error object indicating why the operation failed.
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpVerifyCodeError(error: VerifyCodeError, newState: SignUpCodeRequiredState?)
+
+    /// Notifies the delegate that attributes are required from the user to continue.
+    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpVerifyCodeError(error:newState:)`` will be called.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+
+    /// Notifies the delegate that a password is required from the user to continue.
+    /// - Note: If a flow requires a password but this optional method is not implemented, then ``onSignUpVerifyCodeError(error:newState:)`` will be called.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor @objc optional func onSignUpPasswordRequired(newState: SignUpPasswordRequiredState)
+
+    /// Notifies the delegate that the sign up operation completed successfully.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpCompleted(newState: SignInAfterSignUpState)
+}
+
+@objc
+public protocol SignUpResendCodeDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignUpResendCodeError(error: ResendCodeError)
+
+    /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Parameters:
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    ///   - sentTo: The email/phone number that the code was sent to.
+    ///   - channelTargetType: The channel (email/phone) the code was sent through.
+    ///   - codeLength: The length of the code required.
+    @MainActor func onSignUpResendCodeCodeRequired(
+        newState: SignUpCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    )
+}
+
+@objc
+public protocol SignUpPasswordRequiredDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameters:
+    ///   - error: An error object indicating why the operation failed.
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpPasswordRequiredError(error: PasswordRequiredError, newState: SignUpPasswordRequiredState?)
+
+    /// Notifies the delegate that attributes are required from the user to continue.
+    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpPasswordRequiredError(error:newState:)`` will be called.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+
+    /// Notifies the delegate that the sign up operation completed successfully.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpCompleted(newState: SignInAfterSignUpState)
+}
+
+@objc
+public protocol SignUpAttributesRequiredDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignUpAttributesRequiredError(error: AttributesRequiredError)
+
+    /// Notifies the delegate that there are some required attributes to be sent.
+    /// - Parameters:
+    ///     - attributes:  List of required attributes.
+    ///     - newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+
+    /// Notifies the delegate that invalid attributes were sent.
+    /// - Parameters:
+    ///     - attributeNames: List of attribute names that failed validation.
+    ///     - newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpAttributesInvalid(attributeNames: [String], newState: SignUpAttributesRequiredState)
+
+    /// Notifies the delegate that the sign up operation completed successfully.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpCompleted(newState: SignInAfterSignUpState)
+}

--- a/MSAL/src/native_auth/public/state_machine/error/AttributesRequiredError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/AttributesRequiredError.swift
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class AttributesRequiredError: MSALNativeAuthError {
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        return "General error"
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/error/MSALNativeAuthError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/MSALNativeAuthError.swift
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class MSALNativeAuthError: NSObject, LocalizedError {
+    private let message: String?
+
+    init(message: String? = nil) {
+        self.message = message
+    }
+
+    public var errorDescription: String? {
+        message
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/error/PasswordRequiredError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/PasswordRequiredError.swift
@@ -1,0 +1,70 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class PasswordRequiredError: MSALNativeAuthError {
+    /// An error type indicating the type of error that occurred
+    @objc public let type: PasswordRequiredErrorType
+
+    init(type: PasswordRequiredErrorType, message: String? = nil) {
+        self.type = type
+        super.init(message: message)
+    }
+
+    init(signInPasswordError: SignInPasswordStartError) {
+        switch signInPasswordError.type {
+        case .browserRequired:
+            self.type = .browserRequired
+        case .invalidPassword:
+            self.type = .invalidPassword
+        default:
+            self.type = .generalError
+        }
+        super.init(message: signInPasswordError.errorDescription)
+    }
+
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        switch type {
+        case .browserRequired:
+            return "Browser required"
+        case .invalidPassword:
+            return "Invalid password"
+        case .generalError:
+            return "General error"
+        }
+    }
+}
+
+@objc
+public enum PasswordRequiredErrorType: Int {
+    case browserRequired
+    case generalError
+    case invalidPassword
+}

--- a/MSAL/src/native_auth/public/state_machine/error/ResendCodeError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/ResendCodeError.swift
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import Foundation
+
+@objc
+public class ResendCodeError: MSALNativeAuthError {
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        return "General error"
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/error/RetrieveAccessTokenError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/RetrieveAccessTokenError.swift
@@ -1,0 +1,61 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class RetrieveAccessTokenError: MSALNativeAuthError {
+    /// An error type indicating the type of error that occurred
+    @objc public let type: RetrieveAccessTokenErrorType
+
+    init(type: RetrieveAccessTokenErrorType, message: String? = nil) {
+        self.type = type
+        super.init(message: message)
+    }
+
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        switch type {
+        case .generalError:
+            return "General error"
+        case .refreshTokenExpired:
+            return "Refresh token expired"
+        case .tokenNotFound:
+            return "Token not found"
+        case .browserRequired:
+            return "Browser required"
+        }
+    }
+}
+
+@objc
+public enum RetrieveAccessTokenErrorType: Int {
+    case generalError
+    case refreshTokenExpired
+    case tokenNotFound
+    case browserRequired
+}

--- a/MSAL/src/native_auth/public/state_machine/error/SignUpPasswordStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignUpPasswordStartError.swift
@@ -1,0 +1,65 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class SignUpPasswordStartError: MSALNativeAuthError {
+    /// An error type indicating the type of error that occurred
+    @objc public let type: SignUpPasswordStartErrorType
+
+    init(type: SignUpPasswordStartErrorType, message: String? = nil) {
+        self.type = type
+        super.init(message: message)
+    }
+
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        switch type {
+        case .browserRequired:
+            return "Browser required"
+        case .userAlreadyExists:
+            return "User already exists"
+        case .invalidPassword:
+            return "Invalid password"
+        case .invalidUsername:
+            return "Invalid username"
+        case .generalError:
+            return "General error"
+        }
+    }
+
+}
+
+@objc
+public enum SignUpPasswordStartErrorType: Int {
+    case browserRequired
+    case userAlreadyExists
+    case invalidPassword
+    case invalidUsername
+    case generalError
+}

--- a/MSAL/src/native_auth/public/state_machine/error/SignUpStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignUpStartError.swift
@@ -1,0 +1,61 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class SignUpStartError: MSALNativeAuthError {
+    /// An error type indicating the type of error that occurred
+    @objc public let type: SignUpStartErrorType
+
+    init(type: SignUpStartErrorType, message: String? = nil) {
+        self.type = type
+        super.init(message: message)
+    }
+
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        switch type {
+        case .browserRequired:
+            return "Browser required"
+        case .userAlreadyExists:
+            return "User already exists"
+        case .invalidUsername:
+            return "Invalid username"
+        case .generalError:
+            return "General error"
+        }
+    }
+}
+
+@objc
+public enum SignUpStartErrorType: Int {
+    case browserRequired
+    case userAlreadyExists
+    case invalidUsername
+    case generalError
+}

--- a/MSAL/src/native_auth/public/state_machine/error/VerifyCodeError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/VerifyCodeError.swift
@@ -1,0 +1,58 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class VerifyCodeError: MSALNativeAuthError {
+    /// An error type indicating the type of error that occurred
+    @objc public let type: VerifyCodeErrorType
+
+    init(type: VerifyCodeErrorType, message: String? = nil) {
+        self.type = type
+        super.init(message: message)
+    }
+
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        switch type {
+        case .browserRequired:
+            return "Browser required"
+        case .generalError:
+            return "General error"
+        case .invalidCode:
+            return "Invalid code"
+        }
+    }
+}
+
+@objc
+public enum VerifyCodeErrorType: Int {
+    case browserRequired
+    case generalError
+    case invalidCode
+}

--- a/MSAL/src/native_auth/public/state_machine/state/MSALNativeAuthBaseState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/MSALNativeAuthBaseState.swift
@@ -1,0 +1,34 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class MSALNativeAuthBaseState: NSObject {
+    let flowToken: String
+
+    init(flowToken: String) {
+        self.flowToken = flowToken
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
@@ -1,0 +1,69 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+extension SignUpCodeRequiredState {
+
+    func resendCodeInternal(correlationId: UUID?) async -> SignUpResendCodeResult {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        return await controller.resendCode(username: username, context: context, signUpToken: flowToken)
+    }
+
+    func submitCodeInternal(code: String, correlationId: UUID?) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        guard inputValidator.isInputValid(code) else {
+            MSALLogger.log(level: .error, context: context, format: "SignUp flow, invalid code")
+            return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
+        }
+
+        return await controller.submitCode(code, username: username, signUpToken: flowToken, context: context)
+    }
+}
+
+extension SignUpPasswordRequiredState {
+
+    func submitPasswordInternal(
+        password: String,
+        correlationId: UUID?
+    ) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        guard inputValidator.isInputValid(password) else {
+            MSALLogger.log(level: .error, context: context, format: "SignUp flow, invalid password")
+            return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
+        }
+
+        return await controller.submitPassword(password, username: username, signUpToken: flowToken, context: context)
+    }
+}
+
+extension SignUpAttributesRequiredState {
+
+    func submitAttributesInternal(attributes: [String: Any], correlationId: UUID?) async -> SignUpAttributesRequiredResult {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        return await controller.submitAttributes(attributes, username: username, signUpToken: flowToken, context: context)
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
@@ -1,0 +1,165 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers
+public class SignUpBaseState: MSALNativeAuthBaseState {
+    let controller: MSALNativeAuthSignUpControlling
+    let username: String
+    let inputValidator: MSALNativeAuthInputValidating
+
+    init(
+        controller: MSALNativeAuthSignUpControlling,
+        username: String,
+        flowToken: String,
+        inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator()
+    ) {
+        self.controller = controller
+        self.username = username
+        self.inputValidator = inputValidator
+        super.init(flowToken: flowToken)
+    }
+}
+
+/// An object of this type is created when a user is required to supply a verification code to continue a sign up flow.
+@objcMembers public class SignUpCodeRequiredState: SignUpBaseState {
+    /// Requests the server to resend the verification code to the user.
+    /// - Parameters:
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func resendCode(delegate: SignUpResendCodeDelegate, correlationId: UUID? = nil) {
+        Task {
+            let result = await resendCodeInternal(correlationId: correlationId)
+
+            switch result {
+            case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
+                await delegate.onSignUpResendCodeCodeRequired(
+                    newState: newState,
+                    sentTo: sentTo,
+                    channelTargetType: channelTargetType,
+                    codeLength: codeLength
+                )
+            case .error(let error):
+                await delegate.onSignUpResendCodeError(error: error)
+            }
+        }
+    }
+
+    /// Submits the code to the server for verification.
+    /// - Parameters:
+    ///   - code: Verification code that the user supplies.
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func submitCode(code: String, delegate: SignUpVerifyCodeDelegate, correlationId: UUID? = nil) {
+        Task {
+            let controllerResponse = await submitCodeInternal(code: code, correlationId: correlationId)
+
+            switch controllerResponse.result {
+            case .completed(let state):
+                await delegate.onSignUpCompleted(newState: state)
+            case .passwordRequired(let state):
+                if let function = delegate.onSignUpPasswordRequired {
+                    controllerResponse.telemetryUpdate?(.success(()))
+                    await function(state)
+                } else {
+                    let error = VerifyCodeError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+                    controllerResponse.telemetryUpdate?(.failure(error))
+                    await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
+                }
+            case .attributesRequired(let attributes, let state):
+                if let function = delegate.onSignUpAttributesRequired {
+                    controllerResponse.telemetryUpdate?(.success(()))
+                    await function(attributes, state)
+                } else {
+                    let error = VerifyCodeError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+                    controllerResponse.telemetryUpdate?(.failure(error))
+                    await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
+                }
+            case .error(let error, let state):
+                await delegate.onSignUpVerifyCodeError(error: error, newState: state)
+            }
+        }
+    }
+}
+
+/// An object of this type is created when a user is required to supply a password to continue a sign up flow.
+@objcMembers public class SignUpPasswordRequiredState: SignUpBaseState {
+
+    /// Submits the password to the server for verification.
+    /// - Parameters:
+    ///   - password: Password that the user supplied.
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func submitPassword(password: String, delegate: SignUpPasswordRequiredDelegate, correlationId: UUID? = nil) {
+        Task {
+            let controllerResponse = await submitPasswordInternal(password: password, correlationId: correlationId)
+
+            switch controllerResponse.result {
+            case .completed(let state):
+                await delegate.onSignUpCompleted(newState: state)
+            case .attributesRequired(let attributes, let state):
+                if let function = delegate.onSignUpAttributesRequired {
+                    controllerResponse.telemetryUpdate?(.success(()))
+                    await function(attributes, state)
+                } else {
+                    let error = PasswordRequiredError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+                    controllerResponse.telemetryUpdate?(.failure(error))
+                    await delegate.onSignUpPasswordRequiredError(error: error, newState: nil)
+                }
+            case .error(let error, let state):
+                await delegate.onSignUpPasswordRequiredError(error: error, newState: state)
+            }
+        }
+    }
+}
+
+/// An object of this type is created when a user is required to supply attributes to continue a sign up flow.
+@objcMembers public class SignUpAttributesRequiredState: SignUpBaseState {
+    /// Submits the attributes to the server for verification.
+    /// - Parameters:
+    ///   - attributes: Dictionary of attributes that the user supplied.
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func submitAttributes(
+        attributes: [String: Any],
+        delegate: SignUpAttributesRequiredDelegate,
+        correlationId: UUID? = nil
+    ) {
+        Task {
+            let result = await submitAttributesInternal(attributes: attributes, correlationId: correlationId)
+
+            switch result {
+            case .completed(let state):
+                await delegate.onSignUpCompleted(newState: state)
+            case .error(let error):
+                await delegate.onSignUpAttributesRequiredError(error: error)
+            case .attributesRequired(let attributes, let state):
+                await delegate.onSignUpAttributesRequired(attributes: attributes, newState: state)
+            case .attributesInvalid(let attributes, let state):
+                await delegate.onSignUpAttributesInvalid(attributeNames: attributes, newState: state)
+            }
+        }
+    }
+}

--- a/MSAL/src/native_auth/telemetry/MSALNativeAuthCurrentRequestTelemetry.swift
+++ b/MSAL/src/native_auth/telemetry/MSALNativeAuthCurrentRequestTelemetry.swift
@@ -1,0 +1,59 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthCurrentRequestTelemetry: NSObject, MSIDTelemetryStringSerializable {
+    let apiId: MSALNativeAuthTelemetryApiId
+    let operationType: MSALNativeAuthOperationType
+    private let schemaVersion: Int
+    private let platformFields: [String]?
+
+    init(apiId: MSALNativeAuthTelemetryApiId,
+         operationType: MSALNativeAuthOperationType,
+         platformFields: [String]?) {
+        self.schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION
+        self.apiId = apiId
+        self.operationType = operationType
+        self.platformFields = platformFields
+    }
+
+    func telemetryString() -> String {
+        return serializeCurrentTelemetryString()
+    }
+
+    private func serializeCurrentTelemetryString() -> String {
+        let currentTelemetryFields = createSerializedItem()
+        return currentTelemetryFields.serialize() ?? ""
+    }
+
+    private func createSerializedItem() -> MSIDCurrentRequestTelemetrySerializedItem {
+        let defaultFields: [NSNumber] = [.init(value: apiId.rawValue),
+                                         .init(value: operationType)]
+        return .init(schemaVersion: .init(value: schemaVersion),
+                     defaultFields: defaultFields,
+                     platformFields: platformFields)
+    }
+}

--- a/MSAL/src/native_auth/telemetry/MSALNativeAuthOperationTypes.swift
+++ b/MSAL/src/native_auth/telemetry/MSALNativeAuthOperationTypes.swift
@@ -1,0 +1,78 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+typealias MSALNativeAuthOperationType = Int
+
+enum MSALNativeAuthSignUpType: MSALNativeAuthOperationType {
+    case signUpWithPassword = 0
+    case signUpWithOTP = 1
+    case signUpWithMFA = 2
+    case signUpStart = 3
+    case signUpChallenge = 4
+    case signUpContinue = 5
+}
+
+enum MSALNativeAuthSignInType: MSALNativeAuthOperationType {
+    case signInWithOTP = 0
+    case signInWithMFA = 1
+    case signInInitiate = 2
+    case signInChallenge = 3
+}
+
+enum MSALNativeAuthTokenType: MSALNativeAuthOperationType {
+    case signInWithPassword = 0
+    case refreshToken = 1
+
+}
+enum MSALNAtiveAuthResetPasswordType: MSALNativeAuthOperationType {
+    case resetPasswordStart = 0
+    case resetPasswordChallenge = 1
+    case resetPasswordContinue = 2
+    case resetPasswordSubmit = 3
+    case resetPasswordPollCompletion = 4
+}
+
+enum MSALNativeAuthResetPasswordStartType: MSALNativeAuthOperationType {
+    case resetPasswordStart = 0
+}
+
+enum MSALNativeAuthResetPasswordCompleteType: MSALNativeAuthOperationType {
+    case resetPasswordComplete = 0
+}
+
+enum MSALNativeAuthResendCodeType: MSALNativeAuthOperationType {
+    case resendCode = 0
+}
+
+enum MSALNativeAuthVerifyCodeType: MSALNativeAuthOperationType {
+    case verifyCode = 0
+}
+
+enum MSALNativeAuthSignOutType: MSALNativeAuthOperationType {
+    case signOutAction = 0
+    case signOutForced = 1
+}

--- a/MSAL/src/native_auth/telemetry/MSALNativeAuthServerTelemetry.swift
+++ b/MSAL/src/native_auth/telemetry/MSALNativeAuthServerTelemetry.swift
@@ -1,0 +1,67 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthServerTelemetry: NSObject, MSIDHttpRequestServerTelemetryHandling {
+
+    let currentRequestTelemetry: MSALNativeAuthCurrentRequestTelemetry
+    let context: MSIDRequestContext
+    private let lastRequestTelemetry: MSIDLastRequestTelemetry
+    init(currentRequestTelemetry: MSALNativeAuthCurrentRequestTelemetry,
+         context: MSIDRequestContext) {
+        self.currentRequestTelemetry = currentRequestTelemetry
+        self.context = context
+        self.lastRequestTelemetry = MSIDLastRequestTelemetry.sharedInstance()
+    }
+
+    func handleError(_ error: Error?, context: MSIDRequestContext) {
+        guard let error = error else { return }
+        let errorString = (error as NSError).msidServerTelemetryErrorString()
+        handleError(error, errorString: errorString, context: context)
+    }
+
+    func handleError(_ error: Error?, errorString: String, context: MSIDRequestContext) {
+        lastRequestTelemetry.update(withApiId: currentRequestTelemetry.apiId.rawValue,
+                                    errorString: errorString,
+                                    context: context)
+    }
+
+    func setTelemetryToRequest(_ request: MSIDHttpRequestProtocol) {
+
+        let currentRequestTelemetryString = currentRequestTelemetry.telemetryString()
+        let lastRequestTelemetryString = lastRequestTelemetry.telemetryString()
+
+        guard let mutableUrlRequest = (request.urlRequest as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Mutable copy of request could not be made for telemetry")
+            return
+        }
+        mutableUrlRequest.setValue(currentRequestTelemetryString, forHTTPHeaderField: "x-client-current-telemetry")
+        mutableUrlRequest.setValue(lastRequestTelemetryString, forHTTPHeaderField: "x-client-last-telemetry")
+        request.urlRequest = mutableUrlRequest as URLRequest
+    }
+}

--- a/MSAL/src/native_auth/telemetry/MSALNativeAuthTelemetryApiId.swift
+++ b/MSAL/src/native_auth/telemetry/MSALNativeAuthTelemetryApiId.swift
@@ -1,0 +1,57 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthTelemetryApiId: Int {
+    // TODO: Resolve the below comment about the correct definitions of these constants:
+    // Until we know exactly how to define them,
+    // to prevent any clashes with existing id's
+    // a number that is unlikely to be used has been added
+    case telemetryApiIdSignUp = 75001
+    case telemetryApiIdToken = 75002
+    case telemetryApiIdRefreshToken = 75003
+    case telemetryApiIdResendCode = 75006
+    case telemetryApiIdVerifyCode = 75007
+    case telemetryApiIdSignOut = 75008
+    case telemetryApiIdResetPassword = 75009
+    case telemetryApiIdSignInWithPasswordStart = 74001
+    case telemetryApiIdSignInWithCodeStart = 74002
+    case telemetryApiIdSignInAfterSignUp = 740014
+    case telemetryApiIdSignInSubmitCode = 74003
+    case telemetryApiIdSignInResendCode = 74004
+    case telemetryApiIdSignInSubmitPassword = 74005
+    case telemetryApiIdResetPasswordStart = 74011
+    case telemetryApiIdResetPasswordResendCode = 74012
+    case telemetryApiIdResetPasswordSubmitCode = 74013
+    case telemetryApiIdResetPasswordSubmit = 75028
+    case telemetryApiIdSignUpPasswordStart = 75019
+    case telemetryApiIdSignUpPasswordChallenge = 75015
+    case telemetryApiIdSignUpCodeStart = 75010
+    case telemetryApiIdSignUpResendCode = 75011
+    case telemetryApiIdSignUpSubmitCode = 75012
+    case telemetryApiIdSignUpSubmitPassword = 75013
+    case telemetryApiIdSignUpSubmitAttributes = 75014
+
+}

--- a/MSAL/src/native_auth/telemetry/MSALNativeAuthTelemetryProvider.swift
+++ b/MSAL/src/native_auth/telemetry/MSALNativeAuthTelemetryProvider.swift
@@ -1,0 +1,108 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+protocol MSALNativeAuthTelemetryProviding {
+    func telemetryForSignUp(
+        type: MSALNativeAuthSignUpType) -> MSALNativeAuthCurrentRequestTelemetry
+    func telemetryForSignIn(
+        type: MSALNativeAuthSignInType) -> MSALNativeAuthCurrentRequestTelemetry
+    func telemetryForToken(
+        type: MSALNativeAuthTokenType) -> MSALNativeAuthCurrentRequestTelemetry
+    func telemetryForResetPassword(
+        type: MSALNAtiveAuthResetPasswordType) -> MSALNativeAuthCurrentRequestTelemetry
+    func telemetryForResetPasswordStart(
+        type: MSALNativeAuthResetPasswordStartType) -> MSALNativeAuthCurrentRequestTelemetry
+    func telemetryForResendCode(
+        type: MSALNativeAuthResendCodeType) -> MSALNativeAuthCurrentRequestTelemetry
+    func telemetryForVerifyCode(
+        type: MSALNativeAuthVerifyCodeType) -> MSALNativeAuthCurrentRequestTelemetry
+    func telemetryForSignOut(
+        type: MSALNativeAuthSignOutType) -> MSALNativeAuthCurrentRequestTelemetry
+}
+
+class MSALNativeAuthTelemetryProvider: MSALNativeAuthTelemetryProviding {
+    func telemetryForSignUp(
+        type: MSALNativeAuthSignUpType) -> MSALNativeAuthCurrentRequestTelemetry {
+        return MSALNativeAuthCurrentRequestTelemetry(
+            apiId: .telemetryApiIdSignUpCodeStart,
+            operationType: type.rawValue,
+            platformFields: nil)
+    }
+
+    func telemetryForSignIn(
+        type: MSALNativeAuthSignInType) -> MSALNativeAuthCurrentRequestTelemetry {
+        return MSALNativeAuthCurrentRequestTelemetry(
+            apiId: .telemetryApiIdSignInWithCodeStart,
+            operationType: type.rawValue,
+            platformFields: nil)
+    }
+
+    func telemetryForToken(
+        type: MSALNativeAuthTokenType) -> MSALNativeAuthCurrentRequestTelemetry {
+        return MSALNativeAuthCurrentRequestTelemetry(
+            apiId: .telemetryApiIdToken,
+            operationType: type.rawValue,
+            platformFields: nil)
+    }
+
+    func telemetryForResetPassword(type: MSALNAtiveAuthResetPasswordType) -> MSALNativeAuthCurrentRequestTelemetry {
+        return MSALNativeAuthCurrentRequestTelemetry(
+            apiId: .telemetryApiIdResetPassword,
+            operationType: type.rawValue,
+            platformFields: nil)
+    }
+
+    func telemetryForResetPasswordStart(
+        type: MSALNativeAuthResetPasswordStartType) -> MSALNativeAuthCurrentRequestTelemetry {
+        return MSALNativeAuthCurrentRequestTelemetry(
+            apiId: .telemetryApiIdResetPasswordStart,
+            operationType: type.rawValue,
+            platformFields: nil)
+    }
+
+    func telemetryForResendCode(
+        type: MSALNativeAuthResendCodeType) -> MSALNativeAuthCurrentRequestTelemetry {
+        return MSALNativeAuthCurrentRequestTelemetry(
+            apiId: .telemetryApiIdResendCode,
+            operationType: type.rawValue,
+            platformFields: nil)
+    }
+
+    func telemetryForVerifyCode(
+        type: MSALNativeAuthVerifyCodeType) -> MSALNativeAuthCurrentRequestTelemetry {
+        return MSALNativeAuthCurrentRequestTelemetry(
+            apiId: .telemetryApiIdVerifyCode,
+            operationType: type.rawValue,
+            platformFields: nil)
+    }
+
+    func telemetryForSignOut(
+        type: MSALNativeAuthSignOutType) -> MSALNativeAuthCurrentRequestTelemetry {
+        return MSALNativeAuthCurrentRequestTelemetry(
+            apiId: .telemetryApiIdSignOut,
+            operationType: type.rawValue,
+            platformFields: nil)
+    }
+}

--- a/MSAL/src/native_auth/validation/MSALNativeAuthAuthorityProvider.swift
+++ b/MSAL/src/native_auth/validation/MSALNativeAuthAuthorityProvider.swift
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthAuthorityProviding {
+    func authority(rawTenant: String) throws -> MSALCIAMAuthority
+}
+
+final class MSALNativeAuthAuthorityProvider: MSALNativeAuthAuthorityProviding {
+
+    func authority(rawTenant: String) throws -> MSALCIAMAuthority {
+        let ciamUrlString = "https://\(rawTenant).ciamlogin.com"
+        guard let url = URL(string: ciamUrlString) else {
+            assert(false, "URL for default CIAM Authority must be valid")
+            throw MSALNativeAuthInternalError.invalidAuthority
+        }
+
+        return try MSALCIAMAuthority(url: url)
+    }
+}

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -79,6 +79,7 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALSignoutParameters.h>
 #import <MSAL/MSALParameters.h>
 #import <MSAL/MSALPublicClientApplication+SingleAccount.h>
+#import <MSAL/MSALNativeAuthChallengeTypes.h>
 #if TARGET_OS_IPHONE
 #import <MSAL/MSALLegacySharedAccountsProvider.h>
 #endif

--- a/MSAL/test/integration/native_auth/MockAPIHandlerTest.swift
+++ b/MSAL/test/integration/native_auth/MockAPIHandlerTest.swift
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+
+final class MockAPIHandlerTest: MSALNativeAuthIntegrationBaseTests {
+    
+    func testAddNewResponse() async {
+        do {
+            try await mockAPIHandler.addResponse(endpoint: .signInInitiate, correlationId: correlationId, responses: [.invalidClient, .userNotFound])
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func testGetAllConfig() async {
+        do {
+            print(try await mockAPIHandler.getAllConfig())
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+}

--- a/MSAL/test/integration/native_auth/common/MSALNativeAuthIntegrationBaseTests.swift
+++ b/MSAL/test/integration/native_auth/common/MSALNativeAuthIntegrationBaseTests.swift
@@ -1,0 +1,127 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthIntegrationBaseTests: XCTestCase {
+
+    var defaultTimeout: TimeInterval = 5
+    let mockAPIHandler = MockAPIHandler()
+    let correlationId = UUID()
+    let config: MSALNativeAuthConfiguration = try! MSALNativeAuthConfiguration(clientId: UUID().uuidString,
+                                                                               authority: MSALCIAMAuthority(url:  URL(string: "https://native-ux-mock-api.azurewebsites.net/test")!),
+                                                                               challengeTypes: [.password, .oob, .redirect])
+    var sut: MSIDHttpRequest!
+    
+    override func tearDown() {
+        try? mockAPIHandler.clearQueues(correlationId: correlationId)
+    }
+
+    // MARK: - Utility methods
+
+    func performTestSucceed<T: Any>() async throws -> T {
+        return try await withCheckedThrowingContinuation { continuation in
+            let exp = expectation(description: "msal_native_auth_integration_test_exp")
+
+            sut.send { response, error in
+                guard error == nil else {
+                    XCTFail("Error should be nil")
+                    continuation.resume(throwing: MockAPIError.invalidRequest)
+                    return
+                }
+
+                guard let response = response as? T else {
+                    XCTFail("Response should be castable to `T`")
+                    continuation.resume(throwing: MockAPIError.invalidRequest)
+                    return
+                }
+
+                continuation.resume(returning: response)
+                exp.fulfill()
+            }
+
+            wait(for: [exp], timeout: defaultTimeout)
+        }
+    }
+
+    @discardableResult
+    func perform_testFail<Error: MSALNativeAuthResponseError>(
+        endpoint: MockAPIEndpoint,
+        response: MockAPIResponse,
+        expectedError: Error
+    ) async throws -> Error {
+        try await mockResponse(response, endpoint: endpoint)
+        let response: Error = try await perform_uncheckedTestFail()
+
+        XCTAssertEqual(response.error.rawValue, expectedError.error.rawValue)
+
+        // TODO: Fix these checks
+        if expectedError.errorDescription != nil {
+            XCTAssertNotNil(response.errorDescription)
+        }
+        if expectedError.errorCodes != nil {
+            XCTAssertEqual(response.errorCodes, expectedError.errorCodes)
+        }
+
+        if expectedError.errorURI != nil {
+            XCTAssertNotNil(response.errorURI)
+        }
+        return response
+    }
+
+    func mockResponse(_ response: MockAPIResponse, endpoint: MockAPIEndpoint) async throws {
+        try await mockAPIHandler.addResponse(
+            endpoint: endpoint,
+            correlationId: correlationId,
+            responses: [response]
+        )
+    }
+
+    func perform_uncheckedTestFail<T: MSALNativeAuthResponseError>() async throws -> T {
+        return try await withCheckedThrowingContinuation { continuation in
+            let exp = expectation(description: "msal_native_auth_integration_test_exp")
+
+            sut.send { response, error in
+                guard response == nil else {
+                    XCTFail("Response should be nil")
+                    continuation.resume(throwing: MockAPIError.invalidRequest)
+                    return
+                }
+
+                guard let error = error as? T else {
+                    XCTFail("Error should be MSALNativeAuthResponseError")
+                    continuation.resume(throwing: MockAPIError.invalidRequest)
+                    return
+                }
+
+                continuation.resume(returning: error)
+                exp.fulfill()
+            }
+
+            wait(for: [exp], timeout: defaultTimeout)
+        }
+    }
+}

--- a/MSAL/test/integration/native_auth/common/MockAPIHandler.swift
+++ b/MSAL/test/integration/native_auth/common/MockAPIHandler.swift
@@ -1,0 +1,80 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import XCTest
+
+class MockAPIHandler {
+    
+    private let baseURL = "https://native-ux-mock-api.azurewebsites.net/config/"
+
+    func clearQueues(correlationId: UUID) throws {
+        guard let url = URL(string: baseURL + "all") else {
+            XCTFail("Invalid Delete URL")
+            throw MockAPIError.invalidURL
+        }
+        guard let body = try? JSONEncoder().encode(ClearQueueRequestBody(correlationId: correlationId)) else {
+            XCTFail("Invalid Request")
+            throw MockAPIError.invalidRequest
+        }
+        Task {
+            try await performHTTPCall(url: url, body: body, httpMethod: "DELETE")
+        }
+    }
+    
+    func getAllConfig() async throws -> [String: Any] {
+        guard let url = URL(string: baseURL + "all") else {
+            XCTFail("Invalid get all config URL")
+            throw MockAPIError.invalidURL
+        }
+        let result = try await performHTTPCall(url: url)
+        return try JSONSerialization.jsonObject(with: result, options: []) as? [String: Any] ?? [:]
+    }
+    
+    func addResponse(endpoint: MockAPIEndpoint, correlationId: UUID, responses: [MockAPIResponse]) async throws {
+        guard let url = URL(string: baseURL + "response") else {
+            XCTFail("Invalid add response URL")
+            throw MockAPIError.invalidURL
+        }
+        guard let body = try? JSONEncoder().encode(
+            AddResponsesRequestBody(endpoint: endpoint.rawValue, responseList: responses.map({$0.rawValue}), correlationId: correlationId)
+        ) else {
+            XCTFail("Invalid Request")
+            throw MockAPIError.invalidRequest
+        }
+        _ = try await performHTTPCall(url: url, body: body, httpMethod: "POST")
+    }
+    
+    private func performHTTPCall(url: URL, body: Data? = nil, httpMethod: String = "GET") async throws -> Data {
+        var request = URLRequest(url: url)
+        request.httpBody = body
+        request.httpMethod = httpMethod
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw MockAPIError.invalidServerResponse
+        }
+        return data
+    }
+}

--- a/MSAL/test/integration/native_auth/common/Model.swift
+++ b/MSAL/test/integration/native_auth/common/Model.swift
@@ -1,0 +1,103 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import Foundation
+
+enum MockAPIError: Error {
+    case invalidServerResponse
+    case invalidURL
+    case invalidRequest
+}
+
+enum MockAPIEndpoint: String {
+    case signInInitiate = "SignInInitiate"
+    case signInChallenge = "SignInChallenge"
+    case signInToken = "SignInToken"
+    case signUpStart = "SignUpStart"
+    case signUpChallenge = "SignUpChallenge"
+    case signUpContinue = "SignUpContinue"
+    case resetPasswordStart = "SSPRStart"
+    case resetPasswordChallenge = "SSPRChallenge"
+    case resetPasswordContinue = "SSPRContinue"
+    case resetPasswordSubmit = "SSPRSubmit"
+    case resetPasswordPollCompletion = "SSPRPoll"
+}
+
+enum MockAPIResponse: String {
+    case invalidRequest = "InvalidRequest"
+    case invalidToken = "InvalidToken"
+    case invalidClient = "InvalidClient"
+    case invalidGrant = "InvalidGrant"
+    case invalidScope = "InvalidScope"
+    case expiredToken = "ExpiredToken"
+    case invalidPurposeToken = "InvalidPurposeToken"
+    case unsupportedAuthMethod = "UnsupportedAuthMethod"
+    case userAlreadyExists = "UserAlreadyExists"
+    case userNotFound = "UserNotFound"
+    case explicityUserNotFound = "ExplicityUserNotFound"
+    case slowDown = "SlowDown"
+    case invalidPassword = "InvalidPassword"
+    case invalidOOBValue = "InvalidOOBValue"
+    case passwordTooWeak = "PasswordTooWeak"
+    case passwordTooShort = "PasswordTooShort"
+    case passwordTooLong = "PasswordTooLong"
+    case passwordRecentlyUsed = "PasswordRecentlyUsed"
+    case passwordBanned = "PasswordBanned"
+    case authorizationPending = "AuthorizationPending"
+    case challengeTypePassword = "ChallengeTypePassword"
+    case challengeTypeOOB = "ChallengeTypeOOB"
+    case unsupportedChallengeType = "UnsupportedChallengeType"
+    case challengeTypeRedirect = "ChallengeTypeRedirect"
+    case credentialRequired = "CredentialRequired"
+    case initiateSuccess = "InitiateSuccess"
+    case tokenSuccess = "TokenSuccess"
+    case attributesRequired = "AttributesRequired"
+    case invalidAttributes = "InvalidAttributes"
+    case verificationRequired = "VerificationRequired"
+    case attributeValidationFailed = "AttributeValidationFailed"
+    case invalidSignUpToken = "InvalidSignupToken"
+    case explicitInvalidOOBValue = "ExplicitInvalidOOBValue"
+    case invalidPasswordResetToken = "InvalidPasswordResetToken"
+    case ssprStartSuccess = "SSPRStartSuccess"
+    case ssprContinueSuccess = "SSPRContinueSuccess"
+    case ssprSubmitSuccess = "SSPRSubmitSuccess"
+    case ssprPollSuccess = "SSPRPollSuccess"
+    case ssprPollInProgress = "SSPRPollInProgress"
+    case ssprPollFailed = "SSPRPollFailed"
+    case ssprPollNotStarted = "SSPRPollNotStarted"
+    case signUpContinueSuccess = "SignUpContinueSuccess"
+    case invalidUsername = "InvalidUsername"
+}
+
+// MARK: request body
+
+struct ClearQueueRequestBody: Encodable {
+    var correlationId: UUID
+}
+
+struct AddResponsesRequestBody: Encodable {
+    var endpoint: String
+    var responseList: [String]
+    var correlationId: UUID
+}

--- a/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
@@ -1,0 +1,77 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+import MSAL
+
+class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
+    let mockAPIHandler = MockAPIHandler()
+    let correlationId = UUID()
+    var defaultTimeout: TimeInterval = 5
+
+    var sut: MSALNativeAuthPublicClientApplication!
+    var usingMockAPI = false
+
+    class Configuration: NSObject {
+        static let clientId = ProcessInfo.processInfo.environment["clientId"] ?? "<clientId not set>"
+        static let authorityURLString = ProcessInfo.processInfo.environment["authorityURL"] ?? "<authorityURL not set>"
+        static let authorityURL = URL(string: authorityURLString) ?? URL(string: "https://microsoft.com")
+
+        static let authority = try? MSALCIAMAuthority(url: authorityURL!)
+    }
+
+    func mockResponse(_ response: MockAPIResponse, endpoint: MockAPIEndpoint) async throws {
+        try await mockAPIHandler.addResponse(
+            endpoint: endpoint,
+            correlationId: correlationId,
+            responses: [response]
+        )
+    }
+
+    override func tearDown() {
+        try? mockAPIHandler.clearQueues(correlationId: correlationId)
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        sut = try MSALNativeAuthPublicClientApplication(
+            configuration: MSALPublicClientApplicationConfig(
+                clientId: Configuration.clientId,
+                redirectUri: nil,
+                authority: Configuration.authority
+            ),
+            challengeTypes: [.OOB, .password]
+        )
+
+        let useMockAPIBooleanString = ProcessInfo.processInfo.environment["useMockAPI"] ?? "false"
+        usingMockAPI = Bool(useMockAPIBooleanString) ?? false
+
+        if usingMockAPI {
+            print("🤖🤖🤖 Using mock API: \(Configuration.authorityURLString)")
+        } else {
+            print("👩‍💻👩‍💻👩‍💻 Using test tenant: \(Configuration.authorityURLString)")
+        }
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift
@@ -1,0 +1,445 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+import MSAL
+
+final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuthEndToEndBaseTestCase {
+    private let usernamePassword = ProcessInfo.processInfo.environment["existingPasswordUserEmail"] ?? "<existingPasswordUserEmail not set>"
+    private let password = ProcessInfo.processInfo.environment["existingUserPassword"] ?? "<existingUserPassword not set>"
+    private let attributes = ["age": 40]
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipIf(!usingMockAPI)
+    }
+    
+    // Hero Scenario 2.1.1. Sign up - with Email verification as LAST step (Email & Password)
+    func test_signUpWithPassword_withEmailVerificationLastStep_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: password,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 2.1.2. Sign up - with Email verification as LAST step & Custom Attributes (Email & Password)
+    func test_signUpWithPassword_withEmailVerificationAsLastStepAndCustomAttributes_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: "1234",
+            attributes: attributes,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 2.1.3. Sign up - with Email verification as FIRST step (Email & Password)
+    func test_signUpWithPassword_withEmailVerificationAsFirstStep_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: password,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let credentialRequiredExp = expectation(description: "credential required")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: credentialRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.credentialRequired, endpoint: .signUpContinue)
+            try await mockResponse(.challengeTypePassword, endpoint: .signUpChallenge)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [credentialRequiredExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpPasswordRequiredCalled)
+
+        // Now submit the password...
+
+        let attributesRequiredExp = expectation(description: "attributes required")
+        let signUpPasswordDelegate = SignUpPasswordRequiredDelegateSpy(expectation: attributesRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpVerifyCodeDelegate.passwordRequiredState?.submitPassword(
+            password: "1234",
+            delegate: signUpPasswordDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [attributesRequiredExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpPasswordDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpPasswordDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 2.1.4. Sign up - with Email verification as FIRST step & Custom Attribute (Email & Password)
+    func test_signUpWithPasswordWithEmailVerificationAsFirstStepAndCustomAttributes_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: password,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let submitCodeExp = expectation(description: "submit code, credential required")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: submitCodeExp)
+
+        if usingMockAPI {
+            try await mockResponse(.credentialRequired, endpoint: .signUpContinue)
+            try await mockResponse(.challengeTypePassword, endpoint: .signUpChallenge)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpPasswordRequiredCalled)
+
+        // Now submit the password...
+
+        let passwordRequiredExp = expectation(description: "password required")
+        let signUpPasswordDelegate = SignUpPasswordRequiredDelegateSpy(expectation: passwordRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpVerifyCodeDelegate.passwordRequiredState?.submitPassword(
+            password: "1234",
+            delegate: signUpPasswordDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [passwordRequiredExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpPasswordDelegate.onSignUpAttributesRequiredCalled)
+
+        // Now submit the attributes...
+
+        let attributesRequiredExp = expectation(description: "attributes required, sign-up complete")
+        let signUpAttributesRequiredDelegate = SignUpAttributesRequiredDelegateSpy(expectation: attributesRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpPasswordDelegate.attributesRequiredState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [attributesRequiredExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 2.1.5. Sign up - with Email verification as FIRST step & Custom Attributes over MULTIPLE screens (Email & Password)
+    func test_signUpWithPasswordWithEmailVerificationAsFirstStepAndCustomAttributesOverMultipleScreens_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: password,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let submitCodeExp = expectation(description: "submit code, credential required")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: submitCodeExp)
+
+        if usingMockAPI {
+            try await mockResponse(.credentialRequired, endpoint: .signUpContinue)
+            try await mockResponse(.challengeTypePassword, endpoint: .signUpChallenge)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpPasswordRequiredCalled)
+
+        // Now submit the password...
+
+        let attributesRequiredExp1 = expectation(description: "attributes required 1")
+        let signUpPasswordDelegate = SignUpPasswordRequiredDelegateSpy(expectation: attributesRequiredExp1)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpVerifyCodeDelegate.passwordRequiredState?.submitPassword(
+            password: "1234",
+            delegate: signUpPasswordDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [attributesRequiredExp1], timeout: defaultTimeout)
+        XCTAssertTrue(signUpPasswordDelegate.onSignUpAttributesRequiredCalled)
+
+        // Now submit the attributes...
+
+        let attributesRequiredExp2 = expectation(description: "attributes required 2, sign-up complete")
+        let signUpAttributesRequiredDelegate = SignUpAttributesRequiredDelegateSpy(expectation: attributesRequiredExp2)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpPasswordDelegate.attributesRequiredState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [attributesRequiredExp2], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpAttributesRequiredErrorCalled)
+
+        // Now submit more attributes...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        signUpAttributesRequiredDelegate.expectation = signUpCompleteExp
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpAttributesRequiredDelegate.attributesRequiredState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 2.1.6. Sign up – without automatic sign in (Email & Password)
+    func test_signUpWithPasswordWithoutAutomaticSignIn() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: password,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+    }
+
+    private func checkSignUpStartDelegate(_ delegate: SignUpPasswordStartDelegateSpy) {
+        XCTAssertTrue(delegate.onSignUpCodeRequiredCalled)
+        XCTAssertEqual(delegate.channelTargetType, .email)
+        XCTAssertFalse(delegate.sentTo?.isEmpty ?? true)
+        XCTAssertNotNil(delegate.codeLength)
+    }
+
+    private func checkSignInAfterSignUpDelegate(_ delegate: SignInAfterSignUpDelegateSpy) {
+        XCTAssertTrue(delegate.onSignInCompletedCalled)
+        XCTAssertEqual(delegate.result?.account.username, usernamePassword)
+        XCTAssertNotNil(delegate.result?.idToken)
+        XCTAssertNil(delegate.result?.account.accountClaims)
+        XCTAssertEqual(delegate.result?.scopes[0], "openid")
+        XCTAssertEqual(delegate.result?.scopes[1], "offline_access")
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameEndToEndTests.swift
@@ -1,0 +1,313 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+import MSAL
+
+final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBaseTestCase {
+
+    private let usernameOTP = ProcessInfo.processInfo.environment["existingOTPUserEmail"] ?? "<existingOTPUserEmail not set>"
+    private let attributes = ["age": 40]
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipIf(!usingMockAPI)
+    }
+
+    // Hero Scenario 1.1.1. Sign up – with Email Verification (Email & Email OTP)
+    func test_signUpWithCode_withEmailVerification_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUp(username: usernameOTP, correlationId: correlationId, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 1.1.2. Sign up – with Email Verification as LAST step & Custom Attributes (Email & Email OTP)
+    func test_signUpWithCode_withEmailVerificationAsLastStepAndCustomAttributes_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUp(username: usernameOTP, attributes: attributes, correlationId: correlationId, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 1.1.3. Sign up – with Email Verification as FIRST step & Custom Attributes (Email & Email OTP)
+    func test_signUpWithCode_withEmailVerificationAsFirstStepAndCustomAttributes_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUp(username: usernameOTP, attributes: attributes, correlationId: correlationId, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let submitCodeExp = expectation(description: "submit code")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: submitCodeExp)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpAttributesRequiredCalled)
+
+        // Now submit the attributes...
+
+        let attributesExp = expectation(description: "submit attributes, sign-up complete")
+        let signUpAttributesRequiredDelegate = SignUpAttributesRequiredDelegateSpy(expectation: attributesExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpVerifyCodeDelegate.attributesRequiredNewState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [attributesExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 1.1.4. Sign up – with Email Verification as FIRST step & Custom Attributes over MULTIPLE screens (Email & Email OTP)
+    func test_signUpWithCode_withEmailVerificationAsLastStepAndCustomAttributesOverMultipleScreens_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUp(username: usernameOTP, attributes: attributes, correlationId: correlationId, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let submitCodeExp = expectation(description: "submit code")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: submitCodeExp)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpAttributesRequiredCalled)
+
+        // Now submit the attributes...
+
+        let submitAttributesExp1 = expectation(description: "submit attributes 1")
+        let signUpAttributesRequiredDelegate = SignUpAttributesRequiredDelegateSpy(expectation: submitAttributesExp1)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpVerifyCodeDelegate.attributesRequiredNewState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [submitAttributesExp1], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpAttributesRequiredErrorCalled)
+
+        // Now submit more attributes...
+
+        let submitAttributesExp2 = expectation(description: "submit attributes 2, sign-up complete")
+        signUpAttributesRequiredDelegate.expectation = submitAttributesExp2
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpAttributesRequiredDelegate.attributesRequiredState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [submitAttributesExp2], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 1.1.5. Sign up – without automatic sign in (Email & Email OTP)
+    func test_signUpWithoutAutomaticSignIn() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUp(username: usernameOTP, correlationId: correlationId, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+    }
+
+    private func checkSignUpStartDelegate(_ delegate: SignUpStartDelegateSpy) {
+        XCTAssertTrue(delegate.onSignUpCodeRequiredCalled)
+        XCTAssertEqual(delegate.channelTargetType, .email)
+        XCTAssertFalse(delegate.sentTo?.isEmpty ?? true)
+        XCTAssertNotNil(delegate.codeLength)
+    }
+
+    private func checkSignInAfterSignUpDelegate(_ delegate: SignInAfterSignUpDelegateSpy) {
+        XCTAssertTrue(delegate.onSignInCompletedCalled)
+        XCTAssertEqual(delegate.result?.account.username, usernameOTP)
+        XCTAssertNotNil(delegate.result?.idToken)
+        XCTAssertNil(delegate.result?.account.accountClaims)
+        XCTAssertEqual(delegate.result?.scopes[0], "openid")
+        XCTAssertEqual(delegate.result?.scopes[1], "offline_access")
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/SignUpDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/SignUpDelegateSpies.swift
@@ -1,0 +1,267 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import XCTest
+import MSAL
+
+class SignUpPasswordStartDelegateSpy: SignUpPasswordStartDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignUpPasswordErrorCalled = false
+    private(set) var error: MSAL.SignUpPasswordStartError?
+    private(set) var onSignUpCodeRequiredCalled = false
+    private(set) var newState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordError(error: SignUpPasswordStartError) {
+        onSignUpPasswordErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    func onSignUpCodeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        expectation.fulfill()
+    }
+}
+
+class SignUpStartDelegateSpy: SignUpStartDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignUpErrorCalled = false
+    private(set) var error: MSAL.SignUpStartError?
+    private(set) var onSignUpCodeRequiredCalled = false
+    private(set) var newState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpError(error: SignUpStartError) {
+        onSignUpErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    func onSignUpCodeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        expectation.fulfill()
+    }
+}
+
+class SignUpVerifyCodeDelegateSpy: SignUpVerifyCodeDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignUpVerifyCodeErrorCalled = false
+    private(set) var error: VerifyCodeError?
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var attributesRequiredNewState: SignUpAttributesRequiredState?
+    private(set) var onSignUpPasswordRequiredCalled = false
+    private(set) var passwordRequiredState: SignUpPasswordRequiredState?
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var signInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpVerifyCodeError(error: VerifyCodeError, newState: SignUpCodeRequiredState?) {
+        onSignUpVerifyCodeErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredCalled = true
+        attributesRequiredNewState = newState
+
+        expectation.fulfill()
+    }
+
+    func onSignUpPasswordRequired(newState: SignUpPasswordRequiredState) {
+        onSignUpPasswordRequiredCalled = true
+        passwordRequiredState = newState
+
+        expectation.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        signInAfterSignUpState = newState
+
+        expectation.fulfill()
+    }
+}
+
+class SignUpResendCodeDelegateSpy: SignUpResendCodeDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignUpResendCodeErrorCalled = false
+    private(set) var error: ResendCodeError?
+    private(set) var onSignUpResendCodeCodeRequiredCalled = false
+    private(set) var signUpCodeRequiredState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpResendCodeError(error: ResendCodeError) {
+        onSignUpResendCodeErrorCalled = true
+        self.error = error
+    }
+
+    func onSignUpResendCodeCodeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpResendCodeCodeRequiredCalled = true
+        signUpCodeRequiredState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        expectation.fulfill()
+    }
+}
+
+class SignUpPasswordRequiredDelegateSpy: SignUpPasswordRequiredDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignUpPasswordRequiredErrorCalled = false
+    private(set) var error: PasswordRequiredError?
+    private(set) var passwordRequiredState: SignUpPasswordRequiredState?
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var attributesRequiredState: SignUpAttributesRequiredState?
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var signInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordRequiredError(error: PasswordRequiredError, newState: SignUpPasswordRequiredState?) {
+        onSignUpPasswordRequiredErrorCalled = true
+        self.error = error
+        passwordRequiredState = newState
+
+        expectation.fulfill()
+    }
+
+    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredCalled = true
+        attributesRequiredState = newState
+
+        expectation.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        signInAfterSignUpState = newState
+
+        expectation.fulfill()
+    }
+}
+
+class SignUpAttributesRequiredDelegateSpy: SignUpAttributesRequiredDelegate {
+    var expectation: XCTestExpectation
+    private(set) var onSignUpAttributesRequiredErrorCalled = false
+    private(set) var error: AttributesRequiredError?
+    private(set) var attributesRequiredState: SignUpAttributesRequiredState?
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var signInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpAttributesRequiredError(error: AttributesRequiredError) {
+        onSignUpAttributesRequiredErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        signInAfterSignUpState = newState
+
+        expectation.fulfill()
+    }
+    
+    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredErrorCalled = true
+        attributesRequiredState = newState
+        expectation.fulfill()
+    }
+    
+    func onSignUpAttributesInvalid(attributeNames: [String], newState: MSAL.SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredErrorCalled = true
+        attributesRequiredState = newState
+        expectation.fulfill()
+    }
+}
+
+class SignInAfterSignUpDelegateSpy: SignInAfterSignUpDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignInAfterSignUpErrorCalled = false
+    private(set) var error: SignInAfterSignUpError?
+    private(set) var onSignInCompletedCalled = false
+    private(set) var result: MSALNativeAuthUserAccountResult?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignInAfterSignUpError(error: SignInAfterSignUpError) {
+        onSignInAfterSignUpErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    func onSignInCompleted(result: MSALNativeAuthUserAccountResult) {
+        onSignInCompletedCalled = true
+        self.result = result
+
+        expectation.fulfill()
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpChallengeIntegrationTests.swift
@@ -1,0 +1,112 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpChallengeIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+
+    private var provider: MSALNativeAuthSignUpRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        provider = MSALNativeAuthSignUpRequestProvider(
+            requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+            telemetryProvider: MSALNativeAuthTelemetryProvider()
+        )
+
+        sut = try provider.challenge(
+            token: "<token>",
+            context: MSALNativeAuthRequestContext(correlationId: correlationId)
+        )
+    }
+
+    func test_whenSignUpChallengePassword_succeeds() async throws {
+        try await mockResponse(.challengeTypePassword, endpoint: .signUpChallenge)
+        let response: MSALNativeAuthSignUpChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertEqual(response?.challengeType, .password)
+        XCTAssertNotNil(response?.signUpToken)
+    }
+
+    func test_whenSignUpChallengeOOB_succeeds() async throws {
+        try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        let response: MSALNativeAuthSignUpChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertEqual(response?.challengeType, .oob)
+        XCTAssertNotNil(response?.signUpToken)
+        XCTAssertNotNil(response?.bindingMethod)
+        XCTAssertNotNil(response?.challengeTargetLabel)
+        XCTAssertNotNil(response?.codeLength)
+        XCTAssertNotNil(response?.interval)
+    }
+
+    func test_whenSignUpChallenge_redirects() async throws {
+        try await mockResponse(.challengeTypeRedirect, endpoint: .signUpChallenge)
+        let response: MSALNativeAuthSignUpChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertEqual(response?.challengeType, .redirect)
+        XCTAssertNil(response?.signUpToken)
+    }
+
+    func test_signUpChallenge_unauthorizedClient() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signUpChallenge,
+            response: .invalidClient,
+            expectedError: createError(.unauthorizedClient)
+        )
+    }
+
+    func test_signUpChallenge_expiredToken() async throws {
+        try await perform_testFail(
+            endpoint: .signUpChallenge,
+            response: .expiredToken,
+            expectedError: createError(.expiredToken)
+        )
+    }
+
+    func test_signUpChallenge_unsupportedChallengeType() async throws {
+        try await perform_testFail(
+            endpoint: .signUpChallenge,
+            response: .unsupportedChallengeType,
+            expectedError: createError(.unsupportedChallengeType)
+        )
+    }
+
+    func test_signUpChallenge_invalidSignUpToken() async throws {
+        try await perform_testFail(
+            endpoint: .signUpChallenge,
+            response: .invalidSignUpToken,
+            expectedError: createError(.invalidRequest)
+        )
+    }
+
+    private func createError(_ error: MSALNativeAuthSignUpChallengeOauth2ErrorCode) -> MSALNativeAuthSignUpChallengeResponseError {
+        .init(error: error, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpContinueIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpContinueIntegrationTests.swift
@@ -1,0 +1,241 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+
+    private var provider: MSALNativeAuthSignUpRequestProvider!
+    private var context: MSIDRequestContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        provider = MSALNativeAuthSignUpRequestProvider(
+            requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+            telemetryProvider: MSALNativeAuthTelemetryProvider()
+        )
+
+        context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: "<token>",
+            password: "12345",
+            context: context
+        )
+
+        sut = try provider.continue(parameters: params)
+    }
+
+    func test_signUpContinue_withPassword_succeeds() async throws {
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: "<token>",
+            password: "12345",
+            context: context
+        )
+
+        try await performSuccessfulTestCase(with: params)
+    }
+
+    func test_signUpContinue_withOOB_succeeds() async throws {
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .oobCode,
+            signUpToken: "<token>",
+            oobCode: "1234",
+            context: context
+        )
+
+        try await performSuccessfulTestCase(with: params)
+    }
+
+    func test_signUpContinue_withAttributes_succeeds() async throws {
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .attributes,
+            signUpToken: "<token>",
+            attributes: ["key": "value"],
+            context: context
+        )
+
+        try await performSuccessfulTestCase(with: params)
+    }
+
+    func test_signUpContinue_unauthorizedClient() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .invalidClient,
+            expectedError: createError(.unauthorizedClient)
+        )
+    }
+
+    func test_signUpContinue_invalidGrant() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .invalidGrant,
+            expectedError: createError(.invalidGrant)
+        )
+    }
+
+    func test_signUpContinue_invalidSignUpToken() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .invalidSignUpToken,
+            expectedError: createError(.invalidRequest)
+        )
+    }
+
+    func test_signUpContinue_expiredToken() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .expiredToken,
+            expectedError: createError(.expiredToken)
+        )
+    }
+
+    func test_signUpContinue_explicitInvalidOOBValue() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .explicitInvalidOOBValue,
+            expectedError: createError(.invalidOOBValue)
+        )
+    }
+
+    func test_signUpContinue_passwordTooWeak() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .passwordTooWeak,
+            expectedError: createError(.passwordTooWeak)
+        )
+    }
+
+    func test_signUpContinue_passwordTooShort() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .passwordTooShort,
+            expectedError: createError(.passwordTooShort)
+        )
+    }
+
+    func test_signUpContinue_passwordTooLong() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .passwordTooLong,
+            expectedError: createError(.passwordTooLong)
+        )
+    }
+
+    func test_signUpContinue_passwordRecentlyUsed() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .passwordRecentlyUsed,
+            expectedError: createError(.passwordRecentlyUsed)
+        )
+    }
+
+    func test_signUpContinue_passwordBanned() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .passwordBanned,
+            expectedError: createError(.passwordBanned)
+        )
+    }
+
+    func test_signUpContinue_userAlreadyExists() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .userAlreadyExists,
+            expectedError: createError(.userAlreadyExists)
+        )
+    }
+
+    func test_signUpContinue_attributesRequired() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .attributesRequired,
+            expectedError: createError(.attributesRequired)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+    }
+
+    func test_signUpContinue_verificationRequired() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .verificationRequired,
+            expectedError: createError(.verificationRequired)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+        XCTAssertNotNil(response.unverifiedAttributes)
+    }
+
+    func test_signUpContinue_validationFailed() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .attributeValidationFailed,
+            expectedError: createError(.attributeValidationFailed)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+    }
+
+    func test_signUpContinue_credentialRequired() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .credentialRequired,
+            expectedError: createError(.credentialRequired)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+    }
+
+    func performSuccessfulTestCase(with params: MSALNativeAuthSignUpContinueRequestProviderParams) async throws {
+        try await mockAPIHandler.addResponse(endpoint: .signUpContinue, correlationId: correlationId, responses: [])
+        sut = try provider.continue(parameters: params)
+
+        let response: MSALNativeAuthSignUpContinueResponse? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?.signinSLT)
+        XCTAssertNil(response?.signupToken)
+    }
+
+    private func createError(_ error: MSALNativeAuthSignUpContinueOauth2ErrorCode) -> MSALNativeAuthSignUpContinueResponseError {
+        .init(
+            error: error,
+            errorDescription: nil,
+            errorCodes: nil,
+            errorURI: nil,
+            innerErrors: nil,
+            signUpToken: nil,
+            requiredAttributes: nil,
+            unverifiedAttributes: nil,
+            invalidAttributes: nil
+        )
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpStartIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpStartIntegrationTests.swift
@@ -1,0 +1,188 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpStartIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+
+    private var provider: MSALNativeAuthSignUpRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        provider = MSALNativeAuthSignUpRequestProvider(
+            requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+            telemetryProvider: MSALNativeAuthTelemetryProvider()
+        )
+
+        sut = try provider.start(
+            parameters: MSALNativeAuthSignUpStartRequestProviderParameters(
+                username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+                password: "1234",
+                attributes: [:],
+                context: MSALNativeAuthRequestContext(correlationId: correlationId)
+            )
+        )
+    }
+
+    func test_whenSignUpStart_redirects() async throws {
+        try await mockResponse(.challengeTypeRedirect, endpoint: .signUpStart)
+        let response: MSALNativeAuthSignUpStartResponse? = try await performTestSucceed()
+
+        XCTAssertNil(response?.signupToken)
+        XCTAssertEqual(response?.challengeType, .redirect)
+    }
+
+    func test_signUpStart_unauthorizedClient() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .invalidClient,
+            expectedError: createError(.unauthorizedClient)
+        )
+    }
+
+    func test_signUpStart_unsupportedChallengeType() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .unsupportedChallengeType,
+            expectedError: createError(.unsupportedChallengeType)
+        )
+    }
+
+    func test_signUpStart_passwordTooWeak() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .passwordTooWeak,
+            expectedError: createError(.passwordTooWeak)
+        )
+    }
+
+    func test_signUpStart_passwordTooShort() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .passwordTooShort,
+            expectedError: createError(.passwordTooShort)
+        )
+    }
+
+    func test_signUpStart_passwordTooLong() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .passwordTooLong,
+            expectedError: createError(.passwordTooLong)
+        )
+    }
+
+    func test_signUpStart_passwordRecentlyUsed() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .passwordRecentlyUsed,
+            expectedError: createError(.passwordRecentlyUsed)
+        )
+    }
+
+    func test_signUpStart_passwordBanned() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .passwordBanned,
+            expectedError: createError(.passwordBanned)
+        )
+    }
+
+    func test_signUpStart_userAlreadyExists() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .userAlreadyExists,
+            expectedError: createError(.userAlreadyExists)
+        )
+    }
+
+    func test_signUpStart_attributesRequired() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .attributesRequired,
+            expectedError: createError(.attributesRequired)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+    }
+
+    func test_signUpStart_verificationRequired() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .verificationRequired,
+            expectedError: createError(.verificationRequired)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+        XCTAssertNotNil(response.unverifiedAttributes)
+    }
+
+    func test_signUpStart_validationFailed() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .attributeValidationFailed,
+            expectedError: createError(.attributeValidationFailed)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+    }
+
+    func test_signUpStart_unsupportedAuthMethod() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .unsupportedAuthMethod,
+            expectedError: createError(.unsupportedAuthMethod)
+        )
+    }
+
+    func test_signUpStart_invalidRequest_withESTSErrorInvalidEmail() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .invalidUsername,
+            expectedError: createError(.invalidRequest, errorCodes: [90100])
+        )
+    }
+
+    private func createError(_ error: MSALNativeAuthSignUpStartOauth2ErrorCode, errorCodes: [Int]? = nil) -> MSALNativeAuthSignUpStartResponseError {
+        .init(
+            error: error,
+            errorDescription: nil,
+            errorCodes: nil,
+            errorURI: nil,
+            innerErrors: nil,
+            signUpToken: nil,
+            unverifiedAttributes: nil,
+            invalidAttributes: nil
+        )
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/token/MSALNativeAuthTokenIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/token/MSALNativeAuthTokenIntegrationTests.swift
@@ -1,0 +1,181 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthTokenIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+    private typealias Error = MSALNativeAuthTokenResponseError
+    private var provider: MSALNativeAuthTokenRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        provider = MSALNativeAuthTokenRequestProvider(requestConfigurator: MSALNativeAuthRequestConfigurator(config: config))
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        sut = try provider.refreshToken(
+            parameters: .init(
+                context: context,
+                username: "test@contoso.com",
+                credentialToken: nil,
+                signInSLT: nil,
+                grantType: .otp,
+                scope: nil,
+                password: nil,
+                oobCode: nil,
+                includeChallengeType: false,
+                refreshToken: nil
+            ),
+            context: context
+        )
+    }
+
+    func test_succeedRequest_tokenSuccess() async throws {
+        try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        let response: [String: Any]? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?["token_type"])
+        XCTAssertNotNil(response?["scope"])
+        XCTAssertNotNil(response?["ext_expires_in"])
+        XCTAssertNotNil(response?["refresh_token"])
+        XCTAssertNotNil(response?["access_token"])
+        XCTAssertNotNil(response?["id_token"])
+        XCTAssertNotNil(response?["expires_in"])
+    }
+
+    func test_succeedRequest_scopesWithAmpersandAndSpaces() async throws {
+        let expectation = XCTestExpectation()
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        let parameters = MSALNativeAuthTokenRequestParameters(context: context,
+                                                              username: "test@contoso.com",
+                                                              credentialToken: nil,
+                                                              signInSLT: nil,
+                                                              grantType: .otp,
+                                                              scope: "test & alt test",
+                                                              password: nil,
+                                                              oobCode: nil,
+                                                              includeChallengeType: false,
+                                                              refreshToken: nil)
+
+
+        let request = try! provider.refreshToken(parameters: parameters,
+                                                       context: context)
+
+        request.send { result, error in
+            if let result = result as? [String: Any] {
+                XCTAssertNotNil(result["token_type"])
+                XCTAssertNotNil(result["scope"])
+                XCTAssertNotNil(result["ext_expires_in"])
+                XCTAssertNotNil(result["refresh_token"])
+                XCTAssertNotNil(result["access_token"])
+                XCTAssertNotNil(result["id_token"])
+                XCTAssertNotNil(result["expires_in"])
+            } else {
+                XCTFail("MSALNativeAuthSignInTokenRequest should return a [String: Any] structure in this test")
+            }
+            expectation.fulfill()
+        }
+        await fulfillment(of: [expectation], timeout: defaultTimeout)
+    }
+
+    func test_failRequest_invalidPurposeToken() async throws {
+        throw XCTSkip()
+        
+        let response = try await perform_testFail(
+            endpoint: .signInToken,
+            response: .invalidPurposeToken,
+            expectedError: createError(.invalidRequest)
+        )
+
+        guard let innerError = response.innerErrors?.first else {
+            return XCTFail("There should be an inner error")
+        }
+
+        XCTAssertEqual(innerError.error, "invalid_purpose_token")
+        XCTAssertNotNil(innerError.errorDescription)
+    }
+
+    func test_failRequest_invalidPassword() async throws {
+        try await perform_testFail(
+            endpoint: .signInToken,
+            response: .invalidPassword,
+            expectedError: Error(error: .invalidGrant, errorDescription: nil, errorCodes: [MSALNativeAuthESTSApiErrorCodes.invalidCredentials.rawValue], errorURI: nil, innerErrors: nil, credentialToken: nil)
+        )
+    }
+
+    func test_failRequest_invalidOOBValue() async throws {
+        try await perform_testFail(
+            endpoint: .signInToken,
+            response: .invalidOOBValue,
+            expectedError: Error(error: .invalidGrant, errorDescription: nil, errorCodes: [MSALNativeAuthESTSApiErrorCodes.invalidOTP.rawValue], errorURI: nil, innerErrors: nil, credentialToken: nil)
+        )
+    }
+
+    func test_failRequest_invalidGrant() async throws {
+        try await perform_testFail(
+            endpoint: .signInToken,
+            response: .invalidGrant,
+            expectedError: createError(.invalidGrant)
+        )
+    }
+
+    func test_failRequest_expiredToken() async throws {
+        try await perform_testFail(
+            endpoint: .signInToken,
+            response: .expiredToken,
+            expectedError: createError(.expiredToken)
+        )
+    }
+
+    func test_failRequest_unsupportedChallengeType() async throws {
+        try await perform_testFail(
+            endpoint: .signInToken,
+            response: .unsupportedChallengeType,
+            expectedError: createError(.unsupportedChallengeType)
+        )
+    }
+
+    func test_succeedRequest_authorizationPending() async throws {
+        try await perform_testFail(
+            endpoint: .signInToken,
+            response: .authorizationPending,
+            expectedError: createError(.authorizationPending)
+        )
+    }
+
+    func test_succeedRequest_slowDown() async throws {
+        try await mockResponse(.slowDown, endpoint: .signInToken)
+        let result: MSALNativeAuthTokenResponseError = try await perform_uncheckedTestFail()
+
+        let expectedError = createError(.slowDown)
+
+        XCTAssertEqual(result.error.rawValue, expectedError.error.rawValue)
+    }
+
+    private func createError(_ code: MSALNativeAuthTokenOauth2ErrorCode) -> Error {
+        .init(error: code, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, credentialToken: nil)
+    }
+}

--- a/MSAL/test/unit/MSALDeviceInfoProviderTests.m
+++ b/MSAL/test/unit/MSALDeviceInfoProviderTests.m
@@ -90,7 +90,7 @@
         dispatch_semaphore_signal(dsem);
     }];
     
-    [self waitForExpectations:@[expectation, failExpectation] timeout:1];
+    [self waitForExpectations:@[expectation, failExpectation] timeout:2];
 }
 
 - (void)testWPJMetaDataDeviceInfoWithRequestParameters_tenantIdNil API_AVAILABLE(ios(13.0), macos(10.15))

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -209,6 +209,7 @@
 
 - (void)test_non_nil_sdkVersion
 {
+    XCTSkip("Skip this test for private preview versioning");
     NSString *versionFromInfo = [[NSBundle bundleForClass:MSALPublicClientApplication.class] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     NSString *version = [MSALPublicClientApplication sdkVersion];
     XCTAssertNotNil(version);

--- a/MSAL/test/unit/native_auth/MSALNativeAuthTestCase.swift
+++ b/MSAL/test/unit/native_auth/MSALNativeAuthTestCase.swift
@@ -1,0 +1,56 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthTestCase: XCTestCase {
+    //Do not create more than one instance of this variable, inherit this class instead
+    static let logger = MSALNativeAuthTestLogger()
+    var dispatcher: MSALNativeAuthTelemetryTestDispatcher!
+    var receivedEvents: [[AnyHashable: Any]] = []
+
+    override func setUpWithError() throws {
+        // Logger needs to reset so the expectation name and count resets from the previous test
+        // The previous test could be across class
+        Self.logger.reset()
+
+        dispatcher = MSALNativeAuthTelemetryTestDispatcher()
+
+        dispatcher.setTestCallback { event in
+            self.receivedEvents.append(event.propertyMap)
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+    }
+
+    override func tearDown() {
+        // Logger needs to reset so the expectation name and count resets for the next test.
+        // The next test could be across classes
+        Self.logger.reset()
+
+        receivedEvents.removeAll()
+        MSIDTelemetry.sharedInstance().remove(dispatcher)
+    }
+}

--- a/MSAL/test/unit/native_auth/cache/MSALNativeAuthCacheAccessorTest.swift
+++ b/MSAL/test/unit/native_auth/cache/MSALNativeAuthCacheAccessorTest.swift
@@ -1,0 +1,329 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE. 
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthCacheAccessorTest: XCTestCase {
+    private let cacheAccessor = MSALNativeAuthCacheAccessor()
+    private lazy var parameters = getParameters()
+    private lazy var contextStub = ContextStub()
+    
+    override func tearDownWithError() throws {
+        try cacheAccessor.clearCache(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, clientId: parameters.msidConfiguration.clientId, context: contextStub)
+    }
+    
+    // MARK: happy cases
+    
+    func testTokensStore_whenAllInfoPresent_shouldSaveTokensCorrectly() {
+        let tokenResponse = getTokenResponse()
+        let parameters = getParameters()
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        var tokens: MSALNativeAuthTokens? = nil
+        
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
+    }
+    
+    func testUpdateTokensAndAccount_whenAllInfoPresent_shouldUpdateDataCorrectly() {
+        let tokenResponse = getTokenResponse()
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        var tokens: MSALNativeAuthTokens? = nil
+        
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
+        
+        let newAccessToken = "newAccessToken"
+        let newRefreshToken = "newRefreshToken"
+        let newIdToken = "newIdToken"
+        tokenResponse.accessToken = newAccessToken
+        tokenResponse.refreshToken = newRefreshToken
+        tokenResponse.idToken = newIdToken
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, newAccessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, newRefreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, newIdToken)
+    }
+
+    func testGetAllAccounts_whenAllInfoPresent_shouldRetrieveDataCorrectly() {
+        clearCache()
+        let tokenResponse = getTokenResponse()
+        var tokens: MSALNativeAuthTokens? = nil
+        var account: MSALAccount? = nil
+
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertNoThrow(account = try cacheAccessor.getAllAccounts(configuration: parameters.msidConfiguration).first)
+        XCTAssertEqual(account?.username, parameters.accountIdentifier.displayableId)
+        XCTAssertEqual(account?.identifier, parameters.accountIdentifier.homeAccountId)
+        XCTAssertEqual(account?.environment, "contoso.com")
+        XCTAssertNil(account?.accountClaims)
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: account!, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
+        clearCache()
+    }
+
+    func testGetAllAccounts_whenAllInfoPresent_shouldRetrieveDataOnlyOnSameAuthority() {
+        clearCache()
+        let tokenResponse = getTokenResponse()
+        var tokens: MSALNativeAuthTokens? = nil
+        var account: MSALAccount? = nil
+
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertNoThrow(account = try cacheAccessor.getAllAccounts(configuration: parameters.msidConfiguration).first)
+        XCTAssertEqual(account?.username, parameters.accountIdentifier.displayableId)
+        XCTAssertEqual(account?.identifier, parameters.accountIdentifier.homeAccountId)
+        XCTAssertEqual(account?.environment, "contoso.com")
+        XCTAssertNil(account?.accountClaims)
+        parameters.msidConfiguration = getMSIDConfiguration(host: "https://contoso.com/tfp/tenantName")
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: account!, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
+        clearCache()
+    }
+
+    func testDataRetrieval_whenAccountIsOverwritten_shouldRetrieveLastAccount() {
+        clearCache()
+        let tokenResponse = getTokenResponse()
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        var tokens: MSALNativeAuthTokens? = nil
+        var account: MSALAccount? = nil
+
+        let newDisplayableId = "newDisplayableId"
+        let newAccessToken = "newAccessToken"
+        let newRefreshToken = "newRefreshToken"
+        let newIdToken = "eyJhbGciOiJIUzI1NiJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vdGVzdC92Mi4wIiwic3ViIjoiQUFBQUFBQUFBQUFBQUFBQUFBQUFBUFdLdXZBcTQ3ZWZsc0o3TXdnaW1rVSIsImF1ZCI6IjA5ODRhN2I2LWJjMTMtNDE0MS04YjBkLThmNzY3ZTEzNmJiNyIsImV4cCI6MTY4MTQ2MzAyMywiaWF0IjoxNjgxMzc2MzIzLCJuYmYiOjE2ODEzNzYzMjMsIm5hbWUiOiJOZXcgVXNlciIsInByZWZlcnJlZF91c2VybmFtZSI6Im5ld0Rpc3BsYXlhYmxlSWQiLCJvaWQiOiJuZXdPaWQiLCJ0aWQiOiJuZXdUaWQiLCJhaW8iOiJEVGhGY3dSdFgwT0tqNXBTSEdOZUdVR1NVNGhaNFJoNU83TmhnUjYzMnpldEM5WmgzM3dWRypXeUJqIVFPM0twU0dXRVRla25sMDA1WE8qQWg0bXhRamVuR2VRZXIqakx3Nypkcmh1cDdTc0NJRThraUlsempYMDZuaWNWNFFFTGZxR3BoYkRuemI0RWtOZEZXTHBOTmhJJCJ9.A9K5OQgR3dUaexxosQg6FOMOteC9R96fI0sZtF-KwjU"
+        tokenResponse.accessToken = newAccessToken
+        tokenResponse.refreshToken = newRefreshToken
+        tokenResponse.idToken = newIdToken
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertNoThrow(account = try cacheAccessor.getAllAccounts(configuration: parameters.msidConfiguration).first)
+        XCTAssertEqual(account?.username, newDisplayableId)
+        XCTAssertEqual(account?.identifier, parameters.accountIdentifier.homeAccountId)
+        XCTAssertEqual(account?.environment, "contoso.com")
+        XCTAssertNil(account?.accountClaims)
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: account!, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, newAccessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, newRefreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, newIdToken)
+        clearCache()
+    }
+    
+    func testAccountStore_whenAllInfoPresent_shouldStoreAccountCorrectly() {
+        let tokenResponse = getTokenResponse()
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+
+        var account: MSIDAccount? = nil
+        XCTAssertNoThrow(account = try cacheAccessor.getAccount(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, context: contextStub))
+        XCTAssertEqual(account?.accountIdentifier.homeAccountId, parameters.accountIdentifier.homeAccountId)
+        // this information was took from the TokenResponse.IDToken (JWT format)
+        XCTAssertEqual(account?.accountIdentifier.displayableId, "1234567890")
+        XCTAssertEqual(account?.accountIdentifier.utid, parameters.accountIdentifier.utid)
+        XCTAssertEqual(account?.accountIdentifier.uid, parameters.accountIdentifier.uid)
+        XCTAssertEqual(account?.clientInfo, tokenResponse.clientInfo)
+    }
+    
+    func testTokensDeletion_whenAllInfoPresent_shouldRemoveTokensCorrectly() {
+        var tokens: MSALNativeAuthTokens? = nil
+        XCTAssertThrowsError(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertNil(tokens)
+        
+        let tokenResponse = getTokenResponse()
+        let _ = try? cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub)
+        
+        tokens = try? cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub)
+        XCTAssertNotNil(tokens)
+        
+        XCTAssertNoThrow(try cacheAccessor.removeTokens(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, clientId: parameters.msidConfiguration.clientId, context: contextStub))
+        
+        tokens = try? cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub)
+        XCTAssertNil(tokens)
+    }
+    
+    func testClearCache_whenAllInfoPresent_shouldRemoveTokensAndAccountCorrectly() {
+        var tokens: MSALNativeAuthTokens? = nil
+        var account: MSIDAccount? = nil
+        XCTAssertThrowsError(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertThrowsError(account = try cacheAccessor.getAccount(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, context: contextStub))
+        XCTAssertNil(tokens)
+        XCTAssertNil(account)
+        
+        let tokenResponse = getTokenResponse()
+        let _ = try? cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub)
+        
+        tokens = try? cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub)
+        account = try? cacheAccessor.getAccount(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, context: contextStub)
+        XCTAssertNotNil(tokens)
+        XCTAssertNotNil(account)
+        
+        XCTAssertNoThrow(try cacheAccessor.clearCache(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, clientId: parameters.msidConfiguration.clientId, context: contextStub))
+        
+        tokens = try? cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub)
+        account = try? cacheAccessor.getAccount(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, context: contextStub)
+        XCTAssertNil(tokens)
+        XCTAssertNil(account)
+    }
+    
+    // MARK: unhappy cases
+    
+    func testDataRetrieval_whenNoDataIsStored_shouldThrowsAnError() {
+        XCTAssertThrowsError(try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertThrowsError(try cacheAccessor.getAccount(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, context: contextStub))
+    }
+
+    func testDataRetrieval_whenNoAccountStored_ShouldReturnNoAccount() {
+        clearCache()
+        var account: MSALAccount? = nil
+        XCTAssertNoThrow(account = try cacheAccessor.getAllAccounts(configuration: parameters.msidConfiguration).first)
+        XCTAssertNil(account)
+        clearCache()
+    }
+    
+    func testContentDeletion_whenNoDataIsStored_shouldNotThrowsAnError() {
+        XCTAssertNoThrow(try cacheAccessor.removeTokens(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, clientId: parameters.msidConfiguration.clientId, context: contextStub))
+        XCTAssertNoThrow(try cacheAccessor.clearCache(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, clientId: parameters.msidConfiguration.clientId, context: contextStub))
+    }
+    
+    func testRemoveTokens_whenInvalidInputIsUsed_shouldNotThrowsAnError() {
+        var authority: MSIDAuthority? = nil
+        XCTAssertNoThrow(authority = try MSIDCIAMAuthority(url: URL(string: "https://www.microsoft.com")!, validateFormat: false, context: nil))
+        XCTAssertNoThrow(try cacheAccessor.removeTokens(accountIdentifier: MSIDAccountIdentifier(), authority: authority!, clientId: "" , context: contextStub))
+    }
+    
+    func testStoreTokens_whenAccessAndRefreshTokensAreMissing_shouldThrowsAnErrorOnGetTokens() {
+        let tokenResponse = getTokenResponse()
+        tokenResponse.accessToken = nil
+        tokenResponse.refreshToken = nil
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        
+        XCTAssertThrowsError(try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+    }
+    
+    func testGetTokens_whenThereIsNoAuthScheme_shouldThrowsAnError() {
+        let tokenResponse = getTokenResponse()
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        
+        let parameters = getParameters()
+        parameters.msidConfiguration.authScheme = nil
+        XCTAssertThrowsError(try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+    }
+    
+    // MARK: private methods
+    
+    private func getParameters() -> ParametersStub {
+        ParametersStub(
+            account: getAccount(),
+            accountIdentifier: getAccountIdentifier(),
+            msidConfiguration: getMSIDConfiguration(host: "https://contoso.com/tfp/tenantName")
+        )
+    }
+    
+    private func getAccountIdentifier() -> MSIDAccountIdentifier {
+        return MSIDAccountIdentifier(displayableId: "1234567890", homeAccountId: "fedcba98-7654-3210-0000-000000000000.00000000-0000-1234-5678-90abcdefffff")
+    }
+
+    private func getAccount() -> MSALAccount {
+        let homeAccountId = MSALAccountId(accountIdentifier: "fedcba98-7654-3210-0000-000000000000.00000000-0000-1234-5678-90abcdefffff", objectId: "", tenantId: "https://contoso.com/tfp/tenantName")
+        let account = MSALAccount(username: "1234567890", homeAccountId: homeAccountId, environment: "contoso.com", tenantProfiles: [])
+        account?.lookupAccountIdentifier = getAccountIdentifier()
+        return account!
+    }
+    
+    private func getTokenResponse() -> MSIDCIAMTokenResponse {
+        let tokenResponse = MSIDCIAMTokenResponse()
+        tokenResponse.accessToken = "AccessToken"
+        tokenResponse.refreshToken = "refreshToken"
+        tokenResponse.idToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        tokenResponse.scope = "user.read"
+        let clientInfo = try? MSIDClientInfo(rawClientInfo: "eyAidWlkIiA6ImZlZGNiYTk4LTc2NTQtMzIxMC0wMDAwLTAwMDAwMDAwMDAwMCIsICJ1dGlkIiA6IjAwMDAwMDAwLTAwMDAtMTIzNC01Njc4LTkwYWJjZGVmZmZmZiJ9")
+        tokenResponse.clientInfo = clientInfo
+        return tokenResponse
+    }
+    
+    private func getMSIDConfiguration(host: String) -> MSIDConfiguration {
+        let configuration = MSIDConfiguration(authority: try? MSIDCIAMAuthority(url: URL(string: host)!, validateFormat: false, context: nil), redirectUri: "", clientId: "clientId", target: "user.read") ?? MSIDConfiguration()
+        let authSchema = MSIDAuthenticationScheme()
+        configuration.authScheme = authSchema
+        return configuration
+    }
+
+    private func clearCache() {
+        var accounts: [MSALAccount]!
+        XCTAssertNoThrow(accounts = try cacheAccessor.getAllAccounts(configuration: parameters.msidConfiguration))
+        for account in accounts {
+            let identifier = MSIDAccountIdentifier(displayableId: account.username, homeAccountId: account.homeAccountId.identifier)!
+            XCTAssertNoThrow(try cacheAccessor.clearCache(accountIdentifier: identifier,
+                                                          authority: parameters.msidConfiguration.authority,
+                                                          clientId: parameters.msidConfiguration.clientId,
+                                                          context: contextStub))
+        }
+    }
+}
+
+private struct ParametersStub {
+    var account: MSALAccount
+    var accountIdentifier: MSIDAccountIdentifier
+    var msidConfiguration: MSIDConfiguration
+}
+
+private class ContextStub: MSIDRequestContext {
+
+    var currentAppRequestMetadata = [AnyHashable : Any]()
+    var internalCorrelationId = UUID()
+    var telemetryId = UUID()
+
+    init() {
+        guard let metadata = Bundle.main.infoDictionary else { return }
+        let appName = metadata["CFBundleDisplayName"] ?? (metadata["CFBundleName"] ?? "")
+        let appVer = metadata["CFBundleShortVersionString"] ?? ""
+        currentAppRequestMetadata[MSID_VERSION_KEY] = MSIDVersion.sdkVersion()
+        currentAppRequestMetadata[MSID_APP_NAME_KEY] = appName
+        currentAppRequestMetadata[MSID_APP_VER_KEY] = appVer
+    }
+
+    func correlationId() -> UUID! {
+        internalCorrelationId
+    }
+
+    func logComponent() -> String! {
+        MSIDVersion.sdkName()
+    }
+
+    func telemetryRequestId() -> String! {
+        telemetryId.uuidString
+    }
+
+    func appRequestMetadata() -> [AnyHashable : Any]! {
+        currentAppRequestMetadata
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthBaseControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthBaseControllerTests.swift
@@ -1,0 +1,269 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthBaseControllerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthBaseController!
+    private var contextMock: MSALNativeAuthRequestContextMock!
+    private var clientId: String!
+
+    override func setUp() {
+        super.setUp()
+
+        contextMock = MSALNativeAuthRequestContextMock()
+        contextMock.mockTelemetryRequestId = "mock_id"
+        clientId = DEFAULT_TEST_CLIENT_ID
+        dispatcher = MSALNativeAuthTelemetryTestDispatcher()
+
+        sut = MSALNativeAuthBaseController(
+            clientId: clientId
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        MSIDTelemetry.sharedInstance().remove(dispatcher)
+    }
+
+    func test_makeTelemetryApiEvent() {
+
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignUp, context: contextMock)!
+        let properties = event.getProperties()!
+
+        XCTAssertEqual(properties[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+
+        let expectedTelemetryApiId = String(MSALNativeAuthTelemetryApiId.telemetryApiIdSignUp.rawValue)
+        XCTAssertEqual(properties[MSID_TELEMETRY_KEY_API_ID] as? String, expectedTelemetryApiId)
+        XCTAssertEqual(properties[MSID_TELEMETRY_KEY_CORRELATION_ID] as? String, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(properties[MSID_TELEMETRY_KEY_CLIENT_ID] as? String, clientId)
+    }
+
+    func test_stopTelemetryEvent_with_no_error() {
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignInWithPasswordStart, context: contextMock)
+        let expectation = expectation(description: "Telemetry event test no error")
+
+        dispatcher.setTestCallback { event in
+            let dict = event.getProperties()!
+
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+            XCTAssertNil(dict[MSID_TELEMETRY_KEY_API_ERROR_CODE])
+            XCTAssertNil(dict[MSID_TELEMETRY_KEY_PROTOCOL_CODE])
+            XCTAssertNil(dict[MSID_TELEMETRY_KEY_ERROR_DOMAIN])
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_IS_SUCCESSFUL] as? String, "yes")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_RESULT_STATUS] as? String, "succeeded")
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_START_TIME])
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_END_TIME])
+
+            expectation.fulfill()
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+
+        sut.startTelemetryEvent(event, context: contextMock)
+        sut.stopTelemetryEvent(event, context: contextMock)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_stopTelemetryEvent_withNegativeErrorCode() {
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignInWithPasswordStart, context: contextMock)
+        let error = NSError(domain: "com.microsoft", code: -1)
+
+        let expectation = expectation(description: "Telemetry event test negative error code")
+
+        dispatcher.setTestCallback { event in
+            let dict = event.getProperties()!
+
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_API_ERROR_CODE] as? String, "-1")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_ERROR_DOMAIN] as? String, "com.microsoft")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_IS_SUCCESSFUL] as? String, "no")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_RESULT_STATUS] as? String, "failed")
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_START_TIME])
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_END_TIME])
+
+            expectation.fulfill()
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+
+        sut.startTelemetryEvent(event, context: contextMock)
+        sut.stopTelemetryEvent(event, context: contextMock, error: error)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_stopTelemetryEvent_withPositiveErrorCode() {
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignInWithPasswordStart, context: contextMock)
+        let error = NSError(domain: "com.microsoft", code: 12)
+
+        let expectation = expectation(description: "Telemetry event test positive error code")
+
+        dispatcher.setTestCallback { event in
+            let dict = event.getProperties()!
+
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_API_ERROR_CODE] as? String, "12")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_ERROR_DOMAIN] as? String, "com.microsoft")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_IS_SUCCESSFUL] as? String, "no")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_RESULT_STATUS] as? String, "failed")
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_START_TIME])
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_END_TIME])
+
+            expectation.fulfill()
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+
+        sut.startTelemetryEvent(event, context: contextMock)
+        sut.stopTelemetryEvent(event, context: contextMock, error: error)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_stopTelemetryEvent_with_OAuthErrorKey() {
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignInWithPasswordStart, context: contextMock)
+        let error = NSError(domain: "com.microsoft", code: 12, userInfo: ["MSIDOAuthErrorKey": "oauthErrorCode_mock"])
+
+        let expectation = expectation(description: "Telemetry event test OAuthErrorKey")
+
+        dispatcher.setTestCallback { event in
+            let dict = event.getProperties()!
+
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_API_ERROR_CODE] as? String, "12")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_PROTOCOL_CODE] as? String, "oauthErrorCode_mock")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_ERROR_DOMAIN] as? String, "com.microsoft")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_IS_SUCCESSFUL] as? String, "no")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_RESULT_STATUS] as? String, "failed")
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_START_TIME])
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_END_TIME])
+
+            expectation.fulfill()
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+
+        sut.startTelemetryEvent(event, context: contextMock)
+        sut.stopTelemetryEvent(event, context: contextMock, error: error)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_completeWithTelemetry_withInvalidParameters_shouldComplete() {
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignInWithPasswordStart, context: contextMock)
+
+        let exp1 = expectation(description: "Telemetry event")
+        let exp2 = expectation(description: "Completion event")
+
+        dispatcher.setTestCallback { event in
+            let dict = event.getProperties()!
+
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+            exp1.fulfill()
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+
+        sut.startTelemetryEvent(event, context: contextMock)
+
+        let responseNil: String? = nil
+
+        sut.complete(event, response: responseNil, error: nil, context: contextMock) { _, _ in
+            exp2.fulfill()
+        }
+
+        wait(for: [exp1, exp2], timeout: 1)
+    }
+
+    func test_performRequest_withError() async {
+        let baseUrl = URL(string: "https://www.contoso.com")!
+
+        let parameters = ["p1": "v1"]
+
+        let httpResponse = HTTPURLResponse(
+            url: baseUrl,
+            statusCode: 500,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        var urlRequest = URLRequest(url: baseUrl)
+        urlRequest.httpMethod = "POST"
+
+        let testUrlResponse = MSIDTestURLResponse.request(baseUrl, reponse: httpResponse)
+
+        testUrlResponse?.setError(ErrorMock.error)
+
+        testUrlResponse?.setUrlFormEncodedBody(parameters)
+        testUrlResponse?.setResponseJSON([""])
+        MSIDTestURLSession.add(testUrlResponse)
+
+        let request = MSIDHttpRequest()
+
+        request.urlRequest = urlRequest
+        request.parameters = parameters
+
+        let result: Result<String, Error> = await sut.performRequest(request, context: contextMock)
+
+        switch result {
+        case .failure(let error):
+            XCTAssertEqual(error as? ErrorMock, ErrorMock.error)
+        case .success:
+            XCTFail("Unexpected response")
+        }
+    }
+
+    func test_performRequest_withSuccess() async {
+        let request = MSIDHttpRequest()
+        HttpModuleMockConfigurator.configure(request: request, responseJson: ["response"])
+
+        let result: Result<[String], Error> = await sut.performRequest(request, context: contextMock)
+
+        switch result {
+        case .failure:
+            XCTFail("Unexpected response")
+        case .success(let response):
+            XCTAssertEqual(response.first, "response")
+        }
+    }
+
+    func test_performRequest_withUnexpectedError() async {
+        let request = MSIDHttpRequest()
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [nil] as [Any?])
+
+        let result: Result<[String], Error> = await sut.performRequest(request, context: contextMock)
+
+        switch result {
+        case .failure(let error):
+            XCTAssertEqual(error as? MSALNativeAuthInternalError, .invalidResponse)
+        case .success:
+            XCTFail("Unexpected response")
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
@@ -1,0 +1,214 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthCredentialsController!
+    private var requestProviderMock: MSALNativeAuthTokenRequestProviderMock!
+    private var cacheAccessorMock: MSALNativeAuthCacheAccessorMock!
+    private var contextMock: MSALNativeAuthRequestContextMock!
+    private var factory: MSALNativeAuthResultFactoryMock!
+    private var responseValidatorMock: MSALNativeAuthTokenResponseValidatorMock!
+    private var tokenResult = MSIDTokenResult()
+    private var tokenResponse = MSIDCIAMTokenResponse()
+    private var defaultUUID = UUID(uuidString: DEFAULT_TEST_UID)!
+
+    override func setUpWithError() throws {
+        requestProviderMock = .init()
+        cacheAccessorMock = .init()
+        contextMock = .init()
+        contextMock.mockTelemetryRequestId = "telemetry_request_id"
+        factory = .init()
+        responseValidatorMock = .init()
+        sut = .init(
+            clientId: DEFAULT_TEST_CLIENT_ID,
+            requestProvider: requestProviderMock,
+            cacheAccessor: cacheAccessorMock,
+            factory: factory,
+            responseValidator: responseValidatorMock
+        )
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+        
+        try super.setUpWithError()
+    }
+    
+    // MARK: get native user account tests
+
+    func test_whenNoAccountPresent_shouldReturnNoAccounts() {
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let accountResult = sut.retrieveUserAccountResult(context: expectedContext)
+        XCTAssertNil(accountResult)
+    }
+
+    func test_whenNoTokenPresent_shouldReturnNoAccounts() {
+        let account = MSALNativeAuthUserAccountResultStub.account
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
+        let userAccountResult = MSALNativeAuthUserAccountResult(
+            account: account,
+            authTokens: authTokens,
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: MSALNativeAuthCacheAccessorMock()
+        )
+        factory.mockMakeUserAccountResult(userAccountResult)
+        cacheAccessorMock.mockUserAccounts = [account]
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let accountResult = sut.retrieveUserAccountResult(context: expectedContext)
+        XCTAssertNil(accountResult)
+    }
+
+    func test_whenAccountSet_shouldReturnAccount() async {
+        let account = MSALNativeAuthUserAccountResultStub.account
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
+
+        let userAccountResult = MSALNativeAuthUserAccountResult(
+            account: account,
+            authTokens: authTokens,
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: MSALNativeAuthCacheAccessorMock()
+        )
+
+        factory.mockMakeUserAccountResult(userAccountResult)
+        cacheAccessorMock.mockUserAccounts = [account]
+        cacheAccessorMock.mockAuthTokens = authTokens
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let accountResult = sut.retrieveUserAccountResult(context: expectedContext)
+        XCTAssertEqual(accountResult?.account.username, account.username)
+        XCTAssertEqual(accountResult?.idToken, authTokens.rawIdToken)
+        XCTAssertEqual(accountResult?.scopes, authTokens.accessToken?.scopes.array as? [String])
+        XCTAssertEqual(accountResult?.expiresOn, authTokens.accessToken?.expiresOn)
+        XCTAssertTrue(NSDictionary(dictionary: accountResult?.account.accountClaims ?? [:]).isEqual(to: account.accountClaims ?? [:]))
+    }
+
+    func test_whenCreateRequestFails_shouldReturnError() async throws {
+        let expectation = expectation(description: "CredentialsController")
+
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
+
+        requestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: nil, signInSLT: nil, grantType: MSALNativeAuthGrantType.refreshToken, scope: "" , password: nil, oobCode: nil, includeChallengeType: true, refreshToken: "refreshToken")
+        requestProviderMock.throwingTokenError = ErrorMock.error
+
+        let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .generalError))
+
+        let result = await sut.refreshToken(context: expectedContext, authTokens: authTokens)
+        helper.onAccessTokenRetrieveError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdRefreshToken, isSuccessful: false)
+    }
+
+    func test_whenAccountSet_shouldRefreshToken() async {
+        let expectation = expectation(description: "CredentialsController")
+
+        let account = MSALNativeAuthUserAccountResultStub.account
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
+        let userAccountResult = MSALNativeAuthUserAccountResult(account: account,
+                                                                authTokens: authTokens,
+                                                                configuration: MSALNativeAuthConfigStubs.configuration, cacheAccessor: MSALNativeAuthCacheAccessorMock())
+
+        let request = MSIDHttpRequest()
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        requestProviderMock.result = request
+
+        let expectedAccessToken = "accessToken"
+        let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedAccessToken: expectedAccessToken)
+
+        factory.mockMakeUserAccountResult(userAccountResult)
+        tokenResult.accessToken = MSIDAccessToken()
+        tokenResult.accessToken.accessToken = expectedAccessToken
+        responseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        cacheAccessorMock.mockUserAccounts = [account]
+        cacheAccessorMock.mockAuthTokens = authTokens
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+        let result = await sut.refreshToken(context: expectedContext, authTokens: authTokens)
+        helper.onAccessTokenRetrieveCompleted(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertEqual(expectedAccessToken, authTokens.accessToken?.accessToken)
+    }
+
+    func test_whenErrorIsReturnedFromValidator_itIsCorrectlyTranslatedToDelegateError() async  {
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError), validatorError: .generalError)
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError), validatorError: .expiredToken(message: nil))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError), validatorError: .authorizationPending(message: nil))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError), validatorError: .slowDown(message: nil))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError), validatorError: .invalidRequest(message: nil))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.invalidServerResponse), validatorError: .invalidServerResponse)
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, message: "Invalid Client ID"), validatorError: .invalidClient(message: "Invalid Client ID"))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, message: "Unsupported challenge type"), validatorError: .unsupportedChallengeType(message: "Unsupported challenge type"))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, message: "Invalid scope"), validatorError: .invalidScope(message: "Invalid scope"))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .refreshTokenExpired), validatorError: .expiredRefreshToken(message: nil))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .browserRequired, message: "MFA currently not supported. Use the browser instead"), validatorError: .strongAuthRequired(message: "MFA currently not supported. Use the browser instead"))
+    }
+
+    private func checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError, validatorError: MSALNativeAuthTokenValidatedErrorType) async {
+        let request = MSIDHttpRequest()
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "CredentialsController")
+
+        requestProviderMock.result = request
+
+        let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedError: publicError)
+        responseValidatorMock.tokenValidatedResponse = .error(validatorError)
+
+        let result = await sut.refreshToken(context: expectedContext, authTokens: authTokens)
+        helper.onAccessTokenRetrieveError(result)
+
+        checkTelemetryEventResult(id: .telemetryApiIdRefreshToken, isSuccessful: false)
+        receivedEvents.removeAll()
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    private func checkTelemetryEventResult(id: MSALNativeAuthTelemetryApiId, isSuccessful: Bool) {
+        XCTAssertEqual(receivedEvents.count, 1)
+
+        guard let telemetryEventDict = receivedEvents.first else {
+            return XCTFail("Telemetry test fail")
+        }
+
+        let expectedApiId = String(id.rawValue)
+        XCTAssertEqual(telemetryEventDict["api_id"] as? String, expectedApiId)
+        XCTAssertEqual(telemetryEventDict["event_name"] as? String, "api_event" )
+        XCTAssertEqual(telemetryEventDict["correlation_id" ] as? String, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(telemetryEventDict["is_successfull"] as? String, isSuccessful ? "yes" : "no")
+        XCTAssertEqual(telemetryEventDict["status"] as? String, isSuccessful ? "succeeded" : "failed")
+        XCTAssertNotNil(telemetryEventDict["start_time"])
+        XCTAssertNotNil(telemetryEventDict["stop_time"])
+        XCTAssertNotNil(telemetryEventDict["response_time"])
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
@@ -1,0 +1,1948 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthSignUpController!
+    private var contextMock: MSALNativeAuthRequestContext!
+    private var requestProviderMock: MSALNativeAuthSignUpRequestProviderMock!
+    private var validatorMock: MSALNativeAuthSignUpResponseValidatorMock!
+    private var signInControllerMock: MSALNativeAuthSignInControllerMock!
+
+    private var signUpStartPasswordParams: MSALNativeAuthSignUpStartRequestProviderParameters {
+        .init(
+            username: "user@contoso.com",
+            password: "password",
+            attributes: ["key": "value"],
+            context: contextMock
+        )
+    }
+
+    private var signUpStartCodeParams: MSALNativeAuthSignUpStartRequestProviderParameters {
+        .init(
+            username: "user@contoso.com",
+            password: nil,
+            attributes: ["key": "value"],
+            context: contextMock
+        )
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        contextMock = .init(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        requestProviderMock = .init()
+        validatorMock = .init()
+        signInControllerMock = .init()
+
+        sut = MSALNativeAuthSignUpController(
+            config: MSALNativeAuthConfigStubs.configuration,
+            requestProvider: requestProviderMock,
+            responseValidator: validatorMock,
+            signInController: signInControllerMock
+        )
+    }
+
+    // MARK: - SignUpPasswordStart (/start request) tests
+
+    func test_whenSignUpStartPassword_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returnsVerificationRequired_it_returnsChallenge() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let helper = prepareSignUpPasswordStartValidatorHelper()
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returnsAttributeValidationFailed_it_returnsChallenge() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_telemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        let error : MSALNativeAuthSignUpStartValidatedResponse = .error(
+            MSALNativeAuthSignUpStartResponseError(error: .passwordTooLong,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(error)
+        
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+        
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+        
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .invalidPassword)
+        
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returns_invalidUsername_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        let invalidUsername : MSALNativeAuthSignUpStartValidatedResponse = .invalidUsername(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidUsername)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .invalidUsername)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+    
+    func test_whenSignUpStartPassword_returns_invalidClientId_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        let invalidClientId : MSALNativeAuthSignUpStartValidatedResponse = .invalidClientId(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidClientId)
+        
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+        
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartPassword_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    // MARK: - SignUpPasswordStart (/challenge request) tests
+
+    func test_whenSignUpStartPassword_challenge_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_challenge_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpCodeRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: true)
+    }
+
+    func test_whenSignUpStartPassword_challenge_returns_passwordRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired(""))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_challenge_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_challenge_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
+                                                       errorDescription: "Expired Token",
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertEqual(helper.error?.errorDescription, "Expired Token")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartPassword_challenge_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    // MARK: - SignUpCodeStart (/start request) tests
+
+    func test_whenSignUpStartCode_cantCreateRequest_returns_it_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returnsVerificationRequired_it_returnsChallenge() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let helper = prepareSignUpCodeStartValidatorHelper()
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returnsAttributeValidationFailed_it_returnsCorrectError() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        result.telemetryUpdate?(.success(()))
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_telemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        let error : MSALNativeAuthSignUpStartValidatedResponse = .error(
+            MSALNativeAuthSignUpStartResponseError(error: .userAlreadyExists,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .userAlreadyExists)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returns_invalidUsername_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        let invalidUsername : MSALNativeAuthSignUpStartValidatedResponse = .invalidUsername(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidUsername)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .invalidUsername)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+    
+    func test_whenSignUpStartCode_returns_invalidClientId_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        let invalidClientId : MSALNativeAuthSignUpStartValidatedResponse = .invalidClientId(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidClientId)
+        
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+        
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartCode_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    // MARK: - SignUpCodeStart (/challenge request) tests
+
+    func test_whenSignUpStartCode_challenge_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_challenge_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken 1", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 1")
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpCodeRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: true)
+    }
+
+    func test_whenSignUpStartCode_challenge_succeedsPassword_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired(""))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_challenge_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_challenge_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
+                                                       errorDescription: "Expired Token",
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertEqual(helper.error?.errorDescription, "Expired Token")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartCode_challenge_it_returns_unexpectedError_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    // MARK: - ResendCode tests
+
+    func test_whenSignUpResendCode_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeCodeRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpResendCode_succeedsPassword_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 1"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken 2")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .invalidRequest,
+                                                       errorDescription: nil,
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitCode tests
+
+    func test_whenSignUpSubmitCode_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSubmitCode_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.success(""))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitCode_returns_invalidUserInput_it_returnsInvalidCode() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .invalidUserInput(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidOOBValue,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertEqual(helper.newCodeRequiredState?.flowToken, "signUpToken")
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .invalidCode)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_attributesRequired_it_returnsAttributesRequired() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken", requiredAttributes: []))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken")
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitCode_returns_attributesRequired_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken", requiredAttributes: []))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken")
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_attributeValidationFailed_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["name"]))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+        
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .error(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidRequest,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitCode + credential_required error tests
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andCantCreateRequest() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andSucceeds() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 3"))
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpPasswordRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken 3")
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 3"))
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpPasswordRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken 3")
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andSucceedOOB_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("", .email, 4, "signUpToken 3"))
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andRedirects() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andReturnsError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
+                                                       errorDescription: nil,
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andReturnsUnexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitPassword tests
+
+    func test_whenSignUpSubmitPassword_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.success("signInSLT"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_invalidUserInput_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .invalidUserInput(
+            MSALNativeAuthSignUpContinueResponseError(error: .passwordTooWeak,
+                                                      errorDescription: "Password too weak",
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken")
+        XCTAssertEqual(helper.error?.type, .invalidPassword)
+        XCTAssertEqual(helper.error?.errorDescription, "Password too weak")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_attributesRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken 2")
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_attributesRequired_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken 2")
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .error(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidRequest,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_credentialRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_attributeValidationFailed_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["key"]))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    // MARK: - SubmitAttributes tests
+
+    func test_whenSignUpSubmitAttributes_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSubmitAttributes_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.success(""))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_invalidUserInput_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .invalidUserInput(
+            MSALNativeAuthSignUpContinueResponseError(error: .attributeValidationFailed,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .error(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidRequest,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_attributesRequired_it_returnsAttributesRequiredError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_credentialRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_attributeValidationFailed_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["attribute"]))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesValidationFailed(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpInvalidAttributesCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.invalidAttributes, ["attribute"])
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    // MARK: - Sign-in with SLT
+
+    func test_whenSignUpSucceeds_and_userCallsSignInWithSLT_signUpControllerPassesCorrectParams() async {
+        let username = "username"
+        let slt = "signInSLT"
+
+        class SignInAfterSignUpDelegateStub: SignInAfterSignUpDelegate {
+            func onSignInAfterSignUpError(error: MSAL.SignInAfterSignUpError) {}
+            func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {}
+        }
+
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.success(slt))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: username, signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: true)
+
+        let exp2 = expectation(description: "SignInAfterSignUp expectation")
+        signInControllerMock.expectation = exp2
+        signInControllerMock.signInSLTResult = .failure(.init())
+        helper.signInAfterSignUpState?.signIn(delegate: SignInAfterSignUpDelegateStub())
+        await fulfillment(of: [exp2], timeout: 1)
+
+        XCTAssertEqual(signInControllerMock.username, username)
+        XCTAssertEqual(signInControllerMock.slt, slt)
+    }
+
+    // MARK: - Common Methods
+
+    private func checkTelemetryEventResult(id: MSALNativeAuthTelemetryApiId, isSuccessful: Bool) {
+        XCTAssertEqual(receivedEvents.count, 1)
+
+        guard let telemetryEventDict = receivedEvents.first else {
+            return XCTFail("Telemetry test fail")
+        }
+
+        let expectedApiId = String(id.rawValue)
+        XCTAssertEqual(telemetryEventDict["api_id"] as? String, expectedApiId)
+        XCTAssertEqual(telemetryEventDict["event_name"] as? String, "api_event" )
+        XCTAssertEqual(telemetryEventDict["correlation_id" ] as? String, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(telemetryEventDict["is_successfull"] as? String, isSuccessful ? "yes" : "no")
+        XCTAssertEqual(telemetryEventDict["status"] as? String, isSuccessful ? "succeeded" : "failed")
+        XCTAssertNotNil(telemetryEventDict["start_time"])
+        XCTAssertNotNil(telemetryEventDict["stop_time"])
+        XCTAssertNotNil(telemetryEventDict["response_time"])
+    }
+
+    private func prepareSignUpPasswordStartValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpPasswordStartTestsValidatorHelper {
+        let helper = SignUpPasswordStartTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpPasswordErrorCalled)
+        XCTAssertFalse(helper.onSignUpCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpCodeStartValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpCodeStartTestsValidatorHelper {
+        let helper = SignUpCodeStartTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCodeErrorCalled)
+        XCTAssertFalse(helper.onSignUpCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpResendCodeValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpResendCodeTestsValidatorHelper {
+        let helper = SignUpResendCodeTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertFalse(helper.onSignUpResendCodeCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpSubmitCodeValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpVerifyCodeTestsValidatorHelper {
+        let helper = SignUpVerifyCodeTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCompletedCalled)
+        XCTAssertFalse(helper.onSignUpPasswordRequiredCalled)
+        XCTAssertFalse(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertFalse(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpSubmitPasswordValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpPasswordRequiredTestsValidatorHelper {
+        let helper = SignUpPasswordRequiredTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCompletedCalled)
+        XCTAssertFalse(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertFalse(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpSubmitAttributesValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpAttributesRequiredTestsValidatorHelper {
+        let helper = SignUpAttributesRequiredTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCompletedCalled)
+        XCTAssertFalse(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareMockRequest() -> MSIDHttpRequest {
+        let request = MSIDHttpRequest()
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        return request
+    }
+
+    private func expectedChallengeParams(token: String = "signUpToken") -> (token: String, context: MSIDRequestContext) {
+        return (token: token, context: contextMock)
+    }
+
+    private func expectedContinueParams(
+        grantType: MSALNativeAuthGrantType = .oobCode,
+        token: String = "signUpToken",
+        password: String? = nil,
+        oobCode: String? = "1234",
+        attributes: [String: Any]? = nil
+    ) -> MSALNativeAuthSignUpContinueRequestProviderParams {
+        .init(
+            grantType: grantType,
+            signUpToken: token,
+            password: password,
+            oobCode: oobCode,
+            attributes: attributes,
+            context: contextMock
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
@@ -1,0 +1,85 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResultFactoryTests: XCTestCase {
+
+    private var sut: MSALNativeAuthResultFactory!
+
+    private let tokenResponseDict: [String: Any] = [
+        "token_type": "Bearer",
+        "scope": "openid profile email",
+        "expires_in": 4141,
+        "ext_expires_in": 4141,
+        "access_token": "accessToken",
+        "refresh_token": "refreshToken",
+        "id_token": "idToken"
+    ]
+
+    override func setUpWithError() throws {
+        sut = .init(config: MSALNativeAuthConfigStubs.configuration)
+    }
+
+    func test_makeMsidConfiguration() {
+        let result = sut.makeMSIDConfiguration(scopes: ["<scope_1>", "<scope_2>"])
+
+        XCTAssertEqual(result.authority, MSALNativeAuthNetworkStubs.msidAuthority)
+        XCTAssertNil(result.redirectUri)
+        XCTAssertEqual(result.clientId, DEFAULT_TEST_CLIENT_ID)
+        XCTAssertEqual(result.target, "<scope_1> <scope_2>")
+    }
+    
+    func test_makeUserAccount_returnExpectedResult() {
+        let accessTokenString = "accessToken"
+        let idToken = "idToken"
+        let username = "username"
+        let scopes = ["scope1", "scope2"]
+        let expiresOn = Date()
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = accessTokenString
+        accessToken.accountIdentifier = MSIDAccountIdentifier(displayableId: username, homeAccountId: "")
+        accessToken.expiresOn = expiresOn
+        accessToken.scopes = NSOrderedSet(array: scopes)
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.refreshToken = "refreshToken"
+        let msidAccount = MSIDAccount()
+        msidAccount.username = username
+        guard let tokenResult = MSIDTokenResult(accessToken: accessToken, refreshToken: refreshToken, idToken: idToken, account: msidAccount, authority: MSALNativeAuthNetworkStubs.msidAuthority, correlationId: UUID(), tokenResponse: nil) else {
+            XCTFail("Unexpected nil token")
+            return
+        }
+        let context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        guard let accountResult = sut.makeUserAccountResult(tokenResult: tokenResult, context: context) else {
+            XCTFail("Unexpected nil account")
+            return
+        }
+        XCTAssertEqual(accountResult.account.username, username)
+        XCTAssertEqual(accountResult.idToken, idToken)
+        XCTAssertEqual(accountResult.expiresOn, expiresOn)
+        XCTAssertEqual(accountResult.scopes, scopes)
+    }
+}

--- a/MSAL/test/unit/native_auth/input_validator/MSALNativeAuthInputValidatorTest.swift
+++ b/MSAL/test/unit/native_auth/input_validator/MSALNativeAuthInputValidatorTest.swift
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthInputValidatorTest: XCTestCase {
+    
+    private let validator = MSALNativeAuthInputValidator()
+    
+    func testInput_whenValidInputIsUsed_resultShouldBeValid() {
+        XCTAssertTrue(validator.isInputValid("email@contoso.com"))
+        XCTAssertTrue(validator.isInputValid("password"))
+        XCTAssertTrue(validator.isInputValid("1"))
+    }
+    
+    func testInput_whenInvalidStringInputIsUsed_resultShouldBeInvalid() {
+        XCTAssertFalse(validator.isInputValid(""))
+    }
+}

--- a/MSAL/test/unit/native_auth/logger/MSALLogMaskTests.m
+++ b/MSAL/test/unit/native_auth/logger/MSALLogMaskTests.m
@@ -1,0 +1,167 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+#import <XCTest/XCTest.h>
+#import "MSALLogMask.h"
+
+@interface MSALLogMaskTests : XCTestCase
+
+@end
+
+@implementation MSALLogMaskTests
+
+- (void)setUp
+{
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+    [super setUp];
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskAllPII;
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma mark - Correctness
+
+- (void)testMaskPII_returnsCorrect_onNotNil
+{
+    NSString* string = [[MSALLogMask maskPII:@"Test"] description];
+    XCTAssertEqualObjects(string, @"Masked(not-null)");
+    XCTAssertTrue([string isEqualToString:@"Masked(not-null)"]);
+}
+
+- (void)testMaskPII_returnsCorrect_onNil
+{
+    NSString* string = [[MSALLogMask maskPII:nil] description];
+    XCTAssertEqualObjects(string, @"Masked(null)");
+    XCTAssertTrue([string isEqualToString:@"Masked(null)"]);
+}
+
+- (void)testMaskPII_returnsCorrect_onNotNil_andNotMaksed
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskEUIIOnly;
+    NSString* string = [[MSALLogMask maskPII:@"Test"] description];
+    XCTAssertEqualObjects(string, @"Test");
+    XCTAssertTrue([string isEqualToString:@"Test"]);
+}
+
+- (void)testMaskEUII_returnsCorrect_onNotNil
+{
+    NSString* string = [[MSALLogMask maskEUII:@"UserAccountDummy"] description];
+    XCTAssertEqualObjects(string, @"Masked(not-null)");
+    XCTAssertTrue([string isEqualToString:@"Masked(not-null)"]);
+}
+
+- (void)testMaskEUII_returnsCorrect_onNill
+{
+    NSString* string = [[MSALLogMask maskEUII:nil] description];
+    XCTAssertEqualObjects(string, @"Masked(null)");
+    XCTAssertTrue([string isEqualToString:@"Masked(null)"]);
+}
+
+- (void)testMaskEUII_returnsCorrect_onNotNil_andNotMaksed
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
+    NSString* string = [[MSALLogMask maskEUII:@"Test"] description];
+    XCTAssertEqualObjects(string, @"Test");
+    XCTAssertTrue([string isEqualToString:@"Test"]);
+}
+
+- (void) testMaskHashable_returnsCorrect_onNotNil
+{
+    NSString* string = [[MSALLogMask maskTrackablePII:@"HomeAccountId"] description];
+    XCTAssertEqualObjects(string, @"d87b613d");
+    XCTAssertTrue([string isEqualToString:@"d87b613d"]);
+}
+
+- (void) testMaskHashable_returnsCorrect_onNil
+{
+    NSString* string = [[MSALLogMask maskTrackablePII:nil] description];
+    XCTAssertEqualObjects(string, @"Masked(null)");
+    XCTAssertTrue([string isEqualToString:@"Masked(null)"]);
+}
+
+- (void) testMaskHashable_returnsCorrect_onNotNil_andNotMaksed
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskEUIIOnly;
+    NSString* string = [[MSALLogMask maskTrackablePII:@"HomeAccountId"] description];
+    XCTAssertEqualObjects(string, @"HomeAccountId");
+    XCTAssertTrue([string isEqualToString:@"HomeAccountId"]);
+}
+
+- (void) testMaskUsername_returnsCorrect_onNotNil
+{
+    NSString* string = [[MSALLogMask maskUsername:@"user@contoso.com"] description];
+    XCTAssertEqualObjects(string, @"auth.placeholder-04f8996d__contoso.com");
+    XCTAssertTrue([string isEqualToString:@"auth.placeholder-04f8996d__contoso.com"]);
+}
+
+- (void) testMaskUsername_returnsCorrect_onNil
+{
+    NSString* string = [[MSALLogMask maskUsername:nil] description];
+    XCTAssertEqualObjects(string, @"Masked(null)");
+    XCTAssertTrue([string isEqualToString:@"Masked(null)"]);
+}
+
+- (void) testMaskUsernamereturnsCorrect_onNotNil_andNotMaksed
+{
+    [MSIDLogger sharedLogger].logMaskingLevel = MSIDLogMaskingSettingsMaskSecretsOnly;
+    NSString* string = [[MSALLogMask maskUsername:@"user@contoso.com"] description];
+    XCTAssertEqualObjects(string, @"user@contoso.com");
+    XCTAssertTrue([string isEqualToString:@"user@contoso.com"]);
+}
+
+#pragma mark - Macro
+
+- (void) testMaskPII_returnsSameAsMacro
+{
+    NSString* string = [[MSALLogMask maskPII:@"Test"] description];
+    XCTAssertEqualObjects(string, [MSID_PII_LOG_MASKABLE(@"Test") description]);
+    XCTAssertTrue([string isEqualToString:[MSID_PII_LOG_MASKABLE(@"Test") description]]);
+}
+
+- (void) testMaskEUII_returnsSameAsMacro
+{
+    NSString* string = [[MSALLogMask maskEUII:@"Test"] description];
+    XCTAssertEqualObjects(string, [MSID_EUII_ONLY_LOG_MASKABLE(@"Test") description]);
+    XCTAssertTrue([string isEqualToString:[MSID_EUII_ONLY_LOG_MASKABLE(@"Test") description]]);
+}
+
+- (void) testMaskHashable_returnsSameAsMacro
+{
+    NSString* string = [[MSALLogMask maskTrackablePII:@"HomeAccountId"] description];
+    XCTAssertEqualObjects(string, [MSID_PII_LOG_TRACKABLE(@"HomeAccountId") description]);
+    XCTAssertTrue([string isEqualToString:[MSID_PII_LOG_TRACKABLE(@"HomeAccountId") description]]);
+}
+
+- (void) testMaskUsername_returnsSameAsMacro
+{
+    NSString* string = [[MSALLogMask maskUsername:@"user@contoso.com"] description];
+    XCTAssertEqualObjects(string, [MSID_PII_LOG_EMAIL(@"user@contoso.com") description]);
+    XCTAssertTrue([string isEqualToString:[MSID_PII_LOG_EMAIL(@"user@contoso.com") description]]);
+}
+
+@end

--- a/MSAL/test/unit/native_auth/logger/MSALNativeLoggingTests.swift
+++ b/MSAL/test/unit/native_auth/logger/MSALNativeLoggingTests.swift
@@ -1,0 +1,342 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthTestLogger : NSObject {
+    static var instanceCreated = false
+
+    @objc dynamic var containsPII = false
+    @objc dynamic var messages = NSMutableArray()
+    @objc dynamic var level: MSALLogLevel = .nothing
+    var expectation = XCTestExpectation()
+    private var queue = DispatchQueue(label: "test", qos: .default)
+    
+    override init () {
+        super.init()
+        guard Self.instanceCreated == false else {
+            fatalError("Only one instance allowed, inherit the MSALNativeAuthTestCase class and use the Self.logger property there")
+        }
+        Self.instanceCreated = true
+        MSALGlobalConfig.loggerConfig.setLogCallback { [weak self] level, message, containsPII in
+            self?.queue.sync {
+                self?.messages.add(message as Any)
+                self?.containsPII = containsPII
+                self?.level = level
+                // Making sure expectation has been set in the test case
+                if self?.expectation.description != "" {
+                    self?.expectation.fulfill()
+                }
+            }
+        }
+    }
+    
+    func reset() {
+        queue.sync {
+            expectation = XCTestExpectation(description: "")
+            containsPII = false
+            messages.removeAllObjects()
+            MSALGlobalConfig.loggerConfig.logLevel = .last
+        }
+    }
+}
+
+final class MSALNativeLoggingTests: MSALNativeAuthTestCase {
+    // Used for clarity of code. The static object is needed because MSALGlobalConfig.loggerConfig.setLogCallback
+    // must be set only once per execution of test
+
+    let context = MSIDBasicContext()
+    var correlationId = UUID()
+    let messageRegexFormat = "\\[\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} - %@\\] %@"
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskAllPII
+        context.correlationId = UUID()
+        correlationId = UUID()
+    }
+    
+    // MARK: Log With Context
+    
+    func testLogWithContext_noMaskNonNil() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", "String")
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test String"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+
+    
+    func testLogWithContext_andMasked() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(not-null\\)"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+    
+    func testLogWithContext_maskedAndNull() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(null\\)"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+    
+    // MARK: Log PII With Context
+    
+    func testLogPIIWithContext_andMaskAll() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskAllPII
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(not\\-null\\)"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertFalse(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithContext_andMaskEUII() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskEUIIOnly
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test String"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertTrue(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithContext_nilString() throws {
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(null\\)"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertFalse(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithContext_nilStringNotMasked() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskEUIIOnly
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test \\(null\\)"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertTrue(Self.logger.containsPII)
+    }
+    
+    // MARK: Log With Correlation Id
+    
+    func testLogWithCorrelationId_noMaskNonNil() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", "String")
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test String"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+    
+    func testLogWithCorrelationId_andMasked() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(not\\-null\\)"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+    
+    func testLogWithCorrelationId_maskedAndNull() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(null\\)"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+    
+    // MARK: Log PII With CorrelationId
+    
+    func testLogPIIWithCorrelationId_andMaskAll() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskAllPII
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(not\\-null\\)"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertFalse(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithCorrelationId_andMaskEUII() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskEUIIOnly
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test String"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertTrue(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithCorrelationId_nilString() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(null\\)"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertFalse(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithCorrelationId_nilStringNotMasked() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskEUIIOnly
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test \\(null\\)"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertTrue(Self.logger.containsPII)
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/CredentialsDelegateSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/CredentialsDelegateSpies.swift
@@ -1,0 +1,78 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+open class CredentialsDelegateSpy: CredentialsDelegate {
+
+    private let expectation: XCTestExpectation
+    var expectedError: RetrieveAccessTokenError?
+    var expectedAccessToken: String?
+    
+    init(expectation: XCTestExpectation, expectedError: RetrieveAccessTokenError? = nil, expectedAccessToken: String? = nil) {
+        self.expectation = expectation
+        self.expectedError = expectedError
+        self.expectedAccessToken = expectedAccessToken
+    }
+
+    public func onAccessTokenRetrieveCompleted(accessToken: String) {
+        if let expectedAccessToken = expectedAccessToken {
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(expectedAccessToken, accessToken)
+        } else {
+            XCTFail("This method should not be called")
+        }
+        expectation.fulfill()
+    }
+
+    public func onAccessTokenRetrieveError(error: MSAL.RetrieveAccessTokenError) {
+        if let expectedError = expectedError {
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(error.type, expectedError.type)
+            XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
+            expectation.fulfill()
+            return
+        }
+    }
+}
+
+class CredentialsTestValidatorHelper: CredentialsDelegateSpy {
+
+    func onAccessTokenRetrieveCompleted(_ result: Result<String, RetrieveAccessTokenError>) {
+        guard case let .success(token) = result else {
+            return XCTFail("wrong result")
+        }
+
+        Task { await self.onAccessTokenRetrieveCompleted(accessToken: token) }
+    }
+
+    func onAccessTokenRetrieveError(_ result: Result<String, RetrieveAccessTokenError>) {
+        guard case let .failure(error) = result else {
+            return XCTFail("wrong result")
+        }
+
+        Task { await self.onAccessTokenRetrieveError(error: error) }
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthCacheMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthCacheMocks.swift
@@ -1,0 +1,72 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthCacheAccessorMock: MSALNativeAuthCacheInterface {
+    enum E: Error {
+        case notImplemented
+        case noAccount
+        case noTokens
+    }
+
+    private(set) var validateAndSaveTokensWasCalled = false
+    private(set) var clearCacheWasCalled = false
+    var expectedMSIDTokenResult: MSIDTokenResult?
+    var mockUserAccounts: [MSALAccount]?
+    var mockAuthTokens: MSALNativeAuthTokens?
+
+    func getTokens(account: MSALAccount, configuration: MSIDConfiguration, context: MSIDRequestContext) throws -> MSAL.MSALNativeAuthTokens {
+        guard let mockAuthTokens = mockAuthTokens else {
+            throw E.noTokens
+        }
+        return mockAuthTokens
+    }
+
+    func getAccount(accountIdentifier: MSIDAccountIdentifier, authority: MSIDAuthority, context: MSIDRequestContext) throws -> MSIDAccount? {
+        throw E.notImplemented
+    }
+
+    func getAllAccounts(configuration: MSIDConfiguration) throws -> [MSALAccount] {
+        guard let mockUserAccounts = mockUserAccounts else {
+            throw E.noAccount
+        }
+        return mockUserAccounts
+    }
+
+    func validateAndSaveTokensAndAccount(tokenResponse: MSIDTokenResponse, configuration: MSIDConfiguration, context: MSIDRequestContext) throws -> MSIDTokenResult? {
+        validateAndSaveTokensWasCalled = true
+        return expectedMSIDTokenResult
+    }
+
+    func removeTokens(accountIdentifier: MSIDAccountIdentifier, authority: MSIDAuthority, clientId: String, context: MSIDRequestContext) throws {
+        throw E.notImplemented
+    }
+
+    func clearCache(accountIdentifier: MSIDAccountIdentifier, authority: MSIDAuthority, clientId: String, context: MSIDRequestContext) throws {
+        clearCacheWasCalled = true
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthConfigStubs.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthConfigStubs.swift
@@ -1,0 +1,56 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+enum ErrorMock: Error {
+    case error
+}
+
+struct MSALNativeAuthConfigStubs {
+
+    static var configuration: MSALNativeAuthConfiguration {
+        try! .init(
+            clientId: DEFAULT_TEST_CLIENT_ID,
+            authority: try! .init(
+                url: URL(string: DEFAULT_TEST_AUTHORITY)!
+            ),
+            challengeTypes: [.redirect]
+        )
+    }
+
+    static var msidConfiguration: MSIDConfiguration {
+        .init(
+            authority: try! .init(
+                url: URL(string: DEFAULT_TEST_AUTHORITY)!,
+                context: MSALNativeAuthRequestContext()
+            ),
+            redirectUri: "",
+            clientId: DEFAULT_TEST_CLIENT_ID,
+            target: ""
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthCredentialsControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthCredentialsControllerMock.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthCredentialsControllerMock: MSALNativeAuthCredentialsControlling {
+
+    var refreshTokenResult: Result<String, RetrieveAccessTokenError>!
+    var accountResult: MSALNativeAuthUserAccountResult?
+
+    func refreshToken(context: MSAL.MSALNativeAuthRequestContext, authTokens: MSAL.MSALNativeAuthTokens) async -> Result<String, MSAL.RetrieveAccessTokenError> {
+        return refreshTokenResult
+    }
+
+    func retrieveUserAccountResult(context: MSAL.MSALNativeAuthRequestContext) -> MSAL.MSALNativeAuthUserAccountResult? {
+        return accountResult
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
@@ -1,0 +1,93 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthResultFactoryMock: MSALNativeAuthResultBuildable {
+
+    var config: MSAL.MSALNativeAuthConfiguration = MSALNativeAuthConfigStubs.configuration
+    
+    private(set) var makeMsidConfigurationResult: MSIDConfiguration?
+    private(set) var makeNativeAuthUserAccountResult: MSALNativeAuthUserAccountResult?
+
+    func mockMakeUserAccountResult(_ result: MSALNativeAuthUserAccountResult) {
+        self.makeNativeAuthUserAccountResult = result
+    }
+
+    func makeUserAccountResult(tokenResult: MSIDTokenResult, context: MSIDRequestContext) -> MSAL.MSALNativeAuthUserAccountResult? {
+        return makeNativeAuthUserAccountResult ?? .init(
+            account: MSALAccount.init(msidAccount: tokenResult.account, createTenantProfile: false),
+            authTokens: MSALNativeAuthTokens(
+                accessToken: tokenResult.accessToken,
+                refreshToken: tokenResult.refreshToken as? MSIDRefreshToken,
+                rawIdToken: tokenResult.rawIdToken
+            ),
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: MSALNativeAuthCacheAccessorMock()
+        )
+    }
+
+    func makeUserAccountResult(account: MSALAccount, authTokens: MSAL.MSALNativeAuthTokens) -> MSAL.MSALNativeAuthUserAccountResult? {
+        return makeNativeAuthUserAccountResult ?? .init(
+            account: account,
+            authTokens: authTokens,
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: MSALNativeAuthCacheAccessorMock()
+        )
+    }
+
+    func mockMakeMsidConfigurationFunc(_ result: MSIDConfiguration) {
+        self.makeMsidConfigurationResult = result
+    }
+
+    func makeMSIDConfiguration(scopes: [String]) -> MSIDConfiguration {
+        return makeMsidConfigurationResult ?? MSALNativeAuthConfigStubs.msidConfiguration
+    }
+}
+
+class MSALNativeAuthControllerFactoryMock: MSALNativeAuthControllerBuildable {
+
+    var signUpController = MSALNativeAuthSignUpControllerMock()
+    var signInController = MSALNativeAuthSignInControllerMock()
+    var resetPasswordController = MSALNativeAuthResetPasswordControllerMock()
+    var credentialsController = MSALNativeAuthCredentialsControllerMock()
+
+    func makeSignUpController() -> MSAL.MSALNativeAuthSignUpControlling {
+        return signUpController
+    }
+
+    func makeSignInController() -> MSAL.MSALNativeAuthSignInControlling {
+        return signInController
+    }
+
+    func makeResetPasswordController() -> MSAL.MSALNativeAuthResetPasswordControlling {
+        return resetPasswordController
+    }
+
+    func makeCredentialsController() -> MSAL.MSALNativeAuthCredentialsControlling {
+        return credentialsController
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
@@ -1,0 +1,304 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthNetworkStubs {
+
+    static let tenantSubdomain = "test_tenant"
+
+    static var authority: MSALCIAMAuthority {
+        try! .init(
+            url: .init(string: DEFAULT_TEST_AUTHORITY)!
+        )
+    }
+
+    static var msidAuthority: MSIDCIAMAuthority {
+        try! .init(
+            url: .init(string: DEFAULT_TEST_AUTHORITY)!,
+            validateFormat: false,
+            rawTenant: tenantSubdomain,
+            context: nil
+        )
+    }
+}
+
+class MSALNativeAuthRequestContextMock: MSIDRequestContext {
+
+    let mockCorrelationId: UUID
+    var mockTelemetryRequestId = ""
+    var mockLogComponent = ""
+    var mockAppRequestMetadata: [AnyHashable: Any] = [:]
+
+    init(correlationId: UUID = .init(uuidString: DEFAULT_TEST_UID)!) {
+        self.mockCorrelationId = correlationId
+    }
+
+    func correlationId() -> UUID {
+        return mockCorrelationId
+    }
+
+    func logComponent() -> String {
+        return mockLogComponent
+    }
+
+    func telemetryRequestId() -> String {
+        return mockTelemetryRequestId
+    }
+
+    func appRequestMetadata() -> [AnyHashable: Any] {
+        return mockAppRequestMetadata
+    }
+}
+
+class MSALNativeAuthSignInResponseValidatorMock: MSALNativeAuthSignInResponseValidating {
+
+    var expectedRequestContext: MSALNativeAuthRequestContext?
+    var expectedConfiguration: MSIDConfiguration?
+    var expectedChallengeResponse: MSALNativeAuthSignInChallengeResponse?
+    var expectedInitiateResponse: MSALNativeAuthSignInInitiateResponse?
+    var expectedResponseError: Error?
+    var initiateValidatedResponse: MSALNativeAuthSignInInitiateValidatedResponse = .error(.userNotFound(message: nil))
+    var challengeValidatedResponse: MSALNativeAuthSignInChallengeValidatedResponse = .error(.expiredToken(message: nil))
+
+    
+    func validate(context: MSAL.MSALNativeAuthRequestContext, result: Result<MSAL.MSALNativeAuthSignInChallengeResponse, Error>) -> MSAL.MSALNativeAuthSignInChallengeValidatedResponse {
+        checkConfAndContext(context)
+        if case .success(let successChallengeResponse) = result, let expectedChallengeResponse = expectedChallengeResponse {
+            XCTAssertEqual(successChallengeResponse.challengeType, expectedChallengeResponse.challengeType)
+            XCTAssertEqual(successChallengeResponse.credentialToken, expectedChallengeResponse.credentialToken)
+            XCTAssertEqual(successChallengeResponse.challengeTargetLabel, expectedChallengeResponse.challengeTargetLabel)
+            XCTAssertEqual(successChallengeResponse.challengeChannel, expectedChallengeResponse.challengeChannel)
+            XCTAssertEqual(successChallengeResponse.codeLength, expectedChallengeResponse.codeLength)
+        }
+        if case .failure(let challengeResponseError) = result, let expectedChallengeResponseError = expectedResponseError {
+            XCTAssertTrue(type(of: challengeResponseError) == type(of: expectedChallengeResponseError))
+            XCTAssertEqual(challengeResponseError.localizedDescription, expectedChallengeResponseError.localizedDescription)
+        }
+        return challengeValidatedResponse
+    }
+    
+    func validate(context: MSAL.MSALNativeAuthRequestContext, result: Result<MSAL.MSALNativeAuthSignInInitiateResponse, Error>) -> MSAL.MSALNativeAuthSignInInitiateValidatedResponse {
+        checkConfAndContext(context)
+        if case .success(let successInitiateResponse) = result, let expectedInitiateResponse = expectedInitiateResponse {
+            XCTAssertEqual(successInitiateResponse.challengeType, expectedInitiateResponse.challengeType)
+            XCTAssertEqual(successInitiateResponse.credentialToken, expectedInitiateResponse.credentialToken)
+        }
+        if case .failure(let initiateResponseError) = result, let expectedInitiateResponseError = expectedResponseError {
+            XCTAssertTrue(type(of: initiateResponseError) == type(of: expectedInitiateResponseError))
+            XCTAssertEqual(initiateResponseError.localizedDescription, expectedInitiateResponseError.localizedDescription)
+        }
+        return initiateValidatedResponse
+    }
+    
+    private func checkConfAndContext(_ context: MSAL.MSALNativeAuthRequestContext, config: MSIDConfiguration? = nil) {
+        if let expectedRequestContext = expectedRequestContext {
+            XCTAssertEqual(expectedRequestContext.correlationId(), context.correlationId())
+            XCTAssertEqual(expectedRequestContext.telemetryRequestId(), context.telemetryRequestId())
+        }
+        if let expectedConfiguration = expectedConfiguration {
+            XCTAssertEqual(expectedConfiguration, config)
+        }
+    }
+}
+
+class MSALNativeAuthTokenResponseValidatorMock: MSALNativeAuthTokenResponseValidating {
+
+    var expectedRequestContext: MSALNativeAuthRequestContext?
+    var expectedConfiguration: MSIDConfiguration?
+    var expectedTokenResponse: MSIDCIAMTokenResponse?
+    var expectedResponseError: Error?
+    var tokenValidatedResponse: MSALNativeAuthTokenValidatedResponse = .error(.generalError)
+
+    func validate(context: MSAL.MSALNativeAuthRequestContext, msidConfiguration: MSIDConfiguration, result: Result<MSIDCIAMTokenResponse, Error>) -> MSAL.MSALNativeAuthTokenValidatedResponse {
+        checkConfAndContext(context, config: msidConfiguration)
+        if case .success(let successTokenResponse) = result, let expectedTokenResponse = expectedTokenResponse {
+            XCTAssertEqual(successTokenResponse.accessToken, expectedTokenResponse.accessToken)
+            XCTAssertEqual(successTokenResponse.refreshToken, expectedTokenResponse.refreshToken)
+            XCTAssertEqual(successTokenResponse.idToken, expectedTokenResponse.idToken)
+            XCTAssertEqual(successTokenResponse.scope, expectedTokenResponse.scope)
+        }
+        if case .failure(let tokenResponseError) = result, let expectedTokenResponseError = expectedResponseError {
+            XCTAssertTrue(type(of: tokenResponseError) == type(of: expectedResponseError))
+            XCTAssertEqual(tokenResponseError.localizedDescription, expectedTokenResponseError.localizedDescription)
+        }
+        return tokenValidatedResponse
+    }
+
+    func validateAccount(with tokenResult: MSIDTokenResult, context: MSIDRequestContext, accountIdentifier: MSIDAccountIdentifier) throws -> Bool {
+        true
+    }
+
+    private func checkConfAndContext(_ context: MSAL.MSALNativeAuthRequestContext, config: MSIDConfiguration? = nil) {
+        if let expectedRequestContext = expectedRequestContext {
+            XCTAssertEqual(expectedRequestContext.correlationId(), context.correlationId())
+            XCTAssertEqual(expectedRequestContext.telemetryRequestId(), context.telemetryRequestId())
+        }
+        if let expectedConfiguration = expectedConfiguration {
+            XCTAssertEqual(expectedConfiguration, config)
+        }
+    }
+}
+
+class MSALNativeAuthSignInRequestProviderMock: MSALNativeAuthSignInRequestProviding {
+    
+    var throwingInitError: Error?
+    var throwingChallengeError: Error?
+    var throwingTokenError: Error?
+    var result: MSIDHttpRequest?
+    var expectedContext: MSIDRequestContext?
+    var expectedUsername: String?
+    var expectedCredentialToken: String?
+    
+    func inititate(parameters: MSAL.MSALNativeAuthSignInInitiateRequestParameters, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        checkContext(context)
+        if let expectedUsername = expectedUsername {
+            XCTAssertEqual(expectedUsername, parameters.username)
+        }
+        return try returnMockedResult(throwingInitError)
+    }
+    
+    func challenge(parameters: MSAL.MSALNativeAuthSignInChallengeRequestParameters, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        checkContext(context)
+        if let expectedCredentialToken = expectedCredentialToken {
+            XCTAssertEqual(expectedCredentialToken, parameters.credentialToken)
+        }
+        return try returnMockedResult(throwingChallengeError)
+    }
+    
+    fileprivate func checkContext(_ context: MSIDRequestContext) {
+        if let expectedContext = expectedContext {
+            XCTAssertEqual(expectedContext.correlationId(), context.correlationId())
+        }
+    }
+    
+    private func returnMockedResult(_ error: Error?) throws -> MSIDHttpRequest  {
+        if let throwingError = error {
+            throw throwingError
+        }
+        if let result = result {
+            return result
+        }
+        XCTFail("Both parameters are nil")
+        throw ErrorMock.error
+    }
+}
+
+class MSALNativeAuthTokenRequestProviderMock: MSALNativeAuthTokenRequestProviding {
+
+    var throwingInitError: Error?
+    var throwingChallengeError: Error?
+    var throwingTokenError: Error?
+    var result: MSIDHttpRequest?
+    var expectedUsername: String?
+    var expectedCredentialToken: String?
+    var expectedContext: MSIDRequestContext?
+    var expectedTokenParams: MSALNativeAuthTokenRequestParameters?
+
+    func signInWithPassword(parameters: MSAL.MSALNativeAuthTokenRequestParameters, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        checkContext(context)
+        if let expectedTokenParams = expectedTokenParams {
+            XCTAssertEqual(expectedTokenParams.username, parameters.username)
+            XCTAssertEqual(expectedTokenParams.credentialToken, parameters.credentialToken)
+            XCTAssertEqual(expectedTokenParams.signInSLT, parameters.signInSLT)
+            XCTAssertEqual(expectedTokenParams.grantType, parameters.grantType)
+            XCTAssertEqual(expectedTokenParams.scope, parameters.scope)
+            XCTAssertEqual(expectedTokenParams.password, parameters.password)
+            XCTAssertEqual(expectedTokenParams.oobCode, parameters.oobCode)
+            XCTAssertEqual(expectedTokenParams.context.correlationId(), parameters.context.correlationId())
+        }
+        return try returnMockedResult(throwingTokenError)
+    }
+    
+    func refreshToken(parameters: MSAL.MSALNativeAuthTokenRequestParameters, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        checkContext(context)
+        if let expectedTokenParams = expectedTokenParams {
+            XCTAssertEqual(expectedTokenParams.username, parameters.username)
+            XCTAssertEqual(expectedTokenParams.credentialToken, parameters.credentialToken)
+            XCTAssertEqual(expectedTokenParams.signInSLT, parameters.signInSLT)
+            XCTAssertEqual(expectedTokenParams.grantType, parameters.grantType)
+            XCTAssertEqual(expectedTokenParams.scope, parameters.scope)
+            XCTAssertEqual(expectedTokenParams.password, parameters.password)
+            XCTAssertEqual(expectedTokenParams.oobCode, parameters.oobCode)
+            XCTAssertEqual(expectedTokenParams.context.correlationId(), parameters.context.correlationId())
+        }
+        return try returnMockedResult(throwingTokenError)
+    }
+
+
+
+    fileprivate func checkContext(_ context: MSIDRequestContext) {
+        if let expectedContext = expectedContext {
+            XCTAssertEqual(expectedContext.correlationId(), context.correlationId())
+        }
+    }
+
+    private func returnMockedResult(_ error: Error?) throws -> MSIDHttpRequest  {
+        if let throwingError = error {
+            throw throwingError
+        }
+        if let result = result {
+            return result
+        }
+        XCTFail("Both parameters are nil")
+        throw ErrorMock.error
+    }
+}
+
+class HttpModuleMockConfigurator {
+
+    static let baseUrl = URL(string: "https://www.contoso.com")!
+
+    static func configure(request: MSIDHttpRequest,
+                          response: HTTPURLResponse? = nil,
+                          responseJson: Any) {
+
+        let parameters = ["p1": "v1"]
+
+        var httpResponse: HTTPURLResponse!
+        if response == nil {
+            httpResponse = HTTPURLResponse(
+                url: HttpModuleMockConfigurator.baseUrl,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )
+        } else {
+            httpResponse = response
+        }
+
+        var urlRequest = URLRequest(url: HttpModuleMockConfigurator.baseUrl)
+        urlRequest.httpMethod = "POST"
+
+        let testUrlResponse = MSIDTestURLResponse.request(HttpModuleMockConfigurator.baseUrl, reponse: httpResponse)
+        testUrlResponse?.setUrlFormEncodedBody(parameters)
+        testUrlResponse?.setResponseJSON(responseJson)
+        MSIDTestURLSession.add(testUrlResponse)
+
+        request.urlRequest = urlRequest
+        request.parameters = parameters
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
@@ -1,0 +1,61 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignUpControllerMock: MSALNativeAuthSignUpControlling {
+
+    var startPasswordResult: MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse!
+    var startResult: MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse!
+    var resendCodeResult: SignUpResendCodeResult!
+    var submitCodeResult: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse!
+    var submitPasswordResult: MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse!
+    var submitAttributesResult: SignUpAttributesRequiredResult!
+
+    func signUpStartPassword(parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters) async -> MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse {
+        return startPasswordResult
+    }
+
+    func signUpStartCode(parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters) async -> MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse {
+        return startResult
+    }
+
+    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeResult {
+        return resendCodeResult
+    }
+
+    func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
+        return submitCodeResult
+    }
+
+    func submitPassword(_ password: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
+        return submitPasswordResult
+    }
+
+    func submitAttributes(_ attributes: [String : Any], username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpAttributesRequiredResult {
+        return submitAttributesResult
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
@@ -1,0 +1,107 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
+    private let expectation: XCTestExpectation
+    private(set) var context: MSIDRequestContext?
+    private(set) var signUpStartPasswordCalled = false
+    private(set) var signUpStartCalled = false
+    private(set) var resendCodeCalled = false
+    private(set) var submitCodeCalled = false
+    private(set) var submitPasswordCalled = false
+    private(set) var submitAttributesCalled = false
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func signUpStartPassword(
+        parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters
+    ) async -> MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse {
+        self.context = parameters.context
+        signUpStartPasswordCalled = true
+        expectation.fulfill()
+        return .init(.error(.init(type: .generalError)))
+    }
+
+    func signUpStartCode(
+        parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters
+    ) async -> MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse {
+        self.context = parameters.context
+        signUpStartCalled = true
+        expectation.fulfill()
+        return .init(.error(.init(type: .generalError)))
+    }
+
+    func resendCode(
+        username: String,
+        context: MSIDRequestContext,
+        signUpToken: String
+    ) async -> SignUpResendCodeResult {
+        self.context = context
+        resendCodeCalled = true
+        expectation.fulfill()
+        return .error(.init())
+    }
+
+    func submitCode(
+        _ code: String,
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
+        self.context = context
+        submitCodeCalled = true
+        expectation.fulfill()
+        return .init(.error(error: .init(type: .generalError), newState: nil))
+    }
+
+    func submitPassword(
+        _ password: String,
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
+        self.context = context
+        submitPasswordCalled = true
+        expectation.fulfill()
+        return .init(.error(error: .init(type: .generalError), newState: nil))
+    }
+
+    func submitAttributes(
+        _ attributes: [String: Any],
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpAttributesRequiredResult {
+        self.context = context
+        submitAttributesCalled = true
+        expectation.fulfill()
+        return .error(error: .init())
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
@@ -1,0 +1,117 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignUpRequestProviderMock: MSALNativeAuthSignUpRequestProviding {
+    private var requestStart: MSIDHttpRequest?
+    private var requestChallenge: MSIDHttpRequest?
+    private var requestContinue: MSIDHttpRequest?
+    private var throwErrorStart = false
+    private var throwErrorChallenge = false
+    private var throwErrorContinue = false
+    private(set) var startCalled = false
+    private(set) var challengeCalled = false
+    private(set) var continueCalled = false
+    var expectedStartRequestParameters: MSALNativeAuthSignUpStartRequestProviderParameters!
+    var expectedChallengeRequestParameters: (token: String, context: MSIDRequestContext)!
+    var expectedContinueRequestParameters: MSALNativeAuthSignUpContinueRequestProviderParams!
+
+    func mockStartRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {
+        self.requestStart = request
+        self.throwErrorStart = throwError
+    }
+
+    func start(parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters) throws -> MSIDHttpRequest {
+        startCalled = true
+        checkStartParameters(params: parameters)
+        
+        if let request = requestStart {
+            return request
+        } else if throwErrorStart {
+            throw ErrorMock.error
+        } else {
+            fatalError("Make sure to use mockStartRequestFunc()")
+        }
+    }
+
+    private func checkStartParameters(params: MSALNativeAuthSignUpStartRequestProviderParameters) {
+        XCTAssertEqual(params.username, expectedStartRequestParameters.username)
+        XCTAssertEqual(params.password, expectedStartRequestParameters.password)
+        XCTAssertEqual(params.context.correlationId(), expectedStartRequestParameters.context.correlationId())
+        XCTAssertEqual(params.attributes["key"] as? String, expectedStartRequestParameters.attributes["key"] as? String)
+    }
+
+    func mockChallengeRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {
+        self.requestChallenge = request
+        self.throwErrorChallenge = throwError
+    }
+
+    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        challengeCalled = true
+        checkChallengeParameters(token: token, context: context)
+
+        if let request = requestChallenge {
+            return request
+        } else if throwErrorChallenge {
+            throw ErrorMock.error
+        } else {
+            fatalError("Make sure to use mockChallengeRequestFunc()")
+        }
+    }
+
+    private func checkChallengeParameters(token: String, context: MSIDRequestContext) {
+        XCTAssertEqual(token, expectedChallengeRequestParameters.token)
+        XCTAssertEqual(context.correlationId(), expectedChallengeRequestParameters.context.correlationId())
+    }
+
+    func mockContinueRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {
+        self.requestContinue = request
+        self.throwErrorContinue = throwError
+    }
+
+    func `continue`(parameters: MSAL.MSALNativeAuthSignUpContinueRequestProviderParams) throws -> MSIDHttpRequest {
+        continueCalled = true
+        checkContinueParameters(parameters)
+
+        if let request = requestContinue {
+            return request
+        } else if throwErrorContinue {
+            throw ErrorMock.error
+        } else {
+            fatalError("Make sure to use mockContinueRequestFunc()")
+        }
+    }
+
+    private func checkContinueParameters(_ params: MSALNativeAuthSignUpContinueRequestProviderParams) {
+        XCTAssertEqual(params.grantType, expectedContinueRequestParameters.grantType)
+        XCTAssertEqual(params.signUpToken, expectedContinueRequestParameters.signUpToken)
+        XCTAssertEqual(params.password, expectedContinueRequestParameters.password)
+        XCTAssertEqual(params.oobCode, expectedContinueRequestParameters.oobCode)
+        XCTAssertEqual(params.attributes?["key"] as? String, expectedContinueRequestParameters.attributes?["key"] as? String)
+        XCTAssertEqual(params.context.correlationId(), expectedContinueRequestParameters.context.correlationId())
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpResponseValidatorMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpResponseValidatorMock.swift
@@ -1,0 +1,69 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignUpResponseValidatorMock: MSALNativeAuthSignUpResponseValidating {
+
+    private var signUpStartValidatedResponse: MSALNativeAuthSignUpStartValidatedResponse?
+    private var signUpChallengeValidatedResponse: MSALNativeAuthSignUpChallengeValidatedResponse?
+    private var signUpContinueContinueResponse: MSALNativeAuthSignUpContinueValidatedResponse?
+
+    func mockValidateSignUpStartFunc(_ response: MSALNativeAuthSignUpStartValidatedResponse) {
+        self.signUpStartValidatedResponse = response
+    }
+
+    func validate(_ result: Result<MSAL.MSALNativeAuthSignUpStartResponse, Error>, with context: MSIDRequestContext) -> MSAL.MSALNativeAuthSignUpStartValidatedResponse {
+        if let signUpStartValidatedResponse = signUpStartValidatedResponse {
+            return signUpStartValidatedResponse
+        } else {
+            fatalError("Make sure you call mockValidateSignUpStartFunc()")
+        }
+    }
+
+    func mockValidateSignUpChallengeFunc(_ response: MSALNativeAuthSignUpChallengeValidatedResponse) {
+        self.signUpChallengeValidatedResponse = response
+    }
+
+    func validate(_ result: Result<MSAL.MSALNativeAuthSignUpChallengeResponse, Error>, with context: MSIDRequestContext) -> MSAL.MSALNativeAuthSignUpChallengeValidatedResponse {
+        if let signUpChallengeValidatedResponse = signUpChallengeValidatedResponse {
+            return signUpChallengeValidatedResponse
+        } else {
+            fatalError("Make sure you call mockValidateSignUpChallengeFunc()")
+        }
+    }
+
+    func mockValidateSignUpContinueFunc(_ response: MSALNativeAuthSignUpContinueValidatedResponse) {
+        self.signUpContinueContinueResponse = response
+    }
+
+    func validate(_ result: Result<MSAL.MSALNativeAuthSignUpContinueResponse, Error>, with context: MSIDRequestContext) -> MSAL.MSALNativeAuthSignUpContinueValidatedResponse {
+        if let signUpContinueContinueResponse = signUpContinueContinueResponse {
+            return signUpContinueContinueResponse
+        } else {
+            fatalError("Make sure you call mockValidateSignUpContinueFunc()")
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthUserAccountResultStub.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthUserAccountResultStub.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+import Foundation
+
+struct MSALNativeAuthUserAccountResultStub {
+
+    
+    static var result : MSALNativeAuthUserAccountResult {
+        return MSALNativeAuthUserAccountResult(
+            account: account,
+            authTokens: authTokens,
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: MSALNativeAuthCacheAccessorMock()
+        )
+    }
+
+    static var account: MSALAccount {
+        MSALAccount(username: "username",
+                    homeAccountId: MSALAccountId(),
+                    environment: "",
+                    tenantProfiles: [])
+    }
+
+    static var authTokens: MSALNativeAuthTokens {
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = "accessToken"
+        accessToken.expiresOn = Date()
+        accessToken.scopes = []
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.refreshToken = "refreshToken"
+        return MSALNativeAuthTokens(accessToken: accessToken,
+                             refreshToken: refreshToken,
+                             rawIdToken: "idToken")
+    }
+
+}

--- a/MSAL/test/unit/native_auth/mock/SignUpDelegateSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/SignUpDelegateSpies.swift
@@ -1,0 +1,370 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+class SignUpPasswordStartDelegateSpy: SignUpPasswordStartDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onSignUpPasswordErrorCalled = false
+    private(set) var onSignUpCodeRequiredCalled = false
+    private(set) var onSignUpAttributesInvalidCalled = false
+    private(set) var error: SignUpPasswordStartError?
+    private(set) var newState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+    private(set) var attributeNames: [String]?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordError(error: MSAL.SignUpPasswordStartError) {
+        onSignUpPasswordErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+
+    func onSignUpCodeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+    
+    func onSignUpAttributesInvalid(attributeNames: [String]) {
+        self.onSignUpAttributesInvalidCalled = true
+        self.attributeNames = attributeNames
+        
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+}
+
+class SignUpCodeStartDelegateSpy: SignUpStartDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onSignUpCodeErrorCalled = false
+    private(set) var onSignUpCodeRequiredCalled = false
+    private(set) var onSignUpAttributesInvalidCalled = false
+    private(set) var error: SignUpStartError?
+    private(set) var newState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+    private(set) var attributeNames: [String]?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpError(error: MSAL.SignUpStartError) {
+        onSignUpCodeErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+    
+    func onSignUpAttributesInvalid(attributeNames: [String]) {
+        self.onSignUpAttributesInvalidCalled = true
+        self.attributeNames = attributeNames
+        
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+}
+
+class SignUpResendCodeDelegateSpy: SignUpResendCodeDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onSignUpResendCodeErrorCalled = false
+    private(set) var onSignUpResendCodeCodeRequiredCalled = false
+    private(set) var error: ResendCodeError?
+    private(set) var newState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpResendCodeError(error: ResendCodeError) {
+        onSignUpResendCodeErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpResendCodeCodeRequired(newState: MSAL.SignUpCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpResendCodeCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.codeLength = codeLength
+        self.channelTargetType = channelTargetType
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class SignUpVerifyCodeDelegateSpy: SignUpVerifyCodeDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onSignUpVerifyCodeErrorCalled = false
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var onSignUpPasswordRequiredCalled = false
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var error: VerifyCodeError?
+    private(set) var newCodeRequiredState: SignUpCodeRequiredState?
+    private(set) var newAttributesRequiredState: SignUpAttributesRequiredState?
+    private(set) var newPasswordRequiredState: SignUpPasswordRequiredState?
+    private(set) var newSignInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpVerifyCodeError(error: MSAL.VerifyCodeError, newState: MSAL.SignUpCodeRequiredState?) {
+        onSignUpVerifyCodeErrorCalled = true
+        self.error = error
+        newCodeRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredCalled = true
+        newAttributesRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpPasswordRequired(newState: MSAL.SignUpPasswordRequiredState) {
+        onSignUpPasswordRequiredCalled = true
+        newPasswordRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        newSignInAfterSignUpState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class SignUpPasswordRequiredDelegateSpy: SignUpPasswordRequiredDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onSignUpPasswordRequiredErrorCalled = false
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var error: PasswordRequiredError?
+    private(set) var newPasswordRequiredState: SignUpPasswordRequiredState?
+    private(set) var newAttributesRequiredState: SignUpAttributesRequiredState?
+    private(set) var signInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordRequiredError(error: MSAL.PasswordRequiredError, newState: MSAL.SignUpPasswordRequiredState?) {
+        onSignUpPasswordRequiredErrorCalled = true
+        self.error = error
+        newPasswordRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredCalled = true
+        newAttributesRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        self.signInAfterSignUpState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class SignUpAttributesRequiredDelegateSpy: SignUpAttributesRequiredDelegate {
+    private let expectation: XCTestExpectation?
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var onSignUpAttributesRequiredErrorCalled = false
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var error: AttributesRequiredError?
+    private(set) var newState: SignUpAttributesRequiredState?
+    private(set) var attributes: [MSAL.MSALNativeAuthRequiredAttributes]?
+    private(set) var invalidAttributes: [String]?
+    private(set) var newSignInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpAttributesRequiredError(error: MSAL.AttributesRequiredError) {
+        onSignUpAttributesRequiredErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        newSignInAfterSignUpState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+    
+    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+        self.attributes = attributes
+        self.newState = newState
+        onSignUpAttributesRequiredCalled = true
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+    
+    func onSignUpAttributesInvalid(attributeNames: [String], newState: MSAL.SignUpAttributesRequiredState) {
+        self.invalidAttributes = attributeNames
+        self.newState = newState
+        onSignUpAttributesRequiredCalled = true
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class SignUpVerifyCodeDelegateOptionalMethodsNotImplemented: SignUpVerifyCodeDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var error: VerifyCodeError?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpVerifyCodeError(error: MSAL.VerifyCodeError, newState: MSAL.SignUpCodeRequiredState?) {
+        self.error = error
+        XCTAssertTrue(Thread.isMainThread)
+        expectation.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        XCTAssertTrue(Thread.isMainThread)
+    }
+}
+
+class SignUpPasswordStartDelegateOptionalMethodsNotImplemented: SignUpPasswordStartDelegate {
+    private let expectation: XCTestExpectation?
+    private(set) var onSignUpPasswordErrorCalled = false
+    private(set) var error: SignUpPasswordStartError?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordError(error: MSAL.SignUpPasswordStartError) {
+        onSignUpPasswordErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+    
+    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        XCTFail("This method should not be called")
+        self.expectation?.fulfill()
+    }
+}
+
+class SignUpStartDelegateOptionalMethodsNotImplemented: SignUpStartDelegate {
+    private let expectation: XCTestExpectation?
+    private(set) var onSignUpStartErrorCalled = false
+    private(set) var error: SignUpStartError?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpError(error: MSAL.SignUpStartError) {
+        onSignUpStartErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+    
+    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        XCTFail("This method should not be called")
+        self.expectation?.fulfill()
+    }
+}
+
+class SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented: SignUpPasswordRequiredDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var error: PasswordRequiredError?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordRequiredError(error: MSAL.PasswordRequiredError, newState: MSAL.SignUpPasswordRequiredState?) {
+        self.error = error
+        XCTAssertTrue(Thread.isMainThread)
+        expectation.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        XCTAssertTrue(Thread.isMainThread)
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/SignUpTestsValidatorHelpers.swift
+++ b/MSAL/test/unit/native_auth/mock/SignUpTestsValidatorHelpers.swift
@@ -1,0 +1,272 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+class SignUpPasswordStartTestsValidatorHelper: SignUpPasswordStartDelegateSpy {
+
+    func onSignUpPasswordError(_ input: MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse) {
+        guard case let .error(error) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpPasswordError(error: error)
+        }
+    }
+
+    func onSignUpCodeRequired(_ input: MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be .codeRequired")
+        }
+
+        Task {
+            await self.onSignUpCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength)
+        }
+    }
+
+    func onSignUpAttributesInvalid(_ input: MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse) {
+        guard case let .attributesInvalid(attributes) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be .attributeValidationFailed")
+        }
+
+        Task {
+            await self.onSignUpAttributesInvalid(attributeNames: attributes)
+        }
+    }
+}
+
+class SignUpCodeStartTestsValidatorHelper: SignUpCodeStartDelegateSpy {
+
+    func onSignUpError(_ input: MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse) {
+        guard case let .error(error) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpError(error: error)
+        }
+    }
+
+    func onSignUpCodeRequired(_ input: MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be .codeRequired")
+        }
+
+        Task {
+            await self.onSignUpCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength)
+        }
+    }
+
+    func onSignUpAttributesInvalid(_ input: MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse) {
+        guard case let .attributesInvalid(attributes) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be .attributeValidationFailed")
+        }
+
+        Task {
+            await self.onSignUpAttributesInvalid(attributeNames: attributes)
+        }
+    }
+}
+
+class SignUpResendCodeTestsValidatorHelper: SignUpResendCodeDelegateSpy {
+
+    func onSignUpResendCodeError(_ input: SignUpResendCodeResult) {
+        guard case let .error(error) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpResendCodeError(error: error)
+        }
+    }
+
+    func onSignUpResendCodeCodeRequired(_ input: SignUpResendCodeResult) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be .codeRequired")
+        }
+        
+        Task {
+            await self.onSignUpResendCodeCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength)
+        }
+    }
+}
+
+class SignUpVerifyCodeTestsValidatorHelper: SignUpVerifyCodeDelegateSpy {
+
+    func onSignUpVerifyCodeError(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse) {
+        guard case let .error(error, newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpVerifyCodeError(error: error, newState: newState)
+        }
+    }
+
+    func onSignUpAttributesRequired(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse) {
+        guard case let .attributesRequired(attributes, newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpAttributesRequired(attributes: attributes, newState: newState)
+        }
+    }
+
+    func onSignUpPasswordRequired(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse) {
+        guard case let .passwordRequired(newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpPasswordRequired(newState: newState)
+        }
+    }
+
+    func onSignUpCompleted(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse) {
+        guard case let .completed(newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpCompleted(newState: newState)
+        }
+    }
+}
+
+class SignUpPasswordRequiredTestsValidatorHelper: SignUpPasswordRequiredDelegateSpy {
+
+    func onSignUpPasswordRequiredError(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse) {
+        guard case let .error(error, newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpPasswordRequiredError(error: error, newState: newState)
+        }
+    }
+
+    func onSignUpAttributesRequired(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse) {
+        guard case let .attributesRequired(attributes, newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpAttributesRequired(attributes: attributes, newState: newState)
+        }
+    }
+
+    func onSignUpCompleted(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse) {
+        guard case let .completed(newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpCompleted(newState: newState)
+        }
+    }
+}
+
+class SignUpAttributesRequiredTestsValidatorHelper {
+    private let expectation: XCTestExpectation?
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var onSignUpInvalidAttributesCalled = false
+    private(set) var onSignUpAttributesRequiredErrorCalled = false
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var error: AttributesRequiredError?
+    private(set) var newState: SignUpAttributesRequiredState?
+    private(set) var signInAfterSignUpState: SignInAfterSignUpState?
+    private(set) var attributes: [MSALNativeAuthRequiredAttributes]?
+    private(set) var invalidAttributes: [String]?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpAttributesRequired(_ input: SignUpAttributesRequiredResult) {
+        guard case let .attributesRequired(attributes, state) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be .attributesInvalid")
+        }
+
+        onSignUpAttributesRequiredCalled = true
+        self.attributes = attributes
+        self.newState = state
+
+        expectation?.fulfill()
+    }
+
+    func onSignUpAttributesRequiredError(_ input: SignUpAttributesRequiredResult) {
+        guard case let .error(error) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        onSignUpAttributesRequiredErrorCalled = true
+        self.error = error
+
+        expectation?.fulfill()
+    }
+
+    func onSignUpAttributesValidationFailed(_ input: SignUpAttributesRequiredResult) {
+        guard case let .attributesInvalid(attributes, state) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        self.onSignUpInvalidAttributesCalled = true
+        self.invalidAttributes = attributes
+        self.newState = state
+
+        expectation?.fulfill()
+    }
+
+    func onSignUpCompleted(_ input: SignUpAttributesRequiredResult) {
+        guard case .completed = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        onSignUpCompletedCalled = true
+
+        expectation?.fulfill()
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthEndpointTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthEndpointTests.swift
@@ -1,0 +1,79 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthEndpointTests: XCTestCase {
+
+    private typealias sut = MSALNativeAuthEndpoint
+
+    func test_allEndpoints_are_tested() {
+        XCTAssertEqual(sut.allCases.count, 12)
+    }
+
+    func test_signUp_start() {
+        XCTAssertEqual(sut.signUpStart.rawValue, "/signup/v1.0/start")
+    }
+
+    func test_signUp_challenge() {
+        XCTAssertEqual(sut.signUpChallenge.rawValue, "/signup/v1.0/challenge")
+    }
+
+    func test_signUp_continue() {
+        XCTAssertEqual(sut.signUpContinue.rawValue, "/signup/v1.0/continue")
+    }
+
+    func test_signInInitiate_endpoint() {
+        XCTAssertEqual(sut.signInInitiate.rawValue, "/oauth2/v2.0/initiate")
+    }
+
+    func test_signInChallenge_endpoint() {
+        XCTAssertEqual(sut.signInChallenge.rawValue, "/oauth2/v2.0/challenge")
+    }
+
+    func test_token_endpoint() {
+        XCTAssertEqual(sut.token.rawValue, "/oauth2/v2.0/token")
+    }
+
+    func test_resetPasswordStart_endpoint() {
+        XCTAssertEqual(sut.resetPasswordStart.rawValue, "/resetpassword/v1.0/start")
+    }
+
+    func test_resetPasswordChallenge_endpoint() {
+        XCTAssertEqual(sut.resetPasswordChallenge.rawValue, "/resetpassword/v1.0/challenge")
+    }
+
+    func test_resetPasswordContinue_endpoint() {
+        XCTAssertEqual(sut.resetPasswordContinue.rawValue, "/resetpassword/v1.0/continue")
+    }
+
+    func test_resetPasswordSubmit_endpoint() {
+        XCTAssertEqual(sut.resetPasswordSubmit.rawValue, "/resetpassword/v1.0/submit")
+    }
+
+    func test_resetPasswordComplete_endpoint() {
+        XCTAssertEqual(sut.resetPasswordComplete.rawValue, "/resetpassword/v1.0/complete")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
@@ -1,0 +1,451 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
+
+    let telemetryProvider = MSALNativeAuthTelemetryProvider()
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+    
+    let context = MSALNativeAuthRequestContext(
+        correlationId: .init(
+            UUID(uuidString: DEFAULT_TEST_UID)!
+        )
+    )
+
+    func test_signInInititate_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForSignIn(type: .signInInitiate),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthSignInInitiateRequestParameters(context: context,
+                                                                   username: DEFAULT_TEST_ID_TOKEN_USERNAME)
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .signIn(.initiate(params)),
+                      request: request,
+                      telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "challenge_type": "password",
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .signInInitiate)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_signInChallenge_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.otp]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForSignIn(type: .signInChallenge),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthSignInChallengeRequestParameters(context: context,
+                                                                    credentialToken: "Test Credential Token")
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .signIn(.challenge(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "credential_token": "Test Credential Token",
+            "challenge_type": "otp"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .signInChallenge)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_signInToken_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForToken(type: .signInWithPassword),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthTokenRequestParameters(context: context,
+                                                          username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+                                                          credentialToken: "Test Credential Token",
+                                                          signInSLT: "Test SignIn SLT",
+                                                          grantType: .password,
+                                                          scope: "<scope-1>",
+                                                          password: "password",
+                                                          oobCode: "oob",
+                                                          includeChallengeType: true,
+                                                          refreshToken: nil)
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .token(.signInWithPassword(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "credential_token": "Test Credential Token",
+            "signin_slt": "Test SignIn SLT",
+            "grant_type": "password",
+            "challenge_type": "password",
+            "scope": "<scope-1>",
+            "password": "password",
+            "oob": "oob",
+            "client_info" : "true"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .token)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_signUpStartRequest_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForSignUp(type: .signUpStart),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthSignUpStartRequestParameters(username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+                                                                password: "strong-password",
+                                                                attributes: "<attribute1: value1>",
+                                                                context: context)
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .signUp(.start(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "password": "strong-password",
+            "attributes": "<attribute1: value1>",
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .signUpStart)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_signUpChallengeRequest_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForSignUp(type: .signUpChallenge),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthSignUpChallengeRequestParameters(signUpToken: "<sign-up-token>",
+                                                                    context: context)
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .signUp(.challenge(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "signup_token": "<sign-up-token>",
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .signUpChallenge)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_signUpContinueRequest_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForSignUp(type: .signUpContinue),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthSignUpContinueRequestParameters(grantType: .oobCode,
+                                                                   signUpToken: "<sign-up-token>",
+                                                                   password: "<strong-password>",
+                                                                   oobCode: "0000",
+                                                                   attributes: "<attributes>",
+                                                                   context: context)
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .signUp(.continue(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "signup_token": "<sign-up-token>",
+            "password": "<strong-password>",
+            "oob": "0000",
+            "grant_type": "oob",
+            "attributes": "<attributes>"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .signUpContinue)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+
+    func test_resetPasswordStart_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordStart),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthResetPasswordStartRequestParameters(context: context,
+                                                                       username: DEFAULT_TEST_ID_TOKEN_USERNAME)
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .resetPassword(.start(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .resetPasswordStart)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_resetPasswordChallenge_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordChallenge),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthResetPasswordChallengeRequestParameters(context: context,
+                                                                           passwordResetToken: "<password-reset-token>")
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .resetPassword(.challenge(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_reset_token": "<password-reset-token>",
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .resetPasswordChallenge)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_resetPasswordContinue_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordContinue),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthResetPasswordContinueRequestParameters(context: context,
+                                                                          passwordResetToken: "<password-reset-token>",
+                                                                          grantType: .oobCode,
+                                                                          oobCode: "0000")
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .resetPassword(.continue(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_reset_token": "<password-reset-token>",
+            "grant_type": "oob",
+            "oob": "0000"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .resetPasswordContinue)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_resetPasswordSubmit_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordSubmit),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthResetPasswordSubmitRequestParameters(context: context,
+                                                                        passwordSubmitToken: "<password-submit-token>",
+                                                                        newPassword:"new-password")
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .resetPassword(.submit(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_submit_token": "<password-submit-token>",
+            "new_password": "new-password"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .resetPasswordSubmit)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_resetPasswordPollCompletion_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordPollCompletion),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthResetPasswordPollCompletionRequestParameters(context: context,
+                                                                                passwordResetToken: "<password-reset-token")
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .resetPassword(.pollCompletion(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_reset_token": "<password-reset-token"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .resetpasswordPollCompletion)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_refreshToken_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForToken(type: .refreshToken),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthTokenRequestParameters(context: context,
+                                                          username: nil,
+                                                          credentialToken: nil,
+                                                          signInSLT: nil,
+                                                          grantType: .refreshToken,
+                                                          scope: "<scope-1>",
+                                                          password: nil,
+                                                          oobCode: nil,
+                                                          includeChallengeType: false,
+                                                          refreshToken: "refreshToken")
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .token(.refreshToken(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id" : DEFAULT_TEST_CLIENT_ID,
+            "grant_type" : "refresh_token",
+            "scope" : "<scope-1>",
+            "refresh_token" : "refreshToken",
+            "client_info" : "true"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .token)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+
+    private func checkUrlRequest(_ result: URLRequest?, endpoint: MSALNativeAuthEndpoint) {
+        XCTAssertEqual(result?.httpMethod, MSALParameterStringForHttpMethod(.POST))
+
+        let expectedUrl = URL(string: MSALNativeAuthNetworkStubs.authority.url.absoluteString + endpoint.rawValue)!
+        XCTAssertEqual(result?.url, expectedUrl)
+    }
+
+    private func checkHeaders(request: MSIDHttpRequest) {
+        let headers = request.urlRequest?.allHTTPHeaderFields!
+        XCTAssertEqual(headers!["Accept"], "application/json")
+        XCTAssertEqual(headers!["return-client-request-id"], "true")
+        XCTAssertEqual(headers!["x-ms-PkeyAuth+"], "1.0")
+        XCTAssertNotNil("client-request-id")
+        XCTAssertNotNil("x-client-CPU")
+        XCTAssertNotNil("x-client-SKU")
+        XCTAssertNotNil("x-app-name")
+        XCTAssertNotNil("x-app-ver")
+        XCTAssertNotNil("x-client-OS")
+        XCTAssertNotNil("x-client-Ver")
+#if TARGET_OS_IPHONE
+        XCTAssertNotNil("x-client-DM")
+#endif
+    }
+
+    private func checkTelemetry(_ result: MSIDHttpRequestServerTelemetryHandling?, _ expected: MSALNativeAuthServerTelemetry) {
+
+        guard let resultTelemetry = (result as? MSALNativeAuthServerTelemetry)?.currentRequestTelemetry else {
+            return XCTFail()
+        }
+
+        let expectedTelemetry = expected.currentRequestTelemetry
+
+        XCTAssertEqual(resultTelemetry.apiId, expectedTelemetry.apiId)
+        XCTAssertEqual(resultTelemetry.operationType, expectedTelemetry.operationType)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestErrorHandlerTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestErrorHandlerTests.swift
@@ -1,0 +1,281 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
+    // MARK: - Variables
+
+    private var sut: MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInInitiateResponseError>!
+    private let error = NSError(domain:"Test Error Domain", code:400, userInfo:nil)
+    private var httpRequest: MSIDHttpRequest!
+    private let context = MSALNativeAuthRequestContextMock(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+
+    override func setUpWithError() throws {
+        sut = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInInitiateResponseError>()
+        httpRequest = MSIDHttpRequest()
+        try super.setUpWithError()
+    }
+
+    func test_completeWithError_whenBodyMissing() {
+        let expectation = expectation(description: "Handle Error Body Missing")
+        sut.handleError(
+            error,
+            httpResponse: nil,
+            data: nil,
+            httpRequest: nil,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: nil
+        ) { result, error in
+            XCTAssertEqual(self.error.domain, (error! as NSError).domain)
+            XCTAssertEqual(self.error.code, (error! as NSError).code)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldRetry_whenRetryCountGreaterThanZeroAndRetryStatusCode() {
+        let expectation = expectation(description: "Handle Error Retry Success")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 500,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        HttpModuleMockConfigurator.configure(request: httpRequest, response: httpResponse, responseJson: [])
+        httpRequest.retryCounter = 5
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: nil,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual(self.httpRequest.retryCounter, 4)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldNotRetry_whenRetryCountZeroAndRetryStatusCode() {
+        let expectation = expectation(description: "Handle Error No Retries Left")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 500,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        HttpModuleMockConfigurator.configure(request: httpRequest, response: httpResponse, responseJson: [])
+        httpRequest.retryCounter = 0
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: nil,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((error! as NSError).code, MSIDErrorCode.serverUnhandledResponse.rawValue)
+            XCTAssertEqual((error! as NSError).userInfo[MSIDHTTPResponseCodeKey] as! String, "500")
+            XCTAssertEqual((error! as NSError).userInfo[MSIDServerUnavailableStatusKey] as! Int, 1)
+            XCTAssertEqual((error! as NSError).userInfo[MSIDErrorDescriptionKey] as! String, "internal server error")
+            XCTAssertEqual(((error! as NSError).userInfo[MSIDHTTPHeadersKey] as! [String: String]).count, 0)
+            MSIDTestURLSession.clearResponses()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldCompleteAndResend_whenResponseContainsPkeyHeader() {
+        let expectation = expectation(description: "Handle Error Response Pkey Header")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 400,
+            httpVersion: nil,
+            headerFields: [kMSIDWwwAuthenticateHeader: "PKeyAuth Context=TestContext,Version=1.0"]
+        )
+
+        HttpModuleMockConfigurator.configure(request: httpRequest, response: httpResponse, responseJson: [])
+
+        let secondHttpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Authorization": "PKeyAuth  Context=\"TestContext\", Version=\"1.0\"",
+                           "Content-Type": "application/x-www-form-urlencoded"]
+        )
+        let testUrlResponse = MSIDTestURLResponse.request(HttpModuleMockConfigurator.baseUrl, reponse: secondHttpResponse)
+        testUrlResponse?.setRequestHeaders(secondHttpResponse?.allHeaderFields)
+        testUrlResponse?.setResponseJSON(["Test":"Response"])
+        MSIDTestURLSession.add(testUrlResponse)
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: nil,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((result as! NSDictionary)["Test"] as! String, "Response")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldCompleteWithAPIError_whenStatusCode400() {
+        let expectation = expectation(description: "Handle Error Retry Success")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 400,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        var dictionary = [String: Any]()
+        dictionary["error"] = "invalid_request"
+        dictionary["error_description"] = "Request parameter validation failed"
+        dictionary["error_uri"] = HttpModuleMockConfigurator.baseUrl.absoluteString
+        dictionary["inner_errors"] = [["error": "invalid_username", "error_description":"Username was invalid"]]
+
+        let data = try! JSONSerialization.data(withJSONObject: dictionary)
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: data,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((error as! MSALNativeAuthSignInInitiateResponseError).error, MSALNativeAuthSignInInitiateOauth2ErrorCode.invalidRequest)
+            XCTAssertEqual((error as! MSALNativeAuthSignInInitiateResponseError).errorDescription, "Request parameter validation failed")
+            XCTAssertEqual((error as! MSALNativeAuthSignInInitiateResponseError).errorURI, HttpModuleMockConfigurator.baseUrl.absoluteString)
+            XCTAssertEqual((error as! MSALNativeAuthSignInInitiateResponseError).innerErrors![0].error, "invalid_username")
+            XCTAssertEqual((error as! MSALNativeAuthSignInInitiateResponseError).innerErrors![0].errorDescription, "Username was invalid")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldFailWithDecodeError_whenStatusCode400AndJSONMissing() {
+        let expectation = expectation(description: "Handle Error Retry Success")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 400,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        let dictionary = [String: Any]()
+        let data = try! JSONSerialization.data(withJSONObject: dictionary)
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: data,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((error as! DecodingError).localizedDescription,"The data couldn’t be read because it is missing.")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldFailWithDecodeError_whenStatusCode400AndJSONInvalid() {
+        let expectation = expectation(description: "Handle Error Retry Success")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 400,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        var dictionary = [String: Any]()
+        dictionary["error_key_incorrect"] = "invalid_request"
+        let data = try! JSONSerialization.data(withJSONObject: dictionary)
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: data,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((error as! DecodingError).localizedDescription,"The data couldn’t be read because it is missing.")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldCompleteWithHTTPError_whenStatusCodeNotHandled() {
+        let expectation = expectation(description: "Handle Error Retry Success")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 600,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: nil,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((error! as NSError).code, MSIDErrorCode.serverUnhandledResponse.rawValue)
+            XCTAssertEqual((error! as NSError).userInfo[MSIDHTTPResponseCodeKey] as! String, "600")
+            XCTAssertEqual((error! as NSError).userInfo[MSIDErrorDescriptionKey] as! String, "")
+            XCTAssertEqual(((error! as NSError).userInfo[MSIDHTTPHeadersKey] as! [String: String]).count, 0)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
@@ -1,0 +1,79 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthRequestableTests: XCTestCase {
+    
+    var request: MSALNativeAuthResetPasswordStartRequestParameters! = nil
+
+    override func setUpWithError() throws {
+        let context = MSALNativeAuthRequestContext(
+                correlationId: .init(
+                UUID(uuidString: DEFAULT_TEST_UID)!
+            )
+        )
+        
+        request = MSALNativeAuthResetPasswordStartRequestParameters(context: context, username: DEFAULT_TEST_ID_TOKEN_USERNAME)
+    }
+    
+    func test_whenSliceConfigIsUsed_CorrectURLIsGenerated() throws {
+        let sliceDc = "TEST-SLICE-IDENTIFIER"
+        
+        guard let authorityUrl = URL(string: DEFAULT_TEST_AUTHORITY) else {
+            XCTFail()
+            return
+        }
+        
+        let authority = try MSALCIAMAuthority(url: authorityUrl)
+        var config = try MSALNativeAuthConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
+                                                      authority: authority,
+                                                      challengeTypes: [.redirect])
+        
+        config.sliceConfig = MSALSliceConfig(slice: nil, dc: sliceDc)
+        let url = try request.makeEndpointUrl(config: config)
+        
+        let expectedUrlString = config.authority.url.absoluteString + request.endpoint.rawValue + "?dc=\(sliceDc)"
+        XCTAssertEqual(url.absoluteString, expectedUrlString)
+    }
+    
+    func test_whenSliceConfigIsNotUsed_CorrectURLIsGenerated() throws {
+        guard let authorityUrl = URL(string: DEFAULT_TEST_AUTHORITY) else {
+            XCTFail()
+            return
+        }
+        
+        let authority = try MSALCIAMAuthority(url: authorityUrl)
+        var config = try MSALNativeAuthConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
+                                                      authority: authority,
+                                                      challengeTypes: [.redirect])
+        
+        let url = try request.makeEndpointUrl(config: config)
+        
+        let expectedUrlString = config.authority.url.absoluteString + request.endpoint.rawValue
+        XCTAssertEqual(url.absoluteString, expectedUrlString)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseSerializerTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseSerializerTests.swift
@@ -1,0 +1,80 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResponseSerializerTests: XCTestCase {
+
+    func testSerialize_correctResponse_shouldReturnSuccess() {
+        let serializer = MSALNativeAuthResponseSerializer<ResponseStub>()
+        let responseString = """
+        {
+          "token_type": "Bearer",
+          "scope": "scope",
+          "expires_in": 4141,
+          "extended_expires_in": 4141,
+          "access_token": "access",
+          "refresh_token": "refresh",
+          "id_token": "id"
+        }
+        """
+        var response: ResponseStub? = nil
+        XCTAssertNoThrow(response = try serializer.responseObject(for: nil, data:responseString.data(using: .utf8) , context: nil) as? ResponseStub)
+        XCTAssertEqual(response?.idToken, "id")
+        XCTAssertEqual(response?.tokenType, "Bearer")
+        XCTAssertEqual(response?.scope, "scope")
+        XCTAssertEqual(response?.expiresIn, 4141)
+        XCTAssertEqual(response?.extendedExpiresIn, 4141)
+        XCTAssertEqual(response?.refreshToken, "refresh")
+        XCTAssertEqual(response?.accessToken, "access")
+    }
+
+    func testSerialize_wrongResponse_shouldFail() throws {
+        let serializer = MSALNativeAuthResponseSerializer<ResponseStub>()
+        let wrongResponseString = """
+        {
+          "tokenType": "Bearer",
+          "spe": "scope",
+          "expiresIn": 4141,
+          "ext_expires_in": 4141,
+          "access_token": "access",
+          "refresh_token": "refresh",
+          "id_token": "id"
+        }
+        """
+        XCTAssertThrowsError(try serializer.responseObject(for: nil, data: wrongResponseString.data(using: .utf8) , context: nil))
+    }
+}
+
+private struct ResponseStub: Decodable {
+    let tokenType: String
+    let scope: String
+    let expiresIn: Int
+    let extendedExpiresIn: Int
+    let accessToken: String
+    let refreshToken: String
+    let idToken: String
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
@@ -1,0 +1,141 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
+
+    private var sut: MSALNativeAuthSignUpRequestProvider!
+    private var telemetryProvider: MSALNativeAuthTelemetryProvider!
+    private var context: MSIDRequestContext!
+
+    override func setUpWithError() throws {
+        telemetryProvider = MSALNativeAuthTelemetryProvider()
+        context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+
+        sut = .init(requestConfigurator: MSALNativeAuthRequestConfigurator(config: MSALNativeAuthConfigStubs.configuration),
+                    telemetryProvider: telemetryProvider)
+    }
+
+    func test_signUpStartRequest_is_created_successfully() throws {
+        let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            password: "1234",
+            attributes: ["city": "dublin"],
+            context: MSALNativeAuthRequestContext(correlationId: context.correlationId())
+        )
+
+        let request = try sut.start(parameters: parameters)
+
+        checkBodyParams(request.parameters, for: .signUpStart)
+        checkUrlRequest(request.urlRequest!, for: .signUpStart)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpStart).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+
+    func test_signUpChallengeRequest_is_created_successfully() throws {
+        let request = try sut.challenge(token: "sign-up-token", context: context)
+
+        checkBodyParams(request.parameters, for: .signUpChallenge)
+        checkUrlRequest(request.urlRequest!, for: .signUpChallenge)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpChallenge).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+
+    func test_signUpContinueRequest_is_created_successfully() throws {
+        let parameters = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: "sign-up-token",
+            password: "1234",
+            oobCode: nil,
+            attributes: nil,
+            context: context
+        )
+
+        let request = try sut.continue(parameters: parameters)
+
+        checkBodyParams(request.parameters, for: .signUpContinue)
+        checkUrlRequest(request.urlRequest!, for: .signUpContinue)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpContinue).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+
+    private func checkBodyParams(_ bodyParams: [String: String]?, for endpoint: MSALNativeAuthEndpoint) {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        var expectedBodyParams: [String: String]!
+
+        switch endpoint {
+        case .signUpStart:
+            expectedBodyParams = [
+                Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
+                Key.username.rawValue: DEFAULT_TEST_ID_TOKEN_USERNAME,
+                Key.challengeType.rawValue: "redirect",
+                Key.attributes.rawValue: "{\"city\":\"dublin\"}",
+                Key.password.rawValue: "1234"
+            ]
+        case .signUpChallenge:
+            expectedBodyParams = [
+                Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
+                Key.signUpToken.rawValue: "sign-up-token",
+                Key.challengeType.rawValue: "redirect"
+            ]
+        case .signUpContinue:
+            expectedBodyParams = [
+                Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
+                Key.grantType.rawValue: "password",
+                Key.signUpToken.rawValue: "sign-up-token",
+                Key.password.rawValue: "1234"
+            ]
+        default:
+            XCTFail("Case not tested")
+        }
+
+        XCTAssertEqual(bodyParams, expectedBodyParams)
+    }
+
+    private func checkUrlRequest(_ result: URLRequest?, for endpoint: MSALNativeAuthEndpoint) {
+        XCTAssertEqual(result?.httpMethod, MSALParameterStringForHttpMethod(.POST))
+
+        let expectedUrl = URL(string: MSALNativeAuthNetworkStubs.authority.url.absoluteString + endpoint.rawValue)!
+        XCTAssertEqual(result?.url, expectedUrl)
+
+        XCTAssertEqual(result?.allHTTPHeaderFields?["return-client-request-id"], "true")
+        XCTAssertEqual(result?.allHTTPHeaderFields?["Accept"], "application/json")
+    }
+
+    private func checkServerTelemetry(_ result: MSIDHttpRequestServerTelemetryHandling?, expectedTelemetryResult: String) {
+        guard let serverTelemetry = result as? MSALNativeAuthServerTelemetry else {
+            return XCTFail("Server telemetry should be of kind MSALNativeAuthServerTelemetry")
+        }
+
+        XCTAssertEqual(serverTelemetry.context.correlationId().uuidString, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(serverTelemetry.currentRequestTelemetry.telemetryString(), expectedTelemetryResult)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthUrlRequestSerializerTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthUrlRequestSerializerTests.swift
@@ -1,0 +1,196 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthUrlRequestSerializerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthUrlRequestSerializer!
+    private var request: URLRequest!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let url = URL(string: DEFAULT_TEST_RESOURCE)!
+        request = URLRequest(url: url)
+
+        sut = MSALNativeAuthUrlRequestSerializer(context: MSALNativeAuthRequestContext(), encoding: .json)
+    }
+
+    func test_serialize_successfully() throws {
+        let parameters = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "grant_type": "passwordless_otp",
+            "email": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "password": "12345",
+            "scope": DEFAULT_TEST_SCOPE
+        ]
+
+        let headers = [
+            "custom-header": "value"
+        ]
+
+        let result = sut.serialize(with: request, parameters: parameters, headers: headers)
+
+        let bodyParametersResult = try JSONDecoder().decode([String: String].self, from: result.httpBody!)
+
+        XCTAssertEqual(bodyParametersResult.count, 5)
+        XCTAssertEqual(bodyParametersResult["client_id"], DEFAULT_TEST_CLIENT_ID)
+        XCTAssertEqual(bodyParametersResult["grant_type"], "passwordless_otp")
+        XCTAssertEqual(bodyParametersResult["email"], DEFAULT_TEST_ID_TOKEN_USERNAME)
+        XCTAssertEqual(bodyParametersResult["password"], "12345")
+        XCTAssertEqual(bodyParametersResult["scope"], DEFAULT_TEST_SCOPE)
+
+        let httpHeadersResult = result.allHTTPHeaderFields!
+
+        XCTAssertEqual(httpHeadersResult.count, 2)
+        XCTAssertEqual(httpHeadersResult["Content-Type"], "application/json")
+        XCTAssertEqual(httpHeadersResult["custom-header"], "value")
+    }
+
+    func test_serialize_with_dict_in_body() throws {
+        let customAttributes: [String: Codable] = [
+            "name": "John",
+            "surname": "Smith",
+            "age": "37"
+        ]
+
+        let parameters = [
+            "customAttributes": customAttributes
+        ]
+
+        let result = sut.serialize(with: request, parameters: parameters, headers: [:])
+
+        let bodyParametersResult = try JSONDecoder().decode([String: [String: String]].self, from: result.httpBody!)
+
+        XCTAssertEqual(bodyParametersResult.count, 1)
+        let resultCustomAttributes = bodyParametersResult["customAttributes"]!
+
+        XCTAssertEqual(resultCustomAttributes["name"], "John")
+        XCTAssertEqual(resultCustomAttributes["surname"], "Smith")
+        XCTAssertEqual(resultCustomAttributes["age"], "37")
+
+        let httpHeadersResult = result.allHTTPHeaderFields!
+
+        XCTAssertEqual(httpHeadersResult.count, 1)
+        XCTAssertEqual(httpHeadersResult["Content-Type"], "application/json")
+    }
+
+    func test_when_passingEmptyBodyParams_it_still_succeeds() throws {
+        let expectation = expectation(description: "Body request serialization error")
+        expectation.isInverted = true
+
+        Self.logger.expectation = expectation
+
+        let result = sut.serialize(with: request, parameters: [:], headers: [:])
+
+        wait(for: [expectation], timeout: 1)
+
+        let bodyParametersResult = try JSONDecoder().decode([String: [String: String]].self, from: result.httpBody!)
+        XCTAssertEqual(bodyParametersResult.count, 0)
+    }
+
+    func test_when_error_happens_in_headerSerialization_it_logs_it() throws {
+        let expectation = expectation(description: "Header serialization error")
+
+        Self.logger.expectation = expectation
+
+        _ = sut.serialize(with: request, parameters: [:], headers: ["header": 1])
+
+        wait(for: [expectation], timeout: 1)
+
+        let resultingLog = Self.logger.messages[0] as! String
+        XCTAssertTrue(resultingLog.contains("Header serialization failed"))
+    }
+
+    func test_when_error_happens_in_bodySerialization_it_logs_it() throws {
+        let expectation = expectation(description: "Body request serialization error")
+
+        Self.logger.expectation = expectation
+
+        let impossibleToEncode = [
+            "param": UIView()
+        ]
+
+        _ = sut.serialize(with: request, parameters: impossibleToEncode, headers: [:])
+
+        wait(for: [expectation], timeout: 1)
+
+        let resultingLog = Self.logger.messages[0] as! String
+        XCTAssertTrue(resultingLog.contains("HTTP body request serialization failed"))
+    }
+
+    func test_serializeUrlForm_successfully() {
+        let parameters = [
+            "clientId": DEFAULT_TEST_CLIENT_ID,
+            "grantType": "oob",
+            "email": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "password": "12345",
+            "scope": DEFAULT_TEST_SCOPE
+        ]
+
+        let headers = [
+            "custom-header": "value"
+        ]
+
+        sut = MSALNativeAuthUrlRequestSerializer(context: MSALNativeAuthRequestContext(), encoding: .wwwFormUrlEncoded)
+
+        let result = sut.serialize(with: request, parameters: parameters, headers: headers)
+        let bodyResultFormUrlEncoded = String(data: result.httpBody!, encoding: .utf8)
+
+        let expectedScope = "scope=https%3A%2F%2Fgraph.microsoft.com%2Fmail.read"
+        let expectedClientId = "clientId=\(DEFAULT_TEST_CLIENT_ID)"
+        let expectedGrantType = "grantType=oob"
+        let expectedEmail = "email=user%40contoso.com"
+        let expectedPassword = "password=12345"
+
+        let expectedBodyResult = "\(expectedScope)&\(expectedClientId)&\(expectedGrantType)&\(expectedEmail)&\(expectedPassword)"
+
+        XCTAssertEqual(bodyResultFormUrlEncoded?.sorted(), expectedBodyResult.sorted())
+
+        let httpHeadersResult = result.allHTTPHeaderFields!
+
+        XCTAssertEqual(httpHeadersResult.count, 2)
+        XCTAssertEqual(httpHeadersResult["Content-Type"], "application/x-www-form-urlencoded")
+        XCTAssertEqual(httpHeadersResult["custom-header"], "value")
+    }
+
+    func test_when_passingEmptyBodyParamsUsingUrlForm_it_still_succeeds() throws {
+        let expectation = expectation(description: "Body request serialization error")
+        expectation.isInverted = true
+
+        Self.logger.expectation = expectation
+
+        sut = MSALNativeAuthUrlRequestSerializer(context: MSALNativeAuthRequestContext(), encoding: .wwwFormUrlEncoded)
+
+        let result = sut.serialize(with: request, parameters: [:], headers: [:])
+
+        wait(for: [expectation], timeout: 1)
+
+        let bodyResultFormUrlEncoded = String(data: result.httpBody!, encoding: .utf8)!
+        XCTAssertTrue(bodyResultFormUrlEncoded.isEmpty)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/MSALNativeAuthESTSApiErrorDescriptionsTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/MSALNativeAuthESTSApiErrorDescriptionsTests.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthESTSApiErrorDescriptionsTests: XCTestCase {
+    
+    private typealias sut = MSALNativeAuthESTSApiErrorDescriptions
+    
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 2)
+    }
+    
+    func test_usernameParameterIsEmptyOrNotValid() {
+        XCTAssertEqual(sut.usernameParameterIsEmptyOrNotValid.rawValue, "username parameter is empty or not valid")
+    }
+    
+    func test_clientIdParameterIsEmptyOrNotValid() {
+        XCTAssertEqual(sut.clientIdParameterIsEmptyOrNotValid.rawValue, "client_id parameter is empty or not valid")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthErrorRequiredAttributesTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthErrorRequiredAttributesTests.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthErrorRequiredAttributesTests: XCTestCase {
+
+    func test_toString_requiredTrue() {
+        let sut = MSALNativeAuthRequiredAttributesInternal(name: "aName", type: "", required: true)
+        XCTAssertEqual(sut.description, "aName")
+    }
+
+    func test_toString_requiredFalse() {
+        let sut = MSALNativeAuthRequiredAttributesInternal(name: "aName", type: "", required: false)
+        XCTAssertEqual(sut.description, "aName")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests.swift
@@ -1,0 +1,51 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests: XCTestCase {
+    
+    private typealias sut = MSALNativeAuthSignUpChallengeOauth2ErrorCode
+    
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 4)
+    }
+    
+    func test_invalidRequest() {
+        XCTAssertEqual(sut.invalidRequest.rawValue, "invalid_request")
+    }
+    
+    func test_unauthorizedClient() {
+        XCTAssertEqual(sut.unauthorizedClient.rawValue, "unauthorized_client")
+    }
+    
+    func test_unsupportedChallengeType() {
+        XCTAssertEqual(sut.unsupportedChallengeType.rawValue, "unsupported_challenge_type")
+    }
+    
+    func test_expiredToken() {
+        XCTAssertEqual(sut.expiredToken.rawValue, "expired_token")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
@@ -1,0 +1,134 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpChallengeResponseErrorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthSignUpChallengeResponseError!
+    private let testDescription = "testDescription"
+
+    // MARK: - to toSignUpPasswordStartPublicError tests
+
+    func test_toSignUpPasswordStartPublicError_unauthorizedClient() {
+        testSignUpChallengeErrorToSignUpPasswordStart(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpPasswordStartPublicError_unsupportedChallengeType() {
+        testSignUpChallengeErrorToSignUpPasswordStart(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpPasswordStartPublicError_expiredToken() {
+        testSignUpChallengeErrorToSignUpPasswordStart(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpPasswordStartPublicError_invalidRequest() {
+        testSignUpChallengeErrorToSignUpPasswordStart(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    // MARK: - to SignUpCodeStartError tests
+
+    func test_toSignUpCodeStartPublicError_unauthorizedClient() {
+        testSignUpChallengeErrorToSignUpStart(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpCodeStartPublicError_unsupportedChallengeType() {
+        testSignUpChallengeErrorToSignUpStart(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpCodeStartPublicError_expiredToken() {
+        testSignUpChallengeErrorToSignUpStart(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpCodeStartPublicError_invalidRequest() {
+        testSignUpChallengeErrorToSignUpStart(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    // MARK: - to ResendCodeError tests
+
+    func test_toResendCodePublicError_unauthorizedClient() {
+        testSignUpChallengeErrorToResendCodePublic(code: .unauthorizedClient, description: testDescription)
+    }
+
+    func test_toResendCodePublicError_unsupportedChallengeType() {
+        testSignUpChallengeErrorToResendCodePublic(code: .unsupportedChallengeType, description: "General error")
+    }
+
+    func test_toResendCodePublicError_expiredToken() {
+        testSignUpChallengeErrorToResendCodePublic(code: .expiredToken, description: testDescription)
+    }
+
+    func test_toResendCodePublicError_invalidRequest() {
+        testSignUpChallengeErrorToResendCodePublic(code: .invalidRequest, description: testDescription)
+    }
+
+    // MARK: - to PasswordRequiredError tests
+
+    func test_toPasswordRequiredPublicError_unauthorizedClient() {
+        testSignUpChallengeErrorToPasswordRequired(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_unsupportedChallengeType() {
+        testSignUpChallengeErrorToPasswordRequired(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_expiredToken() {
+        testSignUpChallengeErrorToPasswordRequired(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_invalidRequest() {
+        testSignUpChallengeErrorToPasswordRequired(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+        
+    // MARK: private methods
+    
+    private func testSignUpChallengeErrorToSignUpPasswordStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: SignUpPasswordStartErrorType) {
+        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        let error = sut.toSignUpPasswordStartPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpChallengeErrorToSignUpStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartErrorType) {
+        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        let error = sut.toSignUpStartPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpChallengeErrorToResendCodePublic(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?) {
+        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        let error = sut.toResendCodePublicError()
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpChallengeErrorToPasswordRequired(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredErrorType) {
+        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        let error = sut.toPasswordRequiredPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCodeTests.swift
@@ -1,0 +1,95 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpContinueOauth2ErrorCodeTests: XCTestCase {
+
+    private typealias sut = MSALNativeAuthSignUpContinueOauth2ErrorCode
+
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 15)
+    }
+
+    func test_invalidRequest() {
+        XCTAssertEqual(sut.invalidRequest.rawValue, "invalid_request")
+    }
+    
+    func test_unauthorizedClient() {
+        XCTAssertEqual(sut.unauthorizedClient.rawValue, "unauthorized_client")
+    }
+    
+    func test_invalidGrant() {
+        XCTAssertEqual(sut.invalidGrant.rawValue, "invalid_grant")
+    }
+    
+    func test_expiredToken() {
+        XCTAssertEqual(sut.expiredToken.rawValue, "expired_token")
+    }
+    
+    func test_passwordTooWeak() {
+        XCTAssertEqual(sut.passwordTooWeak.rawValue, "password_too_weak")
+    }
+    
+    func test_passwordTooShort() {
+        XCTAssertEqual(sut.passwordTooShort.rawValue, "password_too_short")
+    }
+    
+    func test_passwordTooLong() {
+        XCTAssertEqual(sut.passwordTooLong.rawValue, "password_too_long")
+    }
+    
+    func test_passwordRecentlyUsed() {
+        XCTAssertEqual(sut.passwordRecentlyUsed.rawValue, "password_recently_used")
+    }
+    
+    func test_passwordBanned() {
+        XCTAssertEqual(sut.passwordBanned.rawValue, "password_banned")
+    }
+    
+    func test_userAlreadyExists() {
+        XCTAssertEqual(sut.userAlreadyExists.rawValue, "user_already_exists")
+    }
+    
+    func test_attributesRequired() {
+        XCTAssertEqual(sut.attributesRequired.rawValue, "attributes_required")
+    }
+    
+    func test_verificationRequired() {
+        XCTAssertEqual(sut.verificationRequired.rawValue, "verification_required")
+    }
+    
+    func test_attributeValidationFailed() {
+        XCTAssertEqual(sut.attributeValidationFailed.rawValue, "attribute_validation_failed")
+    }
+    
+    func test_credentialRequired() {
+        XCTAssertEqual(sut.credentialRequired.rawValue, "credential_required")
+    }
+    
+    func test_invalidOOBValue() {
+        XCTAssertEqual(sut.invalidOOBValue.rawValue, "invalid_oob_value")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
@@ -1,0 +1,240 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
+    
+    private var sut: MSALNativeAuthSignUpContinueResponseError!
+    private let testDescription = "testDescription"
+    
+    // MARK: - to toVerifyCodePublicError tests
+    
+    func test_toVerifyCodePublicError_invalidRequest() {
+        testSignUpContinueErrorToVerifyCode(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_unauthorizedClient() {
+        testSignUpContinueErrorToVerifyCode(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_invalidGrant() {
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_expiredToken() {
+        testSignUpContinueErrorToVerifyCode(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_passwordTooWeak() {
+        testSignUpContinueErrorToVerifyCode(code: .passwordTooWeak, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_passwordTooShort() {
+        testSignUpContinueErrorToVerifyCode(code: .passwordTooShort, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_passwordTooLong() {
+        testSignUpContinueErrorToVerifyCode(code: .passwordTooLong, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_passwordRecentlyUsed() {
+        testSignUpContinueErrorToVerifyCode(code: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_passwordBanned() {
+        testSignUpContinueErrorToVerifyCode(code: .passwordBanned, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_userAlreadyExists() {
+        testSignUpContinueErrorToVerifyCode(code: .userAlreadyExists, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_attributesRequired() {
+        testSignUpContinueErrorToVerifyCode(code: .attributesRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_verificationRequired() {
+        testSignUpContinueErrorToVerifyCode(code: .verificationRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_attributeValidationFailed() {
+        testSignUpContinueErrorToVerifyCode(code: .attributeValidationFailed, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_credentialRequired() {
+        testSignUpContinueErrorToVerifyCode(code: .credentialRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_invalidOOBValue() {
+        testSignUpContinueErrorToVerifyCode(code: .invalidOOBValue, description: testDescription, expectedErrorType: .invalidCode)
+    }
+    
+    // MARK: - toPasswordRequiredPublicError tests
+    
+    func test_toPasswordRequiredPublicError_invalidRequest() {
+        testSignUpContinueErrorToPasswordRequired(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_unauthorizedClient() {
+        testSignUpContinueErrorToPasswordRequired(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_invalidGrant() {
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_expiredToken() {
+        testSignUpContinueErrorToPasswordRequired(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_passwordTooWeak() {
+        testSignUpContinueErrorToPasswordRequired(code: .passwordTooWeak, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toPasswordRequiredPublicError_passwordTooShort() {
+        testSignUpContinueErrorToPasswordRequired(code: .passwordTooShort, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toPasswordRequiredPublicError_passwordTooLong() {
+        testSignUpContinueErrorToPasswordRequired(code: .passwordTooLong, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toPasswordRequiredPublicError_passwordRecentlyUsed() {
+        testSignUpContinueErrorToPasswordRequired(code: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toPasswordRequiredPublicError_passwordBanned() {
+        testSignUpContinueErrorToPasswordRequired(code: .passwordBanned, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toPasswordRequiredPublicError_userAlreadyExists() {
+        testSignUpContinueErrorToPasswordRequired(code: .userAlreadyExists, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_attributesRequired() {
+        testSignUpContinueErrorToPasswordRequired(code: .attributesRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_verificationRequired() {
+        testSignUpContinueErrorToPasswordRequired(code: .verificationRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_attributeValidationFailed() {
+        testSignUpContinueErrorToPasswordRequired(code: .attributeValidationFailed, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_credentialRequired() {
+        testSignUpContinueErrorToPasswordRequired(code: .credentialRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_invalidOOBValue() {
+        testSignUpContinueErrorToPasswordRequired(code: .invalidOOBValue, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    // MARK: - toAttributesRequiredPublicError tests
+    
+    func test_toAttributesRequiredPublicError_invalidRequest() {
+        testSignUpContinueErrorToAttributesRequired(code: .invalidRequest, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_unauthorizedClien() {
+        testSignUpContinueErrorToAttributesRequired(code: .unauthorizedClient, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_invalidGrant() {
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_expiredToken() {
+        testSignUpContinueErrorToAttributesRequired(code: .expiredToken, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_passwordTooWeak() {
+        testSignUpContinueErrorToAttributesRequired(code: .passwordTooWeak, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_passwordTooShort() {
+        testSignUpContinueErrorToAttributesRequired(code: .passwordTooShort, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_passwordTooLong() {
+        testSignUpContinueErrorToAttributesRequired(code: .passwordTooLong, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_passwordRecentlyUsed() {
+        testSignUpContinueErrorToAttributesRequired(code: .passwordRecentlyUsed, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_passwordBanned() {
+        testSignUpContinueErrorToAttributesRequired(code: .passwordBanned, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_userAlreadyExists() {
+        testSignUpContinueErrorToAttributesRequired(code: .userAlreadyExists, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_attributesRequired() {
+        testSignUpContinueErrorToAttributesRequired(code: .attributesRequired, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_verificationRequired() {
+        testSignUpContinueErrorToAttributesRequired(code: .verificationRequired, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_attributeValidationFailed() {
+        testSignUpContinueErrorToAttributesRequired(code: .attributeValidationFailed, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_credentialRequired() {
+        testSignUpContinueErrorToAttributesRequired(code: .credentialRequired, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_invalidOOBValue() {
+        testSignUpContinueErrorToAttributesRequired(code: .invalidOOBValue, description: testDescription)
+    }
+    
+    // MARK: private methods
+    
+    private func testSignUpContinueErrorToVerifyCode(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?, expectedErrorType: VerifyCodeErrorType) {
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        let error = sut.toVerifyCodePublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpContinueErrorToPasswordRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredErrorType) {
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        let error = sut.toPasswordRequiredPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpContinueErrorToAttributesRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?) {
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        let error = sut.toAttributesRequiredPublicError()
+        XCTAssertEqual(error.errorDescription, description)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCodeTests.swift
@@ -1,0 +1,87 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpStartOauth2ErrorCodeTests: XCTestCase {
+
+    private typealias sut = MSALNativeAuthSignUpStartOauth2ErrorCode
+
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 13)
+    }
+
+    func test_invalidRequest() {
+        XCTAssertEqual(sut.invalidRequest.rawValue, "invalid_request")
+    }
+
+    func test_unauthorizedClient() {
+        XCTAssertEqual(sut.unauthorizedClient.rawValue, "unauthorized_client")
+    }
+    
+    func test_unsupportedChallengeType() {
+        XCTAssertEqual(sut.unsupportedChallengeType.rawValue, "unsupported_challenge_type")
+    }
+
+    func test_passwordTooWeak() {
+        XCTAssertEqual(sut.passwordTooWeak.rawValue, "password_too_weak")
+    }
+
+    func test_passwordTooShort() {
+        XCTAssertEqual(sut.passwordTooShort.rawValue, "password_too_short")
+    }
+
+    func test_passwordTooLong() {
+        XCTAssertEqual(sut.passwordTooLong.rawValue, "password_too_long")
+    }
+
+    func test_passwordRecentlyUsed() {
+        XCTAssertEqual(sut.passwordRecentlyUsed.rawValue, "password_recently_used")
+    }
+
+    func test_passwordBanned() {
+        XCTAssertEqual(sut.passwordBanned.rawValue, "password_banned")
+    }
+
+    func test_userAlreadyExists() {
+        XCTAssertEqual(sut.userAlreadyExists.rawValue, "user_already_exists")
+    }
+
+    func test_attributesRequired() {
+        XCTAssertEqual(sut.attributesRequired.rawValue, "attributes_required")
+    }
+
+    func test_verificationRequired() {
+        XCTAssertEqual(sut.verificationRequired.rawValue, "verification_required")
+    }
+    
+    func test_unsupportedAuthMethod() {
+        XCTAssertEqual(sut.unsupportedAuthMethod.rawValue, "unsupported_auth_method")
+    }
+
+    func test_attributeValidationFailed() {
+        XCTAssertEqual(sut.attributeValidationFailed.rawValue, "attribute_validation_failed")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
@@ -1,0 +1,156 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpStartResponseErrorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthSignUpStartResponseError!
+    private let testDescription = "testDescription"
+
+    // MARK: - to toSignUpStartPasswordPublicError tests
+
+    func test_toSignUpStartPasswordPublicError_invalidRequest() {
+        testSignUpStartErrorToSignUpStartPassword(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_unauthorizedClient() {
+        testSignUpStartErrorToSignUpStartPassword(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpStartPasswordPublicError_unsupportedChallengeType() {
+        testSignUpStartErrorToSignUpStartPassword(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpStartPasswordPublicError_passwordTooWeak() {
+        testSignUpStartErrorToSignUpStartPassword(code: .passwordTooWeak, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_passwordTooShort() {
+        testSignUpStartErrorToSignUpStartPassword(code: .passwordTooShort, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_passwordTooLong() {
+        testSignUpStartErrorToSignUpStartPassword(code: .passwordTooLong, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_passwordRecentlyUsed() {
+        testSignUpStartErrorToSignUpStartPassword(code: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_passwordBanned() {
+        testSignUpStartErrorToSignUpStartPassword(code: .passwordBanned, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_userAlreadyExists() {
+        testSignUpStartErrorToSignUpStartPassword(code: .userAlreadyExists, description: testDescription, expectedErrorType: .userAlreadyExists)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_attributesRequired() {
+        testSignUpStartErrorToSignUpStartPassword(code: .attributesRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_verificationRequired() {
+        testSignUpStartErrorToSignUpStartPassword(code: .verificationRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_unsupportedAuthMethod() {
+        testSignUpStartErrorToSignUpStartPassword(code: .unsupportedAuthMethod, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_attributeValidationFailed() {
+        testSignUpStartErrorToSignUpStartPassword(code: .attributeValidationFailed, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    // MARK: - to toSignUpStartPublicError tests
+
+    func test_toSignUpStartPublicError_invalidRequest() {
+        testSignUpStartErrorToSignUpStart(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_unauthorizedClient() {
+        testSignUpStartErrorToSignUpStart(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpStartPublicError_unsupportedChallengeType() {
+        testSignUpStartErrorToSignUpStart(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_passwordTooWeak() {
+        testSignUpStartErrorToSignUpStart(code: .passwordTooWeak, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_passwordTooShort() {
+        testSignUpStartErrorToSignUpStart(code: .passwordTooShort, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_passwordTooLong() {
+        testSignUpStartErrorToSignUpStart(code: .passwordTooLong, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_passwordRecentlyUsed() {
+        testSignUpStartErrorToSignUpStart(code: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_passwordBanned() {
+        testSignUpStartErrorToSignUpStart(code: .passwordBanned, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_userAlreadyExists() {
+        testSignUpStartErrorToSignUpStart(code: .userAlreadyExists, description: testDescription, expectedErrorType: .userAlreadyExists)
+    }
+    
+    func test_toSignUpStartPublicError_attributesRequired() {
+        testSignUpStartErrorToSignUpStart(code: .attributesRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_verificationRequired() {
+        testSignUpStartErrorToSignUpStart(code: .verificationRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_unsupportedAuthMethod() {
+        testSignUpStartErrorToSignUpStart(code: .unsupportedAuthMethod, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_attributeValidationFailed() {
+        testSignUpStartErrorToSignUpStart(code: .attributeValidationFailed, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    // MARK: private methods
+    
+    private func testSignUpStartErrorToSignUpStartPassword(code: MSALNativeAuthSignUpStartOauth2ErrorCode, description: String?, expectedErrorType: SignUpPasswordStartErrorType) {
+        sut = MSALNativeAuthSignUpStartResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        let error = sut.toSignUpStartPasswordPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpStartErrorToSignUpStart(code: MSALNativeAuthSignUpStartOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartErrorType) {
+        sut = MSALNativeAuthSignUpStartResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        let error = sut.toSignUpStartPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParametersTest.swift
@@ -1,0 +1,67 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpChallengeRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.redirect]))
+        let parameters = MSALNativeAuthSignUpChallengeRequestParameters(
+            signUpToken: "token",
+            context: MSALNativeAuthRequestContextMock()
+        )
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/signup/v1.0/challenge")
+    }
+
+    func test_allChallengeTypes_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let params = MSALNativeAuthSignUpChallengeRequestParameters(
+            signUpToken: "<sign-up-token>",
+            context: context
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "signup_token": "<sign-up-token>",
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParametersTest.swift
@@ -1,0 +1,78 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpContinueRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let parameters = MSALNativeAuthSignUpContinueRequestParameters(
+            grantType: .oobCode,
+            signUpToken: "token",
+            password: nil,
+            oobCode: "1234",
+            attributes: nil,
+            context: MSALNativeAuthRequestContextMock()
+        )
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/signup/v1.0/continue")
+    }
+
+    func test_allChallengeTypes_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let params = MSALNativeAuthSignUpContinueRequestParameters(
+            grantType: .oobCode,
+            signUpToken: "<sign-up-token>",
+            password: "<strong-password>",
+            oobCode: "0000",
+            attributes: "<attributes>",
+            context: context
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "signup_token": "<sign-up-token>",
+            "password": "<strong-password>",
+            "oob": "0000",
+            "grant_type": "oob",
+            "attributes": "<attributes>"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParametersTest.swift
@@ -1,0 +1,73 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpStartRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.redirect]))
+        let parameters = MSALNativeAuthSignUpStartRequestParameters(
+            username: "username",
+            password: nil,
+            attributes: nil,
+            context: MSALNativeAuthRequestContextMock()
+        )
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/signup/v1.0/start")
+    }
+
+    func test_allChallengeTypes_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let params = MSALNativeAuthSignUpStartRequestParameters(
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            password: "strong-password",
+            attributes: "<attribute1: value1>",
+            context: context
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "password": "strong-password",
+            "attributes": "<attribute1: value1>",
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParametersTest.swift
@@ -1,0 +1,113 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthTokenRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
+        let parameters = MSALNativeAuthTokenRequestParameters(context: MSALNativeAuthRequestContextMock(),
+                                                                    username: "username",
+                                                                    credentialToken: "Test Credential Token",
+                                                                    signInSLT: "Test SignIn SLT",
+                                                                    grantType: .password,
+                                                                    scope: "scope",
+                                                                    password: "password",
+                                                                    oobCode: "Test OTP Code",
+                                                                    includeChallengeType: true,
+                                                                    refreshToken: nil)
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/oauth2/v2.0/token")
+    }
+
+    func test_passwordParameters_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
+        let params = MSALNativeAuthTokenRequestParameters(
+            context: context,
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            credentialToken: "Test Credential Token",
+            signInSLT: "Test SignIn SLT",
+            grantType: .password,
+            scope: "<scope-1>",
+            password: "password",
+            oobCode: "oob",
+            includeChallengeType: true,
+            refreshToken: nil
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "credential_token": "Test Credential Token",
+            "signin_slt": "Test SignIn SLT",
+            "grant_type": "password",
+            "challenge_type": "password",
+            "scope": "<scope-1>",
+            "password": "password",
+            "oob": "oob",
+            "client_info" : "true"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+
+    func test_nilParameters_shouldCreateCorrectParameters() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .redirect]))
+        let params = MSALNativeAuthTokenRequestParameters(
+            context: context,
+            username: nil,
+            credentialToken: nil,
+            signInSLT: nil,
+            grantType: .password,
+            scope: nil,
+            password: nil,
+            oobCode: nil,
+            includeChallengeType: false,
+            refreshToken: nil
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": config.clientId,
+            "grant_type": "password",
+            "client_info" : "true"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
@@ -1,0 +1,742 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthSignUpResponseValidator!
+    private var context: MSIDRequestContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        sut = MSALNativeAuthSignUpResponseValidator()
+        context = MSALNativeAuthRequestContextMock()
+    }
+
+    // MARK: - Start Response
+
+    func test_whenSignUpStartSuccessResponseContainsRedirect_it_returns_redirect() {
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .success(
+            .init(signupToken: nil, challengeType: .redirect)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .redirect)
+    }
+
+    func test_whenSignUpStartSuccessResponseDoesNotContainsTokenOrRedirect_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .success(
+            .init(signupToken: nil, challengeType: .otp)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStartErrorResponseIsNotExpected_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_verificationRequiredErrorWithSignUpTokenAndUnverifiedAttributes_it_returns_verificationRequired() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            signUpToken: "sign-up token",
+            unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes(name: "username")]
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+
+        guard case .verificationRequired(let signUpToken, let unverifiedAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up token")
+        XCTAssertEqual(unverifiedAttributes.first, "username")
+    }
+
+    func test_whenSignUpStart_verificationRequiredErrorWithSignUpToken_but_unverifiedAttributesIsEmpty_it_returns_unexpectedError() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            signUpToken: "sign-up token",
+            unverifiedAttributes: []
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_verificationRequiredErrorWithSignUpToken_but_unverifiedAttributesIsNil_it_returns_unexpectedError() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            signUpToken: "sign-up token",
+            unverifiedAttributes: nil
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_attributeValidationFailedWithSignUpTokenAndInvalidAttributes_it_returns_attributeValidationFailed() {
+        let error = createSignUpStartError(
+            error: .attributeValidationFailed,
+            invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "city")]
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+
+        guard case .attributeValidationFailed(let invalidAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(invalidAttributes.first, "city")
+    }
+
+    func test_whenSignUpStart_attributeValidationFailedWithSignUpToken_but_invalidAttributesIsEmpty_it_returns_attributeValidationFailed() {
+        let error = createSignUpStartError(
+            error: .attributeValidationFailed,
+            invalidAttributes: []
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_attributeValidationFailedWithSignUpToken_but_invalidAttributesIsNil_it_returns_attributeValidationFailed() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            invalidAttributes: nil
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_expectedVerificationRequiredErrorWithoutSignUpToken_it_returns_unexpectedError() {
+        let error = createSignUpStartError(error: .verificationRequired, signUpToken: nil)
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStartErrorResponseIsExpected_it_returns_error() {
+        let error = createSignUpStartError(error: .userAlreadyExists)
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .userAlreadyExists = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpStartErrorResponseIs_invalidRequestWithInvalidUsernameErrorDescription_it_returns_expectedError() {
+        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidRequestParameter.rawValue, Int.max]
+
+        let apiError = createSignUpStartError(
+            error: .invalidRequest,
+            errorDescription: "username parameter is empty or not valid",
+            errorCodes: errorCodes,
+            errorURI: "aURI",
+            signUpToken: "aToken",
+            unverifiedAttributes: attributes,
+            invalidAttributes: attributes
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(apiError)
+
+        let result = sut.validate(response, with: context)
+        guard case .invalidUsername(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(error as MSALNativeAuthSignUpStartResponseError, apiError)
+    }
+    
+    func test_whenSignUpStartErrorResponseIs_invalidRequestWithInvalidClientIdErrorDescription_it_returns_expectedError() {
+        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidRequestParameter.rawValue, Int.max]
+        
+        let apiError = createSignUpStartError(
+            error: .invalidRequest,
+            errorDescription: "client_id parameter is empty or not valid",
+            errorCodes: errorCodes,
+            errorURI: "aURI",
+            signUpToken: "aToken",
+            unverifiedAttributes: attributes,
+            invalidAttributes: attributes
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(apiError)
+        
+        let result = sut.validate(response, with: context)
+        guard case .invalidClientId(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        
+        XCTAssertEqual(error as MSALNativeAuthSignUpStartResponseError, apiError)
+    }
+
+    func test_whenSignUpStartErrorResponseIs_invalidRequestWithGenericErrorCode_it_returns_expectedError() {
+        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let errorCodes = [Int.max]
+
+        let apiError = createSignUpStartError(
+            error: .invalidRequest,
+            errorDescription: "aDescription",
+            errorCodes: errorCodes,
+            errorURI: "aURI",
+            signUpToken: "aToken",
+            unverifiedAttributes: attributes,
+            invalidAttributes: attributes
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(apiError)
+
+        let result = sut.validate(response, with: context)
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        let resultError = error as MSALNativeAuthSignUpStartResponseError
+        XCTAssertEqual(resultError.error, .invalidRequest)
+        XCTAssertEqual(resultError.errorDescription, "aDescription")
+        XCTAssertEqual(resultError.errorCodes, errorCodes)
+        XCTAssertEqual(resultError.errorURI, "aURI")
+        XCTAssertEqual(resultError.signUpToken, "aToken")
+        XCTAssertEqual(resultError.unverifiedAttributes, attributes)
+        XCTAssertEqual(resultError.invalidAttributes, attributes)
+    }
+
+    // MARK: - Challenge Response
+
+    func test_whenSignUpChallengeSuccessResponseDoesNotContainChallengeType_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: nil,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: "token",
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsRedirect_it_returns_redirect() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .redirect,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: "token",
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .redirect)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndOOB_it_returns_success() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .oob,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            signUpToken: "token",
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+
+        guard case .codeRequired(let displayName, let displayType, let codeLength, let signUpToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(displayName, "challenge-type-label")
+        XCTAssertEqual(displayType, .email)
+        XCTAssertEqual(codeLength, 6)
+        XCTAssertEqual(signUpToken, "token")
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndPassword_it_returns_success() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .password,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            signUpToken: "token",
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+
+        guard case .passwordRequired(let signUpToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "token")
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsPassword_but_noToken_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .password,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            signUpToken: nil,
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndOTP_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .otp,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: "token",
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseOmitsSomeAttributes_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .oob,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: nil,
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeErrorResponseIsNotExpected_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeErrorResponseIsExpected_it_returns_error() {
+        let error = createSignUpChallengeError(error: .expiredToken)
+
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    // MARK: - Continue Response
+
+    func test_whenSignUpStartSuccessResponseContainsSLT_it_returns_success() {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .success(
+            .init(signinSLT: "<signin_slt>", expiresIn: nil, signupToken: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .success("<signin_slt>"))
+    }
+
+    func test_whenSignUpStartSuccessResponseButDoesNotContainSLT_it_returns_successWithNoSLT() throws {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .success(
+            .init(signinSLT: nil, expiresIn: nil, signupToken: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .success(nil))
+    }
+
+    func test_whenSignUpContinueErrorResponseIsNotExpected_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_invalidOOBValue_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidOOBValue, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidOOBValue = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordTooWeak_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordTooWeak, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooWeak = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordTooShort_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordTooShort, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooShort = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordTooLong_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordTooLong, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooLong = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordRecentlyUsed_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordRecentlyUsed, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordRecentlyUsed = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordBanned_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordBanned, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordBanned = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, expectedSignUpToken: "sign-up-token", invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "email")])
+
+        guard case .attributeValidationFailed(let signUpToken, let invalidAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up-token")
+        XCTAssertEqual(invalidAttributes.first, "email")
+    }
+    
+    func test_whenSignUpContinueErrorResponseIs_invalidRequestWithInvalidOTPErrorCode_it_returns_expectedError() {
+        let signUpToken = "sign-up-token"
+        var errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidOTP.rawValue, Int.max]
+        var result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        checkInvalidOOBValue()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.incorrectOTP.rawValue]
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        checkInvalidOOBValue()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.OTPNoCacheEntryForUser.rawValue]
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        checkInvalidOOBValue()
+        func checkInvalidOOBValue() {
+            guard case .invalidUserInput(let error) = result else {
+                return XCTFail("Unexpected response")
+            }
+            if case .invalidOOBValue = error.error {} else {
+                XCTFail("Unexpected error: \(error.error)")
+            }
+            XCTAssertNil(error.errorDescription)
+            XCTAssertNil(error.errorURI)
+            XCTAssertNil(error.innerErrors)
+            XCTAssertEqual(error.signUpToken, signUpToken)
+            XCTAssertNil(error.requiredAttributes)
+            XCTAssertNil(error.unverifiedAttributes)
+            XCTAssertNil(error.invalidAttributes)
+            XCTAssertEqual(error.errorCodes, errorCodes)
+        }
+    }
+    
+    func test_whenSignUpContinueErrorResponseIs_invalidRequestWithGenericErrorCode_it_returns_expectedError() {
+        var result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue])
+        checkValidatedErrorResult()
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [Int.max])
+        checkValidatedErrorResult()
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [MSALNativeAuthESTSApiErrorCodes.userNotHaveAPassword.rawValue])
+        checkValidatedErrorResult()
+        func checkValidatedErrorResult() {
+            guard case .error(let error) = result else {
+                return XCTFail("Unexpected response")
+            }
+            if case .invalidRequest = error.error {} else {
+                XCTFail("Unexpected error: \(error.error)")
+            }
+        }
+    }
+    
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_signUpTokenIsNil_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, expectedSignUpToken: nil, invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "email")])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_invalidAttributesIsNil_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, invalidAttributes: nil)
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_invalidAttributesIsEmpty_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, invalidAttributes: [])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_credentialRequired_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedSignUpToken: "sign-up-token")
+
+        guard case .credentialRequired(let signUpToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up-token")
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_credentialRequired_but_signUpToken_isNil_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedSignUpToken: nil)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
+
+        guard case .attributesRequired(let signUpToken, let requiredAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up-token")
+        XCTAssertEqual(requiredAttributes.count, 2)
+        XCTAssertEqual(requiredAttributes[0].name, "email")
+        XCTAssertEqual(requiredAttributes[1].name, "city")
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_signUpToken_IsNil_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: nil, requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_requiredAttributesIsNil_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: nil)
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_requiredAttributes_IsEmpty_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: [])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_verificationRequired_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_unauthorizedClient_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .unauthorizedClient)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .unauthorizedClient = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_invalidGrant_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidGrant)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidGrant = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_expiredToken_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .expiredToken)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_invalidRequest_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidRequest)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidRequest = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_userAlreadyExists_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .userAlreadyExists)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .userAlreadyExists = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    private func buildContinueErrorResponse(
+        expectedError: MSALNativeAuthSignUpContinueOauth2ErrorCode,
+        expectedSignUpToken: String? = nil,
+        requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
+        errorCodes: [Int]? = nil
+    ) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .failure(
+            createSignUpContinueError(
+                error: expectedError,
+                errorCodes: errorCodes,
+                signUpToken: expectedSignUpToken,
+                requiredAttributes: requiredAttributes,
+                invalidAttributes: invalidAttributes
+            )
+        )
+
+        return sut.validate(response, with: context)
+    }
+
+    private func createSignUpStartError(
+        error: MSALNativeAuthSignUpStartOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        signUpToken: String? = nil,
+        unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil
+    ) -> MSALNativeAuthSignUpStartResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            signUpToken: signUpToken,
+            unverifiedAttributes: unverifiedAttributes,
+            invalidAttributes: invalidAttributes
+        )
+    }
+
+    private func createSignUpChallengeError(
+        error: MSALNativeAuthSignUpChallengeOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil
+    ) -> MSALNativeAuthSignUpChallengeResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors
+        )
+    }
+
+    private func createSignUpContinueError(
+        error: MSALNativeAuthSignUpContinueOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        signUpToken: String? = nil,
+        requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]? = nil,
+        unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil
+    ) -> MSALNativeAuthSignUpContinueResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            signUpToken: signUpToken,
+            requiredAttributes: requiredAttributes,
+            unverifiedAttributes: unverifiedAttributes,
+            invalidAttributes: invalidAttributes
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
@@ -1,0 +1,255 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
+
+    private let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    private var sut: MSALNativeAuthTokenResponseValidator!
+    private var defaultUUID = UUID(uuidString: DEFAULT_TEST_UID)!
+    private var tokenResponse = MSIDTokenResponse()
+    private var factory: MSALNativeAuthResultFactoryMock!
+    private var context: MSALNativeAuthRequestContext!
+
+    private let accountIdentifier = MSIDAccountIdentifier(displayableId: "aDisplayableId", homeAccountId: "home.account.id")!
+    private let configuration = MSIDConfiguration()
+
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        factory =  MSALNativeAuthResultFactoryMock()
+        sut = MSALNativeAuthTokenResponseValidator(factory: factory, msidValidator: MSIDDefaultTokenResponseValidator())
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+    }
+    
+    // MARK: token API tests
+
+    func test_whenValidTokenResponse_validationIsSuccessful() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let userAccountResult = MSALNativeAuthUserAccountResult(account:
+                                                                    MSALNativeAuthUserAccountResultStub.account,
+                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
+                                                                                                 refreshToken: nil,
+                                                                                                 rawIdToken: nil),
+                                                                configuration: MSALNativeAuthConfigStubs.configuration,
+                                                                cacheAccessor: MSALNativeAuthCacheAccessorMock())
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.familyId = "familyId"
+        refreshToken.refreshToken = "refreshToken"
+        let tokenResponse = MSIDCIAMTokenResponse()
+        factory.mockMakeUserAccountResult(userAccountResult)
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .success(tokenResponse))
+        if case .success(tokenResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenInvalidErrorTokenResponse_anErrorIsReturned() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(MSALNativeAuthInternalError.headerNotSerialized))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+
+    func test_invalidGrantTokenResponse_withSeveralUnknownErrorCodes_isProperlyHandled() {
+        let unknownErrorCode1 = Int.max
+        let unknownErrorCode2 = unknownErrorCode1 - 1
+
+        let errorCodes: [Int] = [unknownErrorCode1, unknownErrorCode2]
+
+        let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: nil, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+        
+        guard case .error(let innerError) = result else {
+            return XCTFail("Unexpected response")
+        }
+        
+        if case .generalError = innerError {} else {
+            XCTFail("Unexpected Error")
+        }
+    }
+    
+    func test_invalidClient_isProperlyHandled() {
+        let error = MSALNativeAuthTokenResponseError(error: .invalidClient, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+        
+        guard case .error(let innerError) = result else {
+            return XCTFail("Unexpected response")
+        }
+        
+        if case .invalidClient(message: nil) = innerError {} else {
+            XCTFail("Unexpected Error")
+        }
+    }
+    
+    func test_unauthorizedClient_isProperlyHandled() {
+        let error = MSALNativeAuthTokenResponseError(error: .unauthorizedClient, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+        
+        guard case .error(let innerError) = result else {
+            return XCTFail("Unexpected response")
+        }
+        
+        if case .invalidClient(message: nil) = innerError {} else {
+            XCTFail("Unexpected Error")
+        }
+    }
+    
+
+    func test_invalidGrantTokenResponse_withKnownError_andSeveralUnknownErrorCodes_isProperlyHandled() {
+        let description = "description"
+        let unknownErrorCode1 = Int.max
+        let unknownErrorCode2 = unknownErrorCode1 - 1
+
+        var errorCodes: [Int] = [MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .userNotFound(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidOTP.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .invalidOOBCode(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.incorrectOTP.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .invalidOOBCode(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.OTPNoCacheEntryForUser.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .invalidOOBCode(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .strongAuthRequired(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .strongAuthRequired(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidCredentials.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .invalidPassword(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.userNotHaveAPassword.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .generalError = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        func checkErrorCodes() -> MSALNativeAuthTokenValidatedErrorType? {
+            let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+            
+            let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+            
+            guard case .error(let innerError) = result else {
+                return nil
+            }
+            return innerError
+        }
+    }
+
+    func test_invalidGrantTokenResponse_withUnknownErrorCode_andKnownErrorCodes_isProperlyHandled() {
+        let knownErrorCode = MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue
+        let unknownErrorCode1 = Int.max
+        let unknownErrorCode2 = unknownErrorCode1 - 1
+
+        // We only check for the first error, if it's unknown, we return .generalError
+
+        let errorCodes: [Int] = [unknownErrorCode1, knownErrorCode, unknownErrorCode2]
+
+        let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: nil, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+        
+        guard case .error(let innerError) = result else {
+            return XCTFail("Unexpected response")
+        }
+        
+        if case .generalError = innerError {} else {
+            XCTFail("Unexpected Error")
+        }
+    }
+    
+    func test_invalidRequesTokenResponse_withOTPErrorCodes_isTranslatedToInvalidCode() {
+        let unknownErrorCode1 = Int.max
+        var errorCodes: [Int] = [MSALNativeAuthESTSApiErrorCodes.invalidOTP.rawValue, unknownErrorCode1]
+        checkErrorCodes()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.incorrectOTP.rawValue, unknownErrorCode1]
+        checkErrorCodes()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.OTPNoCacheEntryForUser.rawValue, unknownErrorCode1]
+        checkErrorCodes()
+        func checkErrorCodes() {
+            let description = "description"
+            let error = MSALNativeAuthTokenResponseError(error: .invalidRequest, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+            
+            let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+            let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+            
+            guard case .error(let innerError) = result else {
+                return XCTFail("Unexpected response")
+            }
+            
+            guard case .invalidOOBCode(message: description) = innerError else {
+                return XCTFail("Unexpected Error")
+            }
+        }
+    }
+    
+    func test_invalidRequesTokenResponse_withGenericErrorCode_isTranslatedToGeneralError() {
+        let description = "description"
+        let unknownErrorCode1 = Int.max
+        var errorCodes: [Int] = [unknownErrorCode1]
+        checkErrorCodes()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue]
+        checkErrorCodes()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue]
+        checkErrorCodes()
+        func checkErrorCodes() {
+            let error = MSALNativeAuthTokenResponseError(error: .invalidRequest, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+            
+            let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+            let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+            
+            guard case .error(let innerError) = result else {
+                return XCTFail("Unexpected response")
+            }
+            
+            guard case .invalidRequest(message: description) = innerError else {
+                return XCTFail("Unexpected Error")
+            }
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
@@ -1,0 +1,122 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthTokenValidatedErrorTypeTests: XCTestCase {
+    
+    private typealias sut = MSALNativeAuthTokenValidatedErrorType
+    private let testDescription = "testDescription"
+    
+    // MARK: - convertToSignInPasswordStartError tests
+    
+    func test_convertToSignInPasswordStartError_generalError() {
+        let error = sut.generalError.convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, "General error")
+    }
+    
+    func test_convertToSignInPasswordStartError_expiredToken() {
+        let error = sut.expiredToken(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_expiredRefreshToken() {
+        let error = sut.expiredRefreshToken(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_invalidClient() {
+        let error = sut.invalidClient(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_invalidRequest() {
+        let error = sut.invalidRequest(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_invalidServerResponse() {
+        let error = sut.invalidServerResponse.convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.invalidServerResponse)
+    }
+    
+    func test_convertToSignInPasswordStartError_userNotFound() {
+        let error = sut.userNotFound(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .userNotFound)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_invalidPassword() {
+        let error = sut.invalidPassword(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .invalidPassword)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_invalidOOBCode() {
+        let error = sut.invalidOOBCode(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_unsupportedChallengeType() {
+        let error = sut.unsupportedChallengeType(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_strongAuthRequired() {
+        let error = sut.strongAuthRequired(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .browserRequired)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_invalidScope() {
+        let error = sut.invalidScope(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_authorizationPending() {
+        let error = sut.authorizationPending(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_slowDown() {
+        let error = sut.slowDown(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    // MARK: - convertToSignInPasswordStartError tests
+    
+}

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -1,0 +1,367 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
+
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private var sut: MSALNativeAuthPublicClientApplication!
+
+    override func setUp() {
+        super.setUp()
+
+        sut = MSALNativeAuthPublicClientApplication(
+            controllerFactory: controllerFactoryMock,
+            inputValidator: MSALNativeAuthInputValidator(),
+            internalChallengeTypes: []
+        )
+    }
+
+    func testInit_whenPassingB2CAuthority_itShouldThrowError() throws {
+        let b2cAuthority = try MSALB2CAuthority(url: .init(string: "https://login.contoso.com")!)
+        let configuration = MSALPublicClientApplicationConfig(clientId: DEFAULT_TEST_CLIENT_ID, redirectUri: nil, authority: b2cAuthority)
+
+        XCTAssertThrowsError(try MSALNativeAuthPublicClientApplication(configuration: configuration, challengeTypes: [.password]))
+    }
+
+    func testInit_whenPassingNilRedirectUri_itShouldNotThrowError() {
+        XCTAssertNoThrow(try MSALNativeAuthPublicClientApplication(clientId: "genericClient", tenantSubdomain: "genericTenenat", challengeTypes: [.OOB]))
+    }
+
+    // MARK: - Delegates
+
+    // Sign Up with password
+
+    func testSignUpPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
+        sut.signUpUsingPassword(username: "", password: "", delegate: delegate)
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(delegate.error?.type, .invalidUsername)
+    }
+
+    func testSignUpPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
+        sut.signUpUsingPassword(username: "correct", password: "", delegate: delegate)
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(delegate.error?.type, .invalidPassword)
+    }
+
+    func testSignUpPassword_delegate_whenValidDataIsPassed_shouldReturnCodeRequired() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
+
+        let expectedResult: SignUpPasswordStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken"),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controllerFactoryMock.signUpController.startPasswordResult = .init(expectedResult)
+
+        sut.signUpUsingPassword(username: "correct", password: "correct", delegate: delegate)
+
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newState?.flowToken, "flowToken")
+        XCTAssertEqual(delegate.sentTo, "sentTo")
+        XCTAssertEqual(delegate.channelTargetType, .email)
+        XCTAssertEqual(delegate.codeLength, 1)
+    }
+
+    func testSignUpPassword_delegate_whenSendAttributes_shouldReturnAttributesInvalid() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
+        let expectedInvalidAttributes = ["attribute"]
+
+        let expectedResult: SignUpPasswordStartResult = .attributesInvalid(expectedInvalidAttributes)
+        controllerFactoryMock.signUpController.startPasswordResult = .init(expectedResult)
+
+        sut.signUpUsingPassword(username: "correct", password: "correct", delegate: delegate)
+
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.attributeNames, expectedInvalidAttributes)
+    }
+
+    func testSignUpPassword_delegate_whenSendAttributes_butDelegateMethodIsNotImplemented_itShouldReturnAttributesInvalid() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: exp)
+        let expectedInvalidAttributes = ["attribute"]
+
+        let expectedResult: SignUpPasswordStartResult = .attributesInvalid(expectedInvalidAttributes)
+        controllerFactoryMock.signUpController.startPasswordResult = .init(expectedResult)
+
+        sut.signUpUsingPassword(username: "correct", password: "correct", delegate: delegate)
+
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
+    }
+
+    // Sign Up with code
+
+    func testSignUp_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
+        sut.signUp(username: "", delegate: delegate)
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(delegate.error?.type, .invalidUsername)
+    }
+
+    func testSignUp_delegate_whenValidDataIsPassed_shouldReturnCodeRequired() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
+
+        let expectedResult: SignUpStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken"),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult)
+
+        sut.signUp(username: "correct", delegate: delegate)
+
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newState?.flowToken, "flowToken")
+        XCTAssertEqual(delegate.sentTo, "sentTo")
+        XCTAssertEqual(delegate.channelTargetType, .email)
+        XCTAssertEqual(delegate.codeLength, 1)
+    }
+
+    func testSignUp_delegate_whenSendAttributes_shouldReturnAttributesInvalid() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
+        let expectedInvalidAttributes = ["attribute"]
+
+        let expectedResult: SignUpStartResult = .attributesInvalid(expectedInvalidAttributes)
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult)
+
+        sut.signUp(username: "correct", delegate: delegate)
+
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.attributeNames, expectedInvalidAttributes)
+    }
+
+    func testSignUp_delegate_whenSendAttributes_butDelegateMethodIsNotImplemented_itShouldReturnAttributesInvalid() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: exp)
+        let expectedInvalidAttributes = ["attribute"]
+
+        let expectedResult: SignUpStartResult = .attributesInvalid(expectedInvalidAttributes)
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult)
+
+        sut.signUp(username: "correct", delegate: delegate)
+
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
+    }
+
+    // Sign in with password
+
+    func testSignInPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
+        let expectation = expectation(description: "sign-in public interface")
+        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername))
+        sut.signInUsingPassword(username: "", password: "", delegate: delegate)
+        wait(for: [expectation], timeout: 1)
+    }
+    
+    func testSignInPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
+        let expectation = expectation(description: "sign-in public interface")
+        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidPassword))
+        sut.signInUsingPassword(username: "correct", password: "", delegate: delegate)
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testSignInPassword_delegate_whenValidUserAndPasswordAreUsed_shouldReturnSuccess() {
+        let expectation = expectation(description: "sign-in public interface")
+        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedUserAccountResult: MSALNativeAuthUserAccountResultStub.result)
+
+        controllerFactoryMock.signInController.signInPasswordStartResult = .init(.init(.completed(MSALNativeAuthUserAccountResultStub.result)))
+        sut.signInUsingPassword(username: "correct", password: "correct", delegate: delegate)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testSignInPassword_delegate_whenCodeIsRequiredAndUserHasImplementedOptionalDelegate_shouldReturnCodeRequired() {
+        let exp1 = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let delegate = SignInPasswordStartDelegateSpy(expectation: exp1)
+        delegate.expectedSentTo = "sentTo"
+        delegate.expectedCodeLength = 1
+        delegate.expectedChannelTargetType = .email
+
+        let expectedResult: SignInPasswordStartResult = .codeRequired(
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: ""),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        
+        controllerFactoryMock.signInController.signInPasswordStartResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        sut.signInUsingPassword(username: "correct", password: "correct", delegate: delegate)
+
+        wait(for: [exp1, exp2], timeout: 1)
+    }
+
+    func testSignInPassword_delegate_whenCodeIsRequiredButUserHasNotImplementedOptionalDelegate_shouldReturnError() {
+        let exp = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let expectedError = SignInPasswordStartError(type: .generalError, message: MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
+        let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
+
+        let expectedResult: SignInPasswordStartResult = .codeRequired(
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: ""),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+
+        controllerFactoryMock.signInController.signInPasswordStartResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        sut.signInUsingPassword(username: "correct", password: "correct", delegate: delegate)
+
+        wait(for: [exp, exp2], timeout: 1)
+    }
+
+    // Sign in with code
+
+    func testSignIn_delegate_whenInvalidUser_shouldReturnCorrectError() {
+        let expectation = expectation(description: "sign-in public interface")
+        let delegate = SignInCodeStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername))
+        sut.signIn(username: "", delegate: delegate)
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testSignIn_delegate_whenValidUserIsUsed_shouldReturnCodeRequired() {
+        let expectation = expectation(description: "sign-in public interface")
+        let delegate = SignInCodeStartDelegateSpy(expectation: expectation)
+        delegate.expectedSentTo = "sentTo"
+        delegate.expectedCodeLength = 1
+        delegate.expectedChannelTargetType = .email
+
+        let expectedResult: SignInStartResult = .codeRequired(
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: ""),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult)
+        sut.signIn(username: "correct", delegate: delegate)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testSignIn_delegate_whenPasswordIsRequiredAndUserHasImplementedOptionalDelegate_shouldReturnPasswordRequired() {
+        let exp1 = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let delegate = SignInCodeStartDelegateWithPasswordRequiredSpy(expectation: exp1)
+
+        let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, flowToken: "flowToken")
+        let expectedResult: SignInStartResult = .passwordRequired(newState: expectedState)
+
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        sut.signIn(username: "correct", delegate: delegate)
+
+        wait(for: [exp1, exp2], timeout: 1)
+
+        XCTAssertEqual(delegate.passwordRequiredState?.flowToken, expectedState.flowToken)
+    }
+
+    func testSignIn_delegate_whenPasswordIsRequiredButUserHasNotImplementedOptionalDelegate_shouldReturnError() {
+        let exp = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let expectedError = SignInStartError(type: .generalError, message: MSALNativeAuthErrorMessage.passwordRequiredNotImplemented)
+        let delegate = SignInCodeStartDelegateSpy(expectation: exp, expectedError: expectedError)
+
+        let expectedResult: SignInStartResult = .passwordRequired(
+            newState: SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, flowToken: "")
+        )
+
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        sut.signIn(username: "correct", delegate: delegate)
+
+        wait(for: [exp, exp2], timeout: 1)
+    }
+
+    // ResetPassword
+
+    func testResetPassword_delegate_whenInvalidUser_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-in public interface")
+        let delegate = ResetPasswordStartDelegateSpy(expectation: exp)
+        sut.resetPassword(username: "", delegate: delegate)
+        wait(for: [exp])
+        XCTAssertEqual(delegate.error?.type, .invalidUsername)
+    }
+
+    func testResetPassword_delegate_whenValidUserIsUsed_shouldReturnCodeRequired() {
+        let expectation = expectation(description: "sign-in public interface")
+        let delegate = ResetPasswordStartDelegateSpy(expectation: expectation)
+
+        let expectedResult: ResetPasswordStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.resetPasswordController, flowToken: "flowToken"),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+
+        controllerFactoryMock.resetPasswordController.resetPasswordResult = .init(expectedResult)
+        sut.resetPassword(username: "correct", delegate: delegate)
+
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(delegate.newState?.flowToken, "flowToken")
+        XCTAssertEqual(delegate.sentTo, "sentTo")
+        XCTAssertEqual(delegate.channelTargetType, .email)
+        XCTAssertEqual(delegate.codeLength, 1)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -1,0 +1,85 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthUserAccountResultTests: XCTestCase {
+    var sut: MSALNativeAuthUserAccountResult!
+    private var cacheAccessorMock: MSALNativeAuthCacheAccessorMock!
+    private var account: MSALAccount!
+
+    override func setUpWithError() throws {
+
+        account = MSALNativeAuthUserAccountResultStub.account
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = "accessToken"
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.refreshToken = "refreshToken"
+        let rawIdToken = "rawIdToken"
+
+        cacheAccessorMock = MSALNativeAuthCacheAccessorMock()
+
+        sut = MSALNativeAuthUserAccountResult(
+            account: account!,
+            authTokens: MSALNativeAuthTokens(accessToken: accessToken, refreshToken: refreshToken, rawIdToken: rawIdToken),
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: cacheAccessorMock
+        )
+        try super.setUpWithError()
+    }
+
+    // MARK: Call delegate properly tests
+
+    func test_whenAccountAndTokenExist_itReturnsCorrectData() {
+        let expectation = expectation(description: "CredentialsController")
+
+        let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedAccessToken: "accessToken")
+        sut.getAccessToken(delegate: mockDelegate)
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_whenNoAccessToken_itReturnsCorrectError() {
+        let expectation = expectation(description: "CredentialsController")
+        sut = MSALNativeAuthUserAccountResult(
+            account: account!,
+            authTokens: MSALNativeAuthTokens(accessToken: nil, refreshToken: nil, rawIdToken: nil),
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: MSALNativeAuthCacheAccessorMock()
+        )
+        let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .tokenNotFound))
+        sut.getAccessToken(delegate: mockDelegate)
+        wait(for: [expectation], timeout: 1)
+    }
+
+    // MARK: - sign-out tests
+
+    func test_signOut_successfullyCallsCacheAccessor() {
+        sut.signOut()
+        XCTAssertTrue(cacheAccessorMock.clearCacheWasCalled)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
@@ -1,0 +1,109 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+
+final class SignUpAttributesRequiredStateTests: XCTestCase {
+
+    private var controller: MSALNativeAuthSignUpControllerMock!
+    private var sut: SignUpAttributesRequiredState!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        controller = .init()
+        sut = SignUpAttributesRequiredState(controller: controller, username: "<username>", flowToken: "<token>")
+    }
+
+    // MARK: - Delegate
+
+    func test_submitPassword_delegate_whenError_shouldReturnAttributesRequiredError() {
+        let expectedError = AttributesRequiredError()
+
+        let expectedResult: SignUpAttributesRequiredResult = .error(error: expectedError)
+        controller.submitAttributesResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
+
+        sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error, expectedError)
+    }
+
+    func test_submitPassword_delegate_whenSuccess_shouldReturnCompleted() {
+        let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt")
+
+        let expectedResult: SignUpAttributesRequiredResult = .completed(expectedState)
+        controller.submitAttributesResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
+
+        sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newSignInAfterSignUpState, expectedState)
+    }
+
+    func test_submitPassword_delegate_whenAttributesRequired_shouldReturnAttributesRequired() {
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt")
+        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+            .init(name: "anAttribute", type: "aType", required: true)
+        ]
+
+        let expectedResult: SignUpAttributesRequiredResult = .attributesRequired(attributes: expectedAttributes, state: expectedState)
+        controller.submitAttributesResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
+
+        sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.attributes, expectedAttributes)
+        XCTAssertEqual(delegate.newState, expectedState)
+    }
+
+    func test_submitPassword_delegate_whenAttributesAreInvalud_shouldReturnAttributesInvalid() {
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt")
+        let expectedAttributes = ["anAttribute"]
+
+        let expectedResult: SignUpAttributesRequiredResult = .attributesInvalid(attributes: expectedAttributes, newState: expectedState)
+        controller.submitAttributesResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
+
+        sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.invalidAttributes, expectedAttributes)
+        XCTAssertEqual(delegate.newState, expectedState)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
@@ -1,0 +1,197 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class SignUpCodeRequiredStateTests: XCTestCase {
+
+    private var controller: MSALNativeAuthSignUpControllerMock!
+    private var sut: SignUpCodeRequiredState!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        controller = .init()
+        sut = SignUpCodeRequiredState(controller: controller, username: "<username>", flowToken: "<token>")
+    }
+
+    // MARK: - Delegates
+
+    // ResendCode
+
+    func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
+        let expectedError = ResendCodeError(message: "test error")
+
+        let expectedResult: SignUpResendCodeResult = .error(expectedError)
+        controller.resendCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpResendCodeDelegateSpy(expectation: exp)
+
+        sut.resendCode(delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error, expectedError)
+    }
+
+    func test_resendCode_delegate_success_shouldReturnCodeRequired() {
+        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let expectedResult: SignUpResendCodeResult = .codeRequired(
+            newState: expectedState,
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controller.resendCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-in states")
+        let delegate = SignUpResendCodeDelegateSpy(expectation: exp)
+
+        sut.resendCode(delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newState?.flowToken, expectedState.flowToken)
+        XCTAssertEqual(delegate.sentTo, "sentTo")
+        XCTAssertEqual(delegate.channelTargetType, .email)
+        XCTAssertEqual(delegate.codeLength, 1)
+    }
+
+    // SubmitCode
+
+    func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
+        let expectedError = VerifyCodeError(type: .invalidCode)
+        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let expectedResult: SignUpVerifyCodeResult = .error(
+            error: expectedError,
+            newState: expectedState
+        )
+        controller.submitCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpVerifyCodeDelegateSpy(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error, expectedError)
+        XCTAssertEqual(delegate.newCodeRequiredState?.flowToken, expectedState.flowToken)
+    }
+
+    func test_submitCode_delegate_whenPasswordRequired_AndUserHasImplementedOptionalDelegate_shouldReturnPasswordRequired() {
+        let expectedPasswordRequiredState = SignUpPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpVerifyCodeResult = .passwordRequired(expectedPasswordRequiredState)
+        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpVerifyCodeDelegateSpy(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.newPasswordRequiredState, expectedPasswordRequiredState)
+    }
+
+    func test_submitCode_delegate_whenPasswordRequired_ButUserHasNotImplementedOptionalDelegate_shouldReturnCorrectError() {
+        let expectedError = VerifyCodeError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpVerifyCodeResult = .passwordRequired(.init(controller: controller, username: "", flowToken: ""))
+        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, expectedError.type)
+        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.delegateNotImplemented)
+    }
+
+    func test_submitCode_delegate_whenAttributesRequired_AndUserHasImplementedOptionalDelegate_shouldReturnAttributesRequired() {
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpVerifyCodeResult = .attributesRequired(attributes: [], newState: expectedAttributesRequiredState)
+        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpVerifyCodeDelegateSpy(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.newAttributesRequiredState, expectedAttributesRequiredState)
+    }
+
+    func test_submitCode_delegate_whenAttributesRequired_ButUserHasNotImplementedOptionalDelegate_shouldReturnCorrectError() {
+        let expectedError = VerifyCodeError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpVerifyCodeResult = .attributesRequired(attributes: [], newState: .init(controller: controller, username: "", flowToken: "")) //.attributesRequired(.init(controller: controller, flowToken: ""))
+        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, expectedError.type)
+        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.delegateNotImplemented)
+    }
+
+    func test_submitCode_delegate_whenSuccess_shouldReturnAccountResult() {
+        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt")
+
+        let expectedResult: SignUpVerifyCodeResult = .completed(expectedSignInAfterSignUpState)
+        controller.submitCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpVerifyCodeDelegateSpy(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newSignInAfterSignUpState, expectedSignInAfterSignUpState)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
@@ -1,0 +1,116 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+
+final class SignUpPasswordRequiredStateTests: XCTestCase {
+
+    private var controller: MSALNativeAuthSignUpControllerMock!
+    private var sut: SignUpPasswordRequiredState!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        controller = .init()
+        sut = SignUpPasswordRequiredState(controller: controller, username: "<username>", flowToken: "<token>")
+    }
+
+    // MARK: - Delegate
+
+    func test_submitPassword_delegate_whenError_shouldReturnPasswordRequiredError() {
+        let expectedError = PasswordRequiredError(type: .invalidPassword)
+        let expectedState = SignUpPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let expectedResult: SignUpPasswordRequiredResult = .error(error: expectedError, newState: expectedState)
+        controller.submitPasswordResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpPasswordRequiredDelegateSpy(expectation: exp)
+
+        sut.submitPassword(password: "1234", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error, expectedError)
+        XCTAssertEqual(delegate.newPasswordRequiredState?.flowToken, expectedState.flowToken)
+    }
+
+    func test_submitCode_delegate_whenAttributesRequired_AndUserHasImplementedOptionalDelegate_shouldReturnAttributesRequired() {
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpPasswordRequiredResult = .attributesRequired(attributes: [], newState: expectedAttributesRequiredState)
+        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpPasswordRequiredDelegateSpy(expectation: exp)
+
+        sut.submitPassword(password: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.newAttributesRequiredState, expectedAttributesRequiredState)
+    }
+
+    func test_submitCode_delegate_whenAttributesRequired_ButUserHasNotImplementedOptionalDelegate_shouldReturnPasswordRequiredError() {
+        let expectedError = PasswordRequiredError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpPasswordRequiredResult = .attributesRequired(attributes: [], newState: expectedAttributesRequiredState)
+        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitPassword(password: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, expectedError.type)
+        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.delegateNotImplemented)
+    }
+
+    func test_submitCode_delegate_whenSuccess_shouldReturnSignUpCompleted() {
+        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt")
+
+        let exp = expectation(description: "sign-up states")
+
+        let expectedResult: SignUpPasswordRequiredResult = .completed(expectedSignInAfterSignUpState)
+        controller.submitPasswordResult = .init(expectedResult)
+
+        let delegate = SignUpPasswordRequiredDelegateSpy(expectation: exp)
+
+        sut.submitPassword(password: "1234", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.signInAfterSignUpState, expectedSignInAfterSignUpState)
+    }
+}

--- a/MSAL/test/unit/native_auth/telemetry/MSALNativeAuthCurrentRequestTelemetryTests.swift
+++ b/MSAL/test/unit/native_auth/telemetry/MSALNativeAuthCurrentRequestTelemetryTests.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthCurrentRequestTelemetryTests: XCTestCase {
+    
+    func testSerialization_whenValidProperties_shouldCreateString() {
+        let telemetry = MSALNativeAuthCurrentRequestTelemetry(apiId: .telemetryApiIdSignUp,
+                                                              operationType: MSALNativeAuthSignUpType.signUpWithPassword.rawValue,
+                                                              platformFields: nil)
+        let result = telemetry.telemetryString()
+        XCTAssertEqual(result, "4|75001,0|")
+    }
+    
+    func testSerialization_whenSignUpType_SignUpOTP_shouldCreateString() {
+        let telemetry = MSALNativeAuthCurrentRequestTelemetry(apiId: .telemetryApiIdSignUp,
+                                                              operationType: MSALNativeAuthSignUpType.signUpWithOTP.rawValue,
+                                                              platformFields: nil)
+        let result = telemetry.telemetryString()
+        XCTAssertEqual(result, "4|75001,1|")
+    }
+    
+    func testSerialization_withOnePlatfomField_shouldCreateString() {
+        let telemetry = MSALNativeAuthCurrentRequestTelemetry(apiId: .telemetryApiIdSignUp,
+                                                              operationType: MSALNativeAuthSignUpType.signUpWithPassword.rawValue,
+                                                              platformFields: ["iPhone14,5"])
+        let result = telemetry.telemetryString()
+        XCTAssertEqual(result, "4|75001,0|iPhone14,5")
+    }
+    
+    func testSerialization_withMultiplePlatfomField_shouldCreateString() {
+        let telemetry = MSALNativeAuthCurrentRequestTelemetry(apiId: .telemetryApiIdSignUp,
+                                                              operationType: MSALNativeAuthSignUpType.signUpWithPassword.rawValue,
+                                                              platformFields: ["iPhone14,5","iOS 16.0"])
+        let result = telemetry.telemetryString()
+        XCTAssertEqual(result, "4|75001,0|iPhone14,5,iOS 16.0")
+    }
+}

--- a/MSAL/test/unit/native_auth/telemetry/MSALNativeAuthTelemetryProviderTests.swift
+++ b/MSAL/test/unit/native_auth/telemetry/MSALNativeAuthTelemetryProviderTests.swift
@@ -1,0 +1,83 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthTelemetryProviderTests: XCTestCase {
+
+    private var sut : MSALNativeAuthTelemetryProviding!
+
+    override func setUpWithError() throws {
+        sut = MSALNativeAuthTelemetryProvider()
+    }
+    
+    // MARK: Correct API Id tests
+    func testTelemetryForSignUp_returnsCorrectApiId() {
+        let result = sut.telemetryForSignUp(type: MSALNativeAuthSignUpType.signUpWithPassword)
+        XCTAssertEqual(result.apiId, .telemetryApiIdSignUpCodeStart)
+    }
+    
+    func testTelemetryForSignInWithCode_returnsCorrectApiId() {
+        let result = sut.telemetryForSignIn(type: MSALNativeAuthSignInType.signInWithOTP)
+        XCTAssertEqual(result.apiId, .telemetryApiIdSignInWithCodeStart)
+    }
+    
+    func testTelemetryForRefreshToken_returnsCorrectApiId() {
+        let result = sut.telemetryForToken(type: MSALNativeAuthTokenType.refreshToken)
+        XCTAssertEqual(result.apiId, .telemetryApiIdToken)
+    }
+    
+    func testTelemetryForResetPasswordStart_returnsCorrectApiId() {
+        let result = sut.telemetryForResetPasswordStart(type: MSALNativeAuthResetPasswordStartType.resetPasswordStart)
+        XCTAssertEqual(result.apiId, .telemetryApiIdResetPasswordStart)
+    }
+    
+    func testTelemetryForResendCode_returnsCorrectApiId() {
+        let result = sut.telemetryForResendCode(type: MSALNativeAuthResendCodeType.resendCode)
+        XCTAssertEqual(result.apiId, .telemetryApiIdResendCode)
+    }
+    
+    func testTelemetryForVerifyCode_returnsCorrectApiId() {
+        let result = sut.telemetryForVerifyCode(type: MSALNativeAuthVerifyCodeType.verifyCode)
+        XCTAssertEqual(result.apiId, .telemetryApiIdVerifyCode)
+    }
+    
+    func testTelemetryForSignOut_returnsCorrectApiId() {
+        let result = sut.telemetryForSignOut(type: MSALNativeAuthSignOutType.signOutAction)
+        XCTAssertEqual(result.apiId, .telemetryApiIdSignOut)
+    }
+    
+    // MARK: Correct Operation Type tests
+    func testTelemetryForSignUp_returnsCorrectOperationType() {
+        let result = sut.telemetryForSignUp(type: MSALNativeAuthSignUpType.signUpWithOTP)
+        XCTAssertEqual(result.operationType, MSALNativeAuthSignUpType.signUpWithOTP.rawValue)
+    }
+    
+    func testTelemetryForToken_returnsCorrectOperationType() {
+        let result = sut.telemetryForToken(type: MSALNativeAuthTokenType.refreshToken)
+        XCTAssertEqual(result.operationType, MSALNativeAuthTokenType.refreshToken.rawValue)
+    }
+}

--- a/MSAL/test/unit/native_auth/utils/MSALNativeAuthTelemetryTestDispatcher.swift
+++ b/MSAL/test/unit/native_auth/utils/MSALNativeAuthTelemetryTestDispatcher.swift
@@ -1,0 +1,48 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthTelemetryTestDispatcher: NSObject, MSIDTelemetryDispatcher {
+
+    typealias TestCallback = (MSIDTelemetryEventInterface) -> Void
+
+    private var testCallback: TestCallback?
+
+    func setTestCallback(_ callback: @escaping TestCallback) {
+        testCallback = callback
+    }
+
+    func containsObserver(_ observer: Any!) -> Bool {
+        return false
+    }
+
+    func receive(_ requestId: String!, event: MSIDTelemetryEventInterface!) {
+        testCallback?(event)
+    }
+
+    func flush(_ requestId: String!) {
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR shows the SDK that the CIAM team had developed. It is based on the Native Auth merge into MSAL plan here: https://microsofteur.sharepoint.com/:w:/t/DevExDublin/EdfT2AmlFZFIsTtr-EaoSBIBPqcOlRo1MJ1USbEsfjfEcQ

To comply with the design changes made by our API team, we have created a more dynamic SDK. This means that we make different API requests for each authentication flow. There is also some logic involved in each of the responses we get from each request.

We have created a state machine for each flow (check this [Figma](https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0%3A1&t=VUyK4gIoyUChTXWF-1) to see all the possible states), and we are making it external to developers by using delegates instead of completion blocks, as @Serhii Demchenko suggested. In this way we can guide the developer through the authentication process offering a discovering interface. We think that this approach will improve the overall developer experience.

**This PR is focused in the Sign Up feature, but it also holds base/generic Native Auth code. It is not compilable, so validations are not going to pass. To build and test this code, please use the `ciam-master-snapshot` branch.**

The IdentityCore changes can be found in this PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1294

**For context, this is the Native Auth technical overview:** https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview?path=/%5BiOS%5D%20Native%20authentication/technical_overview.md&version=GBdanilo/native-authentication&_a=preview

State Machine:
https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0-1&mode=design&t=80VUxa1RvxMn4rnl-0

## High level overview

**MSALNativeAuthPublicClientApplication.swift**
The public interface is the entry point of the SDK. Here is where all the supported authentication flows begin.
Regarding the sign-up flow, developers can call either `signUp(...)` or `signUpUsingPassword(...)`.
Notice that in those methods they must pass a class that conforms to `SignUpStartDelegate`. or `SignUpPasswordStartDelegate`, respectively.


**MSALNativeAuthSignUpController.swift**
The controller handles most of the logic. Each of the methods inside the MARK: - Internal can be called from the public interfaces, that are:
    - MSALNativeAuthPublicClientApplication
    - One of the States (located in the file SignUpDelegates.swift). These States are returned through the delegates, as we will see.

For each of these methods, the controller:
    - Creates a request (`MSIDHttpRequest`) using its requestProvider (`MSALNativeAuthSignUpRequestProviding`).
    - Executes the request.
    - Passes the result to its responseValidator (`MSALNativeAuthSignUpResponseValidating`)
    - Handles the validated result and returns it to the public interface, which uses the delegate to communicate back to the developer.
    - Creates and handle the local telemetry events.

The controller decides what to do with the ValidatedResponse given by the ResponseValidator.

Every validated response usually has:
**A success:** it means that the SDK moves on to the next state, which usually involves making another request or returning back to the user via the delegate.
Redirect: when the backend detects an error and wants the SDK to fallback to the WebView-based flow.
**A known error:** in some cases, these errors put the user in a recoverable state (for example, an error that requires the user to provide more attributes). In other cases, the error means the end of the flow.
**An unexpected error:** these errors are likely bugs, they happen when we there are missing attributes from the response, etc.
(Please keep in mind that not every ValidatedResponse falls into the same categories, this is just an approximation)


**MSALNativeAuthRequestConfigurator.swift**
Each of the requestProviders from the Controllers uses the RequestConfigurator to create and configure the requests. Although there are different RequestProviders (one per flow), there's only one RequestConfigurator.

The RequestConfigurator injects a custom ErrorHandler (`MSALNativeAuthResponseErrorHandler`) to every request. This is needed in order to decode the errors from the API.
These errors follow a structure that you can see in `MSALNativeAuthSignUpStartResponseError` for example. In the directory native_auth/network/errors/ you can see all the files used.


**MSALNativeAuthSignUpResponseValidator.swift**
The ResponseValidator is in charge of analysing the api response and returning to the Controller a validated response (for instance, for the response of the signup/start endpoint, it returns a `MSALNativeAuthSignUpStartValidatedResponse`).


**SignUpStates.swift**
In this file there are the different States that the Controller can return to the developer through the delegate.

This is how the developer will use them. For more examples of how developers can use the SDK you can check the Sample App (located in /Samples/ios-native-auth-simple in the branch `ciam-master-snapshot`). We will include it in a separate PR:

extension EmailAndPasswordViewController: SignUpPasswordStartDelegate {

    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState,
                                                      sentTo _: String,
                                                      channelTargetType _: MSAL.MSALNativeAuthChannelType,
                                                      codeLength _: Int) {

           // show UI to get the user's email OOB code, and wait for user's input
           // then, use the newState to send it to the SDK.
           newState.submitCode(code: code, delegate: self)
    }
}

Each of these states then calls one of the Controller's internal functions, and it follows the same process that we just described in the previous steps.

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

