### PR TITLE
Native Auth Sign Up

### DIFF
--- a/MSAL/src/native_auth/controllers/responses/SignUpResults.swift
+++ b/MSAL/src/native_auth/controllers/responses/SignUpResults.swift
@@ -1,0 +1,113 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum SignUpPasswordStartResult {
+    /// Returned if a user has received an email with code.
+    ///
+    /// - newState: An object representing the new state of the flow with follow on methods.
+    /// - sentTo: The email/phone number that the code was sent to.
+    /// - channelTargetType: The channel (email/phone) the code was sent through.
+    /// - codeLength: The length of the code required.
+    case codeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
+
+    /// Returned when the attributes sent are invalid.
+    case attributesInvalid([String])
+
+    /// An error object indicating why the operation failed.
+    case error(SignUpPasswordStartError)
+}
+
+enum SignUpStartResult {
+    /// Returned if a user has received an email with code.
+    ///
+    /// - newState: An object representing the new state of the flow with follow on methods.
+    /// - sentTo: The email/phone number that the code was sent to.
+    /// - channelTargetType: The channel (email/phone) the code was sent through.
+    /// - codeLength: The length of the code required.
+    case codeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
+
+    /// Returned when the attributes sent are invalid.
+    case attributesInvalid([String])
+
+    /// An error object indicating why the operation failed.
+    case error(SignUpStartError)
+}
+
+/// An object of this type is returned after a user submits the code sent to their email/phone.
+/// It contains the next state of the flow with follow on methods, depending on the server's response.
+enum SignUpVerifyCodeResult {
+    /// Returned after the sign up operation completed successfully.
+    case completed(SignInAfterSignUpState)
+
+    /// Returned when a password is required.
+    case passwordRequired(SignUpPasswordRequiredState)
+
+    /// Returned when attributes are required.
+    case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+
+    /// An error object indicating why the operation failed.
+    case error(error: VerifyCodeError, newState: SignUpCodeRequiredState?)
+}
+
+enum SignUpResendCodeResult {
+    /// Returned if a user has received an email with code.
+    ///
+    /// - newState: An object representing the new state of the flow with follow on methods.
+    /// - sentTo: The email/phone number that the code was sent to.
+    /// - channelTargetType: The channel (email/phone) the code was sent through.
+    /// - codeLength: The length of the code required.
+    case codeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
+
+    /// An error object indicating why the operation failed.
+    case error(ResendCodeError)
+}
+
+/// An object of this type is returned after a user submits their password.
+/// It contains the next state of the flow with follow on methods, depending on the server's response.
+enum SignUpPasswordRequiredResult {
+    /// Returned after the sign up operation completed successfully.
+    case completed(SignInAfterSignUpState)
+
+    /// Returned when attributes are required.
+    case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+
+    /// An error object indicating why the operation failed.
+    case error(error: PasswordRequiredError, newState: SignUpPasswordRequiredState?)
+}
+
+enum SignUpAttributesRequiredResult {
+    /// Returned after the sign up operation completed successfully.
+    case completed(SignInAfterSignUpState)
+
+    /// Returned when attributes are required.
+    case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], state: SignUpAttributesRequiredState)
+
+    /// Returned when the attributes sent are invalid.
+    case attributesInvalid(attributes: [String], newState: SignUpAttributesRequiredState)
+
+    /// An error object indicating why the operation failed.
+    case error(error: AttributesRequiredError)
+}

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -1,0 +1,664 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
+final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNativeAuthSignUpControlling {
+
+    // MARK: - Variables
+
+    private let requestProvider: MSALNativeAuthSignUpRequestProviding
+    private let responseValidator: MSALNativeAuthSignUpResponseValidating
+    private let signInController: MSALNativeAuthSignInControlling
+
+    // MARK: - Init
+
+    init(
+        config: MSALNativeAuthConfiguration,
+        requestProvider: MSALNativeAuthSignUpRequestProviding,
+        responseValidator: MSALNativeAuthSignUpResponseValidating,
+        signInController: MSALNativeAuthSignInControlling
+    ) {
+        self.requestProvider = requestProvider
+        self.responseValidator = responseValidator
+        self.signInController = signInController
+        super.init(clientId: config.clientId)
+    }
+
+    convenience init(config: MSALNativeAuthConfiguration) {
+        self.init(
+            config: config,
+            requestProvider: MSALNativeAuthSignUpRequestProvider(
+                requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+                telemetryProvider: MSALNativeAuthTelemetryProvider()
+            ),
+            responseValidator: MSALNativeAuthSignUpResponseValidator(),
+            signInController: MSALNativeAuthSignInController(config: config)
+        )
+    }
+
+    // MARK: - Internal
+
+    func signUpStartPassword(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartPasswordControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpPasswordStart, context: parameters.context)
+        let result = await performAndValidateStartRequest(parameters: parameters)
+        return await handleSignUpStartPasswordResult(result, username: parameters.username, event: event, context: parameters.context)
+    }
+
+    func signUpStartCode(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartCodeControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpCodeStart, context: parameters.context)
+        let result = await performAndValidateStartRequest(parameters: parameters)
+        return await handleSignUpStartCodeResult(result, username: parameters.username, event: event, context: parameters.context)
+    }
+
+    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpResendCode, context: context)
+        let challengeResult = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+        return handleResendCodeResult(challengeResult, username: username, event: event, context: context)
+    }
+
+    func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitCode, context: context)
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(grantType: .oobCode, signUpToken: signUpToken, oobCode: code, context: context)
+
+        let result = await performAndValidateContinueRequest(parameters: params)
+        return await handleSubmitCodeResult(result, username: username, signUpToken: signUpToken, event: event, context: context)
+    }
+
+    func submitPassword(
+        _ password: String,
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpSubmitPasswordControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitPassword, context: context)
+
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: signUpToken,
+            password: password,
+            context: context
+        )
+        let continueRequestResult = await performAndValidateContinueRequest(parameters: params)
+        return handleSubmitPasswordResult(continueRequestResult, username: username, signUpToken: signUpToken, event: event, context: context)
+    }
+
+    func submitAttributes(
+        _ attributes: [String: Any],
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpAttributesRequiredResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitAttributes, context: context)
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .attributes,
+            signUpToken: signUpToken,
+            attributes: attributes,
+            context: context
+        )
+
+        let result = await performAndValidateContinueRequest(parameters: params)
+        return handleSubmitAttributesResult(result, username: username, signUpToken: signUpToken, event: event, context: context)
+    }
+
+    // MARK: - Start Request handling
+
+    private func performAndValidateStartRequest(
+        parameters: MSALNativeAuthSignUpStartRequestProviderParameters
+    ) async -> MSALNativeAuthSignUpStartValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.start(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error while creating Start Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing signup/start request")
+
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(response, with: parameters.context)
+    }
+
+    // swiftlint:disable:next function_body_length
+    private func handleSignUpStartPasswordResult(
+        _ result: MSALNativeAuthSignUpStartValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> SignUpStartPasswordControllerResponse {
+        switch result {
+        case .verificationRequired(let signUpToken, let attributes):
+            MSALLogger.log(
+                level: .info,
+                context: context,
+                format: "verification_required received from signup/start with password request for attributes: \(attributes)"
+            )
+            let challengeResult = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+            return handleSignUpPasswordChallengeResult(challengeResult, username: username, event: event, context: context)
+        case .attributeValidationFailed(let invalidAttributes):
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "attribute_validation_failed received from signup/start with password request for attributes: \(invalidAttributes)"
+            )
+            let message = String(format: MSALNativeAuthErrorMessage.attributeValidationFailedSignUpStart, invalidAttributes.description)
+            let error = SignUpPasswordStartError(type: .generalError, message: message)
+            return .init(.attributesInvalid(invalidAttributes), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                case .failure(let error):
+                    MSALLogger.log(
+                        level: .error,
+                        context: context,
+                        format: "SignUp with password error: \(error.errorDescription ?? "No error description")"
+                    )
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .redirect:
+            let error = SignUpPasswordStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "redirect error in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .error(let apiError):
+            let error = apiError.toSignUpStartPasswordPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidUsername(let apiError):
+            let error = SignUpPasswordStartError(type: .invalidUsername, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "InvalidUsername in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidClientId(let apiError):
+            let error = SignUpPasswordStartError(type: .generalError, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Invalid Client Id in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError:
+            let error = SignUpPasswordStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    private func handleSignUpStartCodeResult(
+        _ result: MSALNativeAuthSignUpStartValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> SignUpStartCodeControllerResponse {
+        switch result {
+        case .verificationRequired(let signUpToken, let unverifiedAttributes):
+            MSALLogger.log(
+                level: .info,
+                context: context,
+                format: "verification_required received from signup/start request for attributes: \(unverifiedAttributes)"
+            )
+            let challengeResult = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+            return handleSignUpCodeChallengeResult(challengeResult, username: username, event: event, context: context)
+        case .attributeValidationFailed(let invalidAttributes):
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "attribute_validation_failed received from signup/start request for attributes: \(invalidAttributes)"
+            )
+            let message = String(format: MSALNativeAuthErrorMessage.attributeValidationFailedSignUpStart, invalidAttributes.description)
+            let error = SignUpStartError(type: .generalError, message: message)
+            return .init(.attributesInvalid(invalidAttributes), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .redirect:
+            let error = SignUpStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .error(let apiError):
+            let error = apiError.toSignUpStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidUsername(let apiError):
+            let error = SignUpStartError(type: .invalidUsername, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "InvalidUsername in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidClientId(let apiError):
+            let error = SignUpStartError(type: .generalError, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Invalid Client Id in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError:
+            let error = SignUpStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    // MARK: - Challenge Request handling
+
+    private func performAndValidateChallengeRequest(
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.challenge(token: signUpToken, context: context)
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error while creating Challenge Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: context, format: "Performing signup/challenge request")
+
+        let result: Result<MSALNativeAuthSignUpChallengeResponse, Error> = await performRequest(request, context: context)
+        return responseValidator.validate(result, with: context)
+    }
+
+    private func handleSignUpPasswordChallengeResult(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpStartPasswordControllerResponse {
+        switch result {
+        case .codeRequired(let sentTo, let challengeType, let codeLength, let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge password request")
+            stopTelemetryEvent(event, context: context)
+            return SignUpStartPasswordControllerResponse(
+                .codeRequired(
+                    newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                    sentTo: sentTo,
+                    channelTargetType: challengeType,
+                    codeLength: codeLength
+                )
+            )
+        case .error(let apiError):
+            let error = apiError.toSignUpPasswordStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/challenge password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .redirect:
+            let error = SignUpPasswordStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/challenge password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError,
+             .passwordRequired:
+            let error = SignUpPasswordStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    private func handleSignUpCodeChallengeResult(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpStartCodeControllerResponse {
+        switch result {
+        case .codeRequired(let sentTo, let challengeType, let codeLength, let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge request")
+            stopTelemetryEvent(event, context: context)
+            return SignUpStartCodeControllerResponse(
+                .codeRequired(
+                    newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                    sentTo: sentTo,
+                    channelTargetType: challengeType,
+                    codeLength: codeLength
+                )
+            )
+        case .error(let apiError):
+            let error = apiError.toSignUpStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .redirect:
+            let error = SignUpStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError,
+             .passwordRequired:
+            let error = SignUpStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    private func handleResendCodeResult(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpResendCodeResult {
+        switch result {
+        case .codeRequired(let sentTo, let challengeType, let codeLength, let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge resendCode request")
+            stopTelemetryEvent(event, context: context)
+            return .codeRequired(
+                newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                sentTo: sentTo,
+                channelTargetType: challengeType,
+                codeLength: codeLength
+            )
+        case .error(let apiError):
+            let error = apiError.toResendCodePublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/challenge resendCode request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        case .redirect,
+             .unexpectedError,
+             .passwordRequired:
+            let error = ResendCodeError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge resendCode request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        }
+    }
+
+    /// This method handles the /challenge response after receiving a "credential_required" error
+    private func handlePerformChallengeAfterContinueRequest(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpSubmitCodeControllerResponse {
+        switch result {
+        case .passwordRequired(let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge request after credential_required")
+
+            let state = SignUpPasswordRequiredState(controller: self, username: username, flowToken: signUpToken)
+
+            return .init(.passwordRequired(state), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .redirect:
+            let error = VerifyCodeError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        case .error,
+             .codeRequired,
+             .unexpectedError:
+            let error = VerifyCodeError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        }
+    }
+
+    // MARK: - Continue Request handling
+
+    private func performAndValidateContinueRequest(
+        parameters: MSALNativeAuthSignUpContinueRequestProviderParams
+    ) async -> MSALNativeAuthSignUpContinueValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.continue(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error while creating Continue Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing signup/continue request")
+
+        let result: Result<MSALNativeAuthSignUpContinueResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(result, with: parameters.context)
+    }
+
+    private func handleSubmitCodeResult(
+        _ result: MSALNativeAuthSignUpContinueValidatedResponse,
+        username: String,
+        signUpToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> SignUpSubmitCodeControllerResponse {
+        switch result {
+        case .success(let slt):
+            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+            return .init(.completed(state))
+        case .invalidUserInput:
+            MSALLogger.log(level: .error, context: context, format: "invalid_user_input error in signup/continue request")
+
+            let error = VerifyCodeError(type: .invalidCode)
+            stopTelemetryEvent(event, context: context, error: error)
+            let state = SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .init(.error(error: error, newState: state))
+        case .credentialRequired(let signUpToken):
+            MSALLogger.log(level: .verbose, context: context, format: "credential_required received in signup/continue request")
+
+            let result = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+            return handlePerformChallengeAfterContinueRequest(result, username: username, event: event, context: context)
+        case .attributesRequired(let signUpToken, let attributes):
+            MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .init(.attributesRequired(attributes: attributes, newState: state), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .error(let apiError):
+            let error = apiError.toVerifyCodePublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/continue request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        case .attributeValidationFailed,
+             .unexpectedError:
+            let error = VerifyCodeError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        }
+    }
+
+    private func handleSubmitPasswordResult(
+        _ result: MSALNativeAuthSignUpContinueValidatedResponse,
+        username: String,
+        signUpToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpSubmitPasswordControllerResponse {
+        switch result {
+        case .success(let slt):
+            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+            return .init(.completed(state))
+        case .invalidUserInput(let error):
+            let error = error.toPasswordRequiredPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "invalid_user_input error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")"
+            )
+
+            let state = SignUpPasswordRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .init(.error(error: error, newState: state))
+        case .attributesRequired(let signUpToken, let attributes):
+            MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+
+            return .init(.attributesRequired(attributes: attributes, newState: state), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .error(let apiError):
+            let error = apiError.toPasswordRequiredPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        case .attributeValidationFailed,
+             .credentialRequired,
+             .unexpectedError:
+            let error = PasswordRequiredError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        }
+    }
+
+    private func handleSubmitAttributesResult(
+        _ result: MSALNativeAuthSignUpContinueValidatedResponse,
+        username: String,
+        signUpToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpAttributesRequiredResult {
+        switch result {
+        case .success(let slt):
+            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+            return .completed(state)
+        case .attributesRequired(let signUpToken, let attributes):
+            let error = AttributesRequiredError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "attributes_required received in signup/continue submitAttributes request: \(attributes)")
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .attributesRequired(attributes: attributes, state: state)
+        case .attributeValidationFailed(let signUpToken, let invalidAttributes):
+            let message = "attribute_validation_failed from signup/continue submitAttributes request. Make sure these attributes are correct: \(invalidAttributes)" // swiftlint:disable:this line_length
+            MSALLogger.log(level: .error, context: context, format: message)
+
+            let errorMessage = String(format: MSALNativeAuthErrorMessage.attributeValidationFailed, invalidAttributes.description)
+            let error = AttributesRequiredError(message: errorMessage)
+            stopTelemetryEvent(event, context: context, error: error)
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .attributesInvalid(attributes: invalidAttributes, newState: state)
+        case .error(let apiError):
+            let error = apiError.toAttributesRequiredPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/continue submitAttributes request \(error.errorDescription ?? "No error description")")
+            return .error(error: error)
+        case .credentialRequired,
+             .unexpectedError,
+             .invalidUserInput:
+            let error = AttributesRequiredError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue submitAttributes request \(error.errorDescription ?? "No error description")")
+            return .error(error: error)
+        }
+    }
+
+    private func createSignInAfterSignUpStateUsingSLT(
+        _ slt: String?,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignInAfterSignUpState {
+        MSALLogger.log(level: .info, context: context, format: "SignUp completed successfully")
+        stopTelemetryEvent(event, context: context)
+        return SignInAfterSignUpState(controller: signInController, username: username, slt: slt)
+    }
+}

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
@@ -1,0 +1,55 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignUpControlling: AnyObject {
+
+    typealias SignUpStartPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpPasswordStartResult>
+    typealias SignUpStartCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpStartResult>
+    typealias SignUpSubmitCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpVerifyCodeResult>
+    typealias SignUpSubmitPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpPasswordRequiredResult>
+
+    func signUpStartPassword(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartPasswordControllerResponse
+
+    func signUpStartCode(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartCodeControllerResponse
+
+    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeResult
+
+    func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse
+
+    func submitPassword(
+        _ password: String,
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpSubmitPasswordControllerResponse
+
+    func submitAttributes(
+        _ attributes: [String: Any],
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpAttributesRequiredResult
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthErrorBasicAttributes.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthErrorBasicAttributes.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+class MSALNativeAuthErrorBasicAttributes: NSObject, Decodable {
+    let name: String
+
+    init(name: String) {
+        self.name = name
+    }
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthRequiredAttributeOptions.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthRequiredAttributeOptions.swift
@@ -1,0 +1,29 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+class MSALNativeAuthRequiredAttributeOptions: Decodable {
+    let regex: String?
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthRequiredAttributesInternal.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthRequiredAttributesInternal.swift
@@ -1,0 +1,47 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+class MSALNativeAuthRequiredAttributesInternal: NSObject, Decodable {
+    let name: String
+    let type: String
+    let required: Bool
+    let options: MSALNativeAuthRequiredAttributeOptions?
+
+    init(name: String, type: String, required: Bool, options: MSALNativeAuthRequiredAttributeOptions? = nil) {
+        self.name = name
+        self.type = type
+        self.required = required
+        self.options = options
+    }
+
+    override var description: String {
+        return "\(name)"
+    }
+
+    func toRequiredAttributesPublic() -> MSALNativeAuthRequiredAttributes {
+        MSALNativeAuthRequiredAttributes(name: name, type: type, required: required, regex: options?.regex)
+    }
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCode.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthSignUpChallengeOauth2ErrorCode: String, Decodable, CaseIterable {
+    case invalidRequest = "invalid_request"
+    case unauthorizedClient = "unauthorized_client"
+    case unsupportedChallengeType = "unsupported_challenge_type"
+    case expiredToken = "expired_token"
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
@@ -1,0 +1,84 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
+    let error: MSALNativeAuthSignUpChallengeOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+    }
+}
+
+extension MSALNativeAuthSignUpChallengeResponseError {
+
+    func toSignUpPasswordStartPublicError() -> SignUpPasswordStartError {
+        switch error {
+        case .unauthorizedClient,
+             .unsupportedChallengeType,
+             .expiredToken,
+             .invalidRequest:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+
+    func toSignUpStartPublicError() -> SignUpStartError {
+        switch error {
+        case .unauthorizedClient,
+             .unsupportedChallengeType,
+             .expiredToken,
+             .invalidRequest:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+
+    func toResendCodePublicError() -> ResendCodeError {
+        switch error {
+        case .unauthorizedClient,
+             .unsupportedChallengeType,
+             .expiredToken,
+             .invalidRequest:
+            return .init(message: errorDescription)
+        }
+    }
+
+    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+        switch error {
+        case .unauthorizedClient,
+             .unsupportedChallengeType,
+             .expiredToken,
+             .invalidRequest:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCode.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthSignUpContinueOauth2ErrorCode: String, Decodable, CaseIterable {
+    case invalidRequest = "invalid_request"
+    case unauthorizedClient = "unauthorized_client"
+    case invalidGrant = "invalid_grant"
+    case expiredToken = "expired_token"
+    case passwordTooWeak = "password_too_weak"
+    case passwordTooShort = "password_too_short"
+    case passwordTooLong = "password_too_long"
+    case passwordRecentlyUsed = "password_recently_used"
+    case passwordBanned = "password_banned"
+    case userAlreadyExists = "user_already_exists"
+    case attributesRequired = "attributes_required"
+    case verificationRequired = "verification_required"
+    case attributeValidationFailed = "attribute_validation_failed"
+    case credentialRequired = "credential_required"
+    case invalidOOBValue = "invalid_oob_value"
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
@@ -1,0 +1,100 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
+    let error: MSALNativeAuthSignUpContinueOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+    let signUpToken: String?
+    let requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]?
+    let unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]?
+    let invalidAttributes: [MSALNativeAuthErrorBasicAttributes]?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+        case signUpToken = "signup_token"
+        case requiredAttributes = "required_attributes"
+        case unverifiedAttributes = "unverified_attributes"
+        case invalidAttributes = "invalid_attributes"
+    }
+}
+
+extension MSALNativeAuthSignUpContinueResponseError {
+
+    func toVerifyCodePublicError() -> VerifyCodeError {
+        switch error {
+        case .invalidOOBValue:
+            return .init(type: .invalidCode, message: errorDescription)
+        case .unauthorizedClient,
+             .expiredToken,
+             .invalidRequest,
+             .invalidGrant,
+             .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned,
+             .userAlreadyExists,
+             .attributesRequired,
+             .verificationRequired,
+             .credentialRequired,
+             .attributeValidationFailed:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+
+    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+        switch error {
+        case .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .init(type: .invalidPassword, message: errorDescription)
+        case .unauthorizedClient,
+             .expiredToken,
+             .invalidRequest,
+             .invalidGrant,
+             .userAlreadyExists,
+             .attributesRequired,
+             .verificationRequired,
+             .credentialRequired,
+             .attributeValidationFailed,
+             .invalidOOBValue:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+
+    func toAttributesRequiredPublicError() -> AttributesRequiredError {
+        return AttributesRequiredError(message: errorDescription)
+    }
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCode.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthSignUpStartOauth2ErrorCode: String, Decodable, CaseIterable, Equatable {
+    case invalidRequest = "invalid_request"
+    case unauthorizedClient = "unauthorized_client"
+    case unsupportedChallengeType = "unsupported_challenge_type"
+    case passwordTooWeak = "password_too_weak"
+    case passwordTooShort = "password_too_short"
+    case passwordTooLong = "password_too_long"
+    case passwordRecentlyUsed = "password_recently_used"
+    case passwordBanned = "password_banned"
+    case userAlreadyExists = "user_already_exists"
+    case attributesRequired = "attributes_required"
+    case verificationRequired = "verification_required"
+    case unsupportedAuthMethod = "unsupported_auth_method"
+    case attributeValidationFailed = "attribute_validation_failed"
+}

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
@@ -1,0 +1,92 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
+
+    let error: MSALNativeAuthSignUpStartOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+    let signUpToken: String?
+    let unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]?
+    let invalidAttributes: [MSALNativeAuthErrorBasicAttributes]?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+        case signUpToken = "signup_token"
+        case unverifiedAttributes = "unverified_attributes"
+        case invalidAttributes = "invalid_attributes"
+    }
+}
+
+extension MSALNativeAuthSignUpStartResponseError {
+
+    func toSignUpStartPasswordPublicError() -> SignUpPasswordStartError {
+        switch error {
+        case .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .init(type: .invalidPassword, message: errorDescription)
+        case .userAlreadyExists:
+            return .init(type: .userAlreadyExists, message: errorDescription)
+        case .attributeValidationFailed,
+             .attributesRequired,
+             .unauthorizedClient,
+             .unsupportedChallengeType,
+             .unsupportedAuthMethod,
+             .invalidRequest,
+             .verificationRequired: /// .verificationRequired is not supported by the API team yet. We treat it as an unexpectedError in the validator
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+
+    func toSignUpStartPublicError() -> SignUpStartError {
+        switch error {
+        case .userAlreadyExists:
+            return .init(type: .userAlreadyExists, message: errorDescription)
+        case .attributeValidationFailed,
+             .attributesRequired,
+             .unauthorizedClient,
+             .invalidRequest,
+             .passwordTooWeak, /// password errors should not occur when signing up code
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned,
+             .unsupportedAuthMethod,
+             .unsupportedChallengeType,
+             .verificationRequired: /// .verificationRequired is not supported by the API team yet. We treat it as an unexpectedError in the validator
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParameters.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthSignUpChallengeRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .signUpChallenge
+    let signUpToken: String
+    let context: MSIDRequestContext
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.signUpToken.rawValue: signUpToken,
+            Key.challengeType.rawValue: config.challengeTypesString
+        ].compactMapValues { $0 }
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParameters.swift
@@ -1,0 +1,48 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthSignUpContinueRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .signUpContinue
+    let grantType: MSALNativeAuthGrantType
+    let signUpToken: String
+    let password: String?
+    let oobCode: String?
+    let attributes: String?
+    let context: MSIDRequestContext
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.grantType.rawValue: grantType.rawValue,
+            Key.signUpToken.rawValue: signUpToken,
+            Key.password.rawValue: password,
+            Key.oobCode.rawValue: oobCode,
+            Key.attributes.rawValue: attributes
+        ].compactMapValues { $0 }
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParameters.swift
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthSignUpStartRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .signUpStart
+    let username: String
+    let password: String?
+    let attributes: String?
+    let context: MSIDRequestContext
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.username.rawValue: username,
+            Key.password.rawValue: password,
+            Key.attributes.rawValue: attributes,
+            Key.challengeType.rawValue: config.challengeTypesString
+        ].compactMapValues { $0 }
+    }
+}

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpChallengeResponse: Decodable {
+    let challengeType: MSALNativeAuthInternalChallengeType?
+    let bindingMethod: String?
+    let interval: Int?
+    let challengeTargetLabel: String?
+    let challengeChannel: MSALNativeAuthInternalChannelType?
+    let signUpToken: String?
+    let codeLength: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case challengeType, bindingMethod, interval, challengeTargetLabel, challengeChannel, codeLength
+        // API returns signup_token not sign_up_token
+        case signUpToken = "signupToken"
+    }
+}

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpContinueResponse: Decodable {
+    let signinSLT: String?
+    let expiresIn: Int?
+    let signupToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case expiresIn, signupToken
+        // API returns signin_slt not sign_in_slt
+        case signinSLT = "signinSlt"
+    }
+}

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpStartResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpStartResponse.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthSignUpStartResponse: Decodable {
+    let signupToken: String?
+    let challengeType: MSALNativeAuthInternalChallengeType?
+}

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -1,0 +1,274 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignUpResponseValidating {
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpStartResponse, Error>, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpStartValidatedResponse
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpChallengeResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpChallengeValidatedResponse
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpContinueResponse, Error>, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpContinueValidatedResponse
+}
+
+final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseValidating {
+
+    // MARK: - Start Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpStartResponse, Error>, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpStartValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleStartSuccess(response, with: context)
+        case .failure(let error):
+            return handleStartFailed(error, with: context)
+        }
+    }
+
+    private func handleStartSuccess(
+        _ response: MSALNativeAuthSignUpStartResponse, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpStartValidatedResponse {
+        if response.challengeType == .redirect {
+            return .redirect
+        } else {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Unexpected response in signup/start. SDK expects only 200 with redirect challenge_type"
+            )
+            return .unexpectedError
+        }
+    }
+
+    private func handleStartFailed(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpStartValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthSignUpStartResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "Error type not expected")
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .verificationRequired:
+            if let signUpToken = apiError.signUpToken, let unverifiedAttributes = apiError.unverifiedAttributes, !unverifiedAttributes.isEmpty {
+                return .verificationRequired(signUpToken: signUpToken, unverifiedAttributes: extractAttributeNames(from: unverifiedAttributes))
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/start for verification_required error")
+                return .unexpectedError
+            }
+        case .attributeValidationFailed:
+            if let invalidAttributes = apiError.invalidAttributes, !invalidAttributes.isEmpty {
+                return .attributeValidationFailed(invalidAttributes: extractAttributeNames(from: invalidAttributes))
+            } else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "Missing expected fields in signup/start for attribute_validation_failed error"
+                )
+                return .unexpectedError
+            }
+        case .invalidRequest where isSignUpStartInvalidRequestParameter(
+            apiError,
+            knownErrorDescription: MSALNativeAuthESTSApiErrorDescriptions.usernameParameterIsEmptyOrNotValid.rawValue):
+            return .invalidUsername(apiError)
+        case .invalidRequest where isSignUpStartInvalidRequestParameter(
+            apiError,
+            knownErrorDescription: MSALNativeAuthESTSApiErrorDescriptions.clientIdParameterIsEmptyOrNotValid.rawValue):
+            return .invalidClientId(apiError)
+        default:
+            return .error(apiError)
+        }
+    }
+
+    // MARK: - Challenge Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpChallengeResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleChallengeSuccess(response, with: context)
+        case .failure(let error):
+            return handleChallengeError(error, with: context)
+        }
+    }
+
+    private func handleChallengeSuccess(
+        _ response: MSALNativeAuthSignUpChallengeResponse,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        guard let challengeTypeIssued = response.challengeType else {
+            MSALLogger.log(level: .error, context: context, format: "Missing ChallengeType from backend in signup/challenge response")
+            return .unexpectedError
+        }
+
+        switch challengeTypeIssued {
+        case .redirect:
+            return .redirect
+        case .oob:
+            if let sentTo = response.challengeTargetLabel,
+               let channelType = response.challengeChannel?.toPublicChannelType(),
+               let codeLength = response.codeLength,
+               let signUpChallengeToken = response.signUpToken {
+                return .codeRequired(sentTo, channelType, codeLength, signUpChallengeToken)
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/challenge with challenge_type = oob")
+                return .unexpectedError
+            }
+        case .password:
+            if let signUpToken = response.signUpToken {
+                return .passwordRequired(signUpToken)
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/challenge with challenge_type = password")
+                return .unexpectedError
+            }
+        case .otp:
+            MSALLogger.log(level: .error, context: context, format: "ChallengeType OTP not expected for signup/challenge")
+            return .unexpectedError
+        }
+    }
+
+    private func handleChallengeError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthSignUpChallengeResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "Error type not expected")
+            return .unexpectedError
+        }
+
+        return .error(apiError)
+    }
+
+    // MARK: - Continue Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpContinueResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        switch result {
+        case .success(let response):
+            // Even if the `signInSLT` is nil, the signUp flow is considered successfully completed
+            return .success(response.signinSLT)
+        case .failure(let error):
+            return handleContinueError(error, with: context)
+        }
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private func handleContinueError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthSignUpContinueResponseError else {
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .invalidOOBValue,
+             .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .invalidUserInput(apiError)
+        case .attributeValidationFailed:
+            if let signUpToken = apiError.signUpToken, let invalidAttributes = apiError.invalidAttributes, !invalidAttributes.isEmpty {
+                return .attributeValidationFailed(signUpToken: signUpToken, invalidAttributes: extractAttributeNames(from: invalidAttributes))
+            } else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "Missing expected fields in signup/continue for attribute_validation_failed error"
+                )
+                return .unexpectedError
+            }
+        case .credentialRequired:
+            if let signUpToken = apiError.signUpToken {
+                return .credentialRequired(signUpToken: signUpToken)
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/continue for credential_required error")
+                return .unexpectedError
+            }
+        case .attributesRequired:
+            if let signUpToken = apiError.signUpToken, let requiredAttributes = apiError.requiredAttributes, !requiredAttributes.isEmpty {
+                return .attributesRequired(signUpToken: signUpToken, requiredAttributes: requiredAttributes.map { $0.toRequiredAttributesPublic() })
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/continue for attributes_required error")
+                return .unexpectedError
+            }
+        // TODO: .verificationRequired is not supported by the API team yet. We treat it as an unexpectedError
+        case .verificationRequired:
+            MSALLogger.log(level: .error, context: context, format: "verificationRequired is not supported yet")
+            return .unexpectedError
+        case .unauthorizedClient,
+             .invalidGrant,
+             .expiredToken,
+             .userAlreadyExists:
+            return .error(apiError)
+        case .invalidRequest:
+            return handleInvalidRequestError(apiError)
+        }
+    }
+
+    private func handleInvalidRequestError(_ error: MSALNativeAuthSignUpContinueResponseError) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        guard let errorCode = error.errorCodes?.first, let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: errorCode) else {
+            return .error(error)
+        }
+        switch knownErrorCode {
+        case .invalidOTP,
+            .incorrectOTP,
+            .OTPNoCacheEntryForUser:
+            return .invalidUserInput(
+                MSALNativeAuthSignUpContinueResponseError(
+                    error: .invalidOOBValue,
+                    errorDescription: error.errorDescription,
+                    errorCodes: error.errorCodes,
+                    errorURI: error.errorURI,
+                    innerErrors: error.innerErrors,
+                    signUpToken: error.signUpToken,
+                    requiredAttributes: error.requiredAttributes,
+                    unverifiedAttributes: error.unverifiedAttributes,
+                    invalidAttributes: error.invalidAttributes))
+        case .userNotFound,
+            .invalidCredentials,
+            .strongAuthRequired,
+            .userNotHaveAPassword,
+            .invalidRequestParameter:
+            return .error(error)
+        }
+    }
+
+    private func isSignUpStartInvalidRequestParameter(_ apiError: MSALNativeAuthSignUpStartResponseError, knownErrorDescription: String) -> Bool {
+        guard let errorCode = apiError.errorCodes?.first,
+              let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: errorCode),
+              let errorDescription = apiError.errorDescription else {
+            return false
+        }
+        return knownErrorCode == .invalidRequestParameter && errorDescription.contains(knownErrorDescription)
+    }
+
+    private func extractAttributeNames(from attributes: [MSALNativeAuthErrorBasicAttributes]) -> [String] {
+        return attributes.map { $0.name }
+    }
+}

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
@@ -1,0 +1,53 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+enum MSALNativeAuthSignUpStartValidatedResponse: Equatable {
+    case verificationRequired(signUpToken: String, unverifiedAttributes: [String])
+    case attributeValidationFailed(invalidAttributes: [String])
+    case redirect
+    case error(MSALNativeAuthSignUpStartResponseError)
+    // TODO: Special errors handled separately. Remove after refactor validated error handling
+    case invalidUsername(MSALNativeAuthSignUpStartResponseError)
+    case invalidClientId(MSALNativeAuthSignUpStartResponseError)
+    case unexpectedError
+}
+
+enum MSALNativeAuthSignUpChallengeValidatedResponse: Equatable {
+    case codeRequired(_ sentTo: String, _ channelType: MSALNativeAuthChannelType, _ codeLength: Int, _ signUpChallengeToken: String)
+    case passwordRequired(_ signUpChallengeToken: String)
+    case redirect
+    case error(MSALNativeAuthSignUpChallengeResponseError)
+    case unexpectedError
+}
+
+enum MSALNativeAuthSignUpContinueValidatedResponse: Equatable {
+    case success(_ signInSLT: String?)
+    /// error that represents invalidOOB or invalidPassword, depending on which State the input comes from.
+    case invalidUserInput(_ error: MSALNativeAuthSignUpContinueResponseError)
+    case credentialRequired(signUpToken: String)
+    case attributesRequired(signUpToken: String, requiredAttributes: [MSALNativeAuthRequiredAttributes])
+    case attributeValidationFailed(signUpToken: String, invalidAttributes: [String])
+    case error(MSALNativeAuthSignUpContinueResponseError)
+    case unexpectedError
+}

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpContinueRequestProviderParams.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpContinueRequestProviderParams.swift
@@ -1,0 +1,50 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthSignUpContinueRequestProviderParams {
+    let grantType: MSALNativeAuthGrantType
+    let signUpToken: String
+    let password: String?
+    let oobCode: String?
+    let attributes: [String: Any]?
+    let context: MSIDRequestContext
+
+    init(
+        grantType: MSALNativeAuthGrantType,
+        signUpToken: String,
+        password: String? = nil,
+        oobCode: String? = nil,
+        attributes: [String: Any]? = nil,
+        context: MSIDRequestContext
+    ) {
+        self.grantType = grantType
+        self.signUpToken = signUpToken
+        self.password = password
+        self.oobCode = oobCode
+        self.attributes = attributes
+        self.context = context
+    }
+}

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
@@ -1,0 +1,99 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignUpRequestProviding {
+    func start(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) throws -> MSIDHttpRequest
+    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest
+    func `continue`(parameters: MSALNativeAuthSignUpContinueRequestProviderParams) throws -> MSIDHttpRequest
+}
+
+final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProviding {
+
+    private let requestConfigurator: MSALNativeAuthRequestConfigurator
+    private let telemetryProvider: MSALNativeAuthTelemetryProviding
+
+    init(requestConfigurator: MSALNativeAuthRequestConfigurator,
+         telemetryProvider: MSALNativeAuthTelemetryProviding) {
+        self.requestConfigurator = requestConfigurator
+        self.telemetryProvider = telemetryProvider
+    }
+
+    func start(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) throws -> MSIDHttpRequest {
+        guard let attributes = try formatAttributes(parameters.attributes) else {
+            throw MSALNativeAuthInternalError.invalidAttributes
+        }
+
+        let params = MSALNativeAuthSignUpStartRequestParameters(
+            username: parameters.username,
+            password: parameters.password,
+            attributes: attributes,
+            context: parameters.context
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signUp(.start(params)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        let params = MSALNativeAuthSignUpChallengeRequestParameters(
+            signUpToken: token,
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signUp(.challenge(params)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    func `continue`(parameters: MSALNativeAuthSignUpContinueRequestProviderParams) throws -> MSIDHttpRequest {
+        let attributesFormatted = try parameters.attributes.map { try formatAttributes($0) } ?? nil
+
+        let params = MSALNativeAuthSignUpContinueRequestParameters(
+            grantType: parameters.grantType,
+            signUpToken: parameters.signUpToken,
+            password: parameters.password,
+            oobCode: parameters.oobCode,
+            attributes: attributesFormatted,
+            context: parameters.context
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signUp(.continue(params)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    private func formatAttributes(_ attributes: [String: Any]) throws -> String? {
+        let data = try JSONSerialization.data(withJSONObject: attributes)
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpStartRequestProviderParameters.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpStartRequestProviderParameters.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+struct MSALNativeAuthSignUpStartRequestProviderParameters {
+    let username: String
+    let password: String?
+    let attributes: [String: Any]
+    let context: MSALNativeAuthRequestContext
+}

--- a/MSAL/src/native_auth/public/state_machine/delegate/SignUpDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/SignUpDelegates.swift
@@ -1,0 +1,155 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public protocol SignUpPasswordStartDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignUpPasswordError(error: SignUpPasswordStartError)
+
+    /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Parameters:
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    ///   - sentTo: The email/phone number that the code was sent to.
+    ///   - channelTargetType: The channel (email/phone) the code was sent through.
+    ///   - codeLength: The length of the code required.
+    @MainActor func onSignUpCodeRequired(newState: SignUpCodeRequiredState,
+                                         sentTo: String,
+                                         channelTargetType: MSALNativeAuthChannelType,
+                                         codeLength: Int)
+
+    /// Notifies the delegate that invalid attributes were sent.
+    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpPasswordError(error)`` will be called.
+    /// - Parameter attributeNames: List of attribute names that failed validation.
+    @MainActor @objc optional func onSignUpAttributesInvalid(attributeNames: [String])
+}
+
+@objc
+public protocol SignUpStartDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignUpError(error: SignUpStartError)
+
+    /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Parameters:
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    ///   - sentTo: The email/phone number that the code was sent to.
+    ///   - channelTargetType: The channel (email/phone) the code was sent through.
+    ///   - codeLength: The length of the code required.
+    @MainActor func onSignUpCodeRequired(newState: SignUpCodeRequiredState,
+                                         sentTo: String,
+                                         channelTargetType: MSALNativeAuthChannelType,
+                                         codeLength: Int)
+
+    /// Notifies the delegate that invalid attributes were sent.
+    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpError(error)`` will be called.
+    /// - Parameter attributeNames: List of attribute names that failed validation.
+    @MainActor @objc optional func onSignUpAttributesInvalid(attributeNames: [String])
+}
+
+@objc
+public protocol SignUpVerifyCodeDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameters:
+    ///   - error: An error object indicating why the operation failed.
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpVerifyCodeError(error: VerifyCodeError, newState: SignUpCodeRequiredState?)
+
+    /// Notifies the delegate that attributes are required from the user to continue.
+    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpVerifyCodeError(error:newState:)`` will be called.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+
+    /// Notifies the delegate that a password is required from the user to continue.
+    /// - Note: If a flow requires a password but this optional method is not implemented, then ``onSignUpVerifyCodeError(error:newState:)`` will be called.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor @objc optional func onSignUpPasswordRequired(newState: SignUpPasswordRequiredState)
+
+    /// Notifies the delegate that the sign up operation completed successfully.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpCompleted(newState: SignInAfterSignUpState)
+}
+
+@objc
+public protocol SignUpResendCodeDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignUpResendCodeError(error: ResendCodeError)
+
+    /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Parameters:
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    ///   - sentTo: The email/phone number that the code was sent to.
+    ///   - channelTargetType: The channel (email/phone) the code was sent through.
+    ///   - codeLength: The length of the code required.
+    @MainActor func onSignUpResendCodeCodeRequired(
+        newState: SignUpCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    )
+}
+
+@objc
+public protocol SignUpPasswordRequiredDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameters:
+    ///   - error: An error object indicating why the operation failed.
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpPasswordRequiredError(error: PasswordRequiredError, newState: SignUpPasswordRequiredState?)
+
+    /// Notifies the delegate that attributes are required from the user to continue.
+    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpPasswordRequiredError(error:newState:)`` will be called.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+
+    /// Notifies the delegate that the sign up operation completed successfully.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpCompleted(newState: SignInAfterSignUpState)
+}
+
+@objc
+public protocol SignUpAttributesRequiredDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onSignUpAttributesRequiredError(error: AttributesRequiredError)
+
+    /// Notifies the delegate that there are some required attributes to be sent.
+    /// - Parameters:
+    ///     - attributes:  List of required attributes.
+    ///     - newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+
+    /// Notifies the delegate that invalid attributes were sent.
+    /// - Parameters:
+    ///     - attributeNames: List of attribute names that failed validation.
+    ///     - newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpAttributesInvalid(attributeNames: [String], newState: SignUpAttributesRequiredState)
+
+    /// Notifies the delegate that the sign up operation completed successfully.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpCompleted(newState: SignInAfterSignUpState)
+}

--- a/MSAL/src/native_auth/public/state_machine/error/SignUpPasswordStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignUpPasswordStartError.swift
@@ -1,0 +1,65 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class SignUpPasswordStartError: MSALNativeAuthError {
+    /// An error type indicating the type of error that occurred
+    @objc public let type: SignUpPasswordStartErrorType
+
+    init(type: SignUpPasswordStartErrorType, message: String? = nil) {
+        self.type = type
+        super.init(message: message)
+    }
+
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        switch type {
+        case .browserRequired:
+            return "Browser required"
+        case .userAlreadyExists:
+            return "User already exists"
+        case .invalidPassword:
+            return "Invalid password"
+        case .invalidUsername:
+            return "Invalid username"
+        case .generalError:
+            return "General error"
+        }
+    }
+
+}
+
+@objc
+public enum SignUpPasswordStartErrorType: Int {
+    case browserRequired
+    case userAlreadyExists
+    case invalidPassword
+    case invalidUsername
+    case generalError
+}

--- a/MSAL/src/native_auth/public/state_machine/error/SignUpStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignUpStartError.swift
@@ -1,0 +1,61 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class SignUpStartError: MSALNativeAuthError {
+    /// An error type indicating the type of error that occurred
+    @objc public let type: SignUpStartErrorType
+
+    init(type: SignUpStartErrorType, message: String? = nil) {
+        self.type = type
+        super.init(message: message)
+    }
+
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        switch type {
+        case .browserRequired:
+            return "Browser required"
+        case .userAlreadyExists:
+            return "User already exists"
+        case .invalidUsername:
+            return "Invalid username"
+        case .generalError:
+            return "General error"
+        }
+    }
+}
+
+@objc
+public enum SignUpStartErrorType: Int {
+    case browserRequired
+    case userAlreadyExists
+    case invalidUsername
+    case generalError
+}

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
@@ -1,0 +1,69 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+extension SignUpCodeRequiredState {
+
+    func resendCodeInternal(correlationId: UUID?) async -> SignUpResendCodeResult {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        return await controller.resendCode(username: username, context: context, signUpToken: flowToken)
+    }
+
+    func submitCodeInternal(code: String, correlationId: UUID?) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        guard inputValidator.isInputValid(code) else {
+            MSALLogger.log(level: .error, context: context, format: "SignUp flow, invalid code")
+            return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
+        }
+
+        return await controller.submitCode(code, username: username, signUpToken: flowToken, context: context)
+    }
+}
+
+extension SignUpPasswordRequiredState {
+
+    func submitPasswordInternal(
+        password: String,
+        correlationId: UUID?
+    ) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        guard inputValidator.isInputValid(password) else {
+            MSALLogger.log(level: .error, context: context, format: "SignUp flow, invalid password")
+            return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
+        }
+
+        return await controller.submitPassword(password, username: username, signUpToken: flowToken, context: context)
+    }
+}
+
+extension SignUpAttributesRequiredState {
+
+    func submitAttributesInternal(attributes: [String: Any], correlationId: UUID?) async -> SignUpAttributesRequiredResult {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        return await controller.submitAttributes(attributes, username: username, signUpToken: flowToken, context: context)
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
@@ -1,0 +1,165 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers
+public class SignUpBaseState: MSALNativeAuthBaseState {
+    let controller: MSALNativeAuthSignUpControlling
+    let username: String
+    let inputValidator: MSALNativeAuthInputValidating
+
+    init(
+        controller: MSALNativeAuthSignUpControlling,
+        username: String,
+        flowToken: String,
+        inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator()
+    ) {
+        self.controller = controller
+        self.username = username
+        self.inputValidator = inputValidator
+        super.init(flowToken: flowToken)
+    }
+}
+
+/// An object of this type is created when a user is required to supply a verification code to continue a sign up flow.
+@objcMembers public class SignUpCodeRequiredState: SignUpBaseState {
+    /// Requests the server to resend the verification code to the user.
+    /// - Parameters:
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func resendCode(delegate: SignUpResendCodeDelegate, correlationId: UUID? = nil) {
+        Task {
+            let result = await resendCodeInternal(correlationId: correlationId)
+
+            switch result {
+            case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
+                await delegate.onSignUpResendCodeCodeRequired(
+                    newState: newState,
+                    sentTo: sentTo,
+                    channelTargetType: channelTargetType,
+                    codeLength: codeLength
+                )
+            case .error(let error):
+                await delegate.onSignUpResendCodeError(error: error)
+            }
+        }
+    }
+
+    /// Submits the code to the server for verification.
+    /// - Parameters:
+    ///   - code: Verification code that the user supplies.
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func submitCode(code: String, delegate: SignUpVerifyCodeDelegate, correlationId: UUID? = nil) {
+        Task {
+            let controllerResponse = await submitCodeInternal(code: code, correlationId: correlationId)
+
+            switch controllerResponse.result {
+            case .completed(let state):
+                await delegate.onSignUpCompleted(newState: state)
+            case .passwordRequired(let state):
+                if let function = delegate.onSignUpPasswordRequired {
+                    controllerResponse.telemetryUpdate?(.success(()))
+                    await function(state)
+                } else {
+                    let error = VerifyCodeError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+                    controllerResponse.telemetryUpdate?(.failure(error))
+                    await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
+                }
+            case .attributesRequired(let attributes, let state):
+                if let function = delegate.onSignUpAttributesRequired {
+                    controllerResponse.telemetryUpdate?(.success(()))
+                    await function(attributes, state)
+                } else {
+                    let error = VerifyCodeError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+                    controllerResponse.telemetryUpdate?(.failure(error))
+                    await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
+                }
+            case .error(let error, let state):
+                await delegate.onSignUpVerifyCodeError(error: error, newState: state)
+            }
+        }
+    }
+}
+
+/// An object of this type is created when a user is required to supply a password to continue a sign up flow.
+@objcMembers public class SignUpPasswordRequiredState: SignUpBaseState {
+
+    /// Submits the password to the server for verification.
+    /// - Parameters:
+    ///   - password: Password that the user supplied.
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func submitPassword(password: String, delegate: SignUpPasswordRequiredDelegate, correlationId: UUID? = nil) {
+        Task {
+            let controllerResponse = await submitPasswordInternal(password: password, correlationId: correlationId)
+
+            switch controllerResponse.result {
+            case .completed(let state):
+                await delegate.onSignUpCompleted(newState: state)
+            case .attributesRequired(let attributes, let state):
+                if let function = delegate.onSignUpAttributesRequired {
+                    controllerResponse.telemetryUpdate?(.success(()))
+                    await function(attributes, state)
+                } else {
+                    let error = PasswordRequiredError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+                    controllerResponse.telemetryUpdate?(.failure(error))
+                    await delegate.onSignUpPasswordRequiredError(error: error, newState: nil)
+                }
+            case .error(let error, let state):
+                await delegate.onSignUpPasswordRequiredError(error: error, newState: state)
+            }
+        }
+    }
+}
+
+/// An object of this type is created when a user is required to supply attributes to continue a sign up flow.
+@objcMembers public class SignUpAttributesRequiredState: SignUpBaseState {
+    /// Submits the attributes to the server for verification.
+    /// - Parameters:
+    ///   - attributes: Dictionary of attributes that the user supplied.
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func submitAttributes(
+        attributes: [String: Any],
+        delegate: SignUpAttributesRequiredDelegate,
+        correlationId: UUID? = nil
+    ) {
+        Task {
+            let result = await submitAttributesInternal(attributes: attributes, correlationId: correlationId)
+
+            switch result {
+            case .completed(let state):
+                await delegate.onSignUpCompleted(newState: state)
+            case .error(let error):
+                await delegate.onSignUpAttributesRequiredError(error: error)
+            case .attributesRequired(let attributes, let state):
+                await delegate.onSignUpAttributesRequired(attributes: attributes, newState: state)
+            case .attributesInvalid(let attributes, let state):
+                await delegate.onSignUpAttributesInvalid(attributeNames: attributes, newState: state)
+            }
+        }
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift
@@ -1,0 +1,445 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+import MSAL
+
+final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuthEndToEndBaseTestCase {
+    private let usernamePassword = ProcessInfo.processInfo.environment["existingPasswordUserEmail"] ?? "<existingPasswordUserEmail not set>"
+    private let password = ProcessInfo.processInfo.environment["existingUserPassword"] ?? "<existingUserPassword not set>"
+    private let attributes = ["age": 40]
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipIf(!usingMockAPI)
+    }
+    
+    // Hero Scenario 2.1.1. Sign up - with Email verification as LAST step (Email & Password)
+    func test_signUpWithPassword_withEmailVerificationLastStep_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: password,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 2.1.2. Sign up - with Email verification as LAST step & Custom Attributes (Email & Password)
+    func test_signUpWithPassword_withEmailVerificationAsLastStepAndCustomAttributes_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: "1234",
+            attributes: attributes,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 2.1.3. Sign up - with Email verification as FIRST step (Email & Password)
+    func test_signUpWithPassword_withEmailVerificationAsFirstStep_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: password,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let credentialRequiredExp = expectation(description: "credential required")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: credentialRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.credentialRequired, endpoint: .signUpContinue)
+            try await mockResponse(.challengeTypePassword, endpoint: .signUpChallenge)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [credentialRequiredExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpPasswordRequiredCalled)
+
+        // Now submit the password...
+
+        let attributesRequiredExp = expectation(description: "attributes required")
+        let signUpPasswordDelegate = SignUpPasswordRequiredDelegateSpy(expectation: attributesRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpVerifyCodeDelegate.passwordRequiredState?.submitPassword(
+            password: "1234",
+            delegate: signUpPasswordDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [attributesRequiredExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpPasswordDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpPasswordDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 2.1.4. Sign up - with Email verification as FIRST step & Custom Attribute (Email & Password)
+    func test_signUpWithPasswordWithEmailVerificationAsFirstStepAndCustomAttributes_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: password,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let submitCodeExp = expectation(description: "submit code, credential required")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: submitCodeExp)
+
+        if usingMockAPI {
+            try await mockResponse(.credentialRequired, endpoint: .signUpContinue)
+            try await mockResponse(.challengeTypePassword, endpoint: .signUpChallenge)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpPasswordRequiredCalled)
+
+        // Now submit the password...
+
+        let passwordRequiredExp = expectation(description: "password required")
+        let signUpPasswordDelegate = SignUpPasswordRequiredDelegateSpy(expectation: passwordRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpVerifyCodeDelegate.passwordRequiredState?.submitPassword(
+            password: "1234",
+            delegate: signUpPasswordDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [passwordRequiredExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpPasswordDelegate.onSignUpAttributesRequiredCalled)
+
+        // Now submit the attributes...
+
+        let attributesRequiredExp = expectation(description: "attributes required, sign-up complete")
+        let signUpAttributesRequiredDelegate = SignUpAttributesRequiredDelegateSpy(expectation: attributesRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpPasswordDelegate.attributesRequiredState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [attributesRequiredExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 2.1.5. Sign up - with Email verification as FIRST step & Custom Attributes over MULTIPLE screens (Email & Password)
+    func test_signUpWithPasswordWithEmailVerificationAsFirstStepAndCustomAttributesOverMultipleScreens_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: password,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let submitCodeExp = expectation(description: "submit code, credential required")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: submitCodeExp)
+
+        if usingMockAPI {
+            try await mockResponse(.credentialRequired, endpoint: .signUpContinue)
+            try await mockResponse(.challengeTypePassword, endpoint: .signUpChallenge)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpPasswordRequiredCalled)
+
+        // Now submit the password...
+
+        let attributesRequiredExp1 = expectation(description: "attributes required 1")
+        let signUpPasswordDelegate = SignUpPasswordRequiredDelegateSpy(expectation: attributesRequiredExp1)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpVerifyCodeDelegate.passwordRequiredState?.submitPassword(
+            password: "1234",
+            delegate: signUpPasswordDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [attributesRequiredExp1], timeout: defaultTimeout)
+        XCTAssertTrue(signUpPasswordDelegate.onSignUpAttributesRequiredCalled)
+
+        // Now submit the attributes...
+
+        let attributesRequiredExp2 = expectation(description: "attributes required 2, sign-up complete")
+        let signUpAttributesRequiredDelegate = SignUpAttributesRequiredDelegateSpy(expectation: attributesRequiredExp2)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpPasswordDelegate.attributesRequiredState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [attributesRequiredExp2], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpAttributesRequiredErrorCalled)
+
+        // Now submit more attributes...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        signUpAttributesRequiredDelegate.expectation = signUpCompleteExp
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpAttributesRequiredDelegate.attributesRequiredState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 2.1.6. Sign up – without automatic sign in (Email & Password)
+    func test_signUpWithPasswordWithoutAutomaticSignIn() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUpUsingPassword(
+            username: usernamePassword,
+            password: password,
+            correlationId: correlationId,
+            delegate: signUpStartDelegate
+        )
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+    }
+
+    private func checkSignUpStartDelegate(_ delegate: SignUpPasswordStartDelegateSpy) {
+        XCTAssertTrue(delegate.onSignUpCodeRequiredCalled)
+        XCTAssertEqual(delegate.channelTargetType, .email)
+        XCTAssertFalse(delegate.sentTo?.isEmpty ?? true)
+        XCTAssertNotNil(delegate.codeLength)
+    }
+
+    private func checkSignInAfterSignUpDelegate(_ delegate: SignInAfterSignUpDelegateSpy) {
+        XCTAssertTrue(delegate.onSignInCompletedCalled)
+        XCTAssertEqual(delegate.result?.account.username, usernamePassword)
+        XCTAssertNotNil(delegate.result?.idToken)
+        XCTAssertNil(delegate.result?.account.accountClaims)
+        XCTAssertEqual(delegate.result?.scopes[0], "openid")
+        XCTAssertEqual(delegate.result?.scopes[1], "offline_access")
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameEndToEndTests.swift
@@ -1,0 +1,313 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+import MSAL
+
+final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBaseTestCase {
+
+    private let usernameOTP = ProcessInfo.processInfo.environment["existingOTPUserEmail"] ?? "<existingOTPUserEmail not set>"
+    private let attributes = ["age": 40]
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipIf(!usingMockAPI)
+    }
+
+    // Hero Scenario 1.1.1. Sign up – with Email Verification (Email & Email OTP)
+    func test_signUpWithCode_withEmailVerification_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUp(username: usernameOTP, correlationId: correlationId, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 1.1.2. Sign up – with Email Verification as LAST step & Custom Attributes (Email & Email OTP)
+    func test_signUpWithCode_withEmailVerificationAsLastStepAndCustomAttributes_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUp(username: usernameOTP, attributes: attributes, correlationId: correlationId, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 1.1.3. Sign up – with Email Verification as FIRST step & Custom Attributes (Email & Email OTP)
+    func test_signUpWithCode_withEmailVerificationAsFirstStepAndCustomAttributes_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUp(username: usernameOTP, attributes: attributes, correlationId: correlationId, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let submitCodeExp = expectation(description: "submit code")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: submitCodeExp)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpAttributesRequiredCalled)
+
+        // Now submit the attributes...
+
+        let attributesExp = expectation(description: "submit attributes, sign-up complete")
+        let signUpAttributesRequiredDelegate = SignUpAttributesRequiredDelegateSpy(expectation: attributesExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpVerifyCodeDelegate.attributesRequiredNewState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [attributesExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 1.1.4. Sign up – with Email Verification as FIRST step & Custom Attributes over MULTIPLE screens (Email & Email OTP)
+    func test_signUpWithCode_withEmailVerificationAsLastStepAndCustomAttributesOverMultipleScreens_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUp(username: usernameOTP, attributes: attributes, correlationId: correlationId, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let submitCodeExp = expectation(description: "submit code")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: submitCodeExp)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpAttributesRequiredCalled)
+
+        // Now submit the attributes...
+
+        let submitAttributesExp1 = expectation(description: "submit attributes 1")
+        let signUpAttributesRequiredDelegate = SignUpAttributesRequiredDelegateSpy(expectation: submitAttributesExp1)
+
+        if usingMockAPI {
+            try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
+        }
+
+        signUpVerifyCodeDelegate.attributesRequiredNewState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [submitAttributesExp1], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpAttributesRequiredErrorCalled)
+
+        // Now submit more attributes...
+
+        let submitAttributesExp2 = expectation(description: "submit attributes 2, sign-up complete")
+        signUpAttributesRequiredDelegate.expectation = submitAttributesExp2
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpAttributesRequiredDelegate.attributesRequiredState?.submitAttributes(
+            attributes: attributes,
+            delegate: signUpAttributesRequiredDelegate,
+            correlationId: correlationId
+        )
+
+        await fulfillment(of: [submitAttributesExp2], timeout: defaultTimeout)
+        XCTAssertTrue(signUpAttributesRequiredDelegate.onSignUpCompletedCalled)
+
+        // Now sign in...
+
+        let signInExp = expectation(description: "sign-in after sign-up")
+        let signInAfterSignUpDelegate = SignInAfterSignUpDelegateSpy(expectation: signInExp)
+
+        if usingMockAPI {
+            try await mockResponse(.tokenSuccess, endpoint: .signInToken)
+        }
+
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+
+        await fulfillment(of: [signInExp], timeout: defaultTimeout)
+        checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
+    }
+
+    // Hero Scenario 1.1.5. Sign up – without automatic sign in (Email & Email OTP)
+    func test_signUpWithoutAutomaticSignIn() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.verificationRequired, endpoint: .signUpStart)
+            try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        }
+
+        sut.signUp(username: usernameOTP, correlationId: correlationId, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        // Now submit the code...
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        if usingMockAPI {
+            try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
+        }
+
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate, correlationId: correlationId)
+
+        await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
+        XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
+    }
+
+    private func checkSignUpStartDelegate(_ delegate: SignUpStartDelegateSpy) {
+        XCTAssertTrue(delegate.onSignUpCodeRequiredCalled)
+        XCTAssertEqual(delegate.channelTargetType, .email)
+        XCTAssertFalse(delegate.sentTo?.isEmpty ?? true)
+        XCTAssertNotNil(delegate.codeLength)
+    }
+
+    private func checkSignInAfterSignUpDelegate(_ delegate: SignInAfterSignUpDelegateSpy) {
+        XCTAssertTrue(delegate.onSignInCompletedCalled)
+        XCTAssertEqual(delegate.result?.account.username, usernameOTP)
+        XCTAssertNotNil(delegate.result?.idToken)
+        XCTAssertNil(delegate.result?.account.accountClaims)
+        XCTAssertEqual(delegate.result?.scopes[0], "openid")
+        XCTAssertEqual(delegate.result?.scopes[1], "offline_access")
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/SignUpDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/SignUpDelegateSpies.swift
@@ -1,0 +1,267 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import XCTest
+import MSAL
+
+class SignUpPasswordStartDelegateSpy: SignUpPasswordStartDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignUpPasswordErrorCalled = false
+    private(set) var error: MSAL.SignUpPasswordStartError?
+    private(set) var onSignUpCodeRequiredCalled = false
+    private(set) var newState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordError(error: SignUpPasswordStartError) {
+        onSignUpPasswordErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    func onSignUpCodeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        expectation.fulfill()
+    }
+}
+
+class SignUpStartDelegateSpy: SignUpStartDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignUpErrorCalled = false
+    private(set) var error: MSAL.SignUpStartError?
+    private(set) var onSignUpCodeRequiredCalled = false
+    private(set) var newState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpError(error: SignUpStartError) {
+        onSignUpErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    func onSignUpCodeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        expectation.fulfill()
+    }
+}
+
+class SignUpVerifyCodeDelegateSpy: SignUpVerifyCodeDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignUpVerifyCodeErrorCalled = false
+    private(set) var error: VerifyCodeError?
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var attributesRequiredNewState: SignUpAttributesRequiredState?
+    private(set) var onSignUpPasswordRequiredCalled = false
+    private(set) var passwordRequiredState: SignUpPasswordRequiredState?
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var signInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpVerifyCodeError(error: VerifyCodeError, newState: SignUpCodeRequiredState?) {
+        onSignUpVerifyCodeErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredCalled = true
+        attributesRequiredNewState = newState
+
+        expectation.fulfill()
+    }
+
+    func onSignUpPasswordRequired(newState: SignUpPasswordRequiredState) {
+        onSignUpPasswordRequiredCalled = true
+        passwordRequiredState = newState
+
+        expectation.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        signInAfterSignUpState = newState
+
+        expectation.fulfill()
+    }
+}
+
+class SignUpResendCodeDelegateSpy: SignUpResendCodeDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignUpResendCodeErrorCalled = false
+    private(set) var error: ResendCodeError?
+    private(set) var onSignUpResendCodeCodeRequiredCalled = false
+    private(set) var signUpCodeRequiredState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpResendCodeError(error: ResendCodeError) {
+        onSignUpResendCodeErrorCalled = true
+        self.error = error
+    }
+
+    func onSignUpResendCodeCodeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpResendCodeCodeRequiredCalled = true
+        signUpCodeRequiredState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        expectation.fulfill()
+    }
+}
+
+class SignUpPasswordRequiredDelegateSpy: SignUpPasswordRequiredDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignUpPasswordRequiredErrorCalled = false
+    private(set) var error: PasswordRequiredError?
+    private(set) var passwordRequiredState: SignUpPasswordRequiredState?
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var attributesRequiredState: SignUpAttributesRequiredState?
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var signInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordRequiredError(error: PasswordRequiredError, newState: SignUpPasswordRequiredState?) {
+        onSignUpPasswordRequiredErrorCalled = true
+        self.error = error
+        passwordRequiredState = newState
+
+        expectation.fulfill()
+    }
+
+    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredCalled = true
+        attributesRequiredState = newState
+
+        expectation.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        signInAfterSignUpState = newState
+
+        expectation.fulfill()
+    }
+}
+
+class SignUpAttributesRequiredDelegateSpy: SignUpAttributesRequiredDelegate {
+    var expectation: XCTestExpectation
+    private(set) var onSignUpAttributesRequiredErrorCalled = false
+    private(set) var error: AttributesRequiredError?
+    private(set) var attributesRequiredState: SignUpAttributesRequiredState?
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var signInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpAttributesRequiredError(error: AttributesRequiredError) {
+        onSignUpAttributesRequiredErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        signInAfterSignUpState = newState
+
+        expectation.fulfill()
+    }
+    
+    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredErrorCalled = true
+        attributesRequiredState = newState
+        expectation.fulfill()
+    }
+    
+    func onSignUpAttributesInvalid(attributeNames: [String], newState: MSAL.SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredErrorCalled = true
+        attributesRequiredState = newState
+        expectation.fulfill()
+    }
+}
+
+class SignInAfterSignUpDelegateSpy: SignInAfterSignUpDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignInAfterSignUpErrorCalled = false
+    private(set) var error: SignInAfterSignUpError?
+    private(set) var onSignInCompletedCalled = false
+    private(set) var result: MSALNativeAuthUserAccountResult?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignInAfterSignUpError(error: SignInAfterSignUpError) {
+        onSignInAfterSignUpErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    func onSignInCompleted(result: MSALNativeAuthUserAccountResult) {
+        onSignInCompletedCalled = true
+        self.result = result
+
+        expectation.fulfill()
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpChallengeIntegrationTests.swift
@@ -1,0 +1,112 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpChallengeIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+
+    private var provider: MSALNativeAuthSignUpRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        provider = MSALNativeAuthSignUpRequestProvider(
+            requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+            telemetryProvider: MSALNativeAuthTelemetryProvider()
+        )
+
+        sut = try provider.challenge(
+            token: "<token>",
+            context: MSALNativeAuthRequestContext(correlationId: correlationId)
+        )
+    }
+
+    func test_whenSignUpChallengePassword_succeeds() async throws {
+        try await mockResponse(.challengeTypePassword, endpoint: .signUpChallenge)
+        let response: MSALNativeAuthSignUpChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertEqual(response?.challengeType, .password)
+        XCTAssertNotNil(response?.signUpToken)
+    }
+
+    func test_whenSignUpChallengeOOB_succeeds() async throws {
+        try await mockResponse(.challengeTypeOOB, endpoint: .signUpChallenge)
+        let response: MSALNativeAuthSignUpChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertEqual(response?.challengeType, .oob)
+        XCTAssertNotNil(response?.signUpToken)
+        XCTAssertNotNil(response?.bindingMethod)
+        XCTAssertNotNil(response?.challengeTargetLabel)
+        XCTAssertNotNil(response?.codeLength)
+        XCTAssertNotNil(response?.interval)
+    }
+
+    func test_whenSignUpChallenge_redirects() async throws {
+        try await mockResponse(.challengeTypeRedirect, endpoint: .signUpChallenge)
+        let response: MSALNativeAuthSignUpChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertEqual(response?.challengeType, .redirect)
+        XCTAssertNil(response?.signUpToken)
+    }
+
+    func test_signUpChallenge_unauthorizedClient() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signUpChallenge,
+            response: .invalidClient,
+            expectedError: createError(.unauthorizedClient)
+        )
+    }
+
+    func test_signUpChallenge_expiredToken() async throws {
+        try await perform_testFail(
+            endpoint: .signUpChallenge,
+            response: .expiredToken,
+            expectedError: createError(.expiredToken)
+        )
+    }
+
+    func test_signUpChallenge_unsupportedChallengeType() async throws {
+        try await perform_testFail(
+            endpoint: .signUpChallenge,
+            response: .unsupportedChallengeType,
+            expectedError: createError(.unsupportedChallengeType)
+        )
+    }
+
+    func test_signUpChallenge_invalidSignUpToken() async throws {
+        try await perform_testFail(
+            endpoint: .signUpChallenge,
+            response: .invalidSignUpToken,
+            expectedError: createError(.invalidRequest)
+        )
+    }
+
+    private func createError(_ error: MSALNativeAuthSignUpChallengeOauth2ErrorCode) -> MSALNativeAuthSignUpChallengeResponseError {
+        .init(error: error, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpContinueIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpContinueIntegrationTests.swift
@@ -1,0 +1,241 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+
+    private var provider: MSALNativeAuthSignUpRequestProvider!
+    private var context: MSIDRequestContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        provider = MSALNativeAuthSignUpRequestProvider(
+            requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+            telemetryProvider: MSALNativeAuthTelemetryProvider()
+        )
+
+        context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: "<token>",
+            password: "12345",
+            context: context
+        )
+
+        sut = try provider.continue(parameters: params)
+    }
+
+    func test_signUpContinue_withPassword_succeeds() async throws {
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: "<token>",
+            password: "12345",
+            context: context
+        )
+
+        try await performSuccessfulTestCase(with: params)
+    }
+
+    func test_signUpContinue_withOOB_succeeds() async throws {
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .oobCode,
+            signUpToken: "<token>",
+            oobCode: "1234",
+            context: context
+        )
+
+        try await performSuccessfulTestCase(with: params)
+    }
+
+    func test_signUpContinue_withAttributes_succeeds() async throws {
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .attributes,
+            signUpToken: "<token>",
+            attributes: ["key": "value"],
+            context: context
+        )
+
+        try await performSuccessfulTestCase(with: params)
+    }
+
+    func test_signUpContinue_unauthorizedClient() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .invalidClient,
+            expectedError: createError(.unauthorizedClient)
+        )
+    }
+
+    func test_signUpContinue_invalidGrant() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .invalidGrant,
+            expectedError: createError(.invalidGrant)
+        )
+    }
+
+    func test_signUpContinue_invalidSignUpToken() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .invalidSignUpToken,
+            expectedError: createError(.invalidRequest)
+        )
+    }
+
+    func test_signUpContinue_expiredToken() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .expiredToken,
+            expectedError: createError(.expiredToken)
+        )
+    }
+
+    func test_signUpContinue_explicitInvalidOOBValue() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .explicitInvalidOOBValue,
+            expectedError: createError(.invalidOOBValue)
+        )
+    }
+
+    func test_signUpContinue_passwordTooWeak() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .passwordTooWeak,
+            expectedError: createError(.passwordTooWeak)
+        )
+    }
+
+    func test_signUpContinue_passwordTooShort() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .passwordTooShort,
+            expectedError: createError(.passwordTooShort)
+        )
+    }
+
+    func test_signUpContinue_passwordTooLong() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .passwordTooLong,
+            expectedError: createError(.passwordTooLong)
+        )
+    }
+
+    func test_signUpContinue_passwordRecentlyUsed() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .passwordRecentlyUsed,
+            expectedError: createError(.passwordRecentlyUsed)
+        )
+    }
+
+    func test_signUpContinue_passwordBanned() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .passwordBanned,
+            expectedError: createError(.passwordBanned)
+        )
+    }
+
+    func test_signUpContinue_userAlreadyExists() async throws {
+        try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .userAlreadyExists,
+            expectedError: createError(.userAlreadyExists)
+        )
+    }
+
+    func test_signUpContinue_attributesRequired() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .attributesRequired,
+            expectedError: createError(.attributesRequired)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+    }
+
+    func test_signUpContinue_verificationRequired() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .verificationRequired,
+            expectedError: createError(.verificationRequired)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+        XCTAssertNotNil(response.unverifiedAttributes)
+    }
+
+    func test_signUpContinue_validationFailed() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .attributeValidationFailed,
+            expectedError: createError(.attributeValidationFailed)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+    }
+
+    func test_signUpContinue_credentialRequired() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpContinue,
+            response: .credentialRequired,
+            expectedError: createError(.credentialRequired)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+    }
+
+    func performSuccessfulTestCase(with params: MSALNativeAuthSignUpContinueRequestProviderParams) async throws {
+        try await mockAPIHandler.addResponse(endpoint: .signUpContinue, correlationId: correlationId, responses: [])
+        sut = try provider.continue(parameters: params)
+
+        let response: MSALNativeAuthSignUpContinueResponse? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?.signinSLT)
+        XCTAssertNil(response?.signupToken)
+    }
+
+    private func createError(_ error: MSALNativeAuthSignUpContinueOauth2ErrorCode) -> MSALNativeAuthSignUpContinueResponseError {
+        .init(
+            error: error,
+            errorDescription: nil,
+            errorCodes: nil,
+            errorURI: nil,
+            innerErrors: nil,
+            signUpToken: nil,
+            requiredAttributes: nil,
+            unverifiedAttributes: nil,
+            invalidAttributes: nil
+        )
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpStartIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpStartIntegrationTests.swift
@@ -1,0 +1,188 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpStartIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+
+    private var provider: MSALNativeAuthSignUpRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        provider = MSALNativeAuthSignUpRequestProvider(
+            requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+            telemetryProvider: MSALNativeAuthTelemetryProvider()
+        )
+
+        sut = try provider.start(
+            parameters: MSALNativeAuthSignUpStartRequestProviderParameters(
+                username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+                password: "1234",
+                attributes: [:],
+                context: MSALNativeAuthRequestContext(correlationId: correlationId)
+            )
+        )
+    }
+
+    func test_whenSignUpStart_redirects() async throws {
+        try await mockResponse(.challengeTypeRedirect, endpoint: .signUpStart)
+        let response: MSALNativeAuthSignUpStartResponse? = try await performTestSucceed()
+
+        XCTAssertNil(response?.signupToken)
+        XCTAssertEqual(response?.challengeType, .redirect)
+    }
+
+    func test_signUpStart_unauthorizedClient() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .invalidClient,
+            expectedError: createError(.unauthorizedClient)
+        )
+    }
+
+    func test_signUpStart_unsupportedChallengeType() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .unsupportedChallengeType,
+            expectedError: createError(.unsupportedChallengeType)
+        )
+    }
+
+    func test_signUpStart_passwordTooWeak() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .passwordTooWeak,
+            expectedError: createError(.passwordTooWeak)
+        )
+    }
+
+    func test_signUpStart_passwordTooShort() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .passwordTooShort,
+            expectedError: createError(.passwordTooShort)
+        )
+    }
+
+    func test_signUpStart_passwordTooLong() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .passwordTooLong,
+            expectedError: createError(.passwordTooLong)
+        )
+    }
+
+    func test_signUpStart_passwordRecentlyUsed() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .passwordRecentlyUsed,
+            expectedError: createError(.passwordRecentlyUsed)
+        )
+    }
+
+    func test_signUpStart_passwordBanned() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .passwordBanned,
+            expectedError: createError(.passwordBanned)
+        )
+    }
+
+    func test_signUpStart_userAlreadyExists() async throws {
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .userAlreadyExists,
+            expectedError: createError(.userAlreadyExists)
+        )
+    }
+
+    func test_signUpStart_attributesRequired() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .attributesRequired,
+            expectedError: createError(.attributesRequired)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+    }
+
+    func test_signUpStart_verificationRequired() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .verificationRequired,
+            expectedError: createError(.verificationRequired)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+        XCTAssertNotNil(response.unverifiedAttributes)
+    }
+
+    func test_signUpStart_validationFailed() async throws {
+        let response = try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .attributeValidationFailed,
+            expectedError: createError(.attributeValidationFailed)
+        )
+
+        XCTAssertNotNil(response.signUpToken)
+    }
+
+    func test_signUpStart_unsupportedAuthMethod() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .unsupportedAuthMethod,
+            expectedError: createError(.unsupportedAuthMethod)
+        )
+    }
+
+    func test_signUpStart_invalidRequest_withESTSErrorInvalidEmail() async throws {
+        throw XCTSkip()
+        
+        try await perform_testFail(
+            endpoint: .signUpStart,
+            response: .invalidUsername,
+            expectedError: createError(.invalidRequest, errorCodes: [90100])
+        )
+    }
+
+    private func createError(_ error: MSALNativeAuthSignUpStartOauth2ErrorCode, errorCodes: [Int]? = nil) -> MSALNativeAuthSignUpStartResponseError {
+        .init(
+            error: error,
+            errorDescription: nil,
+            errorCodes: nil,
+            errorURI: nil,
+            innerErrors: nil,
+            signUpToken: nil,
+            unverifiedAttributes: nil,
+            invalidAttributes: nil
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
@@ -1,0 +1,1948 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthSignUpController!
+    private var contextMock: MSALNativeAuthRequestContext!
+    private var requestProviderMock: MSALNativeAuthSignUpRequestProviderMock!
+    private var validatorMock: MSALNativeAuthSignUpResponseValidatorMock!
+    private var signInControllerMock: MSALNativeAuthSignInControllerMock!
+
+    private var signUpStartPasswordParams: MSALNativeAuthSignUpStartRequestProviderParameters {
+        .init(
+            username: "user@contoso.com",
+            password: "password",
+            attributes: ["key": "value"],
+            context: contextMock
+        )
+    }
+
+    private var signUpStartCodeParams: MSALNativeAuthSignUpStartRequestProviderParameters {
+        .init(
+            username: "user@contoso.com",
+            password: nil,
+            attributes: ["key": "value"],
+            context: contextMock
+        )
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        contextMock = .init(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        requestProviderMock = .init()
+        validatorMock = .init()
+        signInControllerMock = .init()
+
+        sut = MSALNativeAuthSignUpController(
+            config: MSALNativeAuthConfigStubs.configuration,
+            requestProvider: requestProviderMock,
+            responseValidator: validatorMock,
+            signInController: signInControllerMock
+        )
+    }
+
+    // MARK: - SignUpPasswordStart (/start request) tests
+
+    func test_whenSignUpStartPassword_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returnsVerificationRequired_it_returnsChallenge() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let helper = prepareSignUpPasswordStartValidatorHelper()
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returnsAttributeValidationFailed_it_returnsChallenge() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_telemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        let error : MSALNativeAuthSignUpStartValidatedResponse = .error(
+            MSALNativeAuthSignUpStartResponseError(error: .passwordTooLong,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(error)
+        
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+        
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+        
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .invalidPassword)
+        
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returns_invalidUsername_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        let invalidUsername : MSALNativeAuthSignUpStartValidatedResponse = .invalidUsername(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidUsername)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .invalidUsername)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+    
+    func test_whenSignUpStartPassword_returns_invalidClientId_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        let invalidClientId : MSALNativeAuthSignUpStartValidatedResponse = .invalidClientId(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidClientId)
+        
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+        
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartPassword_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    // MARK: - SignUpPasswordStart (/challenge request) tests
+
+    func test_whenSignUpStartPassword_challenge_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_challenge_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpCodeRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: true)
+    }
+
+    func test_whenSignUpStartPassword_challenge_returns_passwordRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired(""))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_challenge_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_challenge_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
+                                                       errorDescription: "Expired Token",
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertEqual(helper.error?.errorDescription, "Expired Token")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartPassword_challenge_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    // MARK: - SignUpCodeStart (/start request) tests
+
+    func test_whenSignUpStartCode_cantCreateRequest_returns_it_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returnsVerificationRequired_it_returnsChallenge() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let helper = prepareSignUpCodeStartValidatorHelper()
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returnsAttributeValidationFailed_it_returnsCorrectError() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        result.telemetryUpdate?(.success(()))
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_telemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        let error : MSALNativeAuthSignUpStartValidatedResponse = .error(
+            MSALNativeAuthSignUpStartResponseError(error: .userAlreadyExists,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .userAlreadyExists)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returns_invalidUsername_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        let invalidUsername : MSALNativeAuthSignUpStartValidatedResponse = .invalidUsername(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidUsername)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .invalidUsername)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+    
+    func test_whenSignUpStartCode_returns_invalidClientId_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        let invalidClientId : MSALNativeAuthSignUpStartValidatedResponse = .invalidClientId(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidClientId)
+        
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+        
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartCode_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    // MARK: - SignUpCodeStart (/challenge request) tests
+
+    func test_whenSignUpStartCode_challenge_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_challenge_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken 1", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 1")
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpCodeRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: true)
+    }
+
+    func test_whenSignUpStartCode_challenge_succeedsPassword_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired(""))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_challenge_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_challenge_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
+                                                       errorDescription: "Expired Token",
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertEqual(helper.error?.errorDescription, "Expired Token")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartCode_challenge_it_returns_unexpectedError_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    // MARK: - ResendCode tests
+
+    func test_whenSignUpResendCode_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeCodeRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpResendCode_succeedsPassword_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 1"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken 2")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .invalidRequest,
+                                                       errorDescription: nil,
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitCode tests
+
+    func test_whenSignUpSubmitCode_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSubmitCode_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.success(""))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitCode_returns_invalidUserInput_it_returnsInvalidCode() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .invalidUserInput(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidOOBValue,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertEqual(helper.newCodeRequiredState?.flowToken, "signUpToken")
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .invalidCode)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_attributesRequired_it_returnsAttributesRequired() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken", requiredAttributes: []))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken")
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitCode_returns_attributesRequired_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken", requiredAttributes: []))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken")
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_attributeValidationFailed_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["name"]))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+        
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .error(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidRequest,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitCode + credential_required error tests
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andCantCreateRequest() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andSucceeds() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 3"))
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpPasswordRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken 3")
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 3"))
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpPasswordRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken 3")
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andSucceedOOB_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("", .email, 4, "signUpToken 3"))
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andRedirects() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andReturnsError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
+                                                       errorDescription: nil,
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andReturnsUnexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitPassword tests
+
+    func test_whenSignUpSubmitPassword_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.success("signInSLT"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_invalidUserInput_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .invalidUserInput(
+            MSALNativeAuthSignUpContinueResponseError(error: .passwordTooWeak,
+                                                      errorDescription: "Password too weak",
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken")
+        XCTAssertEqual(helper.error?.type, .invalidPassword)
+        XCTAssertEqual(helper.error?.errorDescription, "Password too weak")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_attributesRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken 2")
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_attributesRequired_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken 2")
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .error(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidRequest,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_credentialRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_attributeValidationFailed_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["key"]))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    // MARK: - SubmitAttributes tests
+
+    func test_whenSignUpSubmitAttributes_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSubmitAttributes_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.success(""))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_invalidUserInput_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .invalidUserInput(
+            MSALNativeAuthSignUpContinueResponseError(error: .attributeValidationFailed,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .error(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidRequest,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_attributesRequired_it_returnsAttributesRequiredError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_credentialRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_attributeValidationFailed_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["attribute"]))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesValidationFailed(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpInvalidAttributesCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.invalidAttributes, ["attribute"])
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    // MARK: - Sign-in with SLT
+
+    func test_whenSignUpSucceeds_and_userCallsSignInWithSLT_signUpControllerPassesCorrectParams() async {
+        let username = "username"
+        let slt = "signInSLT"
+
+        class SignInAfterSignUpDelegateStub: SignInAfterSignUpDelegate {
+            func onSignInAfterSignUpError(error: MSAL.SignInAfterSignUpError) {}
+            func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {}
+        }
+
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.success(slt))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: username, signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: true)
+
+        let exp2 = expectation(description: "SignInAfterSignUp expectation")
+        signInControllerMock.expectation = exp2
+        signInControllerMock.signInSLTResult = .failure(.init())
+        helper.signInAfterSignUpState?.signIn(delegate: SignInAfterSignUpDelegateStub())
+        await fulfillment(of: [exp2], timeout: 1)
+
+        XCTAssertEqual(signInControllerMock.username, username)
+        XCTAssertEqual(signInControllerMock.slt, slt)
+    }
+
+    // MARK: - Common Methods
+
+    private func checkTelemetryEventResult(id: MSALNativeAuthTelemetryApiId, isSuccessful: Bool) {
+        XCTAssertEqual(receivedEvents.count, 1)
+
+        guard let telemetryEventDict = receivedEvents.first else {
+            return XCTFail("Telemetry test fail")
+        }
+
+        let expectedApiId = String(id.rawValue)
+        XCTAssertEqual(telemetryEventDict["api_id"] as? String, expectedApiId)
+        XCTAssertEqual(telemetryEventDict["event_name"] as? String, "api_event" )
+        XCTAssertEqual(telemetryEventDict["correlation_id" ] as? String, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(telemetryEventDict["is_successfull"] as? String, isSuccessful ? "yes" : "no")
+        XCTAssertEqual(telemetryEventDict["status"] as? String, isSuccessful ? "succeeded" : "failed")
+        XCTAssertNotNil(telemetryEventDict["start_time"])
+        XCTAssertNotNil(telemetryEventDict["stop_time"])
+        XCTAssertNotNil(telemetryEventDict["response_time"])
+    }
+
+    private func prepareSignUpPasswordStartValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpPasswordStartTestsValidatorHelper {
+        let helper = SignUpPasswordStartTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpPasswordErrorCalled)
+        XCTAssertFalse(helper.onSignUpCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpCodeStartValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpCodeStartTestsValidatorHelper {
+        let helper = SignUpCodeStartTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCodeErrorCalled)
+        XCTAssertFalse(helper.onSignUpCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpResendCodeValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpResendCodeTestsValidatorHelper {
+        let helper = SignUpResendCodeTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertFalse(helper.onSignUpResendCodeCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpSubmitCodeValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpVerifyCodeTestsValidatorHelper {
+        let helper = SignUpVerifyCodeTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCompletedCalled)
+        XCTAssertFalse(helper.onSignUpPasswordRequiredCalled)
+        XCTAssertFalse(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertFalse(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpSubmitPasswordValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpPasswordRequiredTestsValidatorHelper {
+        let helper = SignUpPasswordRequiredTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCompletedCalled)
+        XCTAssertFalse(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertFalse(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpSubmitAttributesValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpAttributesRequiredTestsValidatorHelper {
+        let helper = SignUpAttributesRequiredTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCompletedCalled)
+        XCTAssertFalse(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareMockRequest() -> MSIDHttpRequest {
+        let request = MSIDHttpRequest()
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        return request
+    }
+
+    private func expectedChallengeParams(token: String = "signUpToken") -> (token: String, context: MSIDRequestContext) {
+        return (token: token, context: contextMock)
+    }
+
+    private func expectedContinueParams(
+        grantType: MSALNativeAuthGrantType = .oobCode,
+        token: String = "signUpToken",
+        password: String? = nil,
+        oobCode: String? = "1234",
+        attributes: [String: Any]? = nil
+    ) -> MSALNativeAuthSignUpContinueRequestProviderParams {
+        .init(
+            grantType: grantType,
+            signUpToken: token,
+            password: password,
+            oobCode: oobCode,
+            attributes: attributes,
+            context: contextMock
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
@@ -1,0 +1,61 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignUpControllerMock: MSALNativeAuthSignUpControlling {
+
+    var startPasswordResult: MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse!
+    var startResult: MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse!
+    var resendCodeResult: SignUpResendCodeResult!
+    var submitCodeResult: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse!
+    var submitPasswordResult: MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse!
+    var submitAttributesResult: SignUpAttributesRequiredResult!
+
+    func signUpStartPassword(parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters) async -> MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse {
+        return startPasswordResult
+    }
+
+    func signUpStartCode(parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters) async -> MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse {
+        return startResult
+    }
+
+    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeResult {
+        return resendCodeResult
+    }
+
+    func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
+        return submitCodeResult
+    }
+
+    func submitPassword(_ password: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
+        return submitPasswordResult
+    }
+
+    func submitAttributes(_ attributes: [String : Any], username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpAttributesRequiredResult {
+        return submitAttributesResult
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
@@ -1,0 +1,107 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
+    private let expectation: XCTestExpectation
+    private(set) var context: MSIDRequestContext?
+    private(set) var signUpStartPasswordCalled = false
+    private(set) var signUpStartCalled = false
+    private(set) var resendCodeCalled = false
+    private(set) var submitCodeCalled = false
+    private(set) var submitPasswordCalled = false
+    private(set) var submitAttributesCalled = false
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func signUpStartPassword(
+        parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters
+    ) async -> MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse {
+        self.context = parameters.context
+        signUpStartPasswordCalled = true
+        expectation.fulfill()
+        return .init(.error(.init(type: .generalError)))
+    }
+
+    func signUpStartCode(
+        parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters
+    ) async -> MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse {
+        self.context = parameters.context
+        signUpStartCalled = true
+        expectation.fulfill()
+        return .init(.error(.init(type: .generalError)))
+    }
+
+    func resendCode(
+        username: String,
+        context: MSIDRequestContext,
+        signUpToken: String
+    ) async -> SignUpResendCodeResult {
+        self.context = context
+        resendCodeCalled = true
+        expectation.fulfill()
+        return .error(.init())
+    }
+
+    func submitCode(
+        _ code: String,
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
+        self.context = context
+        submitCodeCalled = true
+        expectation.fulfill()
+        return .init(.error(error: .init(type: .generalError), newState: nil))
+    }
+
+    func submitPassword(
+        _ password: String,
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
+        self.context = context
+        submitPasswordCalled = true
+        expectation.fulfill()
+        return .init(.error(error: .init(type: .generalError), newState: nil))
+    }
+
+    func submitAttributes(
+        _ attributes: [String: Any],
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpAttributesRequiredResult {
+        self.context = context
+        submitAttributesCalled = true
+        expectation.fulfill()
+        return .error(error: .init())
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
@@ -1,0 +1,117 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignUpRequestProviderMock: MSALNativeAuthSignUpRequestProviding {
+    private var requestStart: MSIDHttpRequest?
+    private var requestChallenge: MSIDHttpRequest?
+    private var requestContinue: MSIDHttpRequest?
+    private var throwErrorStart = false
+    private var throwErrorChallenge = false
+    private var throwErrorContinue = false
+    private(set) var startCalled = false
+    private(set) var challengeCalled = false
+    private(set) var continueCalled = false
+    var expectedStartRequestParameters: MSALNativeAuthSignUpStartRequestProviderParameters!
+    var expectedChallengeRequestParameters: (token: String, context: MSIDRequestContext)!
+    var expectedContinueRequestParameters: MSALNativeAuthSignUpContinueRequestProviderParams!
+
+    func mockStartRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {
+        self.requestStart = request
+        self.throwErrorStart = throwError
+    }
+
+    func start(parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters) throws -> MSIDHttpRequest {
+        startCalled = true
+        checkStartParameters(params: parameters)
+        
+        if let request = requestStart {
+            return request
+        } else if throwErrorStart {
+            throw ErrorMock.error
+        } else {
+            fatalError("Make sure to use mockStartRequestFunc()")
+        }
+    }
+
+    private func checkStartParameters(params: MSALNativeAuthSignUpStartRequestProviderParameters) {
+        XCTAssertEqual(params.username, expectedStartRequestParameters.username)
+        XCTAssertEqual(params.password, expectedStartRequestParameters.password)
+        XCTAssertEqual(params.context.correlationId(), expectedStartRequestParameters.context.correlationId())
+        XCTAssertEqual(params.attributes["key"] as? String, expectedStartRequestParameters.attributes["key"] as? String)
+    }
+
+    func mockChallengeRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {
+        self.requestChallenge = request
+        self.throwErrorChallenge = throwError
+    }
+
+    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        challengeCalled = true
+        checkChallengeParameters(token: token, context: context)
+
+        if let request = requestChallenge {
+            return request
+        } else if throwErrorChallenge {
+            throw ErrorMock.error
+        } else {
+            fatalError("Make sure to use mockChallengeRequestFunc()")
+        }
+    }
+
+    private func checkChallengeParameters(token: String, context: MSIDRequestContext) {
+        XCTAssertEqual(token, expectedChallengeRequestParameters.token)
+        XCTAssertEqual(context.correlationId(), expectedChallengeRequestParameters.context.correlationId())
+    }
+
+    func mockContinueRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {
+        self.requestContinue = request
+        self.throwErrorContinue = throwError
+    }
+
+    func `continue`(parameters: MSAL.MSALNativeAuthSignUpContinueRequestProviderParams) throws -> MSIDHttpRequest {
+        continueCalled = true
+        checkContinueParameters(parameters)
+
+        if let request = requestContinue {
+            return request
+        } else if throwErrorContinue {
+            throw ErrorMock.error
+        } else {
+            fatalError("Make sure to use mockContinueRequestFunc()")
+        }
+    }
+
+    private func checkContinueParameters(_ params: MSALNativeAuthSignUpContinueRequestProviderParams) {
+        XCTAssertEqual(params.grantType, expectedContinueRequestParameters.grantType)
+        XCTAssertEqual(params.signUpToken, expectedContinueRequestParameters.signUpToken)
+        XCTAssertEqual(params.password, expectedContinueRequestParameters.password)
+        XCTAssertEqual(params.oobCode, expectedContinueRequestParameters.oobCode)
+        XCTAssertEqual(params.attributes?["key"] as? String, expectedContinueRequestParameters.attributes?["key"] as? String)
+        XCTAssertEqual(params.context.correlationId(), expectedContinueRequestParameters.context.correlationId())
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpResponseValidatorMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpResponseValidatorMock.swift
@@ -1,0 +1,69 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignUpResponseValidatorMock: MSALNativeAuthSignUpResponseValidating {
+
+    private var signUpStartValidatedResponse: MSALNativeAuthSignUpStartValidatedResponse?
+    private var signUpChallengeValidatedResponse: MSALNativeAuthSignUpChallengeValidatedResponse?
+    private var signUpContinueContinueResponse: MSALNativeAuthSignUpContinueValidatedResponse?
+
+    func mockValidateSignUpStartFunc(_ response: MSALNativeAuthSignUpStartValidatedResponse) {
+        self.signUpStartValidatedResponse = response
+    }
+
+    func validate(_ result: Result<MSAL.MSALNativeAuthSignUpStartResponse, Error>, with context: MSIDRequestContext) -> MSAL.MSALNativeAuthSignUpStartValidatedResponse {
+        if let signUpStartValidatedResponse = signUpStartValidatedResponse {
+            return signUpStartValidatedResponse
+        } else {
+            fatalError("Make sure you call mockValidateSignUpStartFunc()")
+        }
+    }
+
+    func mockValidateSignUpChallengeFunc(_ response: MSALNativeAuthSignUpChallengeValidatedResponse) {
+        self.signUpChallengeValidatedResponse = response
+    }
+
+    func validate(_ result: Result<MSAL.MSALNativeAuthSignUpChallengeResponse, Error>, with context: MSIDRequestContext) -> MSAL.MSALNativeAuthSignUpChallengeValidatedResponse {
+        if let signUpChallengeValidatedResponse = signUpChallengeValidatedResponse {
+            return signUpChallengeValidatedResponse
+        } else {
+            fatalError("Make sure you call mockValidateSignUpChallengeFunc()")
+        }
+    }
+
+    func mockValidateSignUpContinueFunc(_ response: MSALNativeAuthSignUpContinueValidatedResponse) {
+        self.signUpContinueContinueResponse = response
+    }
+
+    func validate(_ result: Result<MSAL.MSALNativeAuthSignUpContinueResponse, Error>, with context: MSIDRequestContext) -> MSAL.MSALNativeAuthSignUpContinueValidatedResponse {
+        if let signUpContinueContinueResponse = signUpContinueContinueResponse {
+            return signUpContinueContinueResponse
+        } else {
+            fatalError("Make sure you call mockValidateSignUpContinueFunc()")
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthUserAccountResultStub.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthUserAccountResultStub.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+import Foundation
+
+struct MSALNativeAuthUserAccountResultStub {
+
+    
+    static var result : MSALNativeAuthUserAccountResult {
+        return MSALNativeAuthUserAccountResult(
+            account: account,
+            authTokens: authTokens,
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: MSALNativeAuthCacheAccessorMock()
+        )
+    }
+
+    static var account: MSALAccount {
+        MSALAccount(username: "username",
+                    homeAccountId: MSALAccountId(),
+                    environment: "",
+                    tenantProfiles: [])
+    }
+
+    static var authTokens: MSALNativeAuthTokens {
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = "accessToken"
+        accessToken.expiresOn = Date()
+        accessToken.scopes = []
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.refreshToken = "refreshToken"
+        return MSALNativeAuthTokens(accessToken: accessToken,
+                             refreshToken: refreshToken,
+                             rawIdToken: "idToken")
+    }
+
+}

--- a/MSAL/test/unit/native_auth/mock/SignUpDelegateSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/SignUpDelegateSpies.swift
@@ -1,0 +1,370 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+class SignUpPasswordStartDelegateSpy: SignUpPasswordStartDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onSignUpPasswordErrorCalled = false
+    private(set) var onSignUpCodeRequiredCalled = false
+    private(set) var onSignUpAttributesInvalidCalled = false
+    private(set) var error: SignUpPasswordStartError?
+    private(set) var newState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+    private(set) var attributeNames: [String]?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordError(error: MSAL.SignUpPasswordStartError) {
+        onSignUpPasswordErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+
+    func onSignUpCodeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+    
+    func onSignUpAttributesInvalid(attributeNames: [String]) {
+        self.onSignUpAttributesInvalidCalled = true
+        self.attributeNames = attributeNames
+        
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+}
+
+class SignUpCodeStartDelegateSpy: SignUpStartDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onSignUpCodeErrorCalled = false
+    private(set) var onSignUpCodeRequiredCalled = false
+    private(set) var onSignUpAttributesInvalidCalled = false
+    private(set) var error: SignUpStartError?
+    private(set) var newState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+    private(set) var attributeNames: [String]?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpError(error: MSAL.SignUpStartError) {
+        onSignUpCodeErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+    
+    func onSignUpAttributesInvalid(attributeNames: [String]) {
+        self.onSignUpAttributesInvalidCalled = true
+        self.attributeNames = attributeNames
+        
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+}
+
+class SignUpResendCodeDelegateSpy: SignUpResendCodeDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onSignUpResendCodeErrorCalled = false
+    private(set) var onSignUpResendCodeCodeRequiredCalled = false
+    private(set) var error: ResendCodeError?
+    private(set) var newState: SignUpCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpResendCodeError(error: ResendCodeError) {
+        onSignUpResendCodeErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpResendCodeCodeRequired(newState: MSAL.SignUpCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        onSignUpResendCodeCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.codeLength = codeLength
+        self.channelTargetType = channelTargetType
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class SignUpVerifyCodeDelegateSpy: SignUpVerifyCodeDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onSignUpVerifyCodeErrorCalled = false
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var onSignUpPasswordRequiredCalled = false
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var error: VerifyCodeError?
+    private(set) var newCodeRequiredState: SignUpCodeRequiredState?
+    private(set) var newAttributesRequiredState: SignUpAttributesRequiredState?
+    private(set) var newPasswordRequiredState: SignUpPasswordRequiredState?
+    private(set) var newSignInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpVerifyCodeError(error: MSAL.VerifyCodeError, newState: MSAL.SignUpCodeRequiredState?) {
+        onSignUpVerifyCodeErrorCalled = true
+        self.error = error
+        newCodeRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredCalled = true
+        newAttributesRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpPasswordRequired(newState: MSAL.SignUpPasswordRequiredState) {
+        onSignUpPasswordRequiredCalled = true
+        newPasswordRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        newSignInAfterSignUpState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class SignUpPasswordRequiredDelegateSpy: SignUpPasswordRequiredDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onSignUpPasswordRequiredErrorCalled = false
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var error: PasswordRequiredError?
+    private(set) var newPasswordRequiredState: SignUpPasswordRequiredState?
+    private(set) var newAttributesRequiredState: SignUpAttributesRequiredState?
+    private(set) var signInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordRequiredError(error: MSAL.PasswordRequiredError, newState: MSAL.SignUpPasswordRequiredState?) {
+        onSignUpPasswordRequiredErrorCalled = true
+        self.error = error
+        newPasswordRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+        onSignUpAttributesRequiredCalled = true
+        newAttributesRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        self.signInAfterSignUpState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class SignUpAttributesRequiredDelegateSpy: SignUpAttributesRequiredDelegate {
+    private let expectation: XCTestExpectation?
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var onSignUpAttributesRequiredErrorCalled = false
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var error: AttributesRequiredError?
+    private(set) var newState: SignUpAttributesRequiredState?
+    private(set) var attributes: [MSAL.MSALNativeAuthRequiredAttributes]?
+    private(set) var invalidAttributes: [String]?
+    private(set) var newSignInAfterSignUpState: SignInAfterSignUpState?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpAttributesRequiredError(error: MSAL.AttributesRequiredError) {
+        onSignUpAttributesRequiredErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        onSignUpCompletedCalled = true
+        newSignInAfterSignUpState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+    
+    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+        self.attributes = attributes
+        self.newState = newState
+        onSignUpAttributesRequiredCalled = true
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+    
+    func onSignUpAttributesInvalid(attributeNames: [String], newState: MSAL.SignUpAttributesRequiredState) {
+        self.invalidAttributes = attributeNames
+        self.newState = newState
+        onSignUpAttributesRequiredCalled = true
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class SignUpVerifyCodeDelegateOptionalMethodsNotImplemented: SignUpVerifyCodeDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var error: VerifyCodeError?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpVerifyCodeError(error: MSAL.VerifyCodeError, newState: MSAL.SignUpCodeRequiredState?) {
+        self.error = error
+        XCTAssertTrue(Thread.isMainThread)
+        expectation.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        XCTAssertTrue(Thread.isMainThread)
+    }
+}
+
+class SignUpPasswordStartDelegateOptionalMethodsNotImplemented: SignUpPasswordStartDelegate {
+    private let expectation: XCTestExpectation?
+    private(set) var onSignUpPasswordErrorCalled = false
+    private(set) var error: SignUpPasswordStartError?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordError(error: MSAL.SignUpPasswordStartError) {
+        onSignUpPasswordErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+    
+    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        XCTFail("This method should not be called")
+        self.expectation?.fulfill()
+    }
+}
+
+class SignUpStartDelegateOptionalMethodsNotImplemented: SignUpStartDelegate {
+    private let expectation: XCTestExpectation?
+    private(set) var onSignUpStartErrorCalled = false
+    private(set) var error: SignUpStartError?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpError(error: MSAL.SignUpStartError) {
+        onSignUpStartErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        self.expectation?.fulfill()
+    }
+    
+    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        XCTFail("This method should not be called")
+        self.expectation?.fulfill()
+    }
+}
+
+class SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented: SignUpPasswordRequiredDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var error: PasswordRequiredError?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignUpPasswordRequiredError(error: MSAL.PasswordRequiredError, newState: MSAL.SignUpPasswordRequiredState?) {
+        self.error = error
+        XCTAssertTrue(Thread.isMainThread)
+        expectation.fulfill()
+    }
+
+    func onSignUpCompleted(newState: SignInAfterSignUpState) {
+        XCTAssertTrue(Thread.isMainThread)
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/SignUpTestsValidatorHelpers.swift
+++ b/MSAL/test/unit/native_auth/mock/SignUpTestsValidatorHelpers.swift
@@ -1,0 +1,272 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+class SignUpPasswordStartTestsValidatorHelper: SignUpPasswordStartDelegateSpy {
+
+    func onSignUpPasswordError(_ input: MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse) {
+        guard case let .error(error) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpPasswordError(error: error)
+        }
+    }
+
+    func onSignUpCodeRequired(_ input: MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be .codeRequired")
+        }
+
+        Task {
+            await self.onSignUpCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength)
+        }
+    }
+
+    func onSignUpAttributesInvalid(_ input: MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse) {
+        guard case let .attributesInvalid(attributes) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be .attributeValidationFailed")
+        }
+
+        Task {
+            await self.onSignUpAttributesInvalid(attributeNames: attributes)
+        }
+    }
+}
+
+class SignUpCodeStartTestsValidatorHelper: SignUpCodeStartDelegateSpy {
+
+    func onSignUpError(_ input: MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse) {
+        guard case let .error(error) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpError(error: error)
+        }
+    }
+
+    func onSignUpCodeRequired(_ input: MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be .codeRequired")
+        }
+
+        Task {
+            await self.onSignUpCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength)
+        }
+    }
+
+    func onSignUpAttributesInvalid(_ input: MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse) {
+        guard case let .attributesInvalid(attributes) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be .attributeValidationFailed")
+        }
+
+        Task {
+            await self.onSignUpAttributesInvalid(attributeNames: attributes)
+        }
+    }
+}
+
+class SignUpResendCodeTestsValidatorHelper: SignUpResendCodeDelegateSpy {
+
+    func onSignUpResendCodeError(_ input: SignUpResendCodeResult) {
+        guard case let .error(error) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpResendCodeError(error: error)
+        }
+    }
+
+    func onSignUpResendCodeCodeRequired(_ input: SignUpResendCodeResult) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be .codeRequired")
+        }
+        
+        Task {
+            await self.onSignUpResendCodeCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength)
+        }
+    }
+}
+
+class SignUpVerifyCodeTestsValidatorHelper: SignUpVerifyCodeDelegateSpy {
+
+    func onSignUpVerifyCodeError(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse) {
+        guard case let .error(error, newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpVerifyCodeError(error: error, newState: newState)
+        }
+    }
+
+    func onSignUpAttributesRequired(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse) {
+        guard case let .attributesRequired(attributes, newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpAttributesRequired(attributes: attributes, newState: newState)
+        }
+    }
+
+    func onSignUpPasswordRequired(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse) {
+        guard case let .passwordRequired(newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpPasswordRequired(newState: newState)
+        }
+    }
+
+    func onSignUpCompleted(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse) {
+        guard case let .completed(newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpCompleted(newState: newState)
+        }
+    }
+}
+
+class SignUpPasswordRequiredTestsValidatorHelper: SignUpPasswordRequiredDelegateSpy {
+
+    func onSignUpPasswordRequiredError(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse) {
+        guard case let .error(error, newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpPasswordRequiredError(error: error, newState: newState)
+        }
+    }
+
+    func onSignUpAttributesRequired(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse) {
+        guard case let .attributesRequired(attributes, newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpAttributesRequired(attributes: attributes, newState: newState)
+        }
+    }
+
+    func onSignUpCompleted(_ input: MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse) {
+        guard case let .completed(newState) = input.result else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task {
+            await self.onSignUpCompleted(newState: newState)
+        }
+    }
+}
+
+class SignUpAttributesRequiredTestsValidatorHelper {
+    private let expectation: XCTestExpectation?
+    private(set) var onSignUpAttributesRequiredCalled = false
+    private(set) var onSignUpInvalidAttributesCalled = false
+    private(set) var onSignUpAttributesRequiredErrorCalled = false
+    private(set) var onSignUpCompletedCalled = false
+    private(set) var error: AttributesRequiredError?
+    private(set) var newState: SignUpAttributesRequiredState?
+    private(set) var signInAfterSignUpState: SignInAfterSignUpState?
+    private(set) var attributes: [MSALNativeAuthRequiredAttributes]?
+    private(set) var invalidAttributes: [String]?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpAttributesRequired(_ input: SignUpAttributesRequiredResult) {
+        guard case let .attributesRequired(attributes, state) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be .attributesInvalid")
+        }
+
+        onSignUpAttributesRequiredCalled = true
+        self.attributes = attributes
+        self.newState = state
+
+        expectation?.fulfill()
+    }
+
+    func onSignUpAttributesRequiredError(_ input: SignUpAttributesRequiredResult) {
+        guard case let .error(error) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        onSignUpAttributesRequiredErrorCalled = true
+        self.error = error
+
+        expectation?.fulfill()
+    }
+
+    func onSignUpAttributesValidationFailed(_ input: SignUpAttributesRequiredResult) {
+        guard case let .attributesInvalid(attributes, state) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        self.onSignUpInvalidAttributesCalled = true
+        self.invalidAttributes = attributes
+        self.newState = state
+
+        expectation?.fulfill()
+    }
+
+    func onSignUpCompleted(_ input: SignUpAttributesRequiredResult) {
+        guard case .completed = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        onSignUpCompletedCalled = true
+
+        expectation?.fulfill()
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
@@ -1,0 +1,141 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
+
+    private var sut: MSALNativeAuthSignUpRequestProvider!
+    private var telemetryProvider: MSALNativeAuthTelemetryProvider!
+    private var context: MSIDRequestContext!
+
+    override func setUpWithError() throws {
+        telemetryProvider = MSALNativeAuthTelemetryProvider()
+        context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+
+        sut = .init(requestConfigurator: MSALNativeAuthRequestConfigurator(config: MSALNativeAuthConfigStubs.configuration),
+                    telemetryProvider: telemetryProvider)
+    }
+
+    func test_signUpStartRequest_is_created_successfully() throws {
+        let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            password: "1234",
+            attributes: ["city": "dublin"],
+            context: MSALNativeAuthRequestContext(correlationId: context.correlationId())
+        )
+
+        let request = try sut.start(parameters: parameters)
+
+        checkBodyParams(request.parameters, for: .signUpStart)
+        checkUrlRequest(request.urlRequest!, for: .signUpStart)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpStart).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+
+    func test_signUpChallengeRequest_is_created_successfully() throws {
+        let request = try sut.challenge(token: "sign-up-token", context: context)
+
+        checkBodyParams(request.parameters, for: .signUpChallenge)
+        checkUrlRequest(request.urlRequest!, for: .signUpChallenge)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpChallenge).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+
+    func test_signUpContinueRequest_is_created_successfully() throws {
+        let parameters = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: "sign-up-token",
+            password: "1234",
+            oobCode: nil,
+            attributes: nil,
+            context: context
+        )
+
+        let request = try sut.continue(parameters: parameters)
+
+        checkBodyParams(request.parameters, for: .signUpContinue)
+        checkUrlRequest(request.urlRequest!, for: .signUpContinue)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpContinue).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+
+    private func checkBodyParams(_ bodyParams: [String: String]?, for endpoint: MSALNativeAuthEndpoint) {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        var expectedBodyParams: [String: String]!
+
+        switch endpoint {
+        case .signUpStart:
+            expectedBodyParams = [
+                Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
+                Key.username.rawValue: DEFAULT_TEST_ID_TOKEN_USERNAME,
+                Key.challengeType.rawValue: "redirect",
+                Key.attributes.rawValue: "{\"city\":\"dublin\"}",
+                Key.password.rawValue: "1234"
+            ]
+        case .signUpChallenge:
+            expectedBodyParams = [
+                Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
+                Key.signUpToken.rawValue: "sign-up-token",
+                Key.challengeType.rawValue: "redirect"
+            ]
+        case .signUpContinue:
+            expectedBodyParams = [
+                Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
+                Key.grantType.rawValue: "password",
+                Key.signUpToken.rawValue: "sign-up-token",
+                Key.password.rawValue: "1234"
+            ]
+        default:
+            XCTFail("Case not tested")
+        }
+
+        XCTAssertEqual(bodyParams, expectedBodyParams)
+    }
+
+    private func checkUrlRequest(_ result: URLRequest?, for endpoint: MSALNativeAuthEndpoint) {
+        XCTAssertEqual(result?.httpMethod, MSALParameterStringForHttpMethod(.POST))
+
+        let expectedUrl = URL(string: MSALNativeAuthNetworkStubs.authority.url.absoluteString + endpoint.rawValue)!
+        XCTAssertEqual(result?.url, expectedUrl)
+
+        XCTAssertEqual(result?.allHTTPHeaderFields?["return-client-request-id"], "true")
+        XCTAssertEqual(result?.allHTTPHeaderFields?["Accept"], "application/json")
+    }
+
+    private func checkServerTelemetry(_ result: MSIDHttpRequestServerTelemetryHandling?, expectedTelemetryResult: String) {
+        guard let serverTelemetry = result as? MSALNativeAuthServerTelemetry else {
+            return XCTFail("Server telemetry should be of kind MSALNativeAuthServerTelemetry")
+        }
+
+        XCTAssertEqual(serverTelemetry.context.correlationId().uuidString, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(serverTelemetry.currentRequestTelemetry.telemetryString(), expectedTelemetryResult)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthErrorRequiredAttributesTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthErrorRequiredAttributesTests.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthErrorRequiredAttributesTests: XCTestCase {
+
+    func test_toString_requiredTrue() {
+        let sut = MSALNativeAuthRequiredAttributesInternal(name: "aName", type: "", required: true)
+        XCTAssertEqual(sut.description, "aName")
+    }
+
+    func test_toString_requiredFalse() {
+        let sut = MSALNativeAuthRequiredAttributesInternal(name: "aName", type: "", required: false)
+        XCTAssertEqual(sut.description, "aName")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests.swift
@@ -1,0 +1,51 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests: XCTestCase {
+    
+    private typealias sut = MSALNativeAuthSignUpChallengeOauth2ErrorCode
+    
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 4)
+    }
+    
+    func test_invalidRequest() {
+        XCTAssertEqual(sut.invalidRequest.rawValue, "invalid_request")
+    }
+    
+    func test_unauthorizedClient() {
+        XCTAssertEqual(sut.unauthorizedClient.rawValue, "unauthorized_client")
+    }
+    
+    func test_unsupportedChallengeType() {
+        XCTAssertEqual(sut.unsupportedChallengeType.rawValue, "unsupported_challenge_type")
+    }
+    
+    func test_expiredToken() {
+        XCTAssertEqual(sut.expiredToken.rawValue, "expired_token")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
@@ -1,0 +1,134 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpChallengeResponseErrorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthSignUpChallengeResponseError!
+    private let testDescription = "testDescription"
+
+    // MARK: - to toSignUpPasswordStartPublicError tests
+
+    func test_toSignUpPasswordStartPublicError_unauthorizedClient() {
+        testSignUpChallengeErrorToSignUpPasswordStart(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpPasswordStartPublicError_unsupportedChallengeType() {
+        testSignUpChallengeErrorToSignUpPasswordStart(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpPasswordStartPublicError_expiredToken() {
+        testSignUpChallengeErrorToSignUpPasswordStart(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpPasswordStartPublicError_invalidRequest() {
+        testSignUpChallengeErrorToSignUpPasswordStart(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    // MARK: - to SignUpCodeStartError tests
+
+    func test_toSignUpCodeStartPublicError_unauthorizedClient() {
+        testSignUpChallengeErrorToSignUpStart(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpCodeStartPublicError_unsupportedChallengeType() {
+        testSignUpChallengeErrorToSignUpStart(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpCodeStartPublicError_expiredToken() {
+        testSignUpChallengeErrorToSignUpStart(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpCodeStartPublicError_invalidRequest() {
+        testSignUpChallengeErrorToSignUpStart(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    // MARK: - to ResendCodeError tests
+
+    func test_toResendCodePublicError_unauthorizedClient() {
+        testSignUpChallengeErrorToResendCodePublic(code: .unauthorizedClient, description: testDescription)
+    }
+
+    func test_toResendCodePublicError_unsupportedChallengeType() {
+        testSignUpChallengeErrorToResendCodePublic(code: .unsupportedChallengeType, description: "General error")
+    }
+
+    func test_toResendCodePublicError_expiredToken() {
+        testSignUpChallengeErrorToResendCodePublic(code: .expiredToken, description: testDescription)
+    }
+
+    func test_toResendCodePublicError_invalidRequest() {
+        testSignUpChallengeErrorToResendCodePublic(code: .invalidRequest, description: testDescription)
+    }
+
+    // MARK: - to PasswordRequiredError tests
+
+    func test_toPasswordRequiredPublicError_unauthorizedClient() {
+        testSignUpChallengeErrorToPasswordRequired(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_unsupportedChallengeType() {
+        testSignUpChallengeErrorToPasswordRequired(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_expiredToken() {
+        testSignUpChallengeErrorToPasswordRequired(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_invalidRequest() {
+        testSignUpChallengeErrorToPasswordRequired(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+        
+    // MARK: private methods
+    
+    private func testSignUpChallengeErrorToSignUpPasswordStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: SignUpPasswordStartErrorType) {
+        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        let error = sut.toSignUpPasswordStartPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpChallengeErrorToSignUpStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartErrorType) {
+        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        let error = sut.toSignUpStartPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpChallengeErrorToResendCodePublic(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?) {
+        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        let error = sut.toResendCodePublicError()
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpChallengeErrorToPasswordRequired(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredErrorType) {
+        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        let error = sut.toPasswordRequiredPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCodeTests.swift
@@ -1,0 +1,95 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpContinueOauth2ErrorCodeTests: XCTestCase {
+
+    private typealias sut = MSALNativeAuthSignUpContinueOauth2ErrorCode
+
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 15)
+    }
+
+    func test_invalidRequest() {
+        XCTAssertEqual(sut.invalidRequest.rawValue, "invalid_request")
+    }
+    
+    func test_unauthorizedClient() {
+        XCTAssertEqual(sut.unauthorizedClient.rawValue, "unauthorized_client")
+    }
+    
+    func test_invalidGrant() {
+        XCTAssertEqual(sut.invalidGrant.rawValue, "invalid_grant")
+    }
+    
+    func test_expiredToken() {
+        XCTAssertEqual(sut.expiredToken.rawValue, "expired_token")
+    }
+    
+    func test_passwordTooWeak() {
+        XCTAssertEqual(sut.passwordTooWeak.rawValue, "password_too_weak")
+    }
+    
+    func test_passwordTooShort() {
+        XCTAssertEqual(sut.passwordTooShort.rawValue, "password_too_short")
+    }
+    
+    func test_passwordTooLong() {
+        XCTAssertEqual(sut.passwordTooLong.rawValue, "password_too_long")
+    }
+    
+    func test_passwordRecentlyUsed() {
+        XCTAssertEqual(sut.passwordRecentlyUsed.rawValue, "password_recently_used")
+    }
+    
+    func test_passwordBanned() {
+        XCTAssertEqual(sut.passwordBanned.rawValue, "password_banned")
+    }
+    
+    func test_userAlreadyExists() {
+        XCTAssertEqual(sut.userAlreadyExists.rawValue, "user_already_exists")
+    }
+    
+    func test_attributesRequired() {
+        XCTAssertEqual(sut.attributesRequired.rawValue, "attributes_required")
+    }
+    
+    func test_verificationRequired() {
+        XCTAssertEqual(sut.verificationRequired.rawValue, "verification_required")
+    }
+    
+    func test_attributeValidationFailed() {
+        XCTAssertEqual(sut.attributeValidationFailed.rawValue, "attribute_validation_failed")
+    }
+    
+    func test_credentialRequired() {
+        XCTAssertEqual(sut.credentialRequired.rawValue, "credential_required")
+    }
+    
+    func test_invalidOOBValue() {
+        XCTAssertEqual(sut.invalidOOBValue.rawValue, "invalid_oob_value")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
@@ -1,0 +1,240 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
+    
+    private var sut: MSALNativeAuthSignUpContinueResponseError!
+    private let testDescription = "testDescription"
+    
+    // MARK: - to toVerifyCodePublicError tests
+    
+    func test_toVerifyCodePublicError_invalidRequest() {
+        testSignUpContinueErrorToVerifyCode(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_unauthorizedClient() {
+        testSignUpContinueErrorToVerifyCode(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_invalidGrant() {
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_expiredToken() {
+        testSignUpContinueErrorToVerifyCode(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_passwordTooWeak() {
+        testSignUpContinueErrorToVerifyCode(code: .passwordTooWeak, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_passwordTooShort() {
+        testSignUpContinueErrorToVerifyCode(code: .passwordTooShort, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_passwordTooLong() {
+        testSignUpContinueErrorToVerifyCode(code: .passwordTooLong, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_passwordRecentlyUsed() {
+        testSignUpContinueErrorToVerifyCode(code: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_passwordBanned() {
+        testSignUpContinueErrorToVerifyCode(code: .passwordBanned, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_userAlreadyExists() {
+        testSignUpContinueErrorToVerifyCode(code: .userAlreadyExists, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_attributesRequired() {
+        testSignUpContinueErrorToVerifyCode(code: .attributesRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_verificationRequired() {
+        testSignUpContinueErrorToVerifyCode(code: .verificationRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_attributeValidationFailed() {
+        testSignUpContinueErrorToVerifyCode(code: .attributeValidationFailed, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_credentialRequired() {
+        testSignUpContinueErrorToVerifyCode(code: .credentialRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toVerifyCodePublicError_invalidOOBValue() {
+        testSignUpContinueErrorToVerifyCode(code: .invalidOOBValue, description: testDescription, expectedErrorType: .invalidCode)
+    }
+    
+    // MARK: - toPasswordRequiredPublicError tests
+    
+    func test_toPasswordRequiredPublicError_invalidRequest() {
+        testSignUpContinueErrorToPasswordRequired(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_unauthorizedClient() {
+        testSignUpContinueErrorToPasswordRequired(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_invalidGrant() {
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_expiredToken() {
+        testSignUpContinueErrorToPasswordRequired(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_passwordTooWeak() {
+        testSignUpContinueErrorToPasswordRequired(code: .passwordTooWeak, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toPasswordRequiredPublicError_passwordTooShort() {
+        testSignUpContinueErrorToPasswordRequired(code: .passwordTooShort, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toPasswordRequiredPublicError_passwordTooLong() {
+        testSignUpContinueErrorToPasswordRequired(code: .passwordTooLong, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toPasswordRequiredPublicError_passwordRecentlyUsed() {
+        testSignUpContinueErrorToPasswordRequired(code: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toPasswordRequiredPublicError_passwordBanned() {
+        testSignUpContinueErrorToPasswordRequired(code: .passwordBanned, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toPasswordRequiredPublicError_userAlreadyExists() {
+        testSignUpContinueErrorToPasswordRequired(code: .userAlreadyExists, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_attributesRequired() {
+        testSignUpContinueErrorToPasswordRequired(code: .attributesRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_verificationRequired() {
+        testSignUpContinueErrorToPasswordRequired(code: .verificationRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_attributeValidationFailed() {
+        testSignUpContinueErrorToPasswordRequired(code: .attributeValidationFailed, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_credentialRequired() {
+        testSignUpContinueErrorToPasswordRequired(code: .credentialRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toPasswordRequiredPublicError_invalidOOBValue() {
+        testSignUpContinueErrorToPasswordRequired(code: .invalidOOBValue, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    // MARK: - toAttributesRequiredPublicError tests
+    
+    func test_toAttributesRequiredPublicError_invalidRequest() {
+        testSignUpContinueErrorToAttributesRequired(code: .invalidRequest, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_unauthorizedClien() {
+        testSignUpContinueErrorToAttributesRequired(code: .unauthorizedClient, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_invalidGrant() {
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_expiredToken() {
+        testSignUpContinueErrorToAttributesRequired(code: .expiredToken, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_passwordTooWeak() {
+        testSignUpContinueErrorToAttributesRequired(code: .passwordTooWeak, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_passwordTooShort() {
+        testSignUpContinueErrorToAttributesRequired(code: .passwordTooShort, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_passwordTooLong() {
+        testSignUpContinueErrorToAttributesRequired(code: .passwordTooLong, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_passwordRecentlyUsed() {
+        testSignUpContinueErrorToAttributesRequired(code: .passwordRecentlyUsed, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_passwordBanned() {
+        testSignUpContinueErrorToAttributesRequired(code: .passwordBanned, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_userAlreadyExists() {
+        testSignUpContinueErrorToAttributesRequired(code: .userAlreadyExists, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_attributesRequired() {
+        testSignUpContinueErrorToAttributesRequired(code: .attributesRequired, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_verificationRequired() {
+        testSignUpContinueErrorToAttributesRequired(code: .verificationRequired, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_attributeValidationFailed() {
+        testSignUpContinueErrorToAttributesRequired(code: .attributeValidationFailed, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_credentialRequired() {
+        testSignUpContinueErrorToAttributesRequired(code: .credentialRequired, description: testDescription)
+    }
+    
+    func test_toAttributesRequiredPublicError_invalidOOBValue() {
+        testSignUpContinueErrorToAttributesRequired(code: .invalidOOBValue, description: testDescription)
+    }
+    
+    // MARK: private methods
+    
+    private func testSignUpContinueErrorToVerifyCode(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?, expectedErrorType: VerifyCodeErrorType) {
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        let error = sut.toVerifyCodePublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpContinueErrorToPasswordRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredErrorType) {
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        let error = sut.toPasswordRequiredPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpContinueErrorToAttributesRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?) {
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        let error = sut.toAttributesRequiredPublicError()
+        XCTAssertEqual(error.errorDescription, description)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCodeTests.swift
@@ -1,0 +1,87 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpStartOauth2ErrorCodeTests: XCTestCase {
+
+    private typealias sut = MSALNativeAuthSignUpStartOauth2ErrorCode
+
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 13)
+    }
+
+    func test_invalidRequest() {
+        XCTAssertEqual(sut.invalidRequest.rawValue, "invalid_request")
+    }
+
+    func test_unauthorizedClient() {
+        XCTAssertEqual(sut.unauthorizedClient.rawValue, "unauthorized_client")
+    }
+    
+    func test_unsupportedChallengeType() {
+        XCTAssertEqual(sut.unsupportedChallengeType.rawValue, "unsupported_challenge_type")
+    }
+
+    func test_passwordTooWeak() {
+        XCTAssertEqual(sut.passwordTooWeak.rawValue, "password_too_weak")
+    }
+
+    func test_passwordTooShort() {
+        XCTAssertEqual(sut.passwordTooShort.rawValue, "password_too_short")
+    }
+
+    func test_passwordTooLong() {
+        XCTAssertEqual(sut.passwordTooLong.rawValue, "password_too_long")
+    }
+
+    func test_passwordRecentlyUsed() {
+        XCTAssertEqual(sut.passwordRecentlyUsed.rawValue, "password_recently_used")
+    }
+
+    func test_passwordBanned() {
+        XCTAssertEqual(sut.passwordBanned.rawValue, "password_banned")
+    }
+
+    func test_userAlreadyExists() {
+        XCTAssertEqual(sut.userAlreadyExists.rawValue, "user_already_exists")
+    }
+
+    func test_attributesRequired() {
+        XCTAssertEqual(sut.attributesRequired.rawValue, "attributes_required")
+    }
+
+    func test_verificationRequired() {
+        XCTAssertEqual(sut.verificationRequired.rawValue, "verification_required")
+    }
+    
+    func test_unsupportedAuthMethod() {
+        XCTAssertEqual(sut.unsupportedAuthMethod.rawValue, "unsupported_auth_method")
+    }
+
+    func test_attributeValidationFailed() {
+        XCTAssertEqual(sut.attributeValidationFailed.rawValue, "attribute_validation_failed")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
@@ -1,0 +1,156 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthSignUpStartResponseErrorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthSignUpStartResponseError!
+    private let testDescription = "testDescription"
+
+    // MARK: - to toSignUpStartPasswordPublicError tests
+
+    func test_toSignUpStartPasswordPublicError_invalidRequest() {
+        testSignUpStartErrorToSignUpStartPassword(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_unauthorizedClient() {
+        testSignUpStartErrorToSignUpStartPassword(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpStartPasswordPublicError_unsupportedChallengeType() {
+        testSignUpStartErrorToSignUpStartPassword(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpStartPasswordPublicError_passwordTooWeak() {
+        testSignUpStartErrorToSignUpStartPassword(code: .passwordTooWeak, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_passwordTooShort() {
+        testSignUpStartErrorToSignUpStartPassword(code: .passwordTooShort, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_passwordTooLong() {
+        testSignUpStartErrorToSignUpStartPassword(code: .passwordTooLong, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_passwordRecentlyUsed() {
+        testSignUpStartErrorToSignUpStartPassword(code: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_passwordBanned() {
+        testSignUpStartErrorToSignUpStartPassword(code: .passwordBanned, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_userAlreadyExists() {
+        testSignUpStartErrorToSignUpStartPassword(code: .userAlreadyExists, description: testDescription, expectedErrorType: .userAlreadyExists)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_attributesRequired() {
+        testSignUpStartErrorToSignUpStartPassword(code: .attributesRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_verificationRequired() {
+        testSignUpStartErrorToSignUpStartPassword(code: .verificationRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_unsupportedAuthMethod() {
+        testSignUpStartErrorToSignUpStartPassword(code: .unsupportedAuthMethod, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPasswordPublicError_attributeValidationFailed() {
+        testSignUpStartErrorToSignUpStartPassword(code: .attributeValidationFailed, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    // MARK: - to toSignUpStartPublicError tests
+
+    func test_toSignUpStartPublicError_invalidRequest() {
+        testSignUpStartErrorToSignUpStart(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_unauthorizedClient() {
+        testSignUpStartErrorToSignUpStart(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpStartPublicError_unsupportedChallengeType() {
+        testSignUpStartErrorToSignUpStart(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_passwordTooWeak() {
+        testSignUpStartErrorToSignUpStart(code: .passwordTooWeak, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_passwordTooShort() {
+        testSignUpStartErrorToSignUpStart(code: .passwordTooShort, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_passwordTooLong() {
+        testSignUpStartErrorToSignUpStart(code: .passwordTooLong, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_passwordRecentlyUsed() {
+        testSignUpStartErrorToSignUpStart(code: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_passwordBanned() {
+        testSignUpStartErrorToSignUpStart(code: .passwordBanned, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_userAlreadyExists() {
+        testSignUpStartErrorToSignUpStart(code: .userAlreadyExists, description: testDescription, expectedErrorType: .userAlreadyExists)
+    }
+    
+    func test_toSignUpStartPublicError_attributesRequired() {
+        testSignUpStartErrorToSignUpStart(code: .attributesRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_verificationRequired() {
+        testSignUpStartErrorToSignUpStart(code: .verificationRequired, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_unsupportedAuthMethod() {
+        testSignUpStartErrorToSignUpStart(code: .unsupportedAuthMethod, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    func test_toSignUpStartPublicError_attributeValidationFailed() {
+        testSignUpStartErrorToSignUpStart(code: .attributeValidationFailed, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    // MARK: private methods
+    
+    private func testSignUpStartErrorToSignUpStartPassword(code: MSALNativeAuthSignUpStartOauth2ErrorCode, description: String?, expectedErrorType: SignUpPasswordStartErrorType) {
+        sut = MSALNativeAuthSignUpStartResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        let error = sut.toSignUpStartPasswordPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+    
+    private func testSignUpStartErrorToSignUpStart(code: MSALNativeAuthSignUpStartOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartErrorType) {
+        sut = MSALNativeAuthSignUpStartResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        let error = sut.toSignUpStartPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParametersTest.swift
@@ -1,0 +1,67 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpChallengeRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.redirect]))
+        let parameters = MSALNativeAuthSignUpChallengeRequestParameters(
+            signUpToken: "token",
+            context: MSALNativeAuthRequestContextMock()
+        )
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/signup/v1.0/challenge")
+    }
+
+    func test_allChallengeTypes_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let params = MSALNativeAuthSignUpChallengeRequestParameters(
+            signUpToken: "<sign-up-token>",
+            context: context
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "signup_token": "<sign-up-token>",
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParametersTest.swift
@@ -1,0 +1,78 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpContinueRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let parameters = MSALNativeAuthSignUpContinueRequestParameters(
+            grantType: .oobCode,
+            signUpToken: "token",
+            password: nil,
+            oobCode: "1234",
+            attributes: nil,
+            context: MSALNativeAuthRequestContextMock()
+        )
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/signup/v1.0/continue")
+    }
+
+    func test_allChallengeTypes_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let params = MSALNativeAuthSignUpContinueRequestParameters(
+            grantType: .oobCode,
+            signUpToken: "<sign-up-token>",
+            password: "<strong-password>",
+            oobCode: "0000",
+            attributes: "<attributes>",
+            context: context
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "signup_token": "<sign-up-token>",
+            "password": "<strong-password>",
+            "oob": "0000",
+            "grant_type": "oob",
+            "attributes": "<attributes>"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParametersTest.swift
@@ -1,0 +1,73 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpStartRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.redirect]))
+        let parameters = MSALNativeAuthSignUpStartRequestParameters(
+            username: "username",
+            password: nil,
+            attributes: nil,
+            context: MSALNativeAuthRequestContextMock()
+        )
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/signup/v1.0/start")
+    }
+
+    func test_allChallengeTypes_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let params = MSALNativeAuthSignUpStartRequestParameters(
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            password: "strong-password",
+            attributes: "<attribute1: value1>",
+            context: context
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "password": "strong-password",
+            "attributes": "<attribute1: value1>",
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
@@ -1,0 +1,742 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthSignUpResponseValidator!
+    private var context: MSIDRequestContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        sut = MSALNativeAuthSignUpResponseValidator()
+        context = MSALNativeAuthRequestContextMock()
+    }
+
+    // MARK: - Start Response
+
+    func test_whenSignUpStartSuccessResponseContainsRedirect_it_returns_redirect() {
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .success(
+            .init(signupToken: nil, challengeType: .redirect)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .redirect)
+    }
+
+    func test_whenSignUpStartSuccessResponseDoesNotContainsTokenOrRedirect_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .success(
+            .init(signupToken: nil, challengeType: .otp)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStartErrorResponseIsNotExpected_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_verificationRequiredErrorWithSignUpTokenAndUnverifiedAttributes_it_returns_verificationRequired() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            signUpToken: "sign-up token",
+            unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes(name: "username")]
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+
+        guard case .verificationRequired(let signUpToken, let unverifiedAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up token")
+        XCTAssertEqual(unverifiedAttributes.first, "username")
+    }
+
+    func test_whenSignUpStart_verificationRequiredErrorWithSignUpToken_but_unverifiedAttributesIsEmpty_it_returns_unexpectedError() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            signUpToken: "sign-up token",
+            unverifiedAttributes: []
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_verificationRequiredErrorWithSignUpToken_but_unverifiedAttributesIsNil_it_returns_unexpectedError() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            signUpToken: "sign-up token",
+            unverifiedAttributes: nil
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_attributeValidationFailedWithSignUpTokenAndInvalidAttributes_it_returns_attributeValidationFailed() {
+        let error = createSignUpStartError(
+            error: .attributeValidationFailed,
+            invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "city")]
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+
+        guard case .attributeValidationFailed(let invalidAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(invalidAttributes.first, "city")
+    }
+
+    func test_whenSignUpStart_attributeValidationFailedWithSignUpToken_but_invalidAttributesIsEmpty_it_returns_attributeValidationFailed() {
+        let error = createSignUpStartError(
+            error: .attributeValidationFailed,
+            invalidAttributes: []
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_attributeValidationFailedWithSignUpToken_but_invalidAttributesIsNil_it_returns_attributeValidationFailed() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            invalidAttributes: nil
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_expectedVerificationRequiredErrorWithoutSignUpToken_it_returns_unexpectedError() {
+        let error = createSignUpStartError(error: .verificationRequired, signUpToken: nil)
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStartErrorResponseIsExpected_it_returns_error() {
+        let error = createSignUpStartError(error: .userAlreadyExists)
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .userAlreadyExists = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpStartErrorResponseIs_invalidRequestWithInvalidUsernameErrorDescription_it_returns_expectedError() {
+        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidRequestParameter.rawValue, Int.max]
+
+        let apiError = createSignUpStartError(
+            error: .invalidRequest,
+            errorDescription: "username parameter is empty or not valid",
+            errorCodes: errorCodes,
+            errorURI: "aURI",
+            signUpToken: "aToken",
+            unverifiedAttributes: attributes,
+            invalidAttributes: attributes
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(apiError)
+
+        let result = sut.validate(response, with: context)
+        guard case .invalidUsername(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(error as MSALNativeAuthSignUpStartResponseError, apiError)
+    }
+    
+    func test_whenSignUpStartErrorResponseIs_invalidRequestWithInvalidClientIdErrorDescription_it_returns_expectedError() {
+        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidRequestParameter.rawValue, Int.max]
+        
+        let apiError = createSignUpStartError(
+            error: .invalidRequest,
+            errorDescription: "client_id parameter is empty or not valid",
+            errorCodes: errorCodes,
+            errorURI: "aURI",
+            signUpToken: "aToken",
+            unverifiedAttributes: attributes,
+            invalidAttributes: attributes
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(apiError)
+        
+        let result = sut.validate(response, with: context)
+        guard case .invalidClientId(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        
+        XCTAssertEqual(error as MSALNativeAuthSignUpStartResponseError, apiError)
+    }
+
+    func test_whenSignUpStartErrorResponseIs_invalidRequestWithGenericErrorCode_it_returns_expectedError() {
+        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let errorCodes = [Int.max]
+
+        let apiError = createSignUpStartError(
+            error: .invalidRequest,
+            errorDescription: "aDescription",
+            errorCodes: errorCodes,
+            errorURI: "aURI",
+            signUpToken: "aToken",
+            unverifiedAttributes: attributes,
+            invalidAttributes: attributes
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(apiError)
+
+        let result = sut.validate(response, with: context)
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        let resultError = error as MSALNativeAuthSignUpStartResponseError
+        XCTAssertEqual(resultError.error, .invalidRequest)
+        XCTAssertEqual(resultError.errorDescription, "aDescription")
+        XCTAssertEqual(resultError.errorCodes, errorCodes)
+        XCTAssertEqual(resultError.errorURI, "aURI")
+        XCTAssertEqual(resultError.signUpToken, "aToken")
+        XCTAssertEqual(resultError.unverifiedAttributes, attributes)
+        XCTAssertEqual(resultError.invalidAttributes, attributes)
+    }
+
+    // MARK: - Challenge Response
+
+    func test_whenSignUpChallengeSuccessResponseDoesNotContainChallengeType_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: nil,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: "token",
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsRedirect_it_returns_redirect() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .redirect,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: "token",
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .redirect)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndOOB_it_returns_success() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .oob,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            signUpToken: "token",
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+
+        guard case .codeRequired(let displayName, let displayType, let codeLength, let signUpToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(displayName, "challenge-type-label")
+        XCTAssertEqual(displayType, .email)
+        XCTAssertEqual(codeLength, 6)
+        XCTAssertEqual(signUpToken, "token")
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndPassword_it_returns_success() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .password,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            signUpToken: "token",
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+
+        guard case .passwordRequired(let signUpToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "token")
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsPassword_but_noToken_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .password,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            signUpToken: nil,
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndOTP_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .otp,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: "token",
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseOmitsSomeAttributes_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .oob,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: nil,
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeErrorResponseIsNotExpected_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeErrorResponseIsExpected_it_returns_error() {
+        let error = createSignUpChallengeError(error: .expiredToken)
+
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    // MARK: - Continue Response
+
+    func test_whenSignUpStartSuccessResponseContainsSLT_it_returns_success() {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .success(
+            .init(signinSLT: "<signin_slt>", expiresIn: nil, signupToken: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .success("<signin_slt>"))
+    }
+
+    func test_whenSignUpStartSuccessResponseButDoesNotContainSLT_it_returns_successWithNoSLT() throws {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .success(
+            .init(signinSLT: nil, expiresIn: nil, signupToken: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .success(nil))
+    }
+
+    func test_whenSignUpContinueErrorResponseIsNotExpected_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_invalidOOBValue_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidOOBValue, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidOOBValue = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordTooWeak_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordTooWeak, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooWeak = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordTooShort_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordTooShort, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooShort = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordTooLong_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordTooLong, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooLong = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordRecentlyUsed_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordRecentlyUsed, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordRecentlyUsed = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordBanned_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordBanned, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordBanned = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, expectedSignUpToken: "sign-up-token", invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "email")])
+
+        guard case .attributeValidationFailed(let signUpToken, let invalidAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up-token")
+        XCTAssertEqual(invalidAttributes.first, "email")
+    }
+    
+    func test_whenSignUpContinueErrorResponseIs_invalidRequestWithInvalidOTPErrorCode_it_returns_expectedError() {
+        let signUpToken = "sign-up-token"
+        var errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidOTP.rawValue, Int.max]
+        var result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        checkInvalidOOBValue()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.incorrectOTP.rawValue]
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        checkInvalidOOBValue()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.OTPNoCacheEntryForUser.rawValue]
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        checkInvalidOOBValue()
+        func checkInvalidOOBValue() {
+            guard case .invalidUserInput(let error) = result else {
+                return XCTFail("Unexpected response")
+            }
+            if case .invalidOOBValue = error.error {} else {
+                XCTFail("Unexpected error: \(error.error)")
+            }
+            XCTAssertNil(error.errorDescription)
+            XCTAssertNil(error.errorURI)
+            XCTAssertNil(error.innerErrors)
+            XCTAssertEqual(error.signUpToken, signUpToken)
+            XCTAssertNil(error.requiredAttributes)
+            XCTAssertNil(error.unverifiedAttributes)
+            XCTAssertNil(error.invalidAttributes)
+            XCTAssertEqual(error.errorCodes, errorCodes)
+        }
+    }
+    
+    func test_whenSignUpContinueErrorResponseIs_invalidRequestWithGenericErrorCode_it_returns_expectedError() {
+        var result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue])
+        checkValidatedErrorResult()
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [Int.max])
+        checkValidatedErrorResult()
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [MSALNativeAuthESTSApiErrorCodes.userNotHaveAPassword.rawValue])
+        checkValidatedErrorResult()
+        func checkValidatedErrorResult() {
+            guard case .error(let error) = result else {
+                return XCTFail("Unexpected response")
+            }
+            if case .invalidRequest = error.error {} else {
+                XCTFail("Unexpected error: \(error.error)")
+            }
+        }
+    }
+    
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_signUpTokenIsNil_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, expectedSignUpToken: nil, invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "email")])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_invalidAttributesIsNil_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, invalidAttributes: nil)
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_invalidAttributesIsEmpty_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, invalidAttributes: [])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_credentialRequired_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedSignUpToken: "sign-up-token")
+
+        guard case .credentialRequired(let signUpToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up-token")
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_credentialRequired_but_signUpToken_isNil_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedSignUpToken: nil)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
+
+        guard case .attributesRequired(let signUpToken, let requiredAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up-token")
+        XCTAssertEqual(requiredAttributes.count, 2)
+        XCTAssertEqual(requiredAttributes[0].name, "email")
+        XCTAssertEqual(requiredAttributes[1].name, "city")
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_signUpToken_IsNil_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: nil, requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_requiredAttributesIsNil_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: nil)
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_requiredAttributes_IsEmpty_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: [])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_verificationRequired_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_unauthorizedClient_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .unauthorizedClient)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .unauthorizedClient = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_invalidGrant_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidGrant)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidGrant = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_expiredToken_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .expiredToken)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_invalidRequest_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidRequest)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidRequest = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_userAlreadyExists_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .userAlreadyExists)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .userAlreadyExists = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    private func buildContinueErrorResponse(
+        expectedError: MSALNativeAuthSignUpContinueOauth2ErrorCode,
+        expectedSignUpToken: String? = nil,
+        requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
+        errorCodes: [Int]? = nil
+    ) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .failure(
+            createSignUpContinueError(
+                error: expectedError,
+                errorCodes: errorCodes,
+                signUpToken: expectedSignUpToken,
+                requiredAttributes: requiredAttributes,
+                invalidAttributes: invalidAttributes
+            )
+        )
+
+        return sut.validate(response, with: context)
+    }
+
+    private func createSignUpStartError(
+        error: MSALNativeAuthSignUpStartOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        signUpToken: String? = nil,
+        unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil
+    ) -> MSALNativeAuthSignUpStartResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            signUpToken: signUpToken,
+            unverifiedAttributes: unverifiedAttributes,
+            invalidAttributes: invalidAttributes
+        )
+    }
+
+    private func createSignUpChallengeError(
+        error: MSALNativeAuthSignUpChallengeOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil
+    ) -> MSALNativeAuthSignUpChallengeResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors
+        )
+    }
+
+    private func createSignUpContinueError(
+        error: MSALNativeAuthSignUpContinueOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        signUpToken: String? = nil,
+        requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]? = nil,
+        unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil
+    ) -> MSALNativeAuthSignUpContinueResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            signUpToken: signUpToken,
+            requiredAttributes: requiredAttributes,
+            unverifiedAttributes: unverifiedAttributes,
+            invalidAttributes: invalidAttributes
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -1,0 +1,85 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthUserAccountResultTests: XCTestCase {
+    var sut: MSALNativeAuthUserAccountResult!
+    private var cacheAccessorMock: MSALNativeAuthCacheAccessorMock!
+    private var account: MSALAccount!
+
+    override func setUpWithError() throws {
+
+        account = MSALNativeAuthUserAccountResultStub.account
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = "accessToken"
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.refreshToken = "refreshToken"
+        let rawIdToken = "rawIdToken"
+
+        cacheAccessorMock = MSALNativeAuthCacheAccessorMock()
+
+        sut = MSALNativeAuthUserAccountResult(
+            account: account!,
+            authTokens: MSALNativeAuthTokens(accessToken: accessToken, refreshToken: refreshToken, rawIdToken: rawIdToken),
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: cacheAccessorMock
+        )
+        try super.setUpWithError()
+    }
+
+    // MARK: Call delegate properly tests
+
+    func test_whenAccountAndTokenExist_itReturnsCorrectData() {
+        let expectation = expectation(description: "CredentialsController")
+
+        let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedAccessToken: "accessToken")
+        sut.getAccessToken(delegate: mockDelegate)
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_whenNoAccessToken_itReturnsCorrectError() {
+        let expectation = expectation(description: "CredentialsController")
+        sut = MSALNativeAuthUserAccountResult(
+            account: account!,
+            authTokens: MSALNativeAuthTokens(accessToken: nil, refreshToken: nil, rawIdToken: nil),
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: MSALNativeAuthCacheAccessorMock()
+        )
+        let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .tokenNotFound))
+        sut.getAccessToken(delegate: mockDelegate)
+        wait(for: [expectation], timeout: 1)
+    }
+
+    // MARK: - sign-out tests
+
+    func test_signOut_successfullyCallsCacheAccessor() {
+        sut.signOut()
+        XCTAssertTrue(cacheAccessorMock.clearCacheWasCalled)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
@@ -1,0 +1,109 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+
+final class SignUpAttributesRequiredStateTests: XCTestCase {
+
+    private var controller: MSALNativeAuthSignUpControllerMock!
+    private var sut: SignUpAttributesRequiredState!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        controller = .init()
+        sut = SignUpAttributesRequiredState(controller: controller, username: "<username>", flowToken: "<token>")
+    }
+
+    // MARK: - Delegate
+
+    func test_submitPassword_delegate_whenError_shouldReturnAttributesRequiredError() {
+        let expectedError = AttributesRequiredError()
+
+        let expectedResult: SignUpAttributesRequiredResult = .error(error: expectedError)
+        controller.submitAttributesResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
+
+        sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error, expectedError)
+    }
+
+    func test_submitPassword_delegate_whenSuccess_shouldReturnCompleted() {
+        let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt")
+
+        let expectedResult: SignUpAttributesRequiredResult = .completed(expectedState)
+        controller.submitAttributesResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
+
+        sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newSignInAfterSignUpState, expectedState)
+    }
+
+    func test_submitPassword_delegate_whenAttributesRequired_shouldReturnAttributesRequired() {
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt")
+        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+            .init(name: "anAttribute", type: "aType", required: true)
+        ]
+
+        let expectedResult: SignUpAttributesRequiredResult = .attributesRequired(attributes: expectedAttributes, state: expectedState)
+        controller.submitAttributesResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
+
+        sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.attributes, expectedAttributes)
+        XCTAssertEqual(delegate.newState, expectedState)
+    }
+
+    func test_submitPassword_delegate_whenAttributesAreInvalud_shouldReturnAttributesInvalid() {
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt")
+        let expectedAttributes = ["anAttribute"]
+
+        let expectedResult: SignUpAttributesRequiredResult = .attributesInvalid(attributes: expectedAttributes, newState: expectedState)
+        controller.submitAttributesResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
+
+        sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.invalidAttributes, expectedAttributes)
+        XCTAssertEqual(delegate.newState, expectedState)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
@@ -1,0 +1,197 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class SignUpCodeRequiredStateTests: XCTestCase {
+
+    private var controller: MSALNativeAuthSignUpControllerMock!
+    private var sut: SignUpCodeRequiredState!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        controller = .init()
+        sut = SignUpCodeRequiredState(controller: controller, username: "<username>", flowToken: "<token>")
+    }
+
+    // MARK: - Delegates
+
+    // ResendCode
+
+    func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
+        let expectedError = ResendCodeError(message: "test error")
+
+        let expectedResult: SignUpResendCodeResult = .error(expectedError)
+        controller.resendCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpResendCodeDelegateSpy(expectation: exp)
+
+        sut.resendCode(delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error, expectedError)
+    }
+
+    func test_resendCode_delegate_success_shouldReturnCodeRequired() {
+        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let expectedResult: SignUpResendCodeResult = .codeRequired(
+            newState: expectedState,
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controller.resendCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-in states")
+        let delegate = SignUpResendCodeDelegateSpy(expectation: exp)
+
+        sut.resendCode(delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newState?.flowToken, expectedState.flowToken)
+        XCTAssertEqual(delegate.sentTo, "sentTo")
+        XCTAssertEqual(delegate.channelTargetType, .email)
+        XCTAssertEqual(delegate.codeLength, 1)
+    }
+
+    // SubmitCode
+
+    func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
+        let expectedError = VerifyCodeError(type: .invalidCode)
+        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let expectedResult: SignUpVerifyCodeResult = .error(
+            error: expectedError,
+            newState: expectedState
+        )
+        controller.submitCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpVerifyCodeDelegateSpy(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error, expectedError)
+        XCTAssertEqual(delegate.newCodeRequiredState?.flowToken, expectedState.flowToken)
+    }
+
+    func test_submitCode_delegate_whenPasswordRequired_AndUserHasImplementedOptionalDelegate_shouldReturnPasswordRequired() {
+        let expectedPasswordRequiredState = SignUpPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpVerifyCodeResult = .passwordRequired(expectedPasswordRequiredState)
+        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpVerifyCodeDelegateSpy(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.newPasswordRequiredState, expectedPasswordRequiredState)
+    }
+
+    func test_submitCode_delegate_whenPasswordRequired_ButUserHasNotImplementedOptionalDelegate_shouldReturnCorrectError() {
+        let expectedError = VerifyCodeError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpVerifyCodeResult = .passwordRequired(.init(controller: controller, username: "", flowToken: ""))
+        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, expectedError.type)
+        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.delegateNotImplemented)
+    }
+
+    func test_submitCode_delegate_whenAttributesRequired_AndUserHasImplementedOptionalDelegate_shouldReturnAttributesRequired() {
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpVerifyCodeResult = .attributesRequired(attributes: [], newState: expectedAttributesRequiredState)
+        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpVerifyCodeDelegateSpy(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.newAttributesRequiredState, expectedAttributesRequiredState)
+    }
+
+    func test_submitCode_delegate_whenAttributesRequired_ButUserHasNotImplementedOptionalDelegate_shouldReturnCorrectError() {
+        let expectedError = VerifyCodeError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpVerifyCodeResult = .attributesRequired(attributes: [], newState: .init(controller: controller, username: "", flowToken: "")) //.attributesRequired(.init(controller: controller, flowToken: ""))
+        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, expectedError.type)
+        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.delegateNotImplemented)
+    }
+
+    func test_submitCode_delegate_whenSuccess_shouldReturnAccountResult() {
+        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt")
+
+        let expectedResult: SignUpVerifyCodeResult = .completed(expectedSignInAfterSignUpState)
+        controller.submitCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpVerifyCodeDelegateSpy(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newSignInAfterSignUpState, expectedSignInAfterSignUpState)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
@@ -1,0 +1,116 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+
+final class SignUpPasswordRequiredStateTests: XCTestCase {
+
+    private var controller: MSALNativeAuthSignUpControllerMock!
+    private var sut: SignUpPasswordRequiredState!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        controller = .init()
+        sut = SignUpPasswordRequiredState(controller: controller, username: "<username>", flowToken: "<token>")
+    }
+
+    // MARK: - Delegate
+
+    func test_submitPassword_delegate_whenError_shouldReturnPasswordRequiredError() {
+        let expectedError = PasswordRequiredError(type: .invalidPassword)
+        let expectedState = SignUpPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let expectedResult: SignUpPasswordRequiredResult = .error(error: expectedError, newState: expectedState)
+        controller.submitPasswordResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-up states")
+        let delegate = SignUpPasswordRequiredDelegateSpy(expectation: exp)
+
+        sut.submitPassword(password: "1234", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error, expectedError)
+        XCTAssertEqual(delegate.newPasswordRequiredState?.flowToken, expectedState.flowToken)
+    }
+
+    func test_submitCode_delegate_whenAttributesRequired_AndUserHasImplementedOptionalDelegate_shouldReturnAttributesRequired() {
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpPasswordRequiredResult = .attributesRequired(attributes: [], newState: expectedAttributesRequiredState)
+        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpPasswordRequiredDelegateSpy(expectation: exp)
+
+        sut.submitPassword(password: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.newAttributesRequiredState, expectedAttributesRequiredState)
+    }
+
+    func test_submitCode_delegate_whenAttributesRequired_ButUserHasNotImplementedOptionalDelegate_shouldReturnPasswordRequiredError() {
+        let expectedError = PasswordRequiredError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "exp telemetry is called")
+
+        let expectedResult: SignUpPasswordRequiredResult = .attributesRequired(attributes: [], newState: expectedAttributesRequiredState)
+        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitPassword(password: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, expectedError.type)
+        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.delegateNotImplemented)
+    }
+
+    func test_submitCode_delegate_whenSuccess_shouldReturnSignUpCompleted() {
+        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt")
+
+        let exp = expectation(description: "sign-up states")
+
+        let expectedResult: SignUpPasswordRequiredResult = .completed(expectedSignInAfterSignUpState)
+        controller.submitPasswordResult = .init(expectedResult)
+
+        let delegate = SignUpPasswordRequiredDelegateSpy(expectation: exp)
+
+        sut.submitPassword(password: "1234", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.signInAfterSignUpState, expectedSignInAfterSignUpState)
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR shows the SDK that the CIAM team had developed. It is based on the Native Auth merge into MSAL plan here: https://microsofteur.sharepoint.com/:w:/t/DevExDublin/EdfT2AmlFZFIsTtr-EaoSBIBPqcOlRo1MJ1USbEsfjfEcQ

To comply with the design changes made by our API team, we have created a more dynamic SDK. This means that we make different API requests for each authentication flow. There is also some logic involved in each of the responses we get from each request.

We have created a state machine for each flow (check this [Figma](https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0%3A1&t=VUyK4gIoyUChTXWF-1) to see all the possible states), and we are making it external to developers by using delegates instead of completion blocks, as @Serhii Demchenko suggested. In this way we can guide the developer through the authentication process offering a discovering interface. We think that this approach will improve the overall developer experience.

**This PR is focused in the Sign Up feature. It is not compilable, so validations are not going to pass. To build and test this code, please use the `ciam-master-snapshot` branch.**

The IdentityCore changes can be found in this PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1294

**For context, this is the Native Auth technical overview:** https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview?path=/%5BiOS%5D%20Native%20authentication/technical_overview.md&version=GBdanilo/native-authentication&_a=preview

State Machine:
https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0-1&mode=design&t=80VUxa1RvxMn4rnl-0

## High level overview

**MSALNativeAuthPublicClientApplication.swift**
The public interface is the entry point of the SDK. Here is where all the supported authentication flows begin.
Regarding the sign-up flow, developers can call either `signUp(...)` or `signUpUsingPassword(...)`.
Notice that in those methods they must pass a class that conforms to `SignUpStartDelegate`. or `SignUpPasswordStartDelegate`, respectively.


**MSALNativeAuthSignUpController.swift**
The controller handles most of the logic. Each of the methods inside the MARK: - Internal can be called from the public interfaces, that are:
    - MSALNativeAuthPublicClientApplication
    - One of the States (located in the file SignUpDelegates.swift). These States are returned through the delegates, as we will see.

For each of these methods, the controller:
    - Creates a request (`MSIDHttpRequest`) using its requestProvider (`MSALNativeAuthSignUpRequestProviding`).
    - Executes the request.
    - Passes the result to its responseValidator (`MSALNativeAuthSignUpResponseValidating`)
    - Handles the validated result and returns it to the public interface, which uses the delegate to communicate back to the developer.
    - Creates and handle the local telemetry events.

The controller decides what to do with the ValidatedResponse given by the ResponseValidator.

Every validated response usually has:
**A success:** it means that the SDK moves on to the next state, which usually involves making another request or returning back to the user via the delegate.
Redirect: when the backend detects an error and wants the SDK to fallback to the WebView-based flow.
**A known error:** in some cases, these errors put the user in a recoverable state (for example, an error that requires the user to provide more attributes). In other cases, the error means the end of the flow.
**An unexpected error:** these errors are likely bugs, they happen when we there are missing attributes from the response, etc.
(Please keep in mind that not every ValidatedResponse falls into the same categories, this is just an approximation)


**MSALNativeAuthRequestConfigurator.swift**
Each of the requestProviders from the Controllers uses the RequestConfigurator to create and configure the requests. Although there are different RequestProviders (one per flow), there's only one RequestConfigurator.

The RequestConfigurator injects a custom ErrorHandler (`MSALNativeAuthResponseErrorHandler`) to every request. This is needed in order to decode the errors from the API.
These errors follow a structure that you can see in `MSALNativeAuthSignUpStartResponseError` for example. In the directory native_auth/network/errors/ you can see all the files used.


**MSALNativeAuthSignUpResponseValidator.swift**
The ResponseValidator is in charge of analysing the api response and returning to the Controller a validated response (for instance, for the response of the signup/start endpoint, it returns a `MSALNativeAuthSignUpStartValidatedResponse`).


**SignUpStates.swift**
In this file there are the different States that the Controller can return to the developer through the delegate.

This is how the developer will use them. For more examples of how developers can use the SDK you can check the Sample App (located in /Samples/ios-native-auth-simple in the branch `ciam-master-snapshot`). We will include it in a separate PR:

extension EmailAndPasswordViewController: SignUpPasswordStartDelegate {

    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState,
                                                      sentTo _: String,
                                                      channelTargetType _: MSAL.MSALNativeAuthChannelType,
                                                      codeLength _: Int) {

           // show UI to get the user's email OOB code, and wait for user's input
           // then, use the newState to send it to the SDK.
           newState.submitCode(code: code, delegate: self)
    }
}

Each of these states then calls one of the Controller's internal functions, and it follows the same process that we just described in the previous steps.

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

