### PR TITLE
Native Auth Sign In

### DIFF
--- a/MSAL/src/native_auth/controllers/responses/SignInResults.swift
+++ b/MSAL/src/native_auth/controllers/responses/SignInResults.swift
@@ -1,0 +1,82 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/// Represents the result of sign in using password.
+enum SignInPasswordStartResult {
+    /// Returned after the sign in operation completed successfully. An object representing the signed in user account is returned.
+    case completed(MSALNativeAuthUserAccountResult)
+
+    /// Returned if a user registered with email and code tries to sign in using password.
+    /// In this case MSAL will discard the password and will continue the sign in flow with code.
+    ///
+    /// - newState: An object representing the new state of the flow with follow on methods.
+    /// - sentTo: The email/phone number that the code was sent to.
+    /// - channelTargetType: The channel (email/phone) the code was sent through.
+    /// - codeLength: The length of the code required.
+    case codeRequired(newState: SignInCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
+
+    /// An error object indicating why the operation failed.
+    case error(SignInPasswordStartError)
+}
+
+/// Represents the result of sign in using code.
+enum SignInStartResult {
+    /// Returned if a user has received an email with code.
+    ///
+    /// - newState: An object representing the new state of the flow with follow on methods.
+    /// - sentTo: The email/phone number that the code was sent to.
+    /// - channelTargetType: The channel (email/phone) the code was sent through.
+    /// - codeLength: The length of the code required.
+    case codeRequired(newState: SignInCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
+
+    /// Returned if a user registered with email and password tries to sign in using code.
+    case passwordRequired(newState: SignInPasswordRequiredState)
+
+    /// An error object indicating why the operation failed.
+    case error(SignInStartError)
+}
+
+/// Result type that contains information about the code sent, the next state of the reset password process and possible errors.
+/// See ``CodeRequiredGenericResult`` for more information.
+typealias SignInResendCodeResult = CodeRequiredGenericResult<SignInCodeRequiredState, ResendCodeError>
+
+/// Result type that contains information about the state of the sign in process.
+enum SignInPasswordRequiredResult {
+    /// Returned after the sign in operation completed successfully. An object representing the signed in user account is returned.
+    case completed(MSALNativeAuthUserAccountResult)
+
+    /// An error object indicating why the operation failed. It may contain a ``SignInPasswordRequiredState`` to continue the flow.
+    case error(error: PasswordRequiredError, newState: SignInPasswordRequiredState?)
+}
+
+/// Result type that contains information about the state of the sign in process.
+enum SignInVerifyCodeResult {
+    /// Returned after the sign in operation completed successfully. An object representing the signed in user account is returned.
+    case completed(MSALNativeAuthUserAccountResult)
+
+    /// An error object indicating why the operation failed. It may contain a ``SignInPasswordRequiredState`` to continue the flow.
+    case error(error: VerifyCodeError, newState: SignInCodeRequiredState?)
+}

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -1,0 +1,592 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
+final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALNativeAuthSignInControlling {
+
+    // MARK: - Variables
+
+    private let signInRequestProvider: MSALNativeAuthSignInRequestProviding
+    private let signInResponseValidator: MSALNativeAuthSignInResponseValidating
+
+    // MARK: - Init
+
+    init(
+        clientId: String,
+        signInRequestProvider: MSALNativeAuthSignInRequestProviding,
+        tokenRequestProvider: MSALNativeAuthTokenRequestProviding,
+        cacheAccessor: MSALNativeAuthCacheInterface,
+        factory: MSALNativeAuthResultBuildable,
+        signInResponseValidator: MSALNativeAuthSignInResponseValidating,
+        tokenResponseValidator: MSALNativeAuthTokenResponseValidating
+    ) {
+        self.signInRequestProvider = signInRequestProvider
+        self.signInResponseValidator = signInResponseValidator
+        super.init(
+            clientId: clientId,
+            requestProvider: tokenRequestProvider,
+            cacheAccessor: cacheAccessor,
+            factory: factory,
+            responseValidator: tokenResponseValidator
+        )
+    }
+
+    convenience init(config: MSALNativeAuthConfiguration) {
+        let factory = MSALNativeAuthResultFactory(config: config)
+        self.init(
+            clientId: config.clientId,
+            signInRequestProvider: MSALNativeAuthSignInRequestProvider(
+                requestConfigurator: MSALNativeAuthRequestConfigurator(config: config)),
+            tokenRequestProvider: MSALNativeAuthTokenRequestProvider(
+                requestConfigurator: MSALNativeAuthRequestConfigurator(config: config)),
+            cacheAccessor: MSALNativeAuthCacheAccessor(),
+            factory: factory,
+            signInResponseValidator: MSALNativeAuthSignInResponseValidator(),
+            tokenResponseValidator: MSALNativeAuthTokenResponseValidator(
+                factory: factory,
+                msidValidator: MSIDTokenResponseValidator())
+        )
+    }
+
+    // MARK: - Internal
+
+    func signIn(params: MSALNativeAuthSignInWithPasswordParameters) async -> SignInPasswordControllerResponse {
+        MSALLogger.log(level: .verbose, context: params.context, format: "SignIn with username and password started")
+        let telemetryInfo = TelemetryInfo(
+            event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInWithPasswordStart, context: params.context),
+            context: params.context
+        )
+
+        let initiateValidatedResponse = await performAndValidateSignInInitiate(username: params.username, telemetryInfo: telemetryInfo)
+        let result = await handleInitiateResponse(initiateValidatedResponse, telemetryInfo: telemetryInfo)
+
+        switch result {
+        case .success(let challengeValidatedResponse):
+            return await handleChallengeResponse(challengeValidatedResponse, params: params, telemetryInfo: telemetryInfo)
+        case .failure(let error):
+            return .init(.error(error.convertToSignInPasswordStartError()))
+        }
+    }
+
+    func signIn(params: MSALNativeAuthSignInWithCodeParameters) async -> SignInCodeControllerResponse {
+        MSALLogger.log(level: .verbose, context: params.context, format: "SignIn started")
+        let telemetryInfo = TelemetryInfo(
+            event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInWithCodeStart, context: params.context),
+            context: params.context
+        )
+
+        let initiateValidatedResponse = await performAndValidateSignInInitiate(username: params.username, telemetryInfo: telemetryInfo)
+        let result = await handleInitiateResponse(initiateValidatedResponse, telemetryInfo: telemetryInfo)
+
+        switch result {
+        case .success(let challengeValidatedResponse):
+            return await handleChallengeResponse(challengeValidatedResponse, params: params, telemetryInfo: telemetryInfo)
+        case .failure(let error):
+            return .init(.error(error.convertToSignInStartError()))
+        }
+    }
+
+    func signIn(
+        username: String,
+        slt: String?,
+        scopes: [String]?,
+        context: MSALNativeAuthRequestContext
+    ) async -> Result<MSALNativeAuthUserAccountResult, SignInAfterSignUpError> {
+        MSALLogger.log(level: .verbose, context: context, format: "SignIn after signUp started")
+        let telemetryInfo = TelemetryInfo(
+            event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInAfterSignUp, context: context),
+            context: context
+        )
+        guard let slt = slt else {
+            MSALLogger.log(level: .error, context: context, format: "SignIn not available because SLT is nil")
+            let error = SignInAfterSignUpError(message: MSALNativeAuthErrorMessage.signInNotAvailable)
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .failure(error)
+        }
+        let scopes = joinScopes(scopes)
+        guard let request = createTokenRequest(
+            username: username,
+            scopes: scopes,
+            signInSLT: slt,
+            grantType: .slt,
+            context: context
+        ) else {
+            let error = SignInAfterSignUpError()
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .failure(error)
+        }
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        let response = await performAndValidateTokenRequest(request, config: config, context: context)
+
+        return await withCheckedContinuation { continuation in
+            handleTokenResponse(
+                response,
+                scopes: scopes,
+                telemetryInfo: telemetryInfo,
+                onSuccess: { accountResult in
+                    continuation.resume(returning: .success(accountResult))
+                },
+                onError: { error in
+                    continuation.resume(returning: .failure(SignInAfterSignUpError(message: error.errorDescription)))
+                }
+            )
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    func submitCode(
+        _ code: String,
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]
+    ) async -> SignInVerifyCodeResult {
+        let telemetryInfo = TelemetryInfo(
+            event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInSubmitCode, context: context),
+            context: context
+        )
+        guard let request = createTokenRequest(
+            scopes: scopes,
+            credentialToken: credentialToken,
+            oobCode: code,
+            grantType: .oobCode,
+            includeChallengeType: false,
+            context: context) else {
+            MSALLogger.log(level: .error, context: context, format: "SignIn, submit code: unable to create token request")
+
+            return processSubmitCodeFailure(
+                errorType: .generalError,
+                telemetryInfo: telemetryInfo,
+                scopes: scopes,
+                credentialToken: credentialToken,
+                context: context
+            )
+        }
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        let response = await performAndValidateTokenRequest(request, config: config, context: context)
+        switch response {
+        case .success(let tokenResponse):
+            return await withCheckedContinuation { continuation in
+                handleMSIDTokenResponse(
+                    tokenResponse: tokenResponse,
+                    context: context,
+                    telemetryInfo: telemetryInfo,
+                    config: config,
+                    onSuccess: { accountResult in
+                        continuation.resume(returning: .completed(accountResult))
+                    },
+                    onError: { [weak self] error in
+                        MSALLogger.log(level: .error, context: context, format: "SignIn submit code, token request failed with error \(error)")
+                        guard let self = self else { return }
+                        continuation.resume(returning: self.processSubmitCodeFailure(
+                            errorType: .generalError,
+                            telemetryInfo: telemetryInfo,
+                            scopes: scopes,
+                            credentialToken: credentialToken,
+                            context: context
+                        ))
+                    }
+                )
+            }
+        case .error(let errorType):
+            return processSubmitCodeFailure(
+                errorType: errorType,
+                telemetryInfo: telemetryInfo,
+                scopes: scopes,
+                credentialToken: credentialToken,
+                context: context
+            )
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    func submitPassword(
+        _ password: String,
+        username: String,
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]
+    ) async -> SignInPasswordRequiredResult {
+        let telemetryInfo = TelemetryInfo(
+            event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInSubmitPassword, context: context),
+            context: context
+        )
+        guard let request = createTokenRequest(
+            username: username,
+            password: password,
+            scopes: scopes,
+            credentialToken: credentialToken,
+            grantType: .password,
+            context: context) else {
+            MSALLogger.log(level: .error, context: context, format: "SignIn, submit password: unable to create token request")
+            return processSubmitPasswordFailure(
+                errorType: .generalError,
+                telemetryInfo: telemetryInfo,
+                username: username,
+                credentialToken: credentialToken,
+                scopes: scopes
+            )
+        }
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        let response = await performAndValidateTokenRequest(request, config: config, context: context)
+        switch response {
+        case .success(let tokenResponse):
+            return await withCheckedContinuation { continuation in
+                handleMSIDTokenResponse(
+                    tokenResponse: tokenResponse,
+                    context: context,
+                    telemetryInfo: telemetryInfo,
+                    config: config,
+                    onSuccess: { accountResult in
+                        continuation.resume(returning: .completed(accountResult))
+                    },
+                    onError: { [weak self] error in
+                        MSALLogger.log(level: .error, context: context, format: "SignIn submit password, token request failed with error \(error)")
+                        guard let self = self else { return }
+                        continuation.resume(returning: self.processSubmitPasswordFailure(
+                            errorType: .generalError,
+                            telemetryInfo: telemetryInfo,
+                            username: username,
+                            credentialToken: credentialToken,
+                            scopes: scopes
+                        ))
+                    }
+                )
+            }
+
+        case .error(let errorType):
+            return processSubmitPasswordFailure(
+                errorType: errorType,
+                telemetryInfo: telemetryInfo,
+                username: username,
+                credentialToken: credentialToken,
+                scopes: scopes
+            )
+        }
+    }
+
+    func resendCode(
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]
+    ) async -> SignInResendCodeResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignInResendCode, context: context)
+        let result = await performAndValidateChallengeRequest(credentialToken: credentialToken, context: context)
+        switch result {
+        case .passwordRequired:
+            let error = ResendCodeError()
+            MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: received unexpected password required API result")
+            stopTelemetryEvent(event, context: context, error: error)
+            return .error(error: error, newState: nil)
+        case .error(let challengeError):
+            let error = ResendCodeError()
+            MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: received challenge error response: \(challengeError)")
+            stopTelemetryEvent(event, context: context, error: error)
+            return .error(error: error, newState: SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken))
+        case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
+            let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken)
+            stopTelemetryEvent(event, context: context)
+            return .codeRequired(newState: state, sentTo: sentTo, channelTargetType: channelType, codeLength: codeLength)
+        }
+    }
+
+    // MARK: - Private
+
+    private func processSubmitCodeFailure(
+        errorType: MSALNativeAuthTokenValidatedErrorType,
+        telemetryInfo: TelemetryInfo,
+        scopes: [String],
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext
+    ) -> SignInVerifyCodeResult {
+        MSALLogger.log(
+            level: .error,
+            context: context,
+            format: "SignIn completed with errorType: \(errorType)")
+        stopTelemetryEvent(telemetryInfo, error: errorType)
+        let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken)
+        return .error(error: errorType.convertToVerifyCodeError(), newState: state)
+    }
+
+    private func processSubmitPasswordFailure(
+        errorType: MSALNativeAuthTokenValidatedErrorType,
+        telemetryInfo: TelemetryInfo,
+        username: String,
+        credentialToken: String,
+        scopes: [String]
+    ) -> SignInPasswordRequiredResult {
+        MSALLogger.log(
+            level: .error,
+            context: telemetryInfo.context,
+            format: "SignIn with username and password completed with errorType: \(errorType)")
+        stopTelemetryEvent(telemetryInfo, error: errorType)
+        let state = SignInPasswordRequiredState(scopes: scopes, username: username, controller: self, flowToken: credentialToken)
+        return .error(error: errorType.convertToPasswordRequiredError(), newState: state)
+    }
+
+    private func performAndValidateSignInInitiate(
+        username: String,
+        telemetryInfo: TelemetryInfo
+    ) async -> MSALNativeAuthSignInInitiateValidatedResponse {
+        guard let request = createInitiateRequest(username: username, context: telemetryInfo.context) else {
+            let error = MSALNativeAuthSignInInitiateValidatedErrorType.invalidRequest(message: nil)
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .error(error)
+        }
+
+        let initiateResponse: Result<MSALNativeAuthSignInInitiateResponse, Error> = await performRequest(request, context: telemetryInfo.context)
+        let validatedResponse = signInResponseValidator.validate(context: telemetryInfo.context, result: initiateResponse)
+
+        return validatedResponse
+    }
+
+    private func handleInitiateResponse(
+        _ validatedResponse: MSALNativeAuthSignInInitiateValidatedResponse,
+        telemetryInfo: TelemetryInfo
+    ) async -> Result<MSALNativeAuthSignInChallengeValidatedResponse, MSALNativeAuthSignInInitiateValidatedErrorType> {
+        switch validatedResponse {
+        case .success(let credentialToken):
+            let challengeValidatedResponse = await performAndValidateChallengeRequest(
+                credentialToken: credentialToken,
+                context: telemetryInfo.context
+            )
+            return .success(challengeValidatedResponse)
+        case .error(let error):
+            MSALLogger.log(level: .error, context: telemetryInfo.context, format: "SignIn: an error occurred after calling /initiate API: \(error)")
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .failure(error)
+        }
+    }
+
+    private func handleTokenResponse(
+        _ response: MSALNativeAuthTokenValidatedResponse,
+        scopes: [String],
+        telemetryInfo: TelemetryInfo,
+        onSuccess: @escaping (MSALNativeAuthUserAccountResult) -> Void,
+        onError: @escaping (SignInPasswordStartError) -> Void
+    ) {
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        switch response {
+        case .success(let tokenResponse):
+            return handleMSIDTokenResponse(
+                tokenResponse: tokenResponse,
+                context: telemetryInfo.context,
+                telemetryInfo: telemetryInfo,
+                config: config,
+                onSuccess: onSuccess,
+                onError: onError
+            )
+        case .error(let errorType):
+            let error = errorType.convertToSignInPasswordStartError()
+            MSALLogger.log(level: .error,
+                           context: telemetryInfo.context,
+                           format: "SignIn completed with errorType: \(error.errorDescription ?? "No error description")")
+            stopTelemetryEvent(telemetryInfo, error: error)
+            onError(error)
+        }
+    }
+
+    private func handleMSIDTokenResponse(
+        tokenResponse: MSIDTokenResponse,
+        context: MSALNativeAuthRequestContext,
+        telemetryInfo: TelemetryInfo,
+        config: MSIDConfiguration,
+        onSuccess: @escaping (MSALNativeAuthUserAccountResult) -> Void,
+        onError: @escaping (SignInPasswordStartError) -> Void
+    ) {
+        do {
+            let tokenResult = try cacheTokenResponse(tokenResponse, context: context, msidConfiguration: config)
+
+            if let userAccountResult = factory.makeUserAccountResult(tokenResult: tokenResult, context: context) {
+                MSALLogger.log(level: .verbose, context: context, format: "SignIn completed successfully")
+                telemetryInfo.event?.setUserInformation(tokenResult.account)
+                stopTelemetryEvent(telemetryInfo)
+                onSuccess(userAccountResult)
+            } else {
+                let errorType = MSALNativeAuthTokenValidatedErrorType.generalError
+                MSALLogger.log(level: .error, context: telemetryInfo.context, format: "SignIn completed with error. Error creating UserAccountResult")
+                stopTelemetryEvent(telemetryInfo, error: errorType)
+                onError(errorType.convertToSignInPasswordStartError())
+            }
+        } catch {
+            let errorType = MSALNativeAuthTokenValidatedErrorType.generalError
+            MSALLogger.log(level: .error, context: telemetryInfo.context, format: "SignIn completed with error \(error)")
+            stopTelemetryEvent(telemetryInfo, error: errorType)
+            onError(errorType.convertToSignInPasswordStartError())
+        }
+    }
+
+    private func handleChallengeResponse(
+        _ validatedResponse: MSALNativeAuthSignInChallengeValidatedResponse,
+        params: MSALNativeAuthSignInWithCodeParameters,
+        telemetryInfo: TelemetryInfo
+    ) async -> SignInCodeControllerResponse {
+        let scopes = joinScopes(params.scopes)
+
+        switch validatedResponse {
+        case .passwordRequired(let credentialToken):
+            let state = SignInPasswordRequiredState(
+                scopes: scopes,
+                username: params.username,
+                controller: self,
+                flowToken: credentialToken
+            )
+
+            return .init(.passwordRequired(newState: state), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    MSALLogger.log(level: .verbose, context: telemetryInfo.context, format: "SignIn, password required")
+                    self?.stopTelemetryEvent(telemetryInfo)
+                case .failure(let error):
+                    MSALLogger.log(
+                        level: .error,
+                        context: telemetryInfo.context,
+                        format: "SignIn error: \(error.errorDescription ?? "No error description")"
+                    )
+                    self?.stopTelemetryEvent(telemetryInfo, error: error)
+                }
+            })
+        case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
+            let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken)
+            stopTelemetryEvent(telemetryInfo)
+            return .init(.codeRequired(newState: state, sentTo: sentTo, channelTargetType: channelType, codeLength: codeLength))
+        case .error(let challengeError):
+            let error = challengeError.convertToSignInStartError()
+            MSALLogger.log(level: .error,
+                           context: telemetryInfo.context,
+                           format: "SignIn, completed with error: \(error.errorDescription ?? "No error description")")
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .init(.error(error))
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    private func handleChallengeResponse(
+        _ validatedResponse: MSALNativeAuthSignInChallengeValidatedResponse,
+        params: MSALNativeAuthSignInWithPasswordParameters,
+        telemetryInfo: TelemetryInfo
+    ) async -> SignInPasswordControllerResponse {
+        let scopes = joinScopes(params.scopes)
+
+        switch validatedResponse {
+        case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
+            MSALLogger.log(level: .warning, context: telemetryInfo.context, format: MSALNativeAuthErrorMessage.codeRequiredForPasswordUserLog)
+            let result: SignInPasswordStartResult = .codeRequired(
+                newState: SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken),
+                sentTo: sentTo,
+                channelTargetType: channelType,
+                codeLength: codeLength
+            )
+
+            return .init(result, telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(telemetryInfo)
+                case .failure(let error):
+                    MSALLogger.log(
+                        level: .error,
+                        context: telemetryInfo.context,
+                        format: "SignIn error \(error.errorDescription ?? "No error description")"
+                    )
+                    self?.stopTelemetryEvent(telemetryInfo, error: error)
+                }
+            })
+        case .passwordRequired(let credentialToken):
+            guard let request = createTokenRequest(
+                username: params.username,
+                password: params.password,
+                scopes: scopes,
+                credentialToken: credentialToken,
+                grantType: .password,
+                context: telemetryInfo.context
+            ) else {
+                stopTelemetryEvent(telemetryInfo, error: MSALNativeAuthInternalError.invalidRequest)
+                return .init(.error(SignInPasswordStartError(type: .generalError)))
+            }
+
+            let config = factory.makeMSIDConfiguration(scopes: scopes)
+            let response = await performAndValidateTokenRequest(request, config: config, context: telemetryInfo.context)
+
+            return await withCheckedContinuation { continuation in
+                handleTokenResponse(response,
+                    scopes: scopes,
+                    telemetryInfo: telemetryInfo,
+                    onSuccess: { accountResult in
+                        continuation.resume(returning: SignInPasswordControllerResponse(.completed(accountResult)))
+                    },
+                    onError: { error in
+                        continuation.resume(returning: SignInPasswordControllerResponse(.error(error)))
+                    }
+                )
+            }
+        case .error(let challengeError):
+            let error = challengeError.convertToSignInPasswordStartError()
+            MSALLogger.log(level: .error,
+                           context: telemetryInfo.context,
+                           format: "SignIn, completed with error: \(error.errorDescription ?? "No error description")")
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .init(.error(error))
+        }
+    }
+
+    private func performAndValidateChallengeRequest(
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext
+    ) async -> MSALNativeAuthSignInChallengeValidatedResponse {
+        guard let challengeRequest = createChallengeRequest(credentialToken: credentialToken, context: context) else {
+            MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: Cannot create Challenge request object")
+            return .error(.invalidRequest(message: nil))
+        }
+        let challengeResponse: Result<MSALNativeAuthSignInChallengeResponse, Error> = await performRequest(challengeRequest, context: context)
+        return signInResponseValidator.validate(context: context, result: challengeResponse)
+    }
+
+    private func createInitiateRequest(username: String, context: MSIDRequestContext) -> MSIDHttpRequest? {
+        let params = MSALNativeAuthSignInInitiateRequestParameters(context: context, username: username)
+        do {
+            return try signInRequestProvider.inititate(parameters: params, context: context)
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error creating SignIn Initiate Request: \(error)")
+            return nil
+        }
+    }
+
+    private func createChallengeRequest(
+        credentialToken: String,
+        context: MSIDRequestContext
+    ) -> MSIDHttpRequest? {
+        do {
+            let params = MSALNativeAuthSignInChallengeRequestParameters(
+                context: context,
+                credentialToken: credentialToken
+            )
+            return try signInRequestProvider.challenge(parameters: params, context: context)
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error creating SignIn Challenge Request: \(error)")
+            return nil
+        }
+    }
+}

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
@@ -1,0 +1,53 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import Foundation
+
+protocol MSALNativeAuthSignInControlling {
+    typealias SignInPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignInPasswordStartResult>
+    typealias SignInCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignInStartResult>
+
+    func signIn(params: MSALNativeAuthSignInWithPasswordParameters) async -> SignInPasswordControllerResponse
+
+    func signIn(params: MSALNativeAuthSignInWithCodeParameters) async -> SignInCodeControllerResponse
+
+    func signIn(
+        username: String,
+        slt: String?,
+        scopes: [String]?,
+        context: MSALNativeAuthRequestContext
+    ) async -> Result<MSALNativeAuthUserAccountResult, SignInAfterSignUpError>
+
+    func submitCode(_ code: String, credentialToken: String, context: MSALNativeAuthRequestContext, scopes: [String]) async -> SignInVerifyCodeResult
+
+    func submitPassword(
+        _ password: String,
+        username: String,
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]
+    ) async -> SignInPasswordRequiredResult
+
+    func resendCode(credentialToken: String, context: MSALNativeAuthRequestContext, scopes: [String]) async -> SignInResendCodeResult
+}

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInWithCodeParameters.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInWithCodeParameters.swift
@@ -1,0 +1,40 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignInWithCodeParameters {
+    let username: String
+    let context: MSALNativeAuthRequestContext
+    let scopes: [String]?
+
+    init(
+        username: String,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]?) {
+        self.username = username
+        self.context = context
+        self.scopes = scopes
+    }
+}

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInWithPasswordParameters.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInWithPasswordParameters.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignInWithPasswordParameters: MSALNativeAuthSignInWithCodeParameters {
+    let password: String
+
+    init(
+        username: String,
+        password: String,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]?) {
+        self.password = password
+        super.init(
+            username: username,
+            context: context,
+            scopes: scopes)
+    }
+}

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeOauth2ErrorCode.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthSignInChallengeOauth2ErrorCode: String, Decodable {
+    case invalidRequest = "invalid_request"
+    case unauthorizedClient = "unauthorized_client"
+    case invalidGrant = "invalid_grant"
+    case expiredToken = "expired_token"
+    case unsupportedChallengeType = "unsupported_challenge_type"
+}

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
+
+    let error: MSALNativeAuthSignInChallengeOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+    }
+}

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateOauth2ErrorCode.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthSignInInitiateOauth2ErrorCode: String, Decodable, CaseIterable {
+    case invalidRequest = "invalid_request"
+    case unauthorizedClient = "unauthorized_client"
+    case invalidGrant = "invalid_grant"
+    case unsupportedChallengeType = "unsupported_challenge_type"
+}

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateResponseError.swift
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignInInitiateResponseError: MSALNativeAuthResponseError {
+
+    let error: MSALNativeAuthSignInInitiateOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParameters.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthSignInChallengeRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .signInChallenge
+    let context: MSIDRequestContext
+    let credentialToken: String
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.credentialToken.rawValue: credentialToken,
+            Key.challengeType.rawValue: config.challengeTypesString
+        ].compactMapValues { $0 }
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParameters.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthSignInInitiateRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .signInInitiate
+    let context: MSIDRequestContext
+    let username: String
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.username.rawValue: username,
+            Key.challengeType.rawValue: config.challengeTypesString
+        ]
+    }
+}

--- a/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
+++ b/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResendCodeRequestResponse: Decodable {
+
+    // MARK: - Variables
+    let credentialToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case credentialToken = "flowToken"
+    }
+}

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInChallengeResponse.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignInChallengeResponse: Decodable {
+
+    // MARK: - Variables
+    let credentialToken: String?
+    let challengeType: MSALNativeAuthInternalChallengeType
+    let bindingMethod: String?
+    let challengeTargetLabel: String?
+    let challengeChannel: MSALNativeAuthInternalChannelType?
+    let codeLength: Int?
+    let interval: Int?
+}

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInInitiateResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInInitiateResponse.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignInInitiateResponse: Decodable {
+
+    // MARK: - Variables
+    let credentialToken: String?
+    let challengeType: MSALNativeAuthInternalChallengeType?
+
+    enum CodingKeys: String, CodingKey {
+        case credentialToken
+        case challengeType
+    }
+}

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -1,0 +1,160 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignInResponseValidating {
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        result: Result<MSALNativeAuthSignInChallengeResponse, Error>
+    ) -> MSALNativeAuthSignInChallengeValidatedResponse
+
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        result: Result<MSALNativeAuthSignInInitiateResponse, Error>
+    ) -> MSALNativeAuthSignInInitiateValidatedResponse
+}
+
+final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseValidating {
+
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        result: Result<MSALNativeAuthSignInChallengeResponse, Error>
+    ) -> MSALNativeAuthSignInChallengeValidatedResponse {
+        switch result {
+        case .success(let challengeResponse):
+            return handleSuccessfulSignInChallengeResult(context, response: challengeResponse)
+        case .failure(let signInChallengeResponseError):
+            guard let signInChallengeResponseError =
+                    signInChallengeResponseError as? MSALNativeAuthSignInChallengeResponseError else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "SignIn Challenge: Error type not expected, error: \(signInChallengeResponseError)")
+                return .error(.invalidServerResponse)
+            }
+            return handleFailedSignInChallengeResult(context, error: signInChallengeResponseError)
+        }
+    }
+
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        result: Result<MSALNativeAuthSignInInitiateResponse, Error>
+    ) -> MSALNativeAuthSignInInitiateValidatedResponse {
+        switch result {
+        case .success(let initiateResponse):
+            if initiateResponse.challengeType == .redirect {
+                return .error(.redirect)
+            }
+            if let credentialToken = initiateResponse.credentialToken {
+                return .success(credentialToken: credentialToken)
+            }
+            MSALLogger.log(level: .error, context: context, format: "SignIn Initiate: challengeType and credential token empty")
+            return .error(.invalidServerResponse)
+        case .failure(let responseError):
+            guard let initiateResponseError = responseError as? MSALNativeAuthSignInInitiateResponseError else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "SignIn Initiate: Error type not expected, error: \(responseError)")
+                return .error(.invalidServerResponse)
+            }
+            return handleFailedSignInInitiateResult(context, error: initiateResponseError)
+        }
+    }
+
+    // MARK: private methods
+
+    private func handleSuccessfulSignInChallengeResult(
+        _ context: MSALNativeAuthRequestContext,
+        response: MSALNativeAuthSignInChallengeResponse) -> MSALNativeAuthSignInChallengeValidatedResponse {
+        switch response.challengeType {
+        case .otp:
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "SignIn Challenge: Received unexpected challenge type: \(response.challengeType)")
+            return .error(.invalidServerResponse)
+        case .oob:
+            guard let credentialToken = response.credentialToken,
+                    let targetLabel = response.challengeTargetLabel,
+                    let codeLength = response.codeLength,
+                    let channelType = response.challengeChannel else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "SignIn Challenge: Invalid response with challenge type oob, response: \(response)")
+                return .error(.invalidServerResponse)
+            }
+            return .codeRequired(
+                credentialToken: credentialToken,
+                sentTo: targetLabel,
+                channelType: channelType.toPublicChannelType(),
+                codeLength: codeLength)
+        case .password:
+            guard let credentialToken = response.credentialToken else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "SignIn Challenge: Expected credential token not nil with credential type password")
+                return .error(.invalidServerResponse)
+            }
+            return .passwordRequired(credentialToken: credentialToken)
+        case .redirect:
+            return .error(.redirect)
+        }
+    }
+
+    private func handleFailedSignInChallengeResult(
+        _ context: MSALNativeAuthRequestContext,
+        error: MSALNativeAuthSignInChallengeResponseError) -> MSALNativeAuthSignInChallengeValidatedResponse {
+            switch error.error {
+            case .invalidRequest:
+                return .error(.invalidRequest(message: error.errorDescription))
+            case .unauthorizedClient:
+                return .error(.invalidClient(message: error.errorDescription))
+            case .invalidGrant:
+                return .error(.invalidToken(message: error.errorDescription))
+            case .expiredToken:
+                return .error(.expiredToken(message: error.errorDescription))
+            case .unsupportedChallengeType:
+                return .error(.unsupportedChallengeType(message: error.errorDescription))
+            }
+    }
+
+    private func handleFailedSignInInitiateResult(
+        _ context: MSALNativeAuthRequestContext,
+        error: MSALNativeAuthSignInInitiateResponseError) -> MSALNativeAuthSignInInitiateValidatedResponse {
+            switch error.error {
+            case .invalidRequest:
+                return .error(.invalidRequest(message: error.errorDescription))
+            case .unauthorizedClient:
+                return .error(.invalidClient(message: error.errorDescription))
+            case .unsupportedChallengeType:
+                return .error(.unsupportedChallengeType(message: error.errorDescription))
+            case .invalidGrant:
+                return .error(.userNotFound(message: error.errorDescription))
+            }
+    }
+}

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
@@ -1,0 +1,76 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthSignInChallengeValidatedResponse {
+    case codeRequired(credentialToken: String, sentTo: String, channelType: MSALNativeAuthChannelType, codeLength: Int)
+    case passwordRequired(credentialToken: String)
+    case error(MSALNativeAuthSignInChallengeValidatedErrorType)
+}
+
+enum MSALNativeAuthSignInChallengeValidatedErrorType: Error {
+    case redirect
+    case expiredToken(message: String?)
+    case invalidToken(message: String?)
+    case invalidClient(message: String?)
+    case invalidRequest(message: String?)
+    case invalidServerResponse
+    case userNotFound(message: String?)
+    case unsupportedChallengeType(message: String?)
+
+    func convertToSignInStartError() -> SignInStartError {
+        switch self {
+        case .redirect:
+            return .init(type: .browserRequired)
+        case .invalidServerResponse:
+            return .init(type: .generalError)
+        case .expiredToken(let message),
+             .invalidToken(let message),
+             .invalidRequest(let message):
+            return .init(type: .generalError, message: message)
+        case .invalidClient(let message):
+            return .init(type: .generalError, message: message)
+        case .userNotFound(let message):
+            return .init(type: .userNotFound, message: message)
+        case .unsupportedChallengeType(let message):
+            return .init(type: .generalError, message: message)
+        }
+    }
+
+    func convertToSignInPasswordStartError() -> SignInPasswordStartError {
+        switch self {
+        case .redirect:
+            return .init(type: .browserRequired)
+        case .expiredToken, .invalidToken, .invalidRequest, .invalidServerResponse:
+            return .init(type: .generalError)
+        case .invalidClient(let message):
+            return .init(type: .generalError, message: message)
+        case .userNotFound:
+            return .init(type: .userNotFound)
+        case .unsupportedChallengeType(let message):
+            return .init(type: .generalError, message: message)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInInitiateValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInInitiateValidatedResponse.swift
@@ -1,0 +1,69 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthSignInInitiateValidatedResponse {
+    case success(credentialToken: String)
+    case error(MSALNativeAuthSignInInitiateValidatedErrorType)
+}
+
+enum MSALNativeAuthSignInInitiateValidatedErrorType: Error {
+    case redirect
+    case invalidClient(message: String?)
+    case invalidRequest(message: String?)
+    case invalidServerResponse
+    case userNotFound(message: String?)
+    case unsupportedChallengeType(message: String?)
+
+    func convertToSignInStartError() -> SignInStartError {
+        switch self {
+        case .redirect:
+            return .init(type: .browserRequired)
+        case .userNotFound(let message):
+            return .init(type: .userNotFound, message: message)
+        case .invalidServerResponse:
+            return .init(type: .generalError)
+        case .invalidClient(let message),
+             .unsupportedChallengeType(let message),
+             .invalidRequest(let message):
+            return .init(type: .generalError, message: message)
+        }
+    }
+
+    func convertToSignInPasswordStartError() -> SignInPasswordStartError {
+        switch self {
+        case .redirect:
+            return .init(type: .browserRequired)
+        case .userNotFound(let message):
+            return .init(type: .userNotFound, message: message)
+        case .invalidServerResponse:
+            return .init(type: .generalError)
+        case .invalidClient(let message),
+             .unsupportedChallengeType(let message),
+             .invalidRequest(let message):
+            return .init(type: .generalError, message: message)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/sign_in/MSALNativeAuthSignInRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_in/MSALNativeAuthSignInRequestProvider.swift
@@ -1,0 +1,83 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignInRequestProviding {
+    func inititate(
+        parameters: MSALNativeAuthSignInInitiateRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest
+
+    func challenge(
+        parameters: MSALNativeAuthSignInChallengeRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest
+}
+
+final class MSALNativeAuthSignInRequestProvider: MSALNativeAuthSignInRequestProviding {
+
+    // MARK: - Variables
+    private let requestConfigurator: MSALNativeAuthRequestConfigurator
+    private let telemetryProvider: MSALNativeAuthTelemetryProviding
+
+    // MARK: - Init
+
+    init(
+        requestConfigurator: MSALNativeAuthRequestConfigurator,
+        telemetryProvider: MSALNativeAuthTelemetryProviding = MSALNativeAuthTelemetryProvider()
+    ) {
+        self.requestConfigurator = requestConfigurator
+        self.telemetryProvider = telemetryProvider
+    }
+
+    // MARK: - SignIn Initiate
+
+    func inititate(
+        parameters: MSALNativeAuthSignInInitiateRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signIn(.initiate(parameters)),
+                                          request: request,
+                                          telemetryProvider: telemetryProvider)
+
+        return request
+    }
+
+    // MARK: - SignIn Challenge
+
+    func challenge(
+        parameters: MSALNativeAuthSignInChallengeRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signIn(.challenge(parameters)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInOTPParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInOTPParameters.swift
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers
+final public class MSALNativeAuthSignInOTPParameters: MSALNativeAuthParameters {
+
+    public let email: String
+    public let scopes: [String]
+
+    public init(email: String, scopes: [String] = [], correlationId: UUID? = nil) {
+        self.email = email
+        self.scopes = scopes
+        super.init(correlationId: correlationId)
+    }
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers
+final public class MSALNativeAuthSignInParameters: MSALNativeAuthParameters {
+
+    public let email: String
+    public let password: String
+    public let scopes: [String]
+
+    public init(email: String,
+                password: String,
+                scopes: [String] = [],
+                correlationId: UUID? = nil) {
+        self.email = email
+        self.password = password
+        self.scopes = scopes
+        super.init(correlationId: correlationId)
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/MSALNativeAuthRequiredAttributes.swift
+++ b/MSAL/src/native_auth/public/state_machine/MSALNativeAuthRequiredAttributes.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class MSALNativeAuthRequiredAttributes: NSObject {
+    public let name: String
+    public let type: String
+    public let required: Bool
+    public let regex: String?
+
+    init(name: String, type: String, required: Bool, regex: String? = nil) {
+        self.name = name
+        self.type = type
+        self.required = required
+        self.regex = regex
+        super.init()
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/delegate/SignInAfterSignUpDelegate.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/SignInAfterSignUpDelegate.swift
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import Foundation
+
+@objc
+public protocol SignInAfterSignUpDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignInAfterSignUpError(error: SignInAfterSignUpError)
+
+    /// Notifies the delegate that the sign in operation completed successfully.
+    /// - Parameter result: An object representing the signed in user account.
+    @MainActor func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
+}

--- a/MSAL/src/native_auth/public/state_machine/delegate/SignInDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/SignInDelegates.swift
@@ -1,0 +1,113 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public protocol SignInPasswordStartDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignInPasswordError(error: SignInPasswordStartError)
+
+    /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Note: If a flow requires a code but this optional method is not implemented, then ``onSignInPasswordError(error:)`` will be called.
+    /// - Parameters:
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    ///   - sentTo: The email/phone number that the code was sent to.
+    ///   - channelTargetType: The channel (email/phone) the code was sent through.
+    ///   - codeLength: The length of the code required.
+    @MainActor @objc optional func onSignInCodeRequired(newState: SignInCodeRequiredState,
+                                                        sentTo: String,
+                                                        channelTargetType: MSALNativeAuthChannelType,
+                                                        codeLength: Int)
+
+    /// Notifies the delegate that the sign in operation completed successfully.
+    /// - Parameter result: An object representing the signed in user account.
+    @MainActor func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
+}
+
+@objc
+public protocol SignInStartDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignInError(error: SignInStartError)
+
+    /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Parameters:
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    ///   - sentTo: The email/phone number that the code was sent to.
+    ///   - channelTargetType: The channel (email/phone) the code was sent through.
+    ///   - codeLength: The length of the code required.
+    @MainActor func onSignInCodeRequired(newState: SignInCodeRequiredState,
+                                         sentTo: String,
+                                         channelTargetType: MSALNativeAuthChannelType,
+                                         codeLength: Int)
+
+    /// Notifies the delegate that a password is required from the user to continue.
+    /// - Note: If a flow requires a password but this optional method is not implemented, then ``onSignInError(error:)`` will be called.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor @objc optional func onSignInPasswordRequired(newState: SignInPasswordRequiredState)
+}
+
+@objc
+public protocol SignInPasswordRequiredDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameters:
+    ///   - error: An error object indicating why the operation failed.
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignInPasswordRequiredError(error: PasswordRequiredError, newState: SignInPasswordRequiredState?)
+
+    /// Notifies the delegate that the sign in operation completed successfully.
+    /// - Parameter result: An object representing the signed in user account.
+    @MainActor func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
+}
+
+@objc
+public protocol SignInResendCodeDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignInResendCodeError(error: ResendCodeError, newState: SignInCodeRequiredState?)
+
+    /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Parameters:
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    ///   - sentTo: The email/phone number that the code was sent to.
+    ///   - channelTargetType: The channel (email/phone) the code was sent through.
+    ///   - codeLength: The length of the code required.
+    @MainActor func onSignInResendCodeCodeRequired(newState: SignInCodeRequiredState,
+                                                   sentTo: String,
+                                                   channelTargetType: MSALNativeAuthChannelType,
+                                                   codeLength: Int)
+}
+
+@objc
+public protocol SignInVerifyCodeDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignInVerifyCodeError(error: VerifyCodeError, newState: SignInCodeRequiredState?)
+
+    /// Notifies the delegate that the sign in operation completed successfully.
+    /// - Parameter result: An object representing the signed in user account.
+    @MainActor func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
+}

--- a/MSAL/src/native_auth/public/state_machine/error/SignInAfterSignUpError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignInAfterSignUpError.swift
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import Foundation
+
+@objc
+public class SignInAfterSignUpError: MSALNativeAuthError {
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        return "General error"
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/error/SignInPasswordStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignInPasswordStartError.swift
@@ -1,0 +1,64 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class SignInPasswordStartError: MSALNativeAuthError {
+    /// An error type indicating the type of error that occurred
+    @objc public let type: SignInPasswordStartErrorType
+
+    init(type: SignInPasswordStartErrorType, message: String? = nil) {
+        self.type = type
+        super.init(message: message)
+    }
+
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        switch type {
+        case .browserRequired:
+            return "Browser required"
+        case .userNotFound:
+            return "User not found"
+        case .invalidPassword:
+            return "Invalid password"
+        case .invalidUsername:
+            return "Invalid username"
+        case .generalError:
+            return "General error"
+        }
+    }
+}
+
+@objc
+public enum SignInPasswordStartErrorType: Int {
+    case browserRequired
+    case userNotFound
+    case invalidPassword
+    case invalidUsername
+    case generalError
+}

--- a/MSAL/src/native_auth/public/state_machine/error/SignInStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignInStartError.swift
@@ -1,0 +1,61 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class SignInStartError: MSALNativeAuthError {
+    /// An error type indicating the type of error that occurred
+    @objc public let type: SignInStartErrorType
+
+    init(type: SignInStartErrorType, message: String? = nil) {
+        self.type = type
+        super.init(message: message)
+    }
+
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        switch type {
+        case .browserRequired:
+            return "Browser required"
+        case .userNotFound:
+            return "User not found"
+        case .invalidUsername:
+            return "Invalid username"
+        case .generalError:
+            return "General error"
+        }
+    }
+}
+
+@objc
+public enum SignInStartErrorType: Int {
+    case browserRequired
+    case userNotFound
+    case invalidUsername
+    case generalError
+}

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState+Internal.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+extension SignInAfterSignUpState {
+
+    func signInInternal(scopes: [String]?, correlationId: UUID?) async -> Result<MSALNativeAuthUserAccountResult, SignInAfterSignUpError> {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        return await controller.signIn(username: username, slt: slt, scopes: scopes, context: context)
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -1,0 +1,61 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import Foundation
+
+/// An object of this type is created when a user has signed up successfully.
+@objcMembers public class SignInAfterSignUpState: NSObject {
+
+    let controller: MSALNativeAuthSignInControlling
+    let username: String
+    let slt: String?
+
+    init(controller: MSALNativeAuthSignInControlling, username: String, slt: String?) {
+        self.username = username
+        self.slt = slt
+        self.controller = controller
+    }
+
+    /// Sign in the user that signed up.
+    /// - Parameters:
+    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Sign In flow.
+    public func signIn(
+        scopes: [String]? = nil,
+        correlationId: UUID? = nil,
+        delegate: SignInAfterSignUpDelegate
+    ) {
+        Task {
+            let controllerResult = await signInInternal(scopes: scopes, correlationId: correlationId)
+
+            switch controllerResult {
+            case .success(let accountResult):
+                await delegate.onSignInCompleted(result: accountResult)
+            case .failure(let error):
+                await delegate.onSignInAfterSignUpError(error: error)
+            }
+        }
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
@@ -1,0 +1,64 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+extension SignInCodeRequiredState {
+
+    func submitCodeInternal(code: String, correlationId: UUID?) async -> SignInVerifyCodeResult {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, code submitted")
+        guard inputValidator.isInputValid(code) else {
+            MSALLogger.log(level: .error, context: context, format: "SignIn flow, invalid code")
+            return .error(error: VerifyCodeError(type: .invalidCode), newState: self)
+        }
+
+        return await controller.submitCode(code, credentialToken: flowToken, context: context, scopes: scopes)
+    }
+
+    func resendCodeInternal(correlationId: UUID?) async -> SignInResendCodeResult {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, resend code requested")
+
+        return await controller.resendCode(credentialToken: flowToken, context: context, scopes: scopes)
+    }
+}
+
+extension SignInPasswordRequiredState {
+
+    func submitPasswordInternal(
+        password: String,
+        correlationId: UUID?
+    ) async -> SignInPasswordRequiredResult {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        MSALLogger.log(level: .info, context: context, format: "SignIn flow, password submitted")
+
+        guard inputValidator.isInputValid(password) else {
+            MSALLogger.log(level: .error, context: context, format: "SignIn flow, invalid password")
+            return .error(error: PasswordRequiredError(type: .invalidPassword), newState: self)
+        }
+
+        return await controller.submitPassword(password, username: username, credentialToken: flowToken, context: context, scopes: scopes)
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
@@ -1,0 +1,130 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers public class SignInBaseState: MSALNativeAuthBaseState {
+    let controller: MSALNativeAuthSignInControlling
+    let inputValidator: MSALNativeAuthInputValidating
+
+    init(
+        controller: MSALNativeAuthSignInControlling,
+        inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
+        flowToken: String) {
+        self.controller = controller
+        self.inputValidator = inputValidator
+        super.init(flowToken: flowToken)
+    }
+}
+
+/// An object of this type is created when a user is required to supply a verification code to continue a sign in flow.
+@objcMembers public class SignInCodeRequiredState: SignInBaseState {
+
+    let scopes: [String]
+
+    init(
+        scopes: [String],
+        controller: MSALNativeAuthSignInControlling,
+        inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
+        flowToken: String) {
+        self.scopes = scopes
+        super.init(controller: controller, inputValidator: inputValidator, flowToken: flowToken)
+    }
+
+    /// Requests the server to resend the verification code to the user.
+    /// - Parameters:
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func resendCode(delegate: SignInResendCodeDelegate, correlationId: UUID? = nil) {
+        Task {
+            let result = await resendCodeInternal(correlationId: correlationId)
+
+            switch result {
+            case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
+                await delegate.onSignInResendCodeCodeRequired(
+                    newState: newState,
+                    sentTo: sentTo,
+                    channelTargetType: channelTargetType,
+                    codeLength: codeLength
+                )
+            case .error(let error, let newState):
+                await delegate.onSignInResendCodeError(error: error, newState: newState)
+            }
+        }
+    }
+
+    /// Submits the code to the server for verification.
+    /// - Parameters:
+    ///   - code: Verification code that the user supplies.
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func submitCode(code: String, delegate: SignInVerifyCodeDelegate, correlationId: UUID? = nil) {
+        Task {
+            let result = await submitCodeInternal(code: code, correlationId: correlationId)
+
+            switch result {
+            case .completed(let accountResult):
+                await delegate.onSignInCompleted(result: accountResult)
+            case .error(let error, let newState):
+                await delegate.onSignInVerifyCodeError(error: error, newState: newState)
+            }
+        }
+    }
+}
+
+/// An object of this type is created when a user is required to supply a password to continue a sign in flow.
+@objcMembers public class SignInPasswordRequiredState: SignInBaseState {
+
+    let scopes: [String]
+    let username: String
+
+    init(
+        scopes: [String],
+        username: String,
+        controller: MSALNativeAuthSignInControlling,
+        inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
+        flowToken: String) {
+        self.scopes = scopes
+        self.username = username
+        super.init(controller: controller, inputValidator: inputValidator, flowToken: flowToken)
+    }
+
+    /// Submits the password to the server for verification.
+    /// - Parameters:
+    ///   - password: Password that the user supplied.
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func submitPassword(password: String, delegate: SignInPasswordRequiredDelegate, correlationId: UUID? = nil) {
+        Task {
+            let result = await submitPasswordInternal(password: password, correlationId: correlationId)
+
+            switch result {
+            case .completed(let accountResult):
+                await delegate.onSignInCompleted(result: accountResult)
+            case .error(let error, let newState):
+                await delegate.onSignInPasswordRequiredError(error: error, newState: newState)
+            }
+        }
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
@@ -1,0 +1,97 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import XCTest
+
+final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuthEndToEndBaseTestCase {
+    func test_signInUsingPasswordWithUnknownUsernameResultsInError() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        let unknownUsername = UUID().uuidString
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypePassword, endpoint: .signInChallenge)
+            try await mockResponse(.userNotFound, endpoint: .signInToken)
+        }
+
+        sut.signInUsingPassword(username: unknownUsername, password: "testpass", correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: 2)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInPasswordErrorCalled)
+        XCTAssertEqual(signInDelegateSpy.error?.type, .userNotFound)
+    }
+
+    func test_signInWithKnownUsernameInvalidPasswordResultsInError() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingPasswordUserEmail"] ?? "<existingPasswordUserEmail not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypePassword, endpoint: .signInChallenge)
+            try await mockResponse(.invalidPassword, endpoint: .signInToken)
+        }
+
+        sut.signInUsingPassword(username: username, password: "An Invalid Password", correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: 2)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInPasswordErrorCalled)
+        XCTAssertEqual(signInDelegateSpy.error?.type, .invalidPassword)
+    }
+
+    // Hero Scenario 2.2.1. Sign in – Email and Password on SINGLE screen (Email & Password)
+    func test_signInUsingPasswordWithKnownUsernameResultsInSuccess() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingPasswordUserEmail"] ?? "<existingPasswordUserEmail not set>"
+        let password = ProcessInfo.processInfo.environment["existingUserPassword"] ?? "<existingUserPassword not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypePassword, endpoint: .signInChallenge)
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        sut.signInUsingPassword(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: 2)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(signInDelegateSpy.result?.idToken)
+        XCTAssertEqual(signInDelegateSpy.result?.account.username, username)
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
@@ -1,0 +1,248 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import XCTest
+
+final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBaseTestCase {
+    func test_signInWithUnknownUsernameResultsInError() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+
+        let unknownUsername = UUID().uuidString
+
+        if usingMockAPI {
+            try await mockResponse(.userNotFound, endpoint: .signInInitiate)
+        }
+
+        sut.signIn(username: unknownUsername, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: 2)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInErrorCalled)
+        XCTAssertEqual(signInDelegateSpy.error?.type, .userNotFound)
+    }
+
+    func test_signInWithKnownUsernameResultsInOTPSent() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingOTPUserEmail"] ?? "<existingOTPUserEmail not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signInChallenge)
+        }
+
+        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: 2)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInCodeRequiredCalled)
+        XCTAssertNotNil(signInDelegateSpy.newStateCodeRequired)
+        XCTAssertNotNil(signInDelegateSpy.sentTo)
+    }
+
+    func test_signInAndSendingIncorrectOTPResultsInError() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let verifyCodeExpectation = expectation(description: "verifying code")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+        let signInVerifyCodeDelegateSpy = SignInVerifyCodeDelegateSpy(expectation: verifyCodeExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingOTPUserEmail"] ?? "<existingOTPUserEmail not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signInChallenge)
+        }
+
+        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: 2)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInCodeRequiredCalled)
+        XCTAssertNotNil(signInDelegateSpy.newStateCodeRequired)
+        XCTAssertNotNil(signInDelegateSpy.sentTo)
+
+        // Now submit the code..
+
+        if usingMockAPI {
+            try await mockResponse(.invalidOOBValue, endpoint: .signInToken)
+        }
+
+        signInDelegateSpy.newStateCodeRequired?.submitCode(code: "badc0d3", delegate: signInVerifyCodeDelegateSpy, correlationId: correlationId)
+
+        await fulfillment(of: [verifyCodeExpectation], timeout: 2)
+
+        XCTAssertTrue(signInVerifyCodeDelegateSpy.onSignInVerifyCodeErrorCalled)
+        XCTAssertNotNil(signInVerifyCodeDelegateSpy.error)
+        XCTAssertEqual(signInVerifyCodeDelegateSpy.error?.type, .invalidCode)
+    }
+
+    // Hero Scenario 1.2.1. Sign in (Email & Email OTP)
+    func test_signInAndSendingCorrectOTPResultsInSuccess() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let verifyCodeExpectation = expectation(description: "verifying code")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+        let signInVerifyCodeDelegateSpy = SignInVerifyCodeDelegateSpy(expectation: verifyCodeExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingOTPUserEmail"] ?? "<existingOTPUserEmail not set>"
+        let otp = "<otp not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signInChallenge)
+        }
+
+        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: 2)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInCodeRequiredCalled)
+        XCTAssertNotNil(signInDelegateSpy.newStateCodeRequired)
+        XCTAssertNotNil(signInDelegateSpy.sentTo)
+
+        // Now submit the code..
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        } else {
+            // TODO: Replace this with retrieving the OTP from email
+            XCTAssertNotEqual(otp, "<otp not set>")
+        }
+
+        signInDelegateSpy.newStateCodeRequired?.submitCode(code: otp, delegate: signInVerifyCodeDelegateSpy, correlationId: correlationId)
+
+        await fulfillment(of: [verifyCodeExpectation], timeout: 2)
+
+        XCTAssertTrue(signInVerifyCodeDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(signInVerifyCodeDelegateSpy.result)
+        XCTAssertNotNil(signInVerifyCodeDelegateSpy.result?.idToken)
+        XCTAssertEqual(signInVerifyCodeDelegateSpy.result?.account.username, username)
+    }
+
+    func test_signInWithKnownPasswordUsernameResultsInPasswordSent() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingPasswordUserEmail"] ?? "<existingPasswordUserEmail not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypePassword, endpoint: .signInChallenge)
+        }
+
+        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: 2)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInPasswordRequiredCalled)
+        XCTAssertNotNil(signInDelegateSpy.newStatePasswordRequired)
+    }
+
+    func test_signInAndSendingIncorrectPasswordResultsInError() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let passwordRequiredExpectation = expectation(description: "verifying password")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+        let signInPasswordRequiredDelegateSpy = SignInPasswordRequiredDelegateSpy(expectation: passwordRequiredExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingPasswordUserEmail"] ?? "<existingPasswordUserEmail not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypePassword, endpoint: .signInChallenge)
+        }
+
+        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: 2)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInPasswordRequiredCalled)
+        XCTAssertNotNil(signInDelegateSpy.newStatePasswordRequired)
+
+        // Now submit the password..
+
+        if usingMockAPI {
+            try await mockResponse(.invalidPassword, endpoint: .signInToken)
+        }
+
+        signInDelegateSpy.newStatePasswordRequired?.submitPassword(password: "An Invalid Password", delegate: signInPasswordRequiredDelegateSpy, correlationId: correlationId)
+
+        await fulfillment(of: [passwordRequiredExpectation], timeout: 2)
+
+        XCTAssertTrue(signInPasswordRequiredDelegateSpy.onSignInPasswordRequiredErrorCalled)
+        XCTAssertEqual(signInPasswordRequiredDelegateSpy.error?.type, .invalidPassword)
+    }
+
+    // Hero Scenario 2.2.2. Sign in – Email and Password on MULTIPLE screens (Email & Password)
+    func test_signInAndSendingCorrectPasswordResultsInSuccess() async throws {
+        try XCTSkipIf(!usingMockAPI)
+        
+        let signInExpectation = expectation(description: "signing in")
+        let passwordRequiredExpectation = expectation(description: "verifying password")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+        let signInPasswordRequiredDelegateSpy = SignInPasswordRequiredDelegateSpy(expectation: passwordRequiredExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingPasswordUserEmail"] ?? "<existingPasswordUserEmail not set>"
+        let password = ProcessInfo.processInfo.environment["existingUserPassword"] ?? "<existingUserPassword not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypePassword, endpoint: .signInChallenge)
+        }
+
+        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: 2)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInPasswordRequiredCalled)
+        XCTAssertNotNil(signInDelegateSpy.newStatePasswordRequired)
+
+        // Now submit the password..
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signInDelegateSpy.newStatePasswordRequired?.submitPassword(password: password, delegate: signInPasswordRequiredDelegateSpy, correlationId: correlationId)
+
+        await fulfillment(of: [passwordRequiredExpectation], timeout: 2)
+
+        XCTAssertTrue(signInPasswordRequiredDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(signInPasswordRequiredDelegateSpy.result?.idToken)
+        XCTAssertEqual(signInPasswordRequiredDelegateSpy.result?.account.username, username)
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/SignInDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/SignInDelegateSpies.swift
@@ -1,0 +1,152 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import XCTest
+import MSAL
+
+class SignInPasswordStartDelegateSpy: SignInPasswordStartDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignInPasswordErrorCalled = false
+    private(set) var onSignInCompletedCalled = false
+    private(set) var error: MSAL.SignInPasswordStartError?
+    private(set) var result: MSAL.MSALNativeAuthUserAccountResult?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    public func onSignInPasswordError(error: MSAL.SignInPasswordStartError) {
+        onSignInPasswordErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    public func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {
+        onSignInCompletedCalled = true
+        self.result = result
+
+        expectation.fulfill()
+    }
+}
+
+class SignInStartDelegateSpy: SignInStartDelegate {
+    private let expectation: XCTestExpectation
+
+    private(set) var onSignInErrorCalled = false
+    private(set) var error: MSAL.SignInStartError?
+
+    private(set) var onSignInCodeRequiredCalled = false
+    private(set) var newStateCodeRequired: MSAL.SignInCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSAL.MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    private(set) var onSignInPasswordRequiredCalled = false
+    private(set) var newStatePasswordRequired: MSAL.SignInPasswordRequiredState?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    public func onSignInError(error: MSAL.SignInStartError) {
+        onSignInErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    public func onSignInCodeRequired(newState: MSAL.SignInCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        onSignInCodeRequiredCalled = true
+        self.newStateCodeRequired = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        expectation.fulfill()
+    }
+
+    public func onSignInPasswordRequired(newState: SignInPasswordRequiredState) {
+        onSignInPasswordRequiredCalled = true
+        self.newStatePasswordRequired = newState
+
+        expectation.fulfill()
+    }
+}
+
+class SignInVerifyCodeDelegateSpy: SignInVerifyCodeDelegate {
+    private let expectation: XCTestExpectation
+
+    private(set) var onSignInVerifyCodeErrorCalled = false
+    private(set) var error: MSAL.VerifyCodeError?
+
+    private(set) var onSignInCompletedCalled = false
+    private(set) var result: MSAL.MSALNativeAuthUserAccountResult?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    public func onSignInVerifyCodeError(error: MSAL.VerifyCodeError, newState: MSAL.SignInCodeRequiredState?) {
+        onSignInVerifyCodeErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    public func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {
+        onSignInCompletedCalled = true
+        self.result = result
+
+        expectation.fulfill()
+    }
+}
+
+class SignInPasswordRequiredDelegateSpy: SignInPasswordRequiredDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignInPasswordRequiredErrorCalled = false
+    private(set) var onSignInCompletedCalled = false
+    private(set) var error: MSAL.PasswordRequiredError?
+    private(set) var result: MSAL.MSALNativeAuthUserAccountResult?
+    private(set) var newState: MSAL.SignInPasswordRequiredState?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+    func onSignInPasswordRequiredError(error: MSAL.PasswordRequiredError, newState: MSAL.SignInPasswordRequiredState?) {
+        onSignInPasswordRequiredErrorCalled = true
+        self.error = error
+        self.newState = newState
+
+        expectation.fulfill()
+    }
+
+    func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {
+        onSignInCompletedCalled = true
+        self.result = result
+
+        expectation.fulfill()
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/sign_out/MSALNativeAuthSignOutEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_out/MSALNativeAuthSignOutEndToEndTests.swift
@@ -1,0 +1,194 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import XCTest
+
+final class MSALNativeAuthSignOutEndToEndTests: MSALNativeAuthEndToEndBaseTestCase {
+    func test_noSignOutAfterSignInOTPAccountStillPresent() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let verifyCodeExpectation = expectation(description: "verifying code")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+        let signInVerifyCodeDelegateSpy = SignInVerifyCodeDelegateSpy(expectation: verifyCodeExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingOTPUserEmail"] ?? "<existingOTPUserEmail not set>"
+        let otp = "<otp not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signInChallenge)
+        }
+
+        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: defaultTimeout)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInCodeRequiredCalled)
+        XCTAssertNotNil(signInDelegateSpy.newStateCodeRequired)
+        XCTAssertNotNil(signInDelegateSpy.sentTo)
+
+        // Now submit the code..
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        } else {
+            // TODO: Replace this with retrieving the OTP from email
+            XCTAssertNotEqual(otp, "<otp not set>")
+        }
+
+        signInDelegateSpy.newStateCodeRequired?.submitCode(code: otp, delegate: signInVerifyCodeDelegateSpy, correlationId: correlationId)
+
+        await fulfillment(of: [verifyCodeExpectation], timeout: defaultTimeout)
+
+        XCTAssertTrue(signInVerifyCodeDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(signInVerifyCodeDelegateSpy.result)
+        XCTAssertNotNil(signInVerifyCodeDelegateSpy.result?.idToken)
+        XCTAssertEqual(signInVerifyCodeDelegateSpy.result?.account.username, username)
+
+        // Check Account Exists
+
+        let userAccountResult = sut.getNativeAuthUserAccount()
+        XCTAssertNotNil(userAccountResult)
+        XCTAssertEqual(userAccountResult?.account.username, username)
+    }
+
+    // Hero Scenario 1.3.1. Sign out – Local sign out from app on device (no SSO)
+    
+    func test_signOutAfterSignInOTPSuccess() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let verifyCodeExpectation = expectation(description: "verifying code")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+        let signInVerifyCodeDelegateSpy = SignInVerifyCodeDelegateSpy(expectation: verifyCodeExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingOTPUserEmail"] ?? "<existingOTPUserEmail not set>"
+        let otp = "<otp not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signInChallenge)
+        }
+
+        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: defaultTimeout)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInCodeRequiredCalled)
+        XCTAssertNotNil(signInDelegateSpy.newStateCodeRequired)
+        XCTAssertNotNil(signInDelegateSpy.sentTo)
+
+        // Now submit the code..
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        } else {
+            // TODO: Replace this with retrieving the OTP from email
+            XCTAssertNotEqual(otp, "<otp not set>")
+        }
+
+        signInDelegateSpy.newStateCodeRequired?.submitCode(code: otp, delegate: signInVerifyCodeDelegateSpy, correlationId: correlationId)
+
+        await fulfillment(of: [verifyCodeExpectation], timeout: defaultTimeout)
+
+        XCTAssertTrue(signInVerifyCodeDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(signInVerifyCodeDelegateSpy.result)
+        XCTAssertNotNil(signInVerifyCodeDelegateSpy.result?.idToken)
+        XCTAssertEqual(signInVerifyCodeDelegateSpy.result?.account.username, username)
+
+        // Sign out
+
+        var userAccountResult = sut.getNativeAuthUserAccount()
+        userAccountResult?.signOut()
+
+        userAccountResult = sut.getNativeAuthUserAccount()
+        XCTAssertNil(userAccountResult)
+    }
+
+    func test_noSignOutAfterSignInPasswordAccountStillPresent() async throws {
+        try XCTSkipIf(!usingMockAPI)
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingPasswordUserEmail"] ?? "<existingPasswordUserEmail not set>"
+        let password = ProcessInfo.processInfo.environment["existingUserPassword"] ?? "<existingUserPassword not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypePassword, endpoint: .signInChallenge)
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        sut.signInUsingPassword(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: defaultTimeout)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(signInDelegateSpy.result?.idToken)
+        XCTAssertEqual(signInDelegateSpy.result?.account.username, username)
+
+        // Check Account Exists
+
+        let userAccountResult = sut.getNativeAuthUserAccount()
+        XCTAssertNotNil(userAccountResult)
+        XCTAssertEqual(userAccountResult?.account.username, username)
+    }
+
+    // Hero Scenario 2.4.1. Sign out – Local sign out from app on device (no SSO)
+
+    func test_signOutAfterSignInPasswordSuccess() async throws {
+        try XCTSkipIf(!usingMockAPI)
+        
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        let username = ProcessInfo.processInfo.environment["existingPasswordUserEmail"] ?? "<existingPasswordUserEmail not set>"
+        let password = ProcessInfo.processInfo.environment["existingUserPassword"] ?? "<existingUserPassword not set>"
+
+        if usingMockAPI {
+            try await mockResponse(.initiateSuccess, endpoint: .signInInitiate)
+            try await mockResponse(.challengeTypePassword, endpoint: .signInChallenge)
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        sut.signInUsingPassword(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation], timeout: defaultTimeout)
+
+        XCTAssertTrue(signInDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(signInDelegateSpy.result?.idToken)
+        XCTAssertEqual(signInDelegateSpy.result?.account.username, username)
+
+        // Sign out
+
+        var userAccountResult = sut.getNativeAuthUserAccount()
+        userAccountResult?.signOut()
+
+        userAccountResult = sut.getNativeAuthUserAccount()
+        XCTAssertNil(userAccountResult)
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
@@ -1,0 +1,120 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignInChallengeIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+    private typealias Error = MSALNativeAuthSignInChallengeResponseError
+    private var provider: MSALNativeAuthSignInRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        provider = MSALNativeAuthSignInRequestProvider(requestConfigurator: MSALNativeAuthRequestConfigurator(config: config))
+
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        sut = try provider.challenge(
+            parameters: .init(
+                context: context,
+                credentialToken: "Test Credential Token"
+            ),
+            context: context
+        )
+    }
+
+    func test_succeedRequest_challengeTypePassword() async throws {
+        try await mockResponse(.challengeTypePassword, endpoint: .signInChallenge)
+        let response: MSALNativeAuthSignInChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertTrue(response?.challengeType == .password)
+        XCTAssertNotNil(response?.credentialToken)
+    }
+
+    func test_succeedRequest_challengeTypeOOB() async throws {
+        try await mockResponse(.challengeTypeOOB, endpoint: .signInChallenge)
+        let response: MSALNativeAuthSignInChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertTrue(response?.challengeType == .oob)
+        XCTAssertNotNil(response?.credentialToken)
+        XCTAssertNotNil(response?.bindingMethod)
+        XCTAssertNotNil(response?.challengeTargetLabel)
+        XCTAssertNotNil(response?.codeLength)
+        XCTAssertNotNil(response?.interval)
+    }
+
+    func test_succeedRequest_challengeTypeRedirect() async throws {
+        try await mockResponse(.challengeTypeRedirect, endpoint: .signInChallenge)
+        let response: MSALNativeAuthSignInChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertEqual(response?.challengeType, .redirect)
+        XCTAssertNil(response?.credentialToken)
+    }
+
+
+    func test_failRequest_unauthorizedClient() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signInChallenge,
+            response: .invalidClient,
+            expectedError: Error(error: .unauthorizedClient, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        )
+    }
+
+    func test_failRequest_invalidPurposeToken() async throws {
+        throw XCTSkip()
+
+        let response = try await perform_testFail(
+            endpoint: .signInChallenge,
+            response: .invalidPurposeToken,
+            expectedError: Error(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        )
+
+        guard let innerError = response.innerErrors?.first else {
+            return XCTFail("There should be an inner error")
+        }
+
+        XCTAssertEqual(innerError.error, "invalid_purpose_token")
+        XCTAssertNotNil(innerError.errorDescription)
+    }
+
+    func test_failRequest_expiredToken() async throws {
+        try await perform_testFail(
+            endpoint: .signInChallenge,
+            response: .expiredToken,
+            expectedError: Error(error: .expiredToken, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        )
+    }
+
+    func test_failRequest_unsupportedChallengeType() async throws {
+        try await perform_testFail(
+            endpoint: .signInChallenge,
+            response: .unsupportedChallengeType,
+            expectedError: Error(error: .unsupportedChallengeType, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        )
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInInitiateIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInInitiateIntegrationTests.swift
@@ -1,0 +1,92 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignInInitiateIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+    private typealias Error = MSALNativeAuthSignInInitiateResponseError
+    private var provider: MSALNativeAuthSignInRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        provider = MSALNativeAuthSignInRequestProvider(requestConfigurator: MSALNativeAuthRequestConfigurator(config: config))
+
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        sut = try provider.inititate(
+            parameters: .init(
+                context: context,
+                username: "test@contoso.com"
+            ),
+            context: context
+        )
+    }
+
+    func test_succeedRequest_initiateSuccess() async throws {
+        try await mockAPIHandler.addResponse(
+            endpoint: .signInInitiate,
+            correlationId: correlationId,
+            responses: []
+        )
+        let response: MSALNativeAuthSignInInitiateResponse? = try await performTestSucceed()
+        XCTAssertNotNil(response?.credentialToken)
+    }
+
+    func test_succeedRequest_challengeTypeRedirect() async throws {
+        try await mockResponse(.challengeTypeRedirect, endpoint: .signInInitiate)
+        let response: MSALNativeAuthSignInInitiateResponse? = try await performTestSucceed()
+
+        XCTAssertNil(response?.credentialToken)
+        XCTAssertEqual(response?.challengeType, .redirect)
+    }
+
+    func test_failRequest_unauthorizedClient() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signInInitiate,
+            response: .invalidClient,
+            expectedError: Error(error: .unauthorizedClient, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        )
+    }
+
+    func test_failRequest_userNotFound() async throws {
+        try await perform_testFail(
+            endpoint: .signInInitiate,
+            response: .userNotFound,
+            expectedError: Error(error: .invalidGrant, errorDescription: nil, errorCodes:[MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue], errorURI: nil, innerErrors: nil)
+        )
+    }
+
+    func test_failRequest_unsupportedChallengeType() async throws {
+        try await perform_testFail(
+            endpoint: .signInInitiate,
+            response: .unsupportedChallengeType,
+            expectedError: Error(error: .unsupportedChallengeType, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/MSALNativeAuthTestCase.swift
+++ b/MSAL/test/unit/native_auth/MSALNativeAuthTestCase.swift
@@ -1,0 +1,56 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthTestCase: XCTestCase {
+    //Do not create more than one instance of this variable, inherit this class instead
+    static let logger = MSALNativeAuthTestLogger()
+    var dispatcher: MSALNativeAuthTelemetryTestDispatcher!
+    var receivedEvents: [[AnyHashable: Any]] = []
+
+    override func setUpWithError() throws {
+        // Logger needs to reset so the expectation name and count resets from the previous test
+        // The previous test could be across class
+        Self.logger.reset()
+
+        dispatcher = MSALNativeAuthTelemetryTestDispatcher()
+
+        dispatcher.setTestCallback { event in
+            self.receivedEvents.append(event.propertyMap)
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+    }
+
+    override func tearDown() {
+        // Logger needs to reset so the expectation name and count resets for the next test.
+        // The next test could be across classes
+        Self.logger.reset()
+
+        receivedEvents.removeAll()
+        MSIDTelemetry.sharedInstance().remove(dispatcher)
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -1,0 +1,1082 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthSignInController!
+    private var signInRequestProviderMock: MSALNativeAuthSignInRequestProviderMock!
+    private var tokenRequestProviderMock: MSALNativeAuthTokenRequestProviderMock!
+    private var cacheAccessorMock: MSALNativeAuthCacheAccessorMock!
+    private var signInResponseValidatorMock: MSALNativeAuthSignInResponseValidatorMock!
+    private var tokenResponseValidatorMock: MSALNativeAuthTokenResponseValidatorMock!
+    private var contextMock: MSALNativeAuthRequestContextMock!
+    private var tokenResult = MSIDTokenResult()
+    private var tokenResponse = MSIDCIAMTokenResponse()
+    private var defaultUUID = UUID(uuidString: DEFAULT_TEST_UID)!
+    private let defaultScopes = "openid profile offline_access"
+
+    override func setUpWithError() throws {
+        signInRequestProviderMock = .init()
+        tokenRequestProviderMock = .init()
+        cacheAccessorMock = .init()
+        signInResponseValidatorMock = .init()
+        tokenResponseValidatorMock = .init()
+        contextMock = .init()
+        contextMock.mockTelemetryRequestId = "telemetry_request_id"
+        
+        sut = .init(
+            clientId: DEFAULT_TEST_CLIENT_ID,
+            signInRequestProvider: signInRequestProviderMock,
+            tokenRequestProvider: tokenRequestProviderMock,
+            cacheAccessor: cacheAccessorMock,
+            factory: MSALNativeAuthResultFactoryMock(),
+            signInResponseValidator: signInResponseValidatorMock,
+            tokenResponseValidator: tokenResponseValidatorMock
+        )
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+        tokenResult.rawIdToken = "idToken"
+
+        try super.setUpWithError()
+    }
+    
+    // MARK: sign in with username and password tests
+
+    func test_whenCreateRequestFails_shouldReturnError() async throws {
+        let expectation = expectation(description: "SignInController")
+
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedContext = expectedContext
+        signInRequestProviderMock.throwingInitError = ErrorMock.error
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInPasswordStartError(type: .generalError))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenUserSpecifiesScope_defaultScopesShouldBeIncluded() async throws {
+        let expectation = expectation(description: "SignInController")
+
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let expectedScopes = "scope1 scope2 openid profile offline_access"
+        let credentialToken = "credentialToken"
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInPasswordStartError(type: .generalError))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "scope2"]))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenUserSpecifiesScopes_NoDuplicatedScopeShouldBeSent() async throws {
+        let expectation = expectation(description: "SignInController")
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let expectedScopes = "scope1 openid profile offline_access"
+        let credentialToken = "credentialToken"
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.throwingTokenError = ErrorMock.error
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInPasswordStartError(type: .generalError))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "openid", "profile"]))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+    
+    func test_successfulResponseAndValidation_shouldCompleteSignIn() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+
+        let expectation = expectation(description: "SignInController")
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedUsername = expectedUsername
+        tokenRequestProviderMock.expectedContext = expectedContext
+
+        let userAccountResult = MSALNativeAuthUserAccountResultStub.result
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedUserAccountResult: userAccountResult)
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInCompleted(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertTrue(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: true)
+    }
+
+    func test_successfulResponseAndUnsuccessfulValidation_shouldReturnError() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+
+        let expectation = expectation(description: "SignInController")
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedUsername = expectedUsername
+        tokenRequestProviderMock.expectedContext = expectedContext
+
+        let userAccountResult = MSALNativeAuthUserAccountResultStub.result
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedUserAccountResult: userAccountResult)
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+
+        cacheAccessorMock.expectedMSIDTokenResult = nil
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+
+    func test_errorResponse_shouldReturnError() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "invalid token"
+
+        let expectation = expectation(description: "SignInController")
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .error(.invalidToken(message: nil))
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedUsername = expectedUsername
+        tokenRequestProviderMock.expectedContext = expectedContext
+
+        let userAccountResult = MSALNativeAuthUserAccountResultStub.result
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedUserAccountResult: userAccountResult)
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+    
+    func test_whenErrorIsReturnedFromValidator_itIsCorrectlyTranslatedToDelegateError() async  {
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError), validatorError: .generalError)
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError), validatorError: .expiredToken(message: nil))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError), validatorError: .authorizationPending(message: nil))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError), validatorError: .slowDown(message: nil))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError, message: "Invalid server response"), validatorError: .invalidServerResponse)
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError, message: "Invalid Client ID"), validatorError: .invalidClient(message: "Invalid Client ID"))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError, message: "Unsupported challenge type"), validatorError: .unsupportedChallengeType(message: "Unsupported challenge type"))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError, message: "Invalid scope"), validatorError: .invalidScope(message: "Invalid scope"))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .invalidPassword), validatorError: .invalidPassword(message: nil))
+    }
+    
+    func test_whenCredentialsAreRequired_browserRequiredErrorIsReturned() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedCredentialToken = credentialToken
+
+        let expectation = expectation(description: "SignInController")
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: .init(type: .browserRequired, message: MSALNativeAuthErrorMessage.unsupportedMFA))
+
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(.strongAuthRequired(message: "MFA currently not supported. Use the browser instead"))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignInUsingPassword_apiReturnsChallengeTypeOOB_codeRequiredShouldBeCalled() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedSentTo = "sentTo"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+
+        let expectation = expectation(description: "SignInController")
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation)
+        helper.expectedSentTo = expectedSentTo
+        helper.expectedChannelTargetType = expectedChannelTargetType
+        helper.expectedCodeLength = expectedCodeLength
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignInCodeRequired(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: true)
+    }
+
+    func test_whenSignInUsingPassword_apiReturnsChallengeTypeOOB__butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedSentTo = "sentTo"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+
+        let expectation = expectation(description: "SignInController")
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation)
+        helper.expectedSentTo = expectedSentTo
+        helper.expectedChannelTargetType = expectedChannelTargetType
+        helper.expectedCodeLength = expectedCodeLength
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignInCodeRequired(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+    
+    // MARK: sign in with username and code
+    
+    func test_whenSignInWithCodeStartWithValidInfo_codeRequiredShouldBeCalled() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let sentTo = "sentTo"
+        let channelTargetType = MSALNativeAuthChannelType.email
+        let codeLength = 4
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedSentTo: sentTo, expectedChannelTargetType: channelTargetType, expectedCodeLength: codeLength)
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+
+        helper.onSignInCodeRequired(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: true)
+    }
+
+    func test_afterSignInWithCodeSubmitCode_signInShouldCompleteSuccessfully() {
+        let request = MSIDHttpRequest()
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: defaultScopes, password: nil, oobCode: "code", includeChallengeType: false, refreshToken: nil)
+
+        let userAccountResult = MSALNativeAuthUserAccountResultStub.result
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        cacheAccessorMock.mockUserAccounts = [MSALNativeAuthUserAccountResultStub.account]
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+
+        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), flowToken: credentialToken)
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedUserAccountResult: userAccountResult), correlationId: defaultUUID)
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(cacheAccessorMock.clearCacheWasCalled)
+        XCTAssertTrue(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitCode, isSuccessful: true)
+    }
+
+    func test_afterSignInWithCodeSubmitCode_whenTokenCacheIsNotValid_it_shouldReturnCorrectError() {
+        let request = MSIDHttpRequest()
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: defaultScopes, password: nil, oobCode: "code", includeChallengeType: false, refreshToken: nil)
+
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        cacheAccessorMock.expectedMSIDTokenResult = nil
+
+        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), flowToken: credentialToken)
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)), correlationId: defaultUUID)
+
+        wait(for: [expectation], timeout: 1)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitCode, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithCodeStartAndInitiateRequestCreationFail_errorShouldBeReturned() async {
+        let expectedUsername = "username"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedContext = expectedContext
+        signInRequestProviderMock.throwingInitError = MSALNativeAuthError()
+
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+
+        helper.onSignInError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithCodeStartAndInitiateReturnError_properErrorShouldBeReturned() async {
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .browserRequired), validatorError: .redirect)
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .invalidClient(message: nil))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .unsupportedChallengeType(message: nil))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidServerResponse)
+    }
+    
+    func test_whenSignInWithCodeChallengeRequestCreationFail_errorShouldBeReturned() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError()
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: "credentialToken")
+        
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+
+        helper.onSignInError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithCodeChallengeReturnsError_properErrorShouldBeReturned() async {
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .browserRequired), validatorError: .redirect)
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .expiredToken(message: nil))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidToken(message: nil))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidServerResponse)
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .invalidClient(message: nil))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .unsupportedChallengeType(message: nil))
+    }
+    
+    func test_whenSignInWithCodePasswordIsRequired_newStateIsPropagatedToUser() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: expectedCredentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: expectedCredentialToken)
+        
+        let helper = SignInCodeStartWithPasswordRequiredTestsValidatorHelper(expectation: expectation)
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignInPasswordRequired(result.result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: true)
+        XCTAssertEqual(helper.passwordRequiredState?.flowToken, expectedCredentialToken)
+    }
+
+    func test_whenSignInWithCodePasswordIsRequired_newStateIsPropagatedToUser_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: expectedCredentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: expectedCredentialToken)
+
+        let helper = SignInCodeStartWithPasswordRequiredTestsValidatorHelper(expectation: expectation)
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignInPasswordRequired(result.result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
+        XCTAssertEqual(helper.passwordRequiredState?.flowToken, expectedCredentialToken)
+    }
+    
+    func test_whenSignInWithCodeSubmitPassword_signInIsCompletedSuccessfully() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let exp = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedUserAccountResult: MSALNativeAuthUserAccountResultStub.result)
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+        cacheAccessorMock.mockUserAccounts = [MSALNativeAuthUserAccountResultStub.account]
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate, correlationId: defaultUUID)
+
+        await fulfillment(of: [exp], timeout: 1)
+
+        XCTAssertTrue(cacheAccessorMock.clearCacheWasCalled)
+        XCTAssertTrue(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitPassword, isSuccessful: true)
+    }
+
+    func test_whenSignInWithCodeSubmitPassword_whenTokenCacheIsNotValid_it_shouldReturnCorrectError() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let exp = expectation(description: "SignInController")
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+        cacheAccessorMock.expectedMSIDTokenResult = nil
+
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate, correlationId: defaultUUID)
+
+        await fulfillment(of: [exp], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitPassword, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithCodeSubmitPasswordTokenRequestCreationFail_errorShouldBeReturned() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let exp = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
+        signInRequestProviderMock.expectedContext = expectedContext
+        
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
+
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate, correlationId: defaultUUID)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertNotNil(mockDelegate.newPasswordRequiredState)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitPassword, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithCodeSubmitPasswordTokenAPIReturnError_correctErrorShouldBeReturned() async {
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .generalError)
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .expiredToken(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidClient(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidRequest(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidServerResponse)
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .userNotFound(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidOOBCode(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .unsupportedChallengeType(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .browserRequired), validatorError: .strongAuthRequired(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidScope(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .authorizationPending(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .slowDown(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .invalidPassword), validatorError: .invalidPassword(message: nil))
+    }
+    
+    func test_signInWithCodeSubmitCodeTokenRequestFailCreation_errorShouldBeReturned() {
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
+
+        let state = SignInCodeRequiredState(scopes: [], controller: sut, flowToken: credentialToken)
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)), correlationId: defaultUUID)
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitCode, isSuccessful: false)
+    }
+    
+    func test_signInWithCodeSubmitCodeReturnError_correctResultShouldReturned() {
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .generalError)
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .expiredToken(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidClient(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidRequest(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidServerResponse)
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .userNotFound(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .invalidCode, validatorError: .invalidOOBCode(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unsupportedChallengeType(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .browserRequired, validatorError: .strongAuthRequired(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidScope(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .authorizationPending(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .slowDown(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidPassword(message: nil))
+    }
+        
+    func test_signInWithCodeResendCode_shouldSendNewCode() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let sentTo = "sentTo"
+        let channelTargetType = MSALNativeAuthChannelType.email
+        let codeLength = 4
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation, expectedSentTo: sentTo, expectedChannelTargetType: channelTargetType, expectedCodeLength: codeLength)
+
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
+
+        let result = await sut.resendCode(credentialToken: credentialToken, context: expectedContext, scopes: [])
+
+        helper.onSignInResendCodeCodeRequired(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInResendCode, isSuccessful: true)
+    }
+    
+    func test_signInWithCodeResendCodeChallengeCreationFail_errorShouldBeReturned() async {
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError()
+
+        let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
+
+        let result = await sut.resendCode(credentialToken: "credentialToken", context: expectedContext, scopes: [])
+
+        helper.onSignInResendCodeError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertNotNil(helper.newSignInCodeRequiredState)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInResendCode, isSuccessful: false)
+    }
+    
+    func test_signInWithCodeResendCodePasswordRequired_shouldReturnAnError() async {
+        let request = MSIDHttpRequest()
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
+
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        let result = await sut.resendCode(credentialToken: credentialToken, context: expectedContext, scopes: [])
+
+        helper.onSignInResendCodeError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertNil(helper.newSignInCodeRequiredState)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInResendCode, isSuccessful: false)
+    }
+    
+    func test_signInWithCodeResendCodeChallengeReturnError_shouldReturnAnError() async {
+        let request = MSIDHttpRequest()
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
+
+        signInResponseValidatorMock.challengeValidatedResponse = .error(.userNotFound(message: nil))
+
+        let result = await sut.resendCode(credentialToken: credentialToken, context: expectedContext, scopes: [])
+
+        helper.onSignInResendCodeError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertNotNil(helper.newSignInCodeRequiredState)
+        XCTAssertEqual(helper.newSignInCodeRequiredState?.flowToken, credentialToken)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInResendCode, isSuccessful: false)
+    }
+    
+    // MARK: signIn using SLT
+    
+    func test_whenSignInWithSLT_signInIsCompletedSuccessfully() {
+        let request = MSIDHttpRequest()
+        let slt = "signInSLT"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let expectation = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: "", credentialToken: nil, signInSLT: slt, grantType: .slt, scope: defaultScopes, password: nil, oobCode: nil, includeChallengeType: false, refreshToken: nil)
+
+        let userAccountResult = MSALNativeAuthUserAccountResultStub.result
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedUserAccountResult: userAccountResult)
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+        
+        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt)
+        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInAfterSignUp, isSuccessful: true)
+    }
+    
+    func test_whenSignInWithSLTTokenRequestCreationFail_errorShouldBeReturned() {
+        let request = MSIDHttpRequest()
+        let slt = "signInSLT"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let exp = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
+        signInRequestProviderMock.expectedContext = expectedContext
+        
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: exp, expectedError: SignInAfterSignUpError())
+
+        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt)
+        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+        
+        wait(for: [exp], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInAfterSignUp, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithSLTTokenReturnError_shouldReturnAnError() {
+        let request = MSIDHttpRequest()
+        let slt = "signInSLT"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Invalid Client ID"))
+
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(.invalidClient(message: "Invalid Client ID"))
+
+        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt)
+        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInAfterSignUp, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithSLTHaveTokenNil_shouldReturnAnError() {        
+        let expectation = expectation(description: "SignInController")
+
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Sign In is not available at this point, please use the standalone sign in methods"))
+
+        let state = SignInAfterSignUpState(controller: sut, username: "username", slt: nil)
+        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInAfterSignUp, isSuccessful: false)
+    }
+
+    
+    // MARK: private methods
+
+    private func checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: VerifyCodeErrorType, validatorError: MSALNativeAuthTokenValidatedErrorType) {
+        let request = MSIDHttpRequest()
+        let expectedCredentialToken = "credentialToken"
+        let expectedOOBCode = "code"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let exp = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: "", password: nil, oobCode: expectedOOBCode, includeChallengeType: true, refreshToken: nil)
+        let mockDelegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedError: VerifyCodeError(type: delegateError))
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
+        
+        let state = SignInCodeRequiredState(scopes: [], controller: sut, flowToken: expectedCredentialToken)
+        state.submitCode(code: expectedOOBCode, delegate: mockDelegate, correlationId: defaultUUID)
+
+        wait(for: [exp], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitCode, isSuccessful: false)
+        receivedEvents.removeAll()
+    }
+    
+    private func checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError, validatorError: MSALNativeAuthTokenValidatedErrorType) async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let exp = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: publicError)
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
+
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate, correlationId: defaultUUID)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitPassword, isSuccessful: false)
+        receivedEvents.removeAll()
+    }
+    
+    private func checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError, validatorError: MSALNativeAuthSignInChallengeValidatedErrorType) async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: "credentialToken")
+        signInResponseValidatorMock.challengeValidatedResponse = .error(validatorError)
+        
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+
+        helper.onSignInError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
+        receivedEvents.removeAll()
+    }
+    
+    private func checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError, validatorError: MSALNativeAuthSignInInitiateValidatedErrorType) async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedContext = expectedContext
+        signInRequestProviderMock.result = request
+        signInResponseValidatorMock.initiateValidatedResponse = .error(validatorError)
+
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+
+        helper.onSignInError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
+        receivedEvents.removeAll()
+    }
+    
+    private func checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError, validatorError: MSALNativeAuthTokenValidatedErrorType) async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+        
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let expectation = expectation(description: "SignInController")
+
+        tokenRequestProviderMock.result = request
+        
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
+        
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInPasswordError(result)
+        
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+        receivedEvents.removeAll()
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+    
+    private func checkTelemetryEventResult(id: MSALNativeAuthTelemetryApiId, isSuccessful: Bool) {
+        XCTAssertEqual(receivedEvents.count, 1)
+
+        guard let telemetryEventDict = receivedEvents.first else {
+            return XCTFail("Telemetry test fail")
+        }
+
+        let expectedApiId = String(id.rawValue)
+        XCTAssertEqual(telemetryEventDict["api_id"] as? String, expectedApiId)
+        XCTAssertEqual(telemetryEventDict["event_name"] as? String, "api_event" )
+        XCTAssertEqual(telemetryEventDict["correlation_id" ] as? String, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(telemetryEventDict["is_successfull"] as? String, isSuccessful ? "yes" : "no")
+        XCTAssertEqual(telemetryEventDict["status"] as? String, isSuccessful ? "succeeded" : "failed")
+        XCTAssertNotNil(telemetryEventDict["start_time"])
+        XCTAssertNotNil(telemetryEventDict["stop_time"])
+        XCTAssertNotNil(telemetryEventDict["response_time"])
+    }
+
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
@@ -1,0 +1,68 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+@testable import MSAL
+import XCTest
+
+class MSALNativeAuthSignInControllerMock: MSALNativeAuthSignInControlling {
+
+    private(set) var username: String?
+    private(set) var slt: String?
+    var expectation: XCTestExpectation?
+
+    var signInPasswordStartResult: MSALNativeAuthSignInControlling.SignInPasswordControllerResponse!
+    var signInStartResult: MSALNativeAuthSignInControlling.SignInCodeControllerResponse!
+    var signInSLTResult: Result<MSAL.MSALNativeAuthUserAccountResult, MSAL.SignInAfterSignUpError>!
+    var submitCodeResult: SignInVerifyCodeResult!
+    var submitPasswordResult: SignInPasswordRequiredResult!
+    var resendCodeResult: SignInResendCodeResult!
+
+    func signIn(params: MSAL.MSALNativeAuthSignInWithPasswordParameters) async -> MSALNativeAuthSignInControlling.SignInPasswordControllerResponse {
+        return signInPasswordStartResult
+    }
+
+    func signIn(params: MSAL.MSALNativeAuthSignInWithCodeParameters) async -> MSALNativeAuthSignInControlling.SignInCodeControllerResponse {
+        return signInStartResult
+    }
+
+    func signIn(username: String, slt: String?, scopes: [String]?, context: MSAL.MSALNativeAuthRequestContext) async -> Result<MSAL.MSALNativeAuthUserAccountResult, MSAL.SignInAfterSignUpError> {
+        self.username = username
+        self.slt = slt
+        expectation?.fulfill()
+
+        return signInSLTResult
+    }
+
+    func submitCode(_ code: String, credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInVerifyCodeResult {
+        submitCodeResult
+    }
+
+    func submitPassword(_ password: String, username: String, credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInPasswordRequiredResult {
+        return submitPasswordResult
+    }
+
+    func resendCode(credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInResendCodeResult {
+        return resendCodeResult
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/SignInDelegatesSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/SignInDelegatesSpies.swift
@@ -1,0 +1,311 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+open class SignInPasswordStartDelegateSpy: SignInPasswordStartDelegate {
+    let expectation: XCTestExpectation
+    var expectedError: SignInPasswordStartError?
+    var expectedUserAccountResult: MSALNativeAuthUserAccountResult?
+    var expectedSentTo: String?
+    var expectedChannelTargetType: MSALNativeAuthChannelType?
+    var expectedCodeLength: Int?
+
+    init(expectation: XCTestExpectation, expectedError: SignInPasswordStartError? = nil, expectedUserAccountResult: MSALNativeAuthUserAccountResult? = nil) {
+        self.expectation = expectation
+        self.expectedError = expectedError
+        self.expectedUserAccountResult = expectedUserAccountResult
+    }
+
+    public func onSignInPasswordError(error: MSAL.SignInPasswordStartError) {
+        if let expectedError = expectedError {
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(error.type, expectedError.type)
+            XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
+            expectation.fulfill()
+            return
+        }
+        XCTFail("This method should not be called")
+        expectation.fulfill()
+    }
+
+    public func onSignInCodeRequired(newState: MSAL.SignInCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        XCTAssertTrue(Thread.isMainThread)
+        expectedSentTo = sentTo
+        expectedChannelTargetType = channelTargetType
+        expectedCodeLength = codeLength
+
+        expectation.fulfill()
+    }
+
+    public func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {
+        if let expectedUserAccountResult = expectedUserAccountResult {
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(expectedUserAccountResult.idToken, result.idToken)
+            XCTAssertEqual(expectedUserAccountResult.scopes, result.scopes)
+        } else {
+            XCTFail("This method should not be called")
+        }
+        expectation.fulfill()
+    }
+}
+
+class SignInPasswordRequiredDelegateSpy: SignInPasswordRequiredDelegate {
+
+    private(set) var newPasswordRequiredState: SignInPasswordRequiredState?
+    private(set) var newSignInCodeRequiredState: SignInCodeRequiredState?
+    let expectation: XCTestExpectation
+    var expectedError: PasswordRequiredError?
+    var expectedUserAccountResult: MSALNativeAuthUserAccountResult?
+
+    init(expectation: XCTestExpectation, expectedError: PasswordRequiredError? = nil, expectedUserAccountResult: MSALNativeAuthUserAccountResult? = nil) {
+        self.expectation = expectation
+        self.expectedError = expectedError
+        self.expectedUserAccountResult = expectedUserAccountResult
+    }
+
+    func onSignInPasswordRequiredError(error: MSAL.PasswordRequiredError, newState: MSAL.SignInPasswordRequiredState?) {
+        XCTAssertTrue(Thread.isMainThread)
+        XCTAssertEqual(error.type, expectedError?.type)
+        newPasswordRequiredState = newState
+        expectation.fulfill()
+    }
+
+    func onSignInCodeRequired(newState: SignInCodeRequiredState,
+                              sentTo: String,
+                              channelTargetType: MSALNativeAuthChannelType,
+                              codeLength: Int) {
+        XCTAssertTrue(Thread.isMainThread)
+        newSignInCodeRequiredState = newState
+    }
+
+    func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {
+        XCTAssertTrue(Thread.isMainThread)
+        if let expectedUserAccountResult = expectedUserAccountResult {
+            XCTAssertEqual(expectedUserAccountResult.idToken, result.idToken)
+            XCTAssertEqual(expectedUserAccountResult.scopes, result.scopes)
+        } else {
+            XCTFail("This method should not be called")
+        }
+        expectation.fulfill()
+    }
+}
+
+open class SignInPasswordStartDelegateFailureSpy: SignInPasswordStartDelegate {
+
+    public func onSignInPasswordError(error: MSAL.SignInPasswordStartError) {
+        XCTFail("This method should not be called")
+    }
+
+    public func onSignInCodeRequired(newState: MSAL.SignInCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        XCTFail("This method should not be called")
+    }
+
+    public func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {
+        XCTFail("This method should not be called")
+    }
+}
+
+open class SignInCodeStartDelegateSpy: SignInStartDelegate {
+
+    let expectation: XCTestExpectation
+    var expectedError: SignInStartError?
+    var expectedSentTo: String?
+    var expectedChannelTargetType: MSALNativeAuthChannelType?
+    var expectedCodeLength: Int?
+    var verifyCodeDelegate: SignInVerifyCodeDelegate?
+    var correlationId: UUID?
+
+    init(expectation: XCTestExpectation, correlationId: UUID? = nil, verifyCodeDelegate: SignInVerifyCodeDelegate? = nil, expectedError: SignInStartError? = nil, expectedSentTo: String? = nil, expectedChannelTargetType: MSALNativeAuthChannelType? = nil, expectedCodeLength: Int? = nil) {
+        self.expectation = expectation
+        self.verifyCodeDelegate = verifyCodeDelegate
+        self.expectedSentTo = expectedSentTo
+        self.expectedChannelTargetType = expectedChannelTargetType
+        self.expectedCodeLength = expectedCodeLength
+        self.correlationId = correlationId
+        self.expectedError = expectedError
+    }
+
+    public func onSignInError(error: SignInStartError) {
+        XCTAssertEqual(error.type, expectedError?.type)
+        XCTAssertEqual(error.localizedDescription, expectedError?.localizedDescription)
+        XCTAssertTrue(Thread.isMainThread)
+        expectation.fulfill()
+    }
+
+    public func onSignInCodeRequired(newState: SignInCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        XCTAssertEqual(sentTo, expectedSentTo)
+        XCTAssertEqual(channelTargetType, expectedChannelTargetType)
+        XCTAssertEqual(codeLength, expectedCodeLength)
+        XCTAssertTrue(Thread.isMainThread)
+        if let verifyCodeDelegate = verifyCodeDelegate {
+            newState.submitCode(code: "code", delegate: verifyCodeDelegate, correlationId: correlationId)
+        } else {
+            expectation.fulfill()
+        }
+    }
+}
+
+class SignInResendCodeDelegateSpy: SignInResendCodeDelegate {
+
+    private(set) var newSignInCodeRequiredState: SignInCodeRequiredState?
+    private(set) var newSignInResendCodeError: ResendCodeError?
+    let expectation: XCTestExpectation
+    var expectedSentTo: String?
+    var expectedChannelTargetType: MSALNativeAuthChannelType?
+    var expectedCodeLength: Int?
+
+    init(expectation: XCTestExpectation, expectedSentTo: String? = nil, expectedChannelTargetType: MSALNativeAuthChannelType? = nil, expectedCodeLength: Int? = nil) {
+        self.expectation = expectation
+        self.expectedSentTo = expectedSentTo
+        self.expectedChannelTargetType = expectedChannelTargetType
+        self.expectedCodeLength = expectedCodeLength
+    }
+
+    func onSignInResendCodeError(error: ResendCodeError, newState: SignInCodeRequiredState?) {
+        newSignInCodeRequiredState = newState
+        newSignInResendCodeError = error
+        expectation.fulfill()
+    }
+
+    func onSignInResendCodeCodeRequired(newState: SignInCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        XCTAssertEqual(sentTo, expectedSentTo)
+        XCTAssertEqual(channelTargetType, expectedChannelTargetType)
+        XCTAssertEqual(codeLength, expectedCodeLength)
+        XCTAssertTrue(Thread.isMainThread)
+        newSignInCodeRequiredState = newState
+        expectation.fulfill()
+    }
+}
+
+class SignInCodeStartDelegateWithPasswordRequiredSpy: SignInCodeStartDelegateSpy {
+    var passwordRequiredState: SignInPasswordRequiredState?
+
+    public func onSignInPasswordRequired(newState: SignInPasswordRequiredState) {
+        passwordRequiredState = newState
+        expectation.fulfill()
+    }
+}
+
+open class SignInVerifyCodeDelegateSpy: SignInVerifyCodeDelegate {
+
+    private let expectation: XCTestExpectation
+    var expectedError: VerifyCodeError?
+    var expectedUserAccountResult: MSALNativeAuthUserAccountResult?
+    var expectedNewState: SignInCodeRequiredState?
+
+    init(expectation: XCTestExpectation, expectedError: VerifyCodeError? = nil, expectedUserAccountResult: MSALNativeAuthUserAccountResult? = nil) {
+        self.expectation = expectation
+        self.expectedError = expectedError
+        self.expectedUserAccountResult = expectedUserAccountResult
+    }
+
+    public func onSignInVerifyCodeError(error: VerifyCodeError, newState: SignInCodeRequiredState?) {
+        XCTAssertEqual(error.type, expectedError?.type)
+        if let expectedNewState {
+            XCTAssertEqual(newState, expectedNewState)
+        }
+        XCTAssertTrue(Thread.isMainThread)
+        expectation.fulfill()
+    }
+
+    public func onSignInCompleted(result: MSALNativeAuthUserAccountResult) {
+        guard let expectedUserAccountResult = expectedUserAccountResult else {
+            XCTFail("expectedUserAccountResult expected not nil")
+            expectation.fulfill()
+            return
+        }
+        XCTAssertEqual(expectedUserAccountResult.idToken, result.idToken)
+        XCTAssertEqual(expectedUserAccountResult.scopes, result.scopes)
+        XCTAssertTrue(Thread.isMainThread)
+        expectation.fulfill()
+    }
+}
+
+open class SignInAfterSignUpDelegateSpy: SignInAfterSignUpDelegate {
+
+    private let expectation: XCTestExpectation
+    var expectedError: SignInAfterSignUpError?
+    var expectedUserAccountResult: MSALNativeAuthUserAccountResult?
+
+    init(expectation: XCTestExpectation, expectedError: SignInAfterSignUpError? = nil, expectedUserAccountResult: MSALNativeAuthUserAccountResult? = nil) {
+        self.expectation = expectation
+        self.expectedError = expectedError
+        self.expectedUserAccountResult = expectedUserAccountResult
+    }
+
+    public func onSignInAfterSignUpError(error: MSAL.SignInAfterSignUpError) {
+        XCTAssertEqual(error.errorDescription, expectedError?.errorDescription)
+        XCTAssertTrue(Thread.isMainThread)
+        expectation.fulfill()
+    }
+
+    public func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {
+        guard let expectedUserAccountResult = expectedUserAccountResult else {
+            XCTFail("expectedUserAccount expected not nil")
+            expectation.fulfill()
+            return
+        }
+        XCTAssertEqual(expectedUserAccountResult.idToken, result.idToken)
+        XCTAssertEqual(expectedUserAccountResult.scopes, result.scopes)
+        XCTAssertTrue(Thread.isMainThread)
+        expectation.fulfill()
+    }
+}
+
+final class SignInPasswordStartDelegateOptionalMethodNotImplemented: SignInPasswordStartDelegate {
+    private let expectation: XCTestExpectation
+    var expectedError: SignInPasswordStartError?
+    var expectedUserAccountResult: MSALNativeAuthUserAccountResult?
+
+    init(expectation: XCTestExpectation, expectedError: SignInPasswordStartError? = nil, expectedUserAccountResult: MSALNativeAuthUserAccountResult? = nil) {
+        self.expectation = expectation
+        self.expectedError = expectedError
+        self.expectedUserAccountResult = expectedUserAccountResult
+    }
+
+    func onSignInPasswordError(error: MSAL.SignInPasswordStartError) {
+        if let expectedError = expectedError {
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(error.type, expectedError.type)
+            XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
+            expectation.fulfill()
+            return
+        }
+        XCTFail("This method should not be called")
+        expectation.fulfill()
+    }
+
+    func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {
+        if let expectedUserAccountResult = expectedUserAccountResult {
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(expectedUserAccountResult.idToken, result.idToken)
+            XCTAssertEqual(expectedUserAccountResult.scopes, result.scopes)
+        } else {
+            XCTFail("This method should not be called")
+        }
+        expectation.fulfill()
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/SignInTestsValidatorHelpers.swift
+++ b/MSAL/test/unit/native_auth/mock/SignInTestsValidatorHelpers.swift
@@ -1,0 +1,134 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+class SignInPasswordStartTestsValidatorHelper: SignInPasswordStartDelegateSpy {
+
+    func onSignInPasswordError(_ input: MSALNativeAuthSignInController.SignInPasswordControllerResponse) {
+        guard case let .error(error) = input.result else {
+            expectation.fulfill()
+            return XCTFail("input should be .error")
+        }
+
+        self.expectedError = error
+        Task { await self.onSignInPasswordError(error: error) }
+    }
+
+    func onSignInCodeRequired(_ input: MSALNativeAuthSignInController.SignInPasswordControllerResponse) {
+
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input.result else {
+            expectation.fulfill()
+            return XCTFail("input should be .codeRequired")
+        }
+
+        Task { await self.onSignInCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength) }
+    }
+    
+    func onSignInCompleted(_ input: MSALNativeAuthSignInController.SignInPasswordControllerResponse) {
+        guard case let .completed(result) = input.result else {
+            expectation.fulfill()
+            return XCTFail("input should be .success")
+        }
+
+        Task { await self.onSignInCompleted(result: result) }
+    }
+}
+
+class SignInPasswordRequiredTestsValidatorHelper: SignInPasswordRequiredDelegateSpy {
+
+    func onSignInPasswordRequiredError(_ input: SignInPasswordRequiredResult) {
+        guard case let .error(error, newState) = input else {
+            expectation.fulfill()
+            return XCTFail("input should be .error")
+        }
+
+        Task { await self.onSignInPasswordRequiredError(error: error, newState: newState) }
+    }
+
+    func onSignInCompleted(_ input: SignInPasswordRequiredResult) {
+        guard case let .completed(result) = input else {
+            expectation.fulfill()
+            return XCTFail("input should be .complete")
+        }
+
+        Task { await self.onSignInCompleted(result: result) }
+    }
+}
+
+class SignInCodeStartTestsValidatorHelper: SignInCodeStartDelegateSpy {
+    
+    func onSignInError(_ input: MSALNativeAuthSignInControlling.SignInCodeControllerResponse) {
+        guard case let .error(error) = input.result else {
+            expectation.fulfill()
+            return XCTFail("input should be .error")
+        }
+
+        Task { await self.onSignInError(error: error) }
+    }
+    
+    func onSignInCodeRequired(_ input: MSALNativeAuthSignInControlling.SignInCodeControllerResponse) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input.result else {
+            expectation.fulfill()
+            return XCTFail("input should be .codeRequired")
+        }
+
+        Task { await self.onSignInCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength) }
+    }
+}
+
+class SignInResendCodeTestsValidatorHelper: SignInResendCodeDelegateSpy {
+    
+    func onSignInResendCodeError(_ input: SignInResendCodeResult) {
+        guard case let .error(error, newState) = input else {
+            expectation.fulfill()
+            return XCTFail("input should be .error")
+        }
+
+        Task { await self.onSignInResendCodeError(error: error, newState: newState) }
+    }
+
+    func onSignInResendCodeCodeRequired(_ input: SignInResendCodeResult) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input else {
+            expectation.fulfill()
+            return XCTFail("input should be .codeRequired")
+        }
+
+        Task {
+            await self.onSignInResendCodeCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength)
+        }
+    }
+}
+
+class SignInCodeStartWithPasswordRequiredTestsValidatorHelper: SignInCodeStartDelegateWithPasswordRequiredSpy {
+    func onSignInPasswordRequired(_ input: SignInStartResult) {
+        guard case let .passwordRequired(newState) = input else {
+            expectation.fulfill()
+            return XCTFail("input should be .passwordRequired")
+        }
+
+        self.onSignInPasswordRequired(newState: newState)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParametersTest.swift
@@ -1,0 +1,83 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignInChallengeRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
+        let parameters = MSALNativeAuthSignInChallengeRequestParameters(context: MSALNativeAuthRequestContextMock(),
+                                                                        credentialToken: "Test Credential Token")
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/oauth2/v2.0/challenge")
+    }
+
+    func test_otpParameters_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.otp]))
+        let params = MSALNativeAuthSignInChallengeRequestParameters(
+            context: context,
+            credentialToken: "Test Credential Token"
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "credential_token": "Test Credential Token",
+            "challenge_type": "otp"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+
+    func test_nilParameters_shouldCreteCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .redirect]))
+        let params = MSALNativeAuthSignInChallengeRequestParameters(
+            context: context,
+            credentialToken: "Test Credential Token"
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": config.clientId,
+            "credential_token": params.credentialToken,
+            "challenge_type": "password redirect",
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParametersTest.swift
@@ -1,0 +1,83 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignInInitiateRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+    
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
+        let parameters = MSALNativeAuthSignInInitiateRequestParameters(context: MSALNativeAuthRequestContextMock(),
+                                                                       username: "username")
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/oauth2/v2.0/initiate")
+    }
+
+    func test_passwordChallengeType_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
+        let params = MSALNativeAuthSignInInitiateRequestParameters(
+            context: context,
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": config.clientId,
+            "username": params.username,
+            "challenge_type": "password",
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+
+    func test_otpChallenge_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.oob]))
+        let params = MSALNativeAuthSignInInitiateRequestParameters(
+            context: context,
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": config.clientId,
+            "username": params.username,
+            "challenge_type": "oob",
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/requests/sign_in/MSALNativeAuthSignInChallengeRequestTests.swift
+++ b/MSAL/test/unit/native_auth/network/requests/sign_in/MSALNativeAuthSignInChallengeRequestTests.swift
@@ -1,0 +1,137 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignInChallengeRequestTests: XCTestCase {
+
+    let context = MSALNativeAuthRequestContext(
+        correlationId: .init(
+            UUID(uuidString: DEFAULT_TEST_UID)!
+        )
+    )
+
+    private var params: MSALNativeAuthSignInChallengeRequestParameters {
+        .init(
+            config: MSALNativeAuthConfigStubs.configuration,
+            context: context,
+            credentialToken: "Test Credential Token",
+            challengeTypes: [.otp]
+        )
+    }
+
+    func test_signInChallengeRequest_gets_created_successfully() throws {
+
+        let telemetry = MSIDAADTokenRequestServerTelemetry()
+        telemetry.currentRequestTelemetry = .init(
+            appId: 1234,
+            tokenCacheRefreshType: .proactiveTokenRefresh,
+            platformFields: ["ios"]
+        )!
+
+        let sut = try MSALNativeAuthSignInChallengeRequest(params: params)
+
+        XCTAssertEqual(sut.context!.correlationId(), context.correlationId())
+        checkBodyParams(sut.parameters)
+    }
+
+    func test_configure_signInRequest() throws {
+        let telemetry = MSIDAADTokenRequestServerTelemetry()
+        telemetry.currentRequestTelemetry = .init(
+            appId: 1234,
+            tokenCacheRefreshType: .proactiveTokenRefresh,
+            platformFields: ["ios"]
+        )!
+
+        let sut = try MSALNativeAuthSignInChallengeRequest(params: params)
+
+        sut.configure(
+            requestSerializer: MSALNativeAuthUrlRequestSerializer(context: context, encoding: .wwwFormUrlEncoded),
+            serverTelemetry: telemetry
+        )
+
+        checkTelemetry(sut.serverTelemetry, telemetry)
+        checkUrlRequest(sut.urlRequest)
+    }
+
+    func test_configureSignInRequestWithNilParameters_shouldCreateCorrectParameters() throws {
+        let telemetry = MSIDAADTokenRequestServerTelemetry()
+        telemetry.currentRequestTelemetry = .init(
+            appId: 1234,
+            tokenCacheRefreshType: .proactiveTokenRefresh,
+            platformFields: ["ios"]
+        )!
+
+        let sut = try MSALNativeAuthSignInChallengeRequest(params: .init(
+            config: MSALNativeAuthConfigStubs.configuration,
+            context: context,
+            credentialToken: params.credentialToken,
+            challengeTypes: nil
+        ))
+
+        sut.configure(
+            requestSerializer: MSALNativeAuthUrlRequestSerializer(context: context, encoding: .wwwFormUrlEncoded),
+            serverTelemetry: telemetry
+        )
+
+        let expectedBodyParams = [
+            "client_id": params.config.clientId,
+            "credential_token": params.credentialToken
+        ]
+
+        XCTAssertEqual(sut.parameters, expectedBodyParams)
+    }
+
+    private func checkTelemetry(_ result: MSIDHttpRequestServerTelemetryHandling?, _ expected: MSIDAADTokenRequestServerTelemetry) {
+
+        guard let resultTelemetry = (result as? MSIDAADTokenRequestServerTelemetry)?.currentRequestTelemetry else {
+            return XCTFail()
+        }
+
+        let expectedTelemetry = expected.currentRequestTelemetry
+
+        XCTAssertEqual(resultTelemetry.apiId, expectedTelemetry.apiId)
+        XCTAssertEqual(resultTelemetry.tokenCacheRefreshType, expectedTelemetry.tokenCacheRefreshType)
+        XCTAssertEqual(resultTelemetry.platformFields, expectedTelemetry.platformFields)
+    }
+
+    private func checkBodyParams(_ result: [String: String]?) {
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "credential_token": "Test Credential Token",
+            "challenge_type": "otp"
+        ]
+
+        XCTAssertEqual(result, expectedBodyParams)
+    }
+
+    private func checkUrlRequest(_ result: URLRequest?) {
+        XCTAssertEqual(result?.httpMethod, MSALParameterStringForHttpMethod(.POST))
+
+        let expectedUrl = URL(string: MSALNativeAuthNetworkStubs.authority.url.absoluteString + MSALNativeAuthEndpoint.signInChallenge.rawValue)!
+        XCTAssertEqual(result?.url, expectedUrl)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/requests/sign_in/MSALNativeAuthSignInTokenRequestTests.swift
+++ b/MSAL/test/unit/native_auth/network/requests/sign_in/MSALNativeAuthSignInTokenRequestTests.swift
@@ -1,0 +1,158 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignInTokenRequestTests: XCTestCase {
+
+    let context = MSALNativeAuthRequestContext(
+        correlationId: .init(
+            UUID(uuidString: DEFAULT_TEST_UID)!
+        )
+    )
+
+    private var params: MSALNativeAuthSignInTokenRequestParameters {
+        
+        .init(
+            config: MSALNativeAuthConfigStubs.configuration,
+            context: context,
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            credentialToken: "Test Credential Token",
+            signInSLT: "Test SignIn SLT",
+            grantType: .password,
+            challengeTypes: [.password],
+            scope: "<scope-1>",
+            password: "password",
+            oobCode: "oob"
+        )
+    }
+
+    func test_signInRequest_gets_created_successfully() throws {
+
+        let telemetry = MSIDAADTokenRequestServerTelemetry()
+        telemetry.currentRequestTelemetry = .init(
+            appId: 1234,
+            tokenCacheRefreshType: .proactiveTokenRefresh,
+            platformFields: ["ios"]
+        )!
+
+        let sut = try MSALNativeAuthSignInTokenRequest(params: params)
+
+        XCTAssertEqual(sut.context!.correlationId(), context.correlationId())
+        checkBodyParams(sut.parameters)
+    }
+
+    func test_configure_signInRequest() throws {
+        let telemetry = MSIDAADTokenRequestServerTelemetry()
+        telemetry.currentRequestTelemetry = .init(
+            appId: 1234,
+            tokenCacheRefreshType: .proactiveTokenRefresh,
+            platformFields: ["ios"]
+        )!
+
+        let sut = try MSALNativeAuthSignInTokenRequest(params: params)
+
+        sut.configure(
+            requestSerializer: MSALNativeAuthUrlRequestSerializer(context: context, encoding: .wwwFormUrlEncoded),
+            serverTelemetry: telemetry
+        )
+
+        checkTelemetry(sut.serverTelemetry, telemetry)
+        checkUrlRequest(sut.urlRequest)
+    }
+
+    func test_configureSignInRequestWithNilParameters_shouldCreateCorrectParameters() throws {
+        let telemetry = MSIDAADTokenRequestServerTelemetry()
+        telemetry.currentRequestTelemetry = .init(
+            appId: 1234,
+            tokenCacheRefreshType: .proactiveTokenRefresh,
+            platformFields: ["ios"]
+        )!
+
+        let sut = try MSALNativeAuthSignInTokenRequest(params: .init(
+            config: MSALNativeAuthConfigStubs.configuration,
+            context: params.context,
+            username: nil,
+            credentialToken: nil,
+            signInSLT: nil,
+            grantType: .password,
+            challengeTypes: nil,
+            scope: nil,
+            password: nil,
+            oobCode: nil
+        ))
+
+        sut.configure(
+            requestSerializer: MSALNativeAuthUrlRequestSerializer(context: context, encoding: .wwwFormUrlEncoded),
+            serverTelemetry: telemetry
+        )
+
+        let expectedBodyParams = [
+            "client_id": params.config.clientId,
+            "grant_type": "password",
+            "client_info": "true"
+        ]
+
+        XCTAssertEqual(sut.parameters, expectedBodyParams)
+    }
+
+    private func checkTelemetry(_ result: MSIDHttpRequestServerTelemetryHandling?, _ expected: MSIDAADTokenRequestServerTelemetry) {
+
+        guard let resultTelemetry = (result as? MSIDAADTokenRequestServerTelemetry)?.currentRequestTelemetry else {
+            return XCTFail()
+        }
+
+        let expectedTelemetry = expected.currentRequestTelemetry
+
+        XCTAssertEqual(resultTelemetry.apiId, expectedTelemetry.apiId)
+        XCTAssertEqual(resultTelemetry.tokenCacheRefreshType, expectedTelemetry.tokenCacheRefreshType)
+        XCTAssertEqual(resultTelemetry.platformFields, expectedTelemetry.platformFields)
+    }
+
+    private func checkBodyParams(_ result: [String: String]?) {
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "credential_token": "Test Credential Token",
+            "signin_slt": "Test SignIn SLT",
+            "grant_type": "password",
+            "challenge_type": "password",
+            "scope": "<scope-1>",
+            "password": "password",
+            "oob": "oob",
+            "client_info": "true"
+        ]
+
+        XCTAssertEqual(result, expectedBodyParams)
+    }
+
+    private func checkUrlRequest(_ result: URLRequest?) {
+        XCTAssertEqual(result?.httpMethod, MSALParameterStringForHttpMethod(.POST))
+
+        let expectedUrl = URL(string: MSALNativeAuthNetworkStubs.authority.url.absoluteString + MSALNativeAuthEndpoint.token.rawValue)!
+        XCTAssertEqual(result?.url, expectedUrl)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
@@ -1,0 +1,110 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignInInitiateValidatedErrorTypeTests: XCTestCase {
+    
+    private typealias sut = MSALNativeAuthSignInInitiateValidatedErrorType
+    private let testDescription = "testDescription"
+    
+    // MARK: - convertToSignInStartError tests
+    
+    func test_convertToSignInStartError_redirect() {
+        let error = sut.redirect.convertToSignInStartError()
+        XCTAssertEqual(error.type, .browserRequired)
+        XCTAssertEqual(error.errorDescription, "Browser required")
+    }
+    
+    func test_convertToSignInStartError_invalidClient() {
+        let error = sut.invalidClient(message: testDescription).convertToSignInStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInStartError_invalidRequest() {
+        let error = sut.invalidRequest(message: testDescription).convertToSignInStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInStartError_invalidServerResponse() {
+        let error = sut.invalidServerResponse.convertToSignInStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, "General error")
+    }
+    
+    func test_convertToSignInStartError_userNotFound() {
+        let error = sut.userNotFound(message: testDescription).convertToSignInStartError()
+        XCTAssertEqual(error.type, .userNotFound)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInStartError_unsupportedChallengeType() {
+        let error = sut.unsupportedChallengeType(message: testDescription).convertToSignInStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    // MARK: - convertToSignInPasswordStartError tests
+    
+    func test_convertToSignInPasswordStartError_redirect() {
+        let error = sut.redirect.convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .browserRequired)
+        XCTAssertEqual(error.errorDescription, "Browser required")
+    }
+    
+    func test_convertToSignInPasswordStartError_invalidClient() {
+        let error = sut.invalidClient(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_invalidRequest() {
+        let error = sut.invalidRequest(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_invalidServerResponse() {
+        let error = sut.invalidServerResponse.convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, "General error")
+    }
+    
+    func test_convertToSignInPasswordStartError_userNotFound() {
+        let error = sut.userNotFound(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .userNotFound)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_convertToSignInPasswordStartError_unsupportedChallengeType() {
+        let error = sut.unsupportedChallengeType(message: testDescription).convertToSignInPasswordStartError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
@@ -1,0 +1,172 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
+
+    private let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    private var sut: MSALNativeAuthSignInResponseValidator!
+    private var defaultUUID = UUID(uuidString: DEFAULT_TEST_UID)!
+    private var factory: MSALNativeAuthResultFactoryMock!
+
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        factory =  MSALNativeAuthResultFactoryMock()
+        sut = MSALNativeAuthSignInResponseValidator()
+    }
+    
+    // MARK: challenge API tests
+    
+    func test_whenChallengeTypeRedirect_validationShouldReturnRedirectError() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: nil, challengeType: .redirect, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
+        let result = sut.validate(context: context, result: .success(challengeResponse))
+        if case .error(.redirect) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenChallengeTypePassword_validationShouldReturnPasswordRequired() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
+        let result = sut.validate(context: context, result: .success(challengeResponse))
+        if case .passwordRequired(credentialToken: credentialToken) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenChallengeTypePasswordAndNoCredentialToken_validationShouldFail() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: nil, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
+        let result = sut.validate(context: context, result: .success(challengeResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenChallengeTypeOOB_validationShouldReturnCodeRequired() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+        let targetLabel = "targetLabel"
+        let codeLength = 4
+        let channelType = MSALNativeAuthInternalChannelType.email
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
+        let result = sut.validate(context: context, result: .success(challengeResponse))
+        if case .codeRequired(credentialToken: credentialToken, sentTo: targetLabel, channelType: .email, codeLength: codeLength) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenChallengeTypeOOBButMissingAttributes_validationShouldFail() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+        let targetLabel = "targetLabel"
+        let codeLength = 4
+        let channelType = MSALNativeAuthInternalChannelType.email
+        let missingCredentialToken = MSALNativeAuthSignInChallengeResponse(credentialToken: nil, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
+        var result = sut.validate(context: context, result: .success(missingCredentialToken))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+        let missingTargetLabel = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: channelType, codeLength: codeLength, interval: nil)
+        result = sut.validate(context: context, result: .success(missingTargetLabel))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+        let missingChannelType = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: nil, codeLength: codeLength, interval: nil)
+        result = sut.validate(context: context, result: .success(missingChannelType))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+        let missingCodeLength = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: nil, interval: nil)
+        result = sut.validate(context: context, result: .success(missingCodeLength))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenChallengeTypeOTP_validationShouldFail() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: "something", challengeType: .otp, bindingMethod: nil, challengeTargetLabel: "some", challengeChannel: .email, codeLength: 2, interval: nil)
+        let result = sut.validate(context: context, result: .success(challengeResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    // MARK: initiate API tests
+    
+    func test_whenInitiateResponseIsValid_validationShouldBeSuccessful() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+        let initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: credentialToken, challengeType: nil)
+        let result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .success(credentialToken: credentialToken) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenInitiateResponseIsInvalid_validationShouldFail() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: nil)
+        let result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenInitiateChallengeTypeIsRedirect_validationShouldReturnRedirectError() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .redirect)
+        let result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .error(.redirect) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenInitiateChallengeTypeIsInvalid_validationShouldFail() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        var initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .oob)
+        var result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+        initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .otp)
+        result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+        initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .password)
+        result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
@@ -1,0 +1,115 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class SignInCodeRequiredStateTests: XCTestCase {
+
+    private var sut: SignInCodeRequiredState!
+    private var controller: MSALNativeAuthSignInControllerMock!
+
+    override func setUp() {
+        super.setUp()
+
+        controller = .init()
+        sut = .init(scopes: [], controller: controller, flowToken: "flowToken")
+    }
+
+    // MARK: - Delegates
+
+    // ResendCode
+
+    func test_resendCode_delegate_withError_shouldReturnSignInResendCodeError() {
+        let expectedError = ResendCodeError(message: "test error")
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2")
+
+        let expectedResult: SignInResendCodeResult = .error(
+            error: expectedError,
+            newState: expectedState
+        )
+        controller.resendCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-in states")
+        let delegate = SignInResendCodeDelegateSpy(expectation: exp)
+
+        sut.resendCode(delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newSignInResendCodeError, expectedError)
+        XCTAssertEqual(delegate.newSignInCodeRequiredState?.flowToken, expectedState.flowToken)
+    }
+
+    func test_resendCode_delegate_success_shouldReturnSignInResendCodeCodeRequired() {
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2")
+
+        let expectedResult: SignInResendCodeResult = .codeRequired(
+            newState: expectedState,
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controller.resendCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-in states")
+        let delegate = SignInResendCodeDelegateSpy(expectation: exp, expectedSentTo: "sentTo", expectedChannelTargetType: .email, expectedCodeLength: 1)
+
+        sut.resendCode(delegate: delegate)
+        wait(for: [exp])
+        XCTAssertEqual(delegate.newSignInCodeRequiredState?.flowToken, expectedState.flowToken)
+    }
+
+    // SubmitCode
+
+    func test_submitCode_delegate_withError_shouldReturnSignInVerifyCodeError() {
+        let expectedError = VerifyCodeError(type: .invalidCode)
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2")
+
+        let expectedResult: SignInVerifyCodeResult = .error(
+            error: expectedError,
+            newState: expectedState
+        )
+        controller.submitCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-in states")
+        let delegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedError: expectedError)
+        delegate.expectedNewState = expectedState
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp])
+    }
+
+    func test_submitCode_delegate_success_shouldReturnAccountResult() {
+        let expectedAccountResult = MSALNativeAuthUserAccountResultStub.result
+
+        let expectedResult: SignInVerifyCodeResult = .completed(expectedAccountResult)
+        controller.submitCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-in states")
+        let delegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedUserAccountResult: expectedAccountResult)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp])
+    }
+}

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
@@ -1,0 +1,73 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class SignInPasswordRequiredStateTests: XCTestCase {
+
+    private var sut: SignInPasswordRequiredState!
+    private var controller: MSALNativeAuthSignInControllerMock!
+
+    override func setUp() {
+        super.setUp()
+
+        controller = .init()
+        sut = .init(scopes: [], username: "username", controller: controller, flowToken: "flowToken")
+    }
+
+    // MARK: - Delegates
+
+    func test_submitPassword_delegate_withError_shouldReturnError() {
+        let expectedError = PasswordRequiredError(type: .invalidPassword)
+        let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controller, flowToken: "flowToken 2")
+
+        let expectedResult: SignInPasswordRequiredResult = .error(
+            error: expectedError,
+            newState: expectedState
+        )
+        controller.submitPasswordResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-in states")
+        let delegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: expectedError)
+
+        sut.submitPassword(password: "invalid password", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newPasswordRequiredState?.flowToken, expectedState.flowToken)
+    }
+
+    func test_submitPassword_delegate_success_shouldReturnSuccess() {
+        let expectedAccountResult = MSALNativeAuthUserAccountResultStub.result
+
+        let expectedResult: SignInPasswordRequiredResult = .completed(expectedAccountResult)
+        controller.submitPasswordResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-in states")
+        let delegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedUserAccountResult: expectedAccountResult)
+
+        sut.submitPassword(password: "invalid password", delegate: delegate)
+        wait(for: [exp])
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR shows the SDK that the CIAM team had developed. it is base on the Native Auth merge into MSAL plan here: https://microsofteur.sharepoint.com/:w:/t/DevExDublin/EdfT2AmlFZFIsTtr-EaoSBIBPqcOlRo1MJ1USbEsfjfEcQ

To comply with the design changes made by our API team, we have created a more dynamic SDK. This means that we make different API requests for each authentication flow. There is also some logic involved in each of the responses we get from each request.

We have created a state machine for each flow (check this [Figma](https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0%3A1&t=VUyK4gIoyUChTXWF-1) to see all the possible states), and we are making it external to developers by using delegates instead of completion blocks, as @Serhii Demchenko suggested. In this way we can guide the developer through the authentication process offering a discovering interface. We think that this approach will improve the overall developer experience.

**This PR is focused in the Sign In feature.**

The IdentityCore changes can be found in this PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1294

**For context, this is the Native Auth technical overview:** https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview?path=/%5BiOS%5D%20Native%20authentication/technical_overview.md&version=GBdanilo/native-authentication&_a=preview

State Machine:
https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0-1&mode=design&t=80VUxa1RvxMn4rnl-0

## High level overview

**MSALNativeAuthPublicClientApplication.swift**
The public interface is the entry point of the SDK. Here is where all the supported authentication flows begin.
Regarding the sign-up flow, developers can call either `signIn(...)` or `signInUsingPassword(...)`.
Notice that in those methods they must pass a class that conforms to `SignInStartDelegate`. or `SignInPasswordStartDelegate`, respectively.


**MSALNativeAuthSignInController.swift**
The controller handles most of the logic. Each of the methods inside the MARK: - Internal can be called from the public interfaces, that are:
    - MSALNativeAuthPublicClientApplication
    - One of the States (located in the file SignInDelegates.swift). These States are returned through the delegates, as we will see.

For each of these methods, the controller:
    - Creates a request (`MSIDHttpRequest`) using its requestProvider (`MSALNativeAuthSignInRequestProviding`).
    - Executes the request.
    - Passes the result to its responseValidator (`MSALNativeAuthSignInResponseValidating`)
    - Handles the validated result and returns it to the public interface, which uses the delegate to communicate back to the developer.
    - Creates and handle the local telemetry events.

The controller decides what to do with the ValidatedResponse given by the ResponseValidator.

Every validated response usually has:
**A success:** it means that the SDK moves on to the next state, which usually involves making another request or returning back to the user via the delegate.
Redirect: when the backend detects an error and wants the SDK to fallback to the WebView-based flow.
**A known error:** in some cases, these errors put the user in a recoverable state (for example, an error that requires the user to provide more attributes). In other cases, the error means the end of the flow.
**An unexpected error:** these errors are likely bugs, they happen when we there are missing attributes from the response, etc.
(Please keep in mind that not every ValidatedResponse falls into the same categories, this is just an approximation)


**MSALNativeAuthRequestConfigurator.swift**
Each of the requestProviders from the Controllers uses the RequestConfigurator to create and configure the requests. Although there are different RequestProviders (one per flow), there's only one RequestConfigurator.

The RequestConfigurator injects a custom ErrorHandler (`MSALNativeAuthResponseErrorHandler`) to every request. This is needed in order to decode the errors from the API.
These errors follow a structure that you can see in `MSALNativeAuthSignInStartResponseError` for example. In the directory native_auth/network/errors/ you can see all the files used.


**MSALNativeAuthSignInResponseValidator.swift**
The ResponseValidator is in charge of analysing the api response and returning to the Controller a validated response (for instance, for the response of the signin/start endpoint, it returns a `MSALNativeAuthSigninStartValidatedResponse`).


**SignInStates.swift**
In this file there are the different States that the Controller can return to the developer through the delegate.

This is how the developer will use them. For more examples of how developers can use the SDK you can check the Sample App (located in /Samples/ios-native-auth-simple in the branch `ciam-master-snapshot`). We will include it in a separate PR:


## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

