### PR TITLE
Native Auth base classes that interact with MSAL

### DIFF
--- a/MSAL/src/native_auth/cache/MSALNativeAuthCacheAccessor.swift
+++ b/MSAL/src/native_auth/cache/MSALNativeAuthCacheAccessor.swift
@@ -1,0 +1,181 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthCacheAccessor: MSALNativeAuthCacheInterface {
+
+    private let tokenCacheAccessor: MSIDDefaultTokenCacheAccessor = {
+        let dataSource = MSIDKeychainTokenCache()
+        return MSIDDefaultTokenCacheAccessor(dataSource: dataSource, otherCacheAccessors: [])
+    }()
+
+    private let accountMetadataCache: MSIDAccountMetadataCacheAccessor = MSIDAccountMetadataCacheAccessor(dataSource: MSIDKeychainTokenCache())
+    private let externalAccountProvider: MSALExternalAccountHandler = MSALExternalAccountHandler()
+    private let validator = MSIDTokenResponseValidator()
+
+    func getTokens(
+        account: MSALAccount,
+        configuration: MSIDConfiguration,
+        context: MSIDRequestContext) throws -> MSALNativeAuthTokens {
+            let accountConfiguration = try getAccountConfiguration(configuration: configuration, account: account)
+            let idToken = try tokenCacheAccessor.getIDToken(
+                forAccount: account.lookupAccountIdentifier,
+                configuration: accountConfiguration,
+                idTokenType: MSIDCredentialType.MSIDIDTokenType,
+                context: context)
+            let refreshToken = try tokenCacheAccessor.getRefreshToken(
+                withAccount: account.lookupAccountIdentifier,
+                familyId: nil,
+                configuration: accountConfiguration,
+                context: context)
+            let accessToken = try tokenCacheAccessor.getAccessToken(
+                forAccount: account.lookupAccountIdentifier,
+                configuration: accountConfiguration,
+                context: context)
+            return MSALNativeAuthTokens(accessToken: accessToken, refreshToken: refreshToken, rawIdToken: idToken.rawIdToken)
+        }
+
+    func getAccount(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        context: MSIDRequestContext) throws -> MSIDAccount? {
+            return try tokenCacheAccessor.getAccountFor(
+                accountIdentifier,
+                authority: authority,
+                realmHint: nil,
+                context: context)
+        }
+
+    func getAllAccounts(configuration: MSIDConfiguration) throws -> [MSALAccount] {
+        let request = MSALAccountsProvider(tokenCache: tokenCacheAccessor,
+                                           accountMetadataCache: accountMetadataCache,
+                                           clientId: configuration.clientId,
+                                           externalAccountProvider: externalAccountProvider)
+        return try request?.allAccounts() ?? []
+    }
+
+    func validateAndSaveTokensAndAccount(
+        tokenResponse: MSIDTokenResponse,
+        configuration: MSIDConfiguration,
+        context: MSIDRequestContext) throws -> MSIDTokenResult? {
+            let ciamOauth2Provider = getCIAMOauth2Provider(clientId: configuration.clientId)
+            return try? validator.validateAndSave(tokenResponse,
+                                                  oauthFactory: ciamOauth2Provider.msidOauth2Factory,
+                                                  tokenCache: tokenCacheAccessor,
+                                                  accountMetadataCache: accountMetadataCache,
+                                                  requestParameters: getRequestParameters(tokenResponse: tokenResponse,
+                                                                                          configuration: configuration,
+                                                                                          context: context),
+                                                  saveSSOStateOnly: false)
+        }
+
+    // Here we create the MSIDRequestParameters required by the validateAndSave method
+    private func getRequestParameters(
+        tokenResponse: MSIDTokenResponse,
+        configuration: MSIDConfiguration,
+        context: MSIDRequestContext
+    ) -> MSIDRequestParameters {
+
+        // We are creating the default MSIDRequestParameters to prevent unintended functionality changes.
+        // If the method `validateAndSaveTokenResponse` from `MSIDTokenResponseValidator` changes
+        // the implementation here also needs to change to match the properties needed by the method
+        // Currently only the required and used parameters are set
+        let parameters = MSIDRequestParameters()
+        // MSIDRequestParameters has to follow MSIDRequestContext protocol
+        parameters.correlationId = context.correlationId()
+        parameters.logComponent = context.logComponent()
+        parameters.telemetryRequestId = context.telemetryRequestId()
+        parameters.appRequestMetadata = context.appRequestMetadata()
+
+        parameters.msidConfiguration = configuration
+        parameters.clientId = configuration.clientId
+
+        let displayableId = tokenResponse.idTokenObj?.username()
+        let homeAccountId = tokenResponse.idTokenObj?.userId
+
+        let  accountIdentifier = MSIDAccountIdentifier(displayableId: displayableId, homeAccountId: homeAccountId)
+        parameters.accountIdentifier = accountIdentifier
+        parameters.authority = configuration.authority
+        parameters.instanceAware = false
+        let defaultOIDCScopesArray = MSALPublicClientApplication.defaultOIDCScopes().array as? [String]
+        parameters.oidcScope = defaultOIDCScopesArray?.joinScopes()
+        return parameters
+    }
+
+    func removeTokens(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        clientId: String,
+        context: MSIDRequestContext) throws {
+            try tokenCacheAccessor.clearCache(
+                forAccount: accountIdentifier,
+                authority: authority,
+                clientId: clientId,
+                familyId: nil,
+                clearAccounts: false,
+                context: context)
+        }
+
+    func clearCache(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        clientId: String,
+        context: MSIDRequestContext) throws {
+            try tokenCacheAccessor.clearCache(
+                forAccount: accountIdentifier,
+                authority: authority,
+                clientId: clientId,
+                familyId: nil,
+                clearAccounts: true,
+                context: context)
+        }
+
+    private func getCIAMOauth2Provider(clientId: String) -> MSALCIAMOauth2Provider {
+        return MSALCIAMOauth2Provider(clientId: clientId,
+                               tokenCache: tokenCacheAccessor,
+                               accountMetadataCache: accountMetadataCache)
+
+    }
+
+    private func getAccountConfiguration(configuration: MSIDConfiguration,
+                                         account: MSALAccount) throws -> MSIDConfiguration? {
+        // When retrieving tokens from the cache, we first have to get the
+        // Tenant Id from the AccountMetadataCache. Because in NativeAuth
+        // We use only CIAM authorities, we retrieve using its provider
+        let ciamOauth2Provider = getCIAMOauth2Provider(clientId: configuration.clientId)
+        let accountConfiguration = configuration.copy() as? MSIDConfiguration
+        let errorPointer: NSErrorPointer = nil
+        let requestAuthority = ciamOauth2Provider.issuerAuthority(with: account,
+                                                                      request: configuration.authority,
+                                                                      instanceAware: false,
+                                                                      error: errorPointer)
+        if let errorPointer = errorPointer, let error = errorPointer.pointee {
+            throw error
+        }
+        accountConfiguration?.authority = requestAuthority
+        return accountConfiguration
+    }
+}

--- a/MSAL/src/native_auth/cache/MSALNativeAuthCacheInterface.swift
+++ b/MSAL/src/native_auth/cache/MSALNativeAuthCacheInterface.swift
@@ -1,0 +1,57 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthCacheInterface {
+    func getTokens(
+        account: MSALAccount,
+        configuration: MSIDConfiguration,
+        context: MSIDRequestContext) throws -> MSALNativeAuthTokens
+
+    func getAccount(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        context: MSIDRequestContext) throws -> MSIDAccount?
+
+    func getAllAccounts(configuration: MSIDConfiguration) throws -> [MSALAccount]
+
+    func validateAndSaveTokensAndAccount(
+        tokenResponse: MSIDTokenResponse,
+        configuration: MSIDConfiguration,
+        context: MSIDRequestContext) throws -> MSIDTokenResult?
+
+    func removeTokens(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        clientId: String,
+        context: MSIDRequestContext) throws
+
+    func clearCache(
+        accountIdentifier: MSIDAccountIdentifier,
+        authority: MSIDAuthority,
+        clientId: String,
+        context: MSIDRequestContext) throws
+}

--- a/MSAL/src/native_auth/cache/MSALNativeAuthTokens.swift
+++ b/MSAL/src/native_auth/cache/MSALNativeAuthTokens.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthTokens {
+    let accessToken: MSIDAccessToken?
+    let refreshToken: MSIDRefreshToken?
+    let rawIdToken: String?
+
+    init(accessToken: MSIDAccessToken?, refreshToken: MSIDRefreshToken?, rawIdToken: String?) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.rawIdToken = rawIdToken
+    }
+}

--- a/MSAL/src/native_auth/configuration/MSALNativeAuthConfiguration.swift
+++ b/MSAL/src/native_auth/configuration/MSALNativeAuthConfiguration.swift
@@ -1,0 +1,49 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthConfiguration {
+    var challengeTypesString: String {
+        return challengeTypes.map { $0.rawValue }.joined(separator: " ")
+    }
+
+    let clientId: String
+    let authority: MSIDCIAMAuthority
+    let challengeTypes: [MSALNativeAuthInternalChallengeType]
+    var sliceConfig: MSALSliceConfig?
+
+    init(
+        clientId: String,
+        authority: MSALCIAMAuthority,
+        challengeTypes: [MSALNativeAuthInternalChallengeType]) throws {
+        self.clientId = clientId
+        self.authority = try MSIDCIAMAuthority(
+            url: authority.url,
+            validateFormat: false,
+            context: MSALNativeAuthRequestContext()
+        )
+        self.challengeTypes = challengeTypes
+    }
+}

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
@@ -1,0 +1,143 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthBaseController {
+
+    typealias TelemetryInfo = (event: MSIDTelemetryAPIEvent?, context: MSALNativeAuthRequestContext)
+    let clientId: String
+
+    init(
+        clientId: String
+    ) {
+        self.clientId = clientId
+    }
+
+    func makeAndStartTelemetryEvent(
+        id: MSALNativeAuthTelemetryApiId,
+        context: MSIDRequestContext
+    ) -> MSIDTelemetryAPIEvent? {
+        let event = makeLocalTelemetryApiEvent(
+            name: MSID_TELEMETRY_EVENT_API_EVENT,
+            telemetryApiId: id,
+            context: context
+        )
+
+        startTelemetryEvent(event, context: context)
+
+        return event
+    }
+
+    func makeLocalTelemetryApiEvent(
+        name: String,
+        telemetryApiId: MSALNativeAuthTelemetryApiId,
+        context: MSIDRequestContext
+    ) -> MSIDTelemetryAPIEvent? {
+        let event = MSIDTelemetryAPIEvent(
+            name: name,
+            context: context
+        )
+
+        event?.setApiId(String(telemetryApiId.rawValue))
+        event?.setCorrelationId(context.correlationId())
+        event?.setClientId(clientId)
+
+        return event
+    }
+
+    func startTelemetryEvent(_ localEvent: MSIDTelemetryAPIEvent?, context: MSIDRequestContext) {
+        guard let eventName = localEvent?.property(withName: MSID_TELEMETRY_KEY_EVENT_NAME) else {
+            return MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Telemetry event nil not expected"
+            )
+        }
+
+        MSIDTelemetry.sharedInstance().startEvent(
+            context.telemetryRequestId(),
+            eventName: eventName
+        )
+    }
+
+    func stopTelemetryEvent(_ telemetryInfo: TelemetryInfo, error: Error? = nil) {
+        stopTelemetryEvent(telemetryInfo.event, context: telemetryInfo.context, error: error)
+    }
+
+    func stopTelemetryEvent(_ localEvent: MSIDTelemetryAPIEvent?, context: MSIDRequestContext, error: Error? = nil) {
+        guard let event = localEvent else {
+            return MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Telemetry event nil not expected"
+            )
+        }
+
+        if let error = error as? NSError {
+
+            if let key = MSIDErrorConverter.defaultErrorConverter?.oauthErrorKey(),
+                let oauthErrorCode = error.userInfo[key] as? String {
+                event.setOauthErrorCode(oauthErrorCode)
+            }
+
+            event.setErrorCodeString(String(error.code))
+            event.setErrorDomain(error.domain)
+            event.setResultStatus(MSID_TELEMETRY_VALUE_FAILED)
+            event.setIsSuccessfulStatus(MSID_TELEMETRY_VALUE_NO)
+        } else {
+            event.setResultStatus(MSID_TELEMETRY_VALUE_SUCCEEDED)
+            event.setIsSuccessfulStatus(MSID_TELEMETRY_VALUE_YES)
+        }
+
+        MSIDTelemetry.sharedInstance().stopEvent(context.telemetryRequestId(), event: event)
+        MSIDTelemetry.sharedInstance().flush(context.telemetryRequestId())
+    }
+
+    func complete<T>(
+        _ telemetryEvent: MSIDTelemetryAPIEvent?,
+        response: T? = nil,
+        error: Error? = nil,
+        context: MSIDRequestContext,
+        completion: @escaping (T?, Error?) -> Void
+    ) {
+        stopTelemetryEvent(telemetryEvent, context: context, error: error)
+        completion(response, error)
+    }
+
+    func performRequest<T>(_ request: MSIDHttpRequest, context: MSIDRequestContext) async -> Result<T, Error> {
+        return await withCheckedContinuation { continuation in
+            request.send { result, error in
+                if let error = error {
+                    continuation.resume(returning: .failure(error))
+                } else if let response = result as? T {
+                    continuation.resume(returning: .success(response))
+                } else {
+                    MSALLogger.log(level: .error, context: context, format: "Error request - Both result and error are nil")
+                    continuation.resume(returning: .failure(MSALNativeAuthInternalError.invalidResponse))
+                }
+            }
+        }
+    }
+}

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
@@ -1,0 +1,226 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+import Foundation
+
+class MSALNativeAuthTokenController: MSALNativeAuthBaseController {
+
+    // MARK: - Variables
+
+    let factory: MSALNativeAuthResultBuildable
+    private let requestProvider: MSALNativeAuthTokenRequestProviding
+    private let responseValidator: MSALNativeAuthTokenResponseValidating
+    private let cacheAccessor: MSALNativeAuthCacheInterface
+
+    init(
+        clientId: String,
+        requestProvider: MSALNativeAuthTokenRequestProviding,
+        cacheAccessor: MSALNativeAuthCacheInterface,
+        factory: MSALNativeAuthResultBuildable,
+        responseValidator: MSALNativeAuthTokenResponseValidating
+    ) {
+        self.requestProvider = requestProvider
+        self.factory = factory
+        self.responseValidator = responseValidator
+        self.cacheAccessor = cacheAccessor
+        super.init(
+            clientId: clientId
+        )
+    }
+
+    func performAndValidateTokenRequest(
+        _ request: MSIDHttpRequest,
+        config: MSIDConfiguration,
+        context: MSALNativeAuthRequestContext) async -> MSALNativeAuthTokenValidatedResponse {
+            let ciamTokenResponse: Result<MSIDCIAMTokenResponse, Error> = await performTokenRequest(request, context: context)
+            return responseValidator.validate(
+                context: context,
+                msidConfiguration: config,
+                result: ciamTokenResponse
+            )
+        }
+
+    func joinScopes(_ scopes: [String]?) -> [String] {
+        let defaultOIDCScopes = MSALPublicClientApplication.defaultOIDCScopes().array
+        guard let scopes = scopes else {
+            return defaultOIDCScopes as? [String] ?? []
+        }
+        let joinedScopes = NSMutableOrderedSet(array: scopes)
+        joinedScopes.addObjects(from: defaultOIDCScopes)
+        return joinedScopes.array as? [String] ?? []
+    }
+
+    func createTokenRequest(
+        username: String? = nil,
+        password: String? = nil,
+        scopes: [String],
+        credentialToken: String? = nil,
+        oobCode: String? = nil,
+        signInSLT: String? = nil,
+        grantType: MSALNativeAuthGrantType,
+        includeChallengeType: Bool = true,
+        context: MSIDRequestContext) -> MSIDHttpRequest? {
+            do {
+                let params = MSALNativeAuthTokenRequestParameters(
+                    context: context,
+                    username: username,
+                    credentialToken: credentialToken,
+                    signInSLT: signInSLT,
+                    grantType: grantType,
+                    scope: scopes.joinScopes(),
+                    password: password,
+                    oobCode: oobCode,
+                    includeChallengeType: includeChallengeType,
+                    refreshToken: nil)
+                return try requestProvider.signInWithPassword(parameters: params, context: context)
+            } catch {
+                MSALLogger.log(level: .error, context: context, format: "Error creating SignIn Token Request: \(error)")
+                return nil
+            }
+        }
+
+    func createRefreshTokenRequest(
+        scopes: [String],
+        refreshToken: String?,
+        context: MSIDRequestContext) -> MSIDHttpRequest? {
+            guard let refreshToken = refreshToken else {
+                MSALLogger.log(level: .error, context: context, format: "Error creating Refresh Token Request, refresh token is nil!")
+                return nil
+            }
+            do {
+                let params = MSALNativeAuthTokenRequestParameters(
+                    context: context,
+                    username: nil,
+                    credentialToken: nil,
+                    signInSLT: nil,
+                    grantType: .refreshToken,
+                    scope: scopes.joinScopes(),
+                    password: nil,
+                    oobCode: nil,
+                    includeChallengeType: false,
+                    refreshToken: refreshToken)
+                return try requestProvider.refreshToken(parameters: params, context: context)
+            } catch {
+                MSALLogger.log(level: .error, context: context, format: "Error creating Refresh Token Request: \(error)")
+                return nil
+            }
+        }
+
+    func cacheTokenResponse(
+        _ tokenResponse: MSIDTokenResponse,
+        context: MSALNativeAuthRequestContext,
+        msidConfiguration: MSIDConfiguration
+    ) throws -> MSIDTokenResult {
+        let displayableId = tokenResponse.idTokenObj?.username()
+        let homeAccountId = tokenResponse.idTokenObj?.userId
+
+        guard let accountIdentifier = MSIDAccountIdentifier(displayableId: displayableId, homeAccountId: homeAccountId) else {
+            MSALLogger.log(level: .error, context: context, format: "Error creating account identifier")
+            throw MSALNativeAuthInternalError.invalidResponse
+        }
+
+        guard let result = cacheTokenResponseRetrieveTokenResult(tokenResponse,
+                                                                 context: context,
+                                                                 msidConfiguration: msidConfiguration) else {
+            MSALLogger.log(level: .error, context: context, format: "Error caching token response")
+            throw MSALNativeAuthInternalError.invalidResponse
+        }
+
+        guard try responseValidator.validateAccount(with: result,
+                                                    context: context,
+                                                    accountIdentifier: accountIdentifier) else {
+            MSALLogger.log(level: .error, context: context, format: "Error validating account")
+            throw MSALNativeAuthInternalError.invalidResponse
+        }
+
+        return result
+    }
+
+    private func cacheTokenResponseRetrieveTokenResult(
+        _ tokenResponse: MSIDTokenResponse,
+        context: MSALNativeAuthRequestContext,
+        msidConfiguration: MSIDConfiguration
+    ) -> MSIDTokenResult? {
+        do {
+            // If there is an account existing already in the cache, we remove it
+            try clearAccount(msidConfiguration: msidConfiguration, context: context)
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error clearing account \(error) (ignoring)")
+        }
+        do {
+            let result = try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse,
+                                                                           configuration: msidConfiguration,
+                                                                           context: context)
+            return result
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error caching response: \(error) (ignoring)")
+        }
+        return nil
+    }
+
+    private func clearAccount(msidConfiguration: MSIDConfiguration, context: MSALNativeAuthRequestContext) throws {
+        do {
+            let accounts = try cacheAccessor.getAllAccounts(configuration: msidConfiguration)
+            if let account = accounts.first {
+                if let identifier = MSIDAccountIdentifier(displayableId: account.username, homeAccountId: account.identifier) {
+                    try cacheAccessor.clearCache(accountIdentifier: identifier,
+                                                  authority: msidConfiguration.authority,
+                                                  clientId: msidConfiguration.clientId,
+                                                  context: context)
+                }
+            } else {
+                MSALLogger.log(level: .error,
+                               context: context,
+                               format: "Error creating MSIDAccountIdentifier out of MSALAccount (ignoring)")
+            }
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error clearing previous account (ignoring)")
+        }
+    }
+
+    private func performTokenRequest(_ request: MSIDHttpRequest, context: MSIDRequestContext) async -> Result<MSIDCIAMTokenResponse, Error> {
+        return await withCheckedContinuation { continuation in
+            request.send { response, error in
+                if let error = error {
+                    continuation.resume(returning: .failure(error))
+                    return
+                }
+                guard let responseDict = response as? [AnyHashable: Any] else {
+                    continuation.resume(returning: .failure(MSALNativeAuthInternalError.invalidResponse))
+                    return
+                }
+                do {
+                    let tokenResponse = try MSIDCIAMTokenResponse(jsonDictionary: responseDict)
+                    tokenResponse.correlationId = request.context?.correlationId().uuidString
+                    continuation.resume(returning: .success(tokenResponse))
+                } catch {
+                    MSALLogger.log(level: .error, context: context, format: "Error token request - Both result and error are nil")
+                    continuation.resume(returning: .failure(MSALNativeAuthInternalError.invalidResponse))
+                }
+            }
+        }
+    }
+}

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -1,0 +1,192 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, MSALNativeAuthCredentialsControlling {
+
+    // MARK: - Variables
+
+    private let cacheAccessor: MSALNativeAuthCacheInterface
+
+    // MARK: - Init
+
+    override init(
+        clientId: String,
+        requestProvider: MSALNativeAuthTokenRequestProviding,
+        cacheAccessor: MSALNativeAuthCacheInterface,
+        factory: MSALNativeAuthResultBuildable,
+        responseValidator: MSALNativeAuthTokenResponseValidating
+    ) {
+        self.cacheAccessor = cacheAccessor
+        super.init(
+            clientId: clientId,
+            requestProvider: requestProvider,
+            cacheAccessor: cacheAccessor,
+            factory: factory,
+            responseValidator: responseValidator
+        )
+    }
+
+    convenience init(config: MSALNativeAuthConfiguration) {
+        let factory = MSALNativeAuthResultFactory(config: config)
+        self.init(
+            clientId: config.clientId,
+            requestProvider: MSALNativeAuthTokenRequestProvider(
+                requestConfigurator: MSALNativeAuthRequestConfigurator(config: config)),
+            cacheAccessor: MSALNativeAuthCacheAccessor(),
+            factory: factory,
+            responseValidator: MSALNativeAuthTokenResponseValidator(factory: factory,
+                                                                    msidValidator: MSIDTokenResponseValidator())
+        )
+    }
+
+    // MARK: Internal
+
+    func retrieveUserAccountResult(context: MSALNativeAuthRequestContext) -> MSALNativeAuthUserAccountResult? {
+        let accounts = self.allAccounts()
+        if let account = accounts.first {
+            // We pass an empty array of scopes because that will return all tokens for that account identifier
+            // Because we expect to be only one access token per account at this point, it's ok for the array to be empty
+            guard let tokens = retrieveTokens(account: account,
+                                              scopes: [],
+                                              context: context) else {
+                MSALLogger.log(level: .verbose, context: nil, format: "No tokens found")
+                return nil
+            }
+            return factory.makeUserAccountResult(account: account, authTokens: tokens)
+        } else {
+            MSALLogger.log(level: .verbose, context: nil, format: "No account found")
+        }
+        return nil
+    }
+
+    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> Result<String, RetrieveAccessTokenError> {
+        MSALLogger.log(level: .verbose, context: context, format: "Refresh started")
+        let telemetryEvent = makeAndStartTelemetryEvent(id: .telemetryApiIdRefreshToken, context: context)
+        let scopes = authTokens.accessToken?.scopes.array as? [String] ?? []
+        guard let request = createRefreshTokenRequest(
+            scopes: scopes,
+            refreshToken: authTokens.refreshToken?.refreshToken,
+            context: context
+        ) else {
+            stopTelemetryEvent(telemetryEvent, context: context, error: MSALNativeAuthInternalError.invalidRequest)
+            return .failure(RetrieveAccessTokenError(type: .generalError))
+        }
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        let response = await performAndValidateTokenRequest(request, config: config, context: context)
+        return handleTokenResponse(
+            response,
+            scopes: scopes,
+            context: context,
+            telemetryEvent: telemetryEvent
+        )
+    }
+
+    // MARK: - Private
+
+    private func allAccounts() -> [MSALAccount] {
+        do {
+            // We pass an empty array of scopes because that will return all accounts
+            // that have been saved for the current Client Id. We expect only one account to exist at this point per Client Id
+            let config = factory.makeMSIDConfiguration(scopes: [])
+            return try cacheAccessor.getAllAccounts(configuration: config)
+        } catch {
+            MSALLogger.log(
+                level: .error,
+                context: nil,
+                format: "Error retrieving accounts \(error)")
+        }
+        return []
+    }
+
+    private func retrieveTokens(
+        account: MSALAccount,
+        scopes: [String],
+        context: MSALNativeAuthRequestContext
+    ) -> MSALNativeAuthTokens? {
+        do {
+            let config = factory.makeMSIDConfiguration(scopes: scopes)
+            return try cacheAccessor.getTokens(account: account, configuration: config, context: context)
+        } catch {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Error retrieving tokens: \(error)"
+            )
+        }
+        return nil
+    }
+
+    private func handleTokenResponse(
+        _ response: MSALNativeAuthTokenValidatedResponse,
+        scopes: [String],
+        context: MSALNativeAuthRequestContext,
+        telemetryEvent: MSIDTelemetryAPIEvent?
+    ) -> Result<String, RetrieveAccessTokenError> {
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        switch response {
+        case .success(let tokenResponse):
+            return handleMSIDTokenResponse(
+                tokenResponse: tokenResponse,
+                telemetryEvent: telemetryEvent,
+                context: context,
+                config: config
+            )
+        case .error(let errorType):
+            let error = errorType.convertToRetrieveAccessTokenError()
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Refresh Token completed with error: \(error.errorDescription ?? "No error description")")
+            stopTelemetryEvent(telemetryEvent, context: context, error: error)
+            return .failure(error)
+        }
+    }
+
+    private func handleMSIDTokenResponse(
+        tokenResponse: MSIDTokenResponse,
+        telemetryEvent: MSIDTelemetryAPIEvent?,
+        context: MSALNativeAuthRequestContext,
+        config: MSIDConfiguration
+    ) -> Result<String, RetrieveAccessTokenError> {
+        do {
+            let tokenResult = try cacheTokenResponse(tokenResponse, context: context, msidConfiguration: config)
+            telemetryEvent?.setUserInformation(tokenResult.account)
+            stopTelemetryEvent(telemetryEvent, context: context)
+            MSALLogger.log(
+                level: .verbose,
+                context: context,
+                format: "Refresh Token completed successfully")
+            return .success(tokenResult.accessToken.accessToken)
+        } catch {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Token Result was not created properly error - \(error)")
+            return .failure(RetrieveAccessTokenError(type: .generalError))
+        }
+    }
+}

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+protocol MSALNativeAuthCredentialsControlling {
+    func retrieveUserAccountResult(context: MSALNativeAuthRequestContext) -> MSALNativeAuthUserAccountResult?
+    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> Result<String, RetrieveAccessTokenError>
+}

--- a/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
+++ b/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
@@ -1,0 +1,79 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthResultBuildable {
+
+    var config: MSALNativeAuthConfiguration {get}
+
+    func makeUserAccountResult(tokenResult: MSIDTokenResult, context: MSIDRequestContext) -> MSALNativeAuthUserAccountResult?
+
+    func makeUserAccountResult(account: MSALAccount, authTokens: MSALNativeAuthTokens) -> MSALNativeAuthUserAccountResult?
+
+    func makeMSIDConfiguration(scopes: [String]) -> MSIDConfiguration
+}
+
+final class MSALNativeAuthResultFactory: MSALNativeAuthResultBuildable {
+
+    let config: MSALNativeAuthConfiguration
+
+    init(config: MSALNativeAuthConfiguration) {
+        self.config = config
+    }
+
+    func makeUserAccountResult(tokenResult: MSIDTokenResult, context: MSIDRequestContext) -> MSALNativeAuthUserAccountResult? {
+        guard let account = MSALAccount.init(msidAccount: tokenResult.account, createTenantProfile: false) else {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Account could not be created")
+            return nil
+        }
+        guard let refreshToken = tokenResult.refreshToken as? MSIDRefreshToken else {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Refresh token invalid, account result could not be created")
+            return nil
+        }
+        let authTokens = MSALNativeAuthTokens(accessToken: tokenResult.accessToken,
+                                              refreshToken: refreshToken,
+                                              rawIdToken: tokenResult.rawIdToken)
+        return .init(account: account, authTokens: authTokens, configuration: config, cacheAccessor: MSALNativeAuthCacheAccessor())
+    }
+
+    func makeUserAccountResult(account: MSALAccount, authTokens: MSALNativeAuthTokens) -> MSALNativeAuthUserAccountResult? {
+        return .init(account: account, authTokens: authTokens, configuration: config, cacheAccessor: MSALNativeAuthCacheAccessor())
+    }
+
+    func makeMSIDConfiguration(scopes: [String]) -> MSIDConfiguration {
+        return .init(
+            authority: config.authority,
+            redirectUri: nil,
+            clientId: config.clientId,
+            target: scopes.joinScopes()
+        )
+    }
+}

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -1,0 +1,537 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
+final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController, MSALNativeAuthResetPasswordControlling {
+    private let kNumberOfTimesToRetryPollCompletionCall = 5
+
+    private let requestProvider: MSALNativeAuthResetPasswordRequestProviding
+    private let responseValidator: MSALNativeAuthResetPasswordResponseValidating
+
+    init(
+        config: MSALNativeAuthConfiguration,
+        requestProvider: MSALNativeAuthResetPasswordRequestProviding,
+        responseValidator: MSALNativeAuthResetPasswordResponseValidating
+    ) {
+        self.requestProvider = requestProvider
+        self.responseValidator = responseValidator
+
+        super.init(clientId: config.clientId)
+    }
+
+    convenience init(config: MSALNativeAuthConfiguration) {
+        self.init(
+            config: config,
+            requestProvider: MSALNativeAuthResetPasswordRequestProvider(
+                requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+                telemetryProvider: MSALNativeAuthTelemetryProvider()
+            ),
+            responseValidator: MSALNativeAuthResetPasswordResponseValidator()
+        )
+    }
+
+    // MARK: - Internal interface methods
+
+    func resetPassword(parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordStart, context: parameters.context)
+        let response = await performStartRequest(parameters: parameters)
+        return await handleStartResponse(response, event: event, context: parameters.context)
+    }
+
+    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordResendCode, context: context)
+        let response = await performChallengeRequest(passwordResetToken: passwordResetToken, context: context)
+        return await handleResendCodeChallengeResponse(response, event: event, context: context)
+    }
+
+    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordVerifyCodeResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordSubmitCode, context: context)
+
+        let params = MSALNativeAuthResetPasswordContinueRequestParameters(
+            context: context,
+            passwordResetToken: passwordResetToken,
+            grantType: .oobCode,
+            oobCode: code
+        )
+
+        let response = await performContinueRequest(parameters: params)
+        return await handleSubmitCodeResponse(response, passwordResetToken: passwordResetToken, event: event, context: context)
+    }
+
+    func submitPassword(
+        password: String,
+        passwordSubmitToken: String,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordSubmit, context: context)
+
+        let params = MSALNativeAuthResetPasswordSubmitRequestParameters(
+            context: context,
+            passwordSubmitToken: passwordSubmitToken,
+            newPassword: password
+        )
+        let submitRequestResponse = await performSubmitRequest(parameters: params)
+        return await handleSubmitPasswordResponse(submitRequestResponse, passwordSubmitToken: passwordSubmitToken, event: event, context: context)
+    }
+
+    // MARK: - Start Request handling
+
+    private func performStartRequest(
+        parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters
+    ) async -> MSALNativeAuthResetPasswordStartValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.start(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error creating resetpassword/start request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing resetpassword/start request")
+
+        let result: Result<MSALNativeAuthResetPasswordStartResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(result, with: parameters.context)
+    }
+
+    private func handleStartResponse(_ response: MSALNativeAuthResetPasswordStartValidatedResponse,
+                                     event: MSIDTelemetryAPIEvent?,
+                                     context: MSIDRequestContext) async -> ResetPasswordStartResult {
+
+        MSALLogger.log(level: .verbose, context: context, format: "Finished resetpassword/start request")
+
+        switch response {
+        case .success(let passwordResetToken):
+            let challengeResponse = await performChallengeRequest(passwordResetToken: passwordResetToken, context: context)
+            return await handleChallengeResponse(challengeResponse, event: event, context: context)
+        case .redirect:
+            let error = ResetPasswordStartError(type: .browserRequired, message: MSALNativeAuthErrorMessage.browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "redirect error in resetpassword/start request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        case .error(let apiError):
+            let error = apiError.toResetPasswordStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in resetpassword/start request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        case .unexpectedError:
+            let error = ResetPasswordStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in resetpassword/start request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        }
+    }
+
+    // MARK: - Challenge Request handling
+
+    private func performChallengeRequest(
+        passwordResetToken: String,
+        context: MSIDRequestContext
+    ) async -> MSALNativeAuthResetPasswordChallengeValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.challenge(token: passwordResetToken, context: context)
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error creating Challenge Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: context, format: "Performing resetpassword/challenge request")
+
+        let result: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = await performRequest(request, context: context)
+        return responseValidator.validate(result, with: context)
+    }
+
+    private func handleChallengeResponse(
+        _ response: MSALNativeAuthResetPasswordChallengeValidatedResponse,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordStartResult {
+        switch response {
+        case .success(let sentTo, let channelTargetType, let codeLength, let challengeToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/challenge request")
+            stopTelemetryEvent(event, context: context)
+
+            return .codeRequired(
+                newState: ResetPasswordCodeRequiredState(controller: self, flowToken: challengeToken),
+                sentTo: sentTo,
+                channelTargetType: channelTargetType,
+                codeLength: codeLength
+            )
+        case .error(let apiError):
+            let error = apiError.toResetPasswordStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        case .redirect:
+            let error = ResetPasswordStartError(type: .browserRequired, message: MSALNativeAuthErrorMessage.browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        case .unexpectedError:
+            let error = ResetPasswordStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        }
+    }
+
+    private func handleResendCodeChallengeResponse(
+        _ response: MSALNativeAuthResetPasswordChallengeValidatedResponse,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordResendCodeResult {
+        switch response {
+        case .success(let sentTo, let channelTargetType, let codeLength, let challengeToken):
+            stopTelemetryEvent(event, context: context)
+            MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/challenge (resend code) request")
+            return .codeRequired(
+                newState: ResetPasswordCodeRequiredState(controller: self, flowToken: challengeToken),
+                sentTo: sentTo,
+                channelTargetType: channelTargetType,
+                codeLength: codeLength
+            )
+        case .error(let apiError):
+            let error = apiError.toResendCodePublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in resetpassword/challenge request (resend code) \(error.errorDescription ?? "No error description")")
+            return .error(error: error, newState: nil)
+        case .redirect,
+                .unexpectedError:
+            let error = ResendCodeError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in resetpassword/challenge request (resend code) \(error.errorDescription ?? "No error description")")
+            return .error(error: error, newState: nil)
+        }
+    }
+
+    // MARK: - Continue Request handling
+
+    private func performContinueRequest(
+        parameters: MSALNativeAuthResetPasswordContinueRequestParameters
+    ) async -> MSALNativeAuthResetPasswordContinueValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.continue(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error creating Continue Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing resetpassword/continue request")
+
+        let result: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(result, with: parameters.context)
+    }
+
+    private func handleSubmitCodeResponse(
+        _ response: MSALNativeAuthResetPasswordContinueValidatedResponse,
+        passwordResetToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordVerifyCodeResult {
+        switch response {
+        case .success(let passwordSubmitToken):
+            stopTelemetryEvent(event, context: context)
+            MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/continue request")
+            return .passwordRequired(newState: ResetPasswordRequiredState(controller: self, flowToken: passwordSubmitToken))
+        case .error(let apiError):
+            let error = apiError.toVerifyCodePublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in resetpassword/continue request \(error.errorDescription ?? "No error description")")
+            return .error(error: error, newState: nil)
+        case .unexpectedError:
+            let error = VerifyCodeError(type: .generalError)
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error calling resetpassword/continue \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: nil)
+        case .invalidOOB:
+            let error = VerifyCodeError(type: .invalidCode)
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Invalid code error calling resetpassword/continue \(error.errorDescription ?? "No error description")")
+
+            let state = ResetPasswordCodeRequiredState(controller: self, flowToken: passwordResetToken)
+            return .error(error: error, newState: state)
+        }
+    }
+
+    // MARK: - Submit Request handling
+
+    private func performSubmitRequest(
+        parameters: MSALNativeAuthResetPasswordSubmitRequestParameters
+    ) async -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.submit(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error creating Submit Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing resetpassword/submit request")
+
+        let result: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(result, with: parameters.context)
+    }
+
+    private func handleSubmitPasswordResponse(
+        _ response: MSALNativeAuthResetPasswordSubmitValidatedResponse,
+        passwordSubmitToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult {
+        MSALLogger.log(level: .info, context: context, format: "Finished resetpassword/submit request")
+
+        switch response {
+        case .success(let passwordResetToken, let pollInterval):
+            return await doPollCompletionLoop(
+                passwordResetToken: passwordResetToken,
+                pollInterval: pollInterval,
+                retriesRemaining: kNumberOfTimesToRetryPollCompletionCall,
+                event: event,
+                context: context
+            )
+        case .passwordError(let apiError):
+            let error = apiError.toPasswordRequiredPublicError()
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Password error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: ResetPasswordRequiredState(controller: self, flowToken: passwordSubmitToken))
+        case .error(let apiError):
+            let error = apiError.toPasswordRequiredPublicError()
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: nil)
+        case .unexpectedError:
+            let error = PasswordRequiredError(type: .generalError)
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: nil)
+        }
+    }
+
+    // MARK: - Poll Completion Request handling
+
+    private func doPollCompletionLoop(
+        passwordResetToken: String,
+        pollInterval: Int,
+        retriesRemaining: Int,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult {
+        MSALLogger.log(level: .verbose, context: context, format: "performing poll completion request...")
+
+        let pollCompletionResponse = await performPollCompletionRequest(
+            passwordResetToken: passwordResetToken,
+            context: context
+        )
+
+        MSALLogger.log(level: .verbose, context: context, format: "handling poll completion response...")
+
+        return await handlePollCompletionResponse(
+            pollCompletionResponse,
+            pollInterval: pollInterval,
+            retriesRemaining: retriesRemaining,
+            passwordResetToken: passwordResetToken,
+            event: event,
+            context: context
+        )
+    }
+
+    private func performPollCompletionRequest(
+        passwordResetToken: String,
+        context: MSIDRequestContext
+    ) async -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
+        let parameters = MSALNativeAuthResetPasswordPollCompletionRequestParameters(
+            context: context,
+            passwordResetToken: passwordResetToken
+        )
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.pollCompletion(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error creating Poll Completion Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing resetpassword/poll_completion request")
+
+        let result: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = await performRequest(
+            request,
+            context: parameters.context
+        )
+        return responseValidator.validate(result, with: parameters.context)
+    }
+
+    private func handlePollCompletionResponse(
+        _ response: MSALNativeAuthResetPasswordPollCompletionValidatedResponse,
+        pollInterval: Int,
+        retriesRemaining: Int,
+        passwordResetToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult {
+        MSALLogger.log(level: .info, context: context, format: "Finished resetpassword/poll_completion")
+
+        switch response {
+        case .success(let status):
+            switch status {
+            case .inProgress,
+                 .notStarted:
+
+                return await retryPollCompletion(
+                    passwordResetToken: passwordResetToken,
+                    pollInterval: pollInterval,
+                    retriesRemaining: retriesRemaining,
+                    event: event,
+                    context: context
+                )
+            case .succeeded:
+                stopTelemetryEvent(event, context: context)
+
+                return .completed
+            case .failed:
+                let error = PasswordRequiredError(type: .generalError)
+                self.stopTelemetryEvent(event, context: context, error: error)
+                MSALLogger.log(level: .error, context: context, format: "password poll success returned status 'failed'")
+
+                return .error(error: error, newState: nil)
+            }
+        case .passwordError(let apiError):
+            let error = apiError.toPasswordRequiredPublicError()
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Password error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: ResetPasswordRequiredState(controller: self, flowToken: passwordResetToken))
+        case .error(let apiError):
+            let error = apiError.toPasswordRequiredPublicError()
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: nil)
+        case .unexpectedError:
+            let error = PasswordRequiredError(type: .generalError)
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: nil)
+        }
+    }
+
+    private func retryPollCompletion(
+        passwordResetToken: String,
+        pollInterval: Int,
+        retriesRemaining: Int,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult {
+        guard retriesRemaining > 0 else {
+            let error = PasswordRequiredError(type: .generalError)
+            self.stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error, context: context, format: "password poll completion did not complete in time")
+
+            return .error(error: error, newState: nil)
+        }
+
+        MSALLogger.log(
+            level: .info,
+            context: context,
+            format: "resetpassword: waiting for \(pollInterval) seconds before retrying"
+        )
+
+        do {
+            try await Task.sleep(nanoseconds: 1_000_000_000 * UInt64(pollInterval))
+        } catch {
+            // Task.sleep can throw a CancellationError if the Task is cancelled.
+            // We don't expect that to ever happen here so we just log it and carry on
+
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "resetpassword: Task.sleep unexpectedly threw an error: \(error). Ignoring..."
+            )
+        }
+
+        return await doPollCompletionLoop(
+            passwordResetToken: passwordResetToken,
+            pollInterval: pollInterval,
+            retriesRemaining: retriesRemaining - 1,
+            event: event,
+            context: context
+        )
+    }
+}
+// swiftlint:enable file_length

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordControlling.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordControlling.swift
@@ -1,0 +1,40 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthResetPasswordControlling: AnyObject {
+
+    func resetPassword(parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartResult
+
+    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeResult
+
+    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordVerifyCodeResult
+
+    func submitPassword(
+        password: String,
+        passwordSubmitToken: String,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult
+}

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -1,0 +1,592 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
+final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALNativeAuthSignInControlling {
+
+    // MARK: - Variables
+
+    private let signInRequestProvider: MSALNativeAuthSignInRequestProviding
+    private let signInResponseValidator: MSALNativeAuthSignInResponseValidating
+
+    // MARK: - Init
+
+    init(
+        clientId: String,
+        signInRequestProvider: MSALNativeAuthSignInRequestProviding,
+        tokenRequestProvider: MSALNativeAuthTokenRequestProviding,
+        cacheAccessor: MSALNativeAuthCacheInterface,
+        factory: MSALNativeAuthResultBuildable,
+        signInResponseValidator: MSALNativeAuthSignInResponseValidating,
+        tokenResponseValidator: MSALNativeAuthTokenResponseValidating
+    ) {
+        self.signInRequestProvider = signInRequestProvider
+        self.signInResponseValidator = signInResponseValidator
+        super.init(
+            clientId: clientId,
+            requestProvider: tokenRequestProvider,
+            cacheAccessor: cacheAccessor,
+            factory: factory,
+            responseValidator: tokenResponseValidator
+        )
+    }
+
+    convenience init(config: MSALNativeAuthConfiguration) {
+        let factory = MSALNativeAuthResultFactory(config: config)
+        self.init(
+            clientId: config.clientId,
+            signInRequestProvider: MSALNativeAuthSignInRequestProvider(
+                requestConfigurator: MSALNativeAuthRequestConfigurator(config: config)),
+            tokenRequestProvider: MSALNativeAuthTokenRequestProvider(
+                requestConfigurator: MSALNativeAuthRequestConfigurator(config: config)),
+            cacheAccessor: MSALNativeAuthCacheAccessor(),
+            factory: factory,
+            signInResponseValidator: MSALNativeAuthSignInResponseValidator(),
+            tokenResponseValidator: MSALNativeAuthTokenResponseValidator(
+                factory: factory,
+                msidValidator: MSIDTokenResponseValidator())
+        )
+    }
+
+    // MARK: - Internal
+
+    func signIn(params: MSALNativeAuthSignInWithPasswordParameters) async -> SignInPasswordControllerResponse {
+        MSALLogger.log(level: .verbose, context: params.context, format: "SignIn with username and password started")
+        let telemetryInfo = TelemetryInfo(
+            event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInWithPasswordStart, context: params.context),
+            context: params.context
+        )
+
+        let initiateValidatedResponse = await performAndValidateSignInInitiate(username: params.username, telemetryInfo: telemetryInfo)
+        let result = await handleInitiateResponse(initiateValidatedResponse, telemetryInfo: telemetryInfo)
+
+        switch result {
+        case .success(let challengeValidatedResponse):
+            return await handleChallengeResponse(challengeValidatedResponse, params: params, telemetryInfo: telemetryInfo)
+        case .failure(let error):
+            return .init(.error(error.convertToSignInPasswordStartError()))
+        }
+    }
+
+    func signIn(params: MSALNativeAuthSignInWithCodeParameters) async -> SignInCodeControllerResponse {
+        MSALLogger.log(level: .verbose, context: params.context, format: "SignIn started")
+        let telemetryInfo = TelemetryInfo(
+            event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInWithCodeStart, context: params.context),
+            context: params.context
+        )
+
+        let initiateValidatedResponse = await performAndValidateSignInInitiate(username: params.username, telemetryInfo: telemetryInfo)
+        let result = await handleInitiateResponse(initiateValidatedResponse, telemetryInfo: telemetryInfo)
+
+        switch result {
+        case .success(let challengeValidatedResponse):
+            return await handleChallengeResponse(challengeValidatedResponse, params: params, telemetryInfo: telemetryInfo)
+        case .failure(let error):
+            return .init(.error(error.convertToSignInStartError()))
+        }
+    }
+
+    func signIn(
+        username: String,
+        slt: String?,
+        scopes: [String]?,
+        context: MSALNativeAuthRequestContext
+    ) async -> Result<MSALNativeAuthUserAccountResult, SignInAfterSignUpError> {
+        MSALLogger.log(level: .verbose, context: context, format: "SignIn after signUp started")
+        let telemetryInfo = TelemetryInfo(
+            event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInAfterSignUp, context: context),
+            context: context
+        )
+        guard let slt = slt else {
+            MSALLogger.log(level: .error, context: context, format: "SignIn not available because SLT is nil")
+            let error = SignInAfterSignUpError(message: MSALNativeAuthErrorMessage.signInNotAvailable)
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .failure(error)
+        }
+        let scopes = joinScopes(scopes)
+        guard let request = createTokenRequest(
+            username: username,
+            scopes: scopes,
+            signInSLT: slt,
+            grantType: .slt,
+            context: context
+        ) else {
+            let error = SignInAfterSignUpError()
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .failure(error)
+        }
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        let response = await performAndValidateTokenRequest(request, config: config, context: context)
+
+        return await withCheckedContinuation { continuation in
+            handleTokenResponse(
+                response,
+                scopes: scopes,
+                telemetryInfo: telemetryInfo,
+                onSuccess: { accountResult in
+                    continuation.resume(returning: .success(accountResult))
+                },
+                onError: { error in
+                    continuation.resume(returning: .failure(SignInAfterSignUpError(message: error.errorDescription)))
+                }
+            )
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    func submitCode(
+        _ code: String,
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]
+    ) async -> SignInVerifyCodeResult {
+        let telemetryInfo = TelemetryInfo(
+            event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInSubmitCode, context: context),
+            context: context
+        )
+        guard let request = createTokenRequest(
+            scopes: scopes,
+            credentialToken: credentialToken,
+            oobCode: code,
+            grantType: .oobCode,
+            includeChallengeType: false,
+            context: context) else {
+            MSALLogger.log(level: .error, context: context, format: "SignIn, submit code: unable to create token request")
+
+            return processSubmitCodeFailure(
+                errorType: .generalError,
+                telemetryInfo: telemetryInfo,
+                scopes: scopes,
+                credentialToken: credentialToken,
+                context: context
+            )
+        }
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        let response = await performAndValidateTokenRequest(request, config: config, context: context)
+        switch response {
+        case .success(let tokenResponse):
+            return await withCheckedContinuation { continuation in
+                handleMSIDTokenResponse(
+                    tokenResponse: tokenResponse,
+                    context: context,
+                    telemetryInfo: telemetryInfo,
+                    config: config,
+                    onSuccess: { accountResult in
+                        continuation.resume(returning: .completed(accountResult))
+                    },
+                    onError: { [weak self] error in
+                        MSALLogger.log(level: .error, context: context, format: "SignIn submit code, token request failed with error \(error)")
+                        guard let self = self else { return }
+                        continuation.resume(returning: self.processSubmitCodeFailure(
+                            errorType: .generalError,
+                            telemetryInfo: telemetryInfo,
+                            scopes: scopes,
+                            credentialToken: credentialToken,
+                            context: context
+                        ))
+                    }
+                )
+            }
+        case .error(let errorType):
+            return processSubmitCodeFailure(
+                errorType: errorType,
+                telemetryInfo: telemetryInfo,
+                scopes: scopes,
+                credentialToken: credentialToken,
+                context: context
+            )
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    func submitPassword(
+        _ password: String,
+        username: String,
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]
+    ) async -> SignInPasswordRequiredResult {
+        let telemetryInfo = TelemetryInfo(
+            event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInSubmitPassword, context: context),
+            context: context
+        )
+        guard let request = createTokenRequest(
+            username: username,
+            password: password,
+            scopes: scopes,
+            credentialToken: credentialToken,
+            grantType: .password,
+            context: context) else {
+            MSALLogger.log(level: .error, context: context, format: "SignIn, submit password: unable to create token request")
+            return processSubmitPasswordFailure(
+                errorType: .generalError,
+                telemetryInfo: telemetryInfo,
+                username: username,
+                credentialToken: credentialToken,
+                scopes: scopes
+            )
+        }
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        let response = await performAndValidateTokenRequest(request, config: config, context: context)
+        switch response {
+        case .success(let tokenResponse):
+            return await withCheckedContinuation { continuation in
+                handleMSIDTokenResponse(
+                    tokenResponse: tokenResponse,
+                    context: context,
+                    telemetryInfo: telemetryInfo,
+                    config: config,
+                    onSuccess: { accountResult in
+                        continuation.resume(returning: .completed(accountResult))
+                    },
+                    onError: { [weak self] error in
+                        MSALLogger.log(level: .error, context: context, format: "SignIn submit password, token request failed with error \(error)")
+                        guard let self = self else { return }
+                        continuation.resume(returning: self.processSubmitPasswordFailure(
+                            errorType: .generalError,
+                            telemetryInfo: telemetryInfo,
+                            username: username,
+                            credentialToken: credentialToken,
+                            scopes: scopes
+                        ))
+                    }
+                )
+            }
+
+        case .error(let errorType):
+            return processSubmitPasswordFailure(
+                errorType: errorType,
+                telemetryInfo: telemetryInfo,
+                username: username,
+                credentialToken: credentialToken,
+                scopes: scopes
+            )
+        }
+    }
+
+    func resendCode(
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]
+    ) async -> SignInResendCodeResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignInResendCode, context: context)
+        let result = await performAndValidateChallengeRequest(credentialToken: credentialToken, context: context)
+        switch result {
+        case .passwordRequired:
+            let error = ResendCodeError()
+            MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: received unexpected password required API result")
+            stopTelemetryEvent(event, context: context, error: error)
+            return .error(error: error, newState: nil)
+        case .error(let challengeError):
+            let error = ResendCodeError()
+            MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: received challenge error response: \(challengeError)")
+            stopTelemetryEvent(event, context: context, error: error)
+            return .error(error: error, newState: SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken))
+        case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
+            let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken)
+            stopTelemetryEvent(event, context: context)
+            return .codeRequired(newState: state, sentTo: sentTo, channelTargetType: channelType, codeLength: codeLength)
+        }
+    }
+
+    // MARK: - Private
+
+    private func processSubmitCodeFailure(
+        errorType: MSALNativeAuthTokenValidatedErrorType,
+        telemetryInfo: TelemetryInfo,
+        scopes: [String],
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext
+    ) -> SignInVerifyCodeResult {
+        MSALLogger.log(
+            level: .error,
+            context: context,
+            format: "SignIn completed with errorType: \(errorType)")
+        stopTelemetryEvent(telemetryInfo, error: errorType)
+        let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken)
+        return .error(error: errorType.convertToVerifyCodeError(), newState: state)
+    }
+
+    private func processSubmitPasswordFailure(
+        errorType: MSALNativeAuthTokenValidatedErrorType,
+        telemetryInfo: TelemetryInfo,
+        username: String,
+        credentialToken: String,
+        scopes: [String]
+    ) -> SignInPasswordRequiredResult {
+        MSALLogger.log(
+            level: .error,
+            context: telemetryInfo.context,
+            format: "SignIn with username and password completed with errorType: \(errorType)")
+        stopTelemetryEvent(telemetryInfo, error: errorType)
+        let state = SignInPasswordRequiredState(scopes: scopes, username: username, controller: self, flowToken: credentialToken)
+        return .error(error: errorType.convertToPasswordRequiredError(), newState: state)
+    }
+
+    private func performAndValidateSignInInitiate(
+        username: String,
+        telemetryInfo: TelemetryInfo
+    ) async -> MSALNativeAuthSignInInitiateValidatedResponse {
+        guard let request = createInitiateRequest(username: username, context: telemetryInfo.context) else {
+            let error = MSALNativeAuthSignInInitiateValidatedErrorType.invalidRequest(message: nil)
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .error(error)
+        }
+
+        let initiateResponse: Result<MSALNativeAuthSignInInitiateResponse, Error> = await performRequest(request, context: telemetryInfo.context)
+        let validatedResponse = signInResponseValidator.validate(context: telemetryInfo.context, result: initiateResponse)
+
+        return validatedResponse
+    }
+
+    private func handleInitiateResponse(
+        _ validatedResponse: MSALNativeAuthSignInInitiateValidatedResponse,
+        telemetryInfo: TelemetryInfo
+    ) async -> Result<MSALNativeAuthSignInChallengeValidatedResponse, MSALNativeAuthSignInInitiateValidatedErrorType> {
+        switch validatedResponse {
+        case .success(let credentialToken):
+            let challengeValidatedResponse = await performAndValidateChallengeRequest(
+                credentialToken: credentialToken,
+                context: telemetryInfo.context
+            )
+            return .success(challengeValidatedResponse)
+        case .error(let error):
+            MSALLogger.log(level: .error, context: telemetryInfo.context, format: "SignIn: an error occurred after calling /initiate API: \(error)")
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .failure(error)
+        }
+    }
+
+    private func handleTokenResponse(
+        _ response: MSALNativeAuthTokenValidatedResponse,
+        scopes: [String],
+        telemetryInfo: TelemetryInfo,
+        onSuccess: @escaping (MSALNativeAuthUserAccountResult) -> Void,
+        onError: @escaping (SignInPasswordStartError) -> Void
+    ) {
+        let config = factory.makeMSIDConfiguration(scopes: scopes)
+        switch response {
+        case .success(let tokenResponse):
+            return handleMSIDTokenResponse(
+                tokenResponse: tokenResponse,
+                context: telemetryInfo.context,
+                telemetryInfo: telemetryInfo,
+                config: config,
+                onSuccess: onSuccess,
+                onError: onError
+            )
+        case .error(let errorType):
+            let error = errorType.convertToSignInPasswordStartError()
+            MSALLogger.log(level: .error,
+                           context: telemetryInfo.context,
+                           format: "SignIn completed with errorType: \(error.errorDescription ?? "No error description")")
+            stopTelemetryEvent(telemetryInfo, error: error)
+            onError(error)
+        }
+    }
+
+    private func handleMSIDTokenResponse(
+        tokenResponse: MSIDTokenResponse,
+        context: MSALNativeAuthRequestContext,
+        telemetryInfo: TelemetryInfo,
+        config: MSIDConfiguration,
+        onSuccess: @escaping (MSALNativeAuthUserAccountResult) -> Void,
+        onError: @escaping (SignInPasswordStartError) -> Void
+    ) {
+        do {
+            let tokenResult = try cacheTokenResponse(tokenResponse, context: context, msidConfiguration: config)
+
+            if let userAccountResult = factory.makeUserAccountResult(tokenResult: tokenResult, context: context) {
+                MSALLogger.log(level: .verbose, context: context, format: "SignIn completed successfully")
+                telemetryInfo.event?.setUserInformation(tokenResult.account)
+                stopTelemetryEvent(telemetryInfo)
+                onSuccess(userAccountResult)
+            } else {
+                let errorType = MSALNativeAuthTokenValidatedErrorType.generalError
+                MSALLogger.log(level: .error, context: telemetryInfo.context, format: "SignIn completed with error. Error creating UserAccountResult")
+                stopTelemetryEvent(telemetryInfo, error: errorType)
+                onError(errorType.convertToSignInPasswordStartError())
+            }
+        } catch {
+            let errorType = MSALNativeAuthTokenValidatedErrorType.generalError
+            MSALLogger.log(level: .error, context: telemetryInfo.context, format: "SignIn completed with error \(error)")
+            stopTelemetryEvent(telemetryInfo, error: errorType)
+            onError(errorType.convertToSignInPasswordStartError())
+        }
+    }
+
+    private func handleChallengeResponse(
+        _ validatedResponse: MSALNativeAuthSignInChallengeValidatedResponse,
+        params: MSALNativeAuthSignInWithCodeParameters,
+        telemetryInfo: TelemetryInfo
+    ) async -> SignInCodeControllerResponse {
+        let scopes = joinScopes(params.scopes)
+
+        switch validatedResponse {
+        case .passwordRequired(let credentialToken):
+            let state = SignInPasswordRequiredState(
+                scopes: scopes,
+                username: params.username,
+                controller: self,
+                flowToken: credentialToken
+            )
+
+            return .init(.passwordRequired(newState: state), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    MSALLogger.log(level: .verbose, context: telemetryInfo.context, format: "SignIn, password required")
+                    self?.stopTelemetryEvent(telemetryInfo)
+                case .failure(let error):
+                    MSALLogger.log(
+                        level: .error,
+                        context: telemetryInfo.context,
+                        format: "SignIn error: \(error.errorDescription ?? "No error description")"
+                    )
+                    self?.stopTelemetryEvent(telemetryInfo, error: error)
+                }
+            })
+        case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
+            let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken)
+            stopTelemetryEvent(telemetryInfo)
+            return .init(.codeRequired(newState: state, sentTo: sentTo, channelTargetType: channelType, codeLength: codeLength))
+        case .error(let challengeError):
+            let error = challengeError.convertToSignInStartError()
+            MSALLogger.log(level: .error,
+                           context: telemetryInfo.context,
+                           format: "SignIn, completed with error: \(error.errorDescription ?? "No error description")")
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .init(.error(error))
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    private func handleChallengeResponse(
+        _ validatedResponse: MSALNativeAuthSignInChallengeValidatedResponse,
+        params: MSALNativeAuthSignInWithPasswordParameters,
+        telemetryInfo: TelemetryInfo
+    ) async -> SignInPasswordControllerResponse {
+        let scopes = joinScopes(params.scopes)
+
+        switch validatedResponse {
+        case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
+            MSALLogger.log(level: .warning, context: telemetryInfo.context, format: MSALNativeAuthErrorMessage.codeRequiredForPasswordUserLog)
+            let result: SignInPasswordStartResult = .codeRequired(
+                newState: SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken),
+                sentTo: sentTo,
+                channelTargetType: channelType,
+                codeLength: codeLength
+            )
+
+            return .init(result, telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(telemetryInfo)
+                case .failure(let error):
+                    MSALLogger.log(
+                        level: .error,
+                        context: telemetryInfo.context,
+                        format: "SignIn error \(error.errorDescription ?? "No error description")"
+                    )
+                    self?.stopTelemetryEvent(telemetryInfo, error: error)
+                }
+            })
+        case .passwordRequired(let credentialToken):
+            guard let request = createTokenRequest(
+                username: params.username,
+                password: params.password,
+                scopes: scopes,
+                credentialToken: credentialToken,
+                grantType: .password,
+                context: telemetryInfo.context
+            ) else {
+                stopTelemetryEvent(telemetryInfo, error: MSALNativeAuthInternalError.invalidRequest)
+                return .init(.error(SignInPasswordStartError(type: .generalError)))
+            }
+
+            let config = factory.makeMSIDConfiguration(scopes: scopes)
+            let response = await performAndValidateTokenRequest(request, config: config, context: telemetryInfo.context)
+
+            return await withCheckedContinuation { continuation in
+                handleTokenResponse(response,
+                    scopes: scopes,
+                    telemetryInfo: telemetryInfo,
+                    onSuccess: { accountResult in
+                        continuation.resume(returning: SignInPasswordControllerResponse(.completed(accountResult)))
+                    },
+                    onError: { error in
+                        continuation.resume(returning: SignInPasswordControllerResponse(.error(error)))
+                    }
+                )
+            }
+        case .error(let challengeError):
+            let error = challengeError.convertToSignInPasswordStartError()
+            MSALLogger.log(level: .error,
+                           context: telemetryInfo.context,
+                           format: "SignIn, completed with error: \(error.errorDescription ?? "No error description")")
+            stopTelemetryEvent(telemetryInfo, error: error)
+            return .init(.error(error))
+        }
+    }
+
+    private func performAndValidateChallengeRequest(
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext
+    ) async -> MSALNativeAuthSignInChallengeValidatedResponse {
+        guard let challengeRequest = createChallengeRequest(credentialToken: credentialToken, context: context) else {
+            MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: Cannot create Challenge request object")
+            return .error(.invalidRequest(message: nil))
+        }
+        let challengeResponse: Result<MSALNativeAuthSignInChallengeResponse, Error> = await performRequest(challengeRequest, context: context)
+        return signInResponseValidator.validate(context: context, result: challengeResponse)
+    }
+
+    private func createInitiateRequest(username: String, context: MSIDRequestContext) -> MSIDHttpRequest? {
+        let params = MSALNativeAuthSignInInitiateRequestParameters(context: context, username: username)
+        do {
+            return try signInRequestProvider.inititate(parameters: params, context: context)
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error creating SignIn Initiate Request: \(error)")
+            return nil
+        }
+    }
+
+    private func createChallengeRequest(
+        credentialToken: String,
+        context: MSIDRequestContext
+    ) -> MSIDHttpRequest? {
+        do {
+            let params = MSALNativeAuthSignInChallengeRequestParameters(
+                context: context,
+                credentialToken: credentialToken
+            )
+            return try signInRequestProvider.challenge(parameters: params, context: context)
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error creating SignIn Challenge Request: \(error)")
+            return nil
+        }
+    }
+}

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
@@ -1,0 +1,53 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import Foundation
+
+protocol MSALNativeAuthSignInControlling {
+    typealias SignInPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignInPasswordStartResult>
+    typealias SignInCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignInStartResult>
+
+    func signIn(params: MSALNativeAuthSignInWithPasswordParameters) async -> SignInPasswordControllerResponse
+
+    func signIn(params: MSALNativeAuthSignInWithCodeParameters) async -> SignInCodeControllerResponse
+
+    func signIn(
+        username: String,
+        slt: String?,
+        scopes: [String]?,
+        context: MSALNativeAuthRequestContext
+    ) async -> Result<MSALNativeAuthUserAccountResult, SignInAfterSignUpError>
+
+    func submitCode(_ code: String, credentialToken: String, context: MSALNativeAuthRequestContext, scopes: [String]) async -> SignInVerifyCodeResult
+
+    func submitPassword(
+        _ password: String,
+        username: String,
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]
+    ) async -> SignInPasswordRequiredResult
+
+    func resendCode(credentialToken: String, context: MSALNativeAuthRequestContext, scopes: [String]) async -> SignInResendCodeResult
+}

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -1,0 +1,664 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
+final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNativeAuthSignUpControlling {
+
+    // MARK: - Variables
+
+    private let requestProvider: MSALNativeAuthSignUpRequestProviding
+    private let responseValidator: MSALNativeAuthSignUpResponseValidating
+    private let signInController: MSALNativeAuthSignInControlling
+
+    // MARK: - Init
+
+    init(
+        config: MSALNativeAuthConfiguration,
+        requestProvider: MSALNativeAuthSignUpRequestProviding,
+        responseValidator: MSALNativeAuthSignUpResponseValidating,
+        signInController: MSALNativeAuthSignInControlling
+    ) {
+        self.requestProvider = requestProvider
+        self.responseValidator = responseValidator
+        self.signInController = signInController
+        super.init(clientId: config.clientId)
+    }
+
+    convenience init(config: MSALNativeAuthConfiguration) {
+        self.init(
+            config: config,
+            requestProvider: MSALNativeAuthSignUpRequestProvider(
+                requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+                telemetryProvider: MSALNativeAuthTelemetryProvider()
+            ),
+            responseValidator: MSALNativeAuthSignUpResponseValidator(),
+            signInController: MSALNativeAuthSignInController(config: config)
+        )
+    }
+
+    // MARK: - Internal
+
+    func signUpStartPassword(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartPasswordControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpPasswordStart, context: parameters.context)
+        let result = await performAndValidateStartRequest(parameters: parameters)
+        return await handleSignUpStartPasswordResult(result, username: parameters.username, event: event, context: parameters.context)
+    }
+
+    func signUpStartCode(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartCodeControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpCodeStart, context: parameters.context)
+        let result = await performAndValidateStartRequest(parameters: parameters)
+        return await handleSignUpStartCodeResult(result, username: parameters.username, event: event, context: parameters.context)
+    }
+
+    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpResendCode, context: context)
+        let challengeResult = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+        return handleResendCodeResult(challengeResult, username: username, event: event, context: context)
+    }
+
+    func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitCode, context: context)
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(grantType: .oobCode, signUpToken: signUpToken, oobCode: code, context: context)
+
+        let result = await performAndValidateContinueRequest(parameters: params)
+        return await handleSubmitCodeResult(result, username: username, signUpToken: signUpToken, event: event, context: context)
+    }
+
+    func submitPassword(
+        _ password: String,
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpSubmitPasswordControllerResponse {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitPassword, context: context)
+
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: signUpToken,
+            password: password,
+            context: context
+        )
+        let continueRequestResult = await performAndValidateContinueRequest(parameters: params)
+        return handleSubmitPasswordResult(continueRequestResult, username: username, signUpToken: signUpToken, event: event, context: context)
+    }
+
+    func submitAttributes(
+        _ attributes: [String: Any],
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpAttributesRequiredResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitAttributes, context: context)
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .attributes,
+            signUpToken: signUpToken,
+            attributes: attributes,
+            context: context
+        )
+
+        let result = await performAndValidateContinueRequest(parameters: params)
+        return handleSubmitAttributesResult(result, username: username, signUpToken: signUpToken, event: event, context: context)
+    }
+
+    // MARK: - Start Request handling
+
+    private func performAndValidateStartRequest(
+        parameters: MSALNativeAuthSignUpStartRequestProviderParameters
+    ) async -> MSALNativeAuthSignUpStartValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.start(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error while creating Start Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing signup/start request")
+
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(response, with: parameters.context)
+    }
+
+    // swiftlint:disable:next function_body_length
+    private func handleSignUpStartPasswordResult(
+        _ result: MSALNativeAuthSignUpStartValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> SignUpStartPasswordControllerResponse {
+        switch result {
+        case .verificationRequired(let signUpToken, let attributes):
+            MSALLogger.log(
+                level: .info,
+                context: context,
+                format: "verification_required received from signup/start with password request for attributes: \(attributes)"
+            )
+            let challengeResult = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+            return handleSignUpPasswordChallengeResult(challengeResult, username: username, event: event, context: context)
+        case .attributeValidationFailed(let invalidAttributes):
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "attribute_validation_failed received from signup/start with password request for attributes: \(invalidAttributes)"
+            )
+            let message = String(format: MSALNativeAuthErrorMessage.attributeValidationFailedSignUpStart, invalidAttributes.description)
+            let error = SignUpPasswordStartError(type: .generalError, message: message)
+            return .init(.attributesInvalid(invalidAttributes), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                case .failure(let error):
+                    MSALLogger.log(
+                        level: .error,
+                        context: context,
+                        format: "SignUp with password error: \(error.errorDescription ?? "No error description")"
+                    )
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .redirect:
+            let error = SignUpPasswordStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "redirect error in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .error(let apiError):
+            let error = apiError.toSignUpStartPasswordPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidUsername(let apiError):
+            let error = SignUpPasswordStartError(type: .invalidUsername, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "InvalidUsername in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidClientId(let apiError):
+            let error = SignUpPasswordStartError(type: .generalError, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Invalid Client Id in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError:
+            let error = SignUpPasswordStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/start with password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    // swiftlint:disable:next function_body_length
+    private func handleSignUpStartCodeResult(
+        _ result: MSALNativeAuthSignUpStartValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> SignUpStartCodeControllerResponse {
+        switch result {
+        case .verificationRequired(let signUpToken, let unverifiedAttributes):
+            MSALLogger.log(
+                level: .info,
+                context: context,
+                format: "verification_required received from signup/start request for attributes: \(unverifiedAttributes)"
+            )
+            let challengeResult = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+            return handleSignUpCodeChallengeResult(challengeResult, username: username, event: event, context: context)
+        case .attributeValidationFailed(let invalidAttributes):
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "attribute_validation_failed received from signup/start request for attributes: \(invalidAttributes)"
+            )
+            let message = String(format: MSALNativeAuthErrorMessage.attributeValidationFailedSignUpStart, invalidAttributes.description)
+            let error = SignUpStartError(type: .generalError, message: message)
+            return .init(.attributesInvalid(invalidAttributes), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .redirect:
+            let error = SignUpStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .error(let apiError):
+            let error = apiError.toSignUpStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidUsername(let apiError):
+            let error = SignUpStartError(type: .invalidUsername, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "InvalidUsername in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .invalidClientId(let apiError):
+            let error = SignUpStartError(type: .generalError, message: apiError.errorDescription)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Invalid Client Id in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError:
+            let error = SignUpStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/start request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    // MARK: - Challenge Request handling
+
+    private func performAndValidateChallengeRequest(
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.challenge(token: signUpToken, context: context)
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error while creating Challenge Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: context, format: "Performing signup/challenge request")
+
+        let result: Result<MSALNativeAuthSignUpChallengeResponse, Error> = await performRequest(request, context: context)
+        return responseValidator.validate(result, with: context)
+    }
+
+    private func handleSignUpPasswordChallengeResult(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpStartPasswordControllerResponse {
+        switch result {
+        case .codeRequired(let sentTo, let challengeType, let codeLength, let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge password request")
+            stopTelemetryEvent(event, context: context)
+            return SignUpStartPasswordControllerResponse(
+                .codeRequired(
+                    newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                    sentTo: sentTo,
+                    channelTargetType: challengeType,
+                    codeLength: codeLength
+                )
+            )
+        case .error(let apiError):
+            let error = apiError.toSignUpPasswordStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/challenge password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .redirect:
+            let error = SignUpPasswordStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/challenge password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError,
+             .passwordRequired:
+            let error = SignUpPasswordStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge password request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    private func handleSignUpCodeChallengeResult(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpStartCodeControllerResponse {
+        switch result {
+        case .codeRequired(let sentTo, let challengeType, let codeLength, let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge request")
+            stopTelemetryEvent(event, context: context)
+            return SignUpStartCodeControllerResponse(
+                .codeRequired(
+                    newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                    sentTo: sentTo,
+                    channelTargetType: challengeType,
+                    codeLength: codeLength
+                )
+            )
+        case .error(let apiError):
+            let error = apiError.toSignUpStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .redirect:
+            let error = SignUpStartError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        case .unexpectedError,
+             .passwordRequired:
+            let error = SignUpStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error))
+        }
+    }
+
+    private func handleResendCodeResult(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpResendCodeResult {
+        switch result {
+        case .codeRequired(let sentTo, let challengeType, let codeLength, let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge resendCode request")
+            stopTelemetryEvent(event, context: context)
+            return .codeRequired(
+                newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                sentTo: sentTo,
+                channelTargetType: challengeType,
+                codeLength: codeLength
+            )
+        case .error(let apiError):
+            let error = apiError.toResendCodePublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/challenge resendCode request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        case .redirect,
+             .unexpectedError,
+             .passwordRequired:
+            let error = ResendCodeError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge resendCode request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        }
+    }
+
+    /// This method handles the /challenge response after receiving a "credential_required" error
+    private func handlePerformChallengeAfterContinueRequest(
+        _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpSubmitCodeControllerResponse {
+        switch result {
+        case .passwordRequired(let signUpToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge request after credential_required")
+
+            let state = SignUpPasswordRequiredState(controller: self, username: username, flowToken: signUpToken)
+
+            return .init(.passwordRequired(state), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .redirect:
+            let error = VerifyCodeError(type: .browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        case .error,
+             .codeRequired,
+             .unexpectedError:
+            let error = VerifyCodeError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        }
+    }
+
+    // MARK: - Continue Request handling
+
+    private func performAndValidateContinueRequest(
+        parameters: MSALNativeAuthSignUpContinueRequestProviderParams
+    ) async -> MSALNativeAuthSignUpContinueValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.continue(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error while creating Continue Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing signup/continue request")
+
+        let result: Result<MSALNativeAuthSignUpContinueResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(result, with: parameters.context)
+    }
+
+    private func handleSubmitCodeResult(
+        _ result: MSALNativeAuthSignUpContinueValidatedResponse,
+        username: String,
+        signUpToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> SignUpSubmitCodeControllerResponse {
+        switch result {
+        case .success(let slt):
+            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+            return .init(.completed(state))
+        case .invalidUserInput:
+            MSALLogger.log(level: .error, context: context, format: "invalid_user_input error in signup/continue request")
+
+            let error = VerifyCodeError(type: .invalidCode)
+            stopTelemetryEvent(event, context: context, error: error)
+            let state = SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .init(.error(error: error, newState: state))
+        case .credentialRequired(let signUpToken):
+            MSALLogger.log(level: .verbose, context: context, format: "credential_required received in signup/continue request")
+
+            let result = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+            return handlePerformChallengeAfterContinueRequest(result, username: username, event: event, context: context)
+        case .attributesRequired(let signUpToken, let attributes):
+            MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .init(.attributesRequired(attributes: attributes, newState: state), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .error(let apiError):
+            let error = apiError.toVerifyCodePublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/continue request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        case .attributeValidationFailed,
+             .unexpectedError:
+            let error = VerifyCodeError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        }
+    }
+
+    private func handleSubmitPasswordResult(
+        _ result: MSALNativeAuthSignUpContinueValidatedResponse,
+        username: String,
+        signUpToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpSubmitPasswordControllerResponse {
+        switch result {
+        case .success(let slt):
+            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+            return .init(.completed(state))
+        case .invalidUserInput(let error):
+            let error = error.toPasswordRequiredPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "invalid_user_input error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")"
+            )
+
+            let state = SignUpPasswordRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .init(.error(error: error, newState: state))
+        case .attributesRequired(let signUpToken, let attributes):
+            MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+
+            return .init(.attributesRequired(attributes: attributes, newState: state), telemetryUpdate: { [weak self] result in
+                switch result {
+                case .success:
+                    self?.stopTelemetryEvent(event, context: context)
+                case .failure(let error):
+                    MSALLogger.log(level: .error, context: context, format: "SignUp error \(error.errorDescription ?? "No error description")")
+                    self?.stopTelemetryEvent(event, context: context, error: error)
+                }
+            })
+        case .error(let apiError):
+            let error = apiError.toPasswordRequiredPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        case .attributeValidationFailed,
+             .credentialRequired,
+             .unexpectedError:
+            let error = PasswordRequiredError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")")
+            return .init(.error(error: error, newState: nil))
+        }
+    }
+
+    private func handleSubmitAttributesResult(
+        _ result: MSALNativeAuthSignUpContinueValidatedResponse,
+        username: String,
+        signUpToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignUpAttributesRequiredResult {
+        switch result {
+        case .success(let slt):
+            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+            return .completed(state)
+        case .attributesRequired(let signUpToken, let attributes):
+            let error = AttributesRequiredError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "attributes_required received in signup/continue submitAttributes request: \(attributes)")
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .attributesRequired(attributes: attributes, state: state)
+        case .attributeValidationFailed(let signUpToken, let invalidAttributes):
+            let message = "attribute_validation_failed from signup/continue submitAttributes request. Make sure these attributes are correct: \(invalidAttributes)" // swiftlint:disable:this line_length
+            MSALLogger.log(level: .error, context: context, format: message)
+
+            let errorMessage = String(format: MSALNativeAuthErrorMessage.attributeValidationFailed, invalidAttributes.description)
+            let error = AttributesRequiredError(message: errorMessage)
+            stopTelemetryEvent(event, context: context, error: error)
+
+            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            return .attributesInvalid(attributes: invalidAttributes, newState: state)
+        case .error(let apiError):
+            let error = apiError.toAttributesRequiredPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in signup/continue submitAttributes request \(error.errorDescription ?? "No error description")")
+            return .error(error: error)
+        case .credentialRequired,
+             .unexpectedError,
+             .invalidUserInput:
+            let error = AttributesRequiredError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in signup/continue submitAttributes request \(error.errorDescription ?? "No error description")")
+            return .error(error: error)
+        }
+    }
+
+    private func createSignInAfterSignUpStateUsingSLT(
+        _ slt: String?,
+        username: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) -> SignInAfterSignUpState {
+        MSALLogger.log(level: .info, context: context, format: "SignUp completed successfully")
+        stopTelemetryEvent(event, context: context)
+        return SignInAfterSignUpState(controller: signInController, username: username, slt: slt)
+    }
+}

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
@@ -1,0 +1,55 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignUpControlling: AnyObject {
+
+    typealias SignUpStartPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpPasswordStartResult>
+    typealias SignUpStartCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpStartResult>
+    typealias SignUpSubmitCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpVerifyCodeResult>
+    typealias SignUpSubmitPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpPasswordRequiredResult>
+
+    func signUpStartPassword(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartPasswordControllerResponse
+
+    func signUpStartCode(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartCodeControllerResponse
+
+    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeResult
+
+    func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse
+
+    func submitPassword(
+        _ password: String,
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpSubmitPasswordControllerResponse
+
+    func submitAttributes(
+        _ attributes: [String: Any],
+        username: String,
+        signUpToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpAttributesRequiredResult
+}

--- a/MSAL/src/native_auth/logger/MSALLogMask.h
+++ b/MSAL/src/native_auth/logger/MSALLogMask.h
@@ -1,0 +1,55 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALLogMask : NSObject
+
+/// Terms used in to clasify data:
+/// - PII - Personally identifiable Information
+/// - EUII - End User identifiable Information such as UPN, username, email
+/// - EUPII - End User Pseudonymous Identifiers
+/// - OII - Organization Identifiable Information
+
+/// Used for masking any PII (Personally identifiable Information) including EUII and EUPI as long as log level is MSIDLogMaskingSettingsMaskAllPII
+/// - Parameter parameter: Any object that needs to be masked
++ (MSIDMaskedLogParameter*) maskPII:(nullable id) parameter;
+
+/// Used for masking any EUII (End User identifiable Information) such as UPN, username, email as long as log level is MSIDLogMaskingSettingsMaskEUIIOnly or below
+/// - Parameter parameter: Any object that needs to be masked
++ (MSIDMaskedLogParameter*) maskEUII:(nullable id) parameter;
+
+/// Used for masking any Trackable User Information such as Accounts or URLs that should be hashed as long as log level is MSIDLogMaskingSettingsMaskAllPII
+/// - Parameter parameter: Any object that needs to be masked via hashing
++ (MSIDMaskedHashableLogParameter*) maskTrackablePII:(nullable id) parameter;
+
+/// Used for masking any Username (email, id, account identifier) that should be hashed as long as log level is MSIDLogMaskingSettingsMaskEUIIOnly or below
+/// - Parameter parameter: Any Username that needs to be masked via hashing
++ (MSIDMaskedUsernameLogParameter*) maskUsername:(nullable id) parameter;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/native_auth/logger/MSALLogMask.m
+++ b/MSAL/src/native_auth/logger/MSALLogMask.m
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSALLogMask.h"
+
+@implementation MSALLogMask
+
++ (MSIDMaskedLogParameter*) maskPII:(nullable id) parameter {
+    return MSID_PII_LOG_MASKABLE(parameter);
+}
+
++ (MSIDMaskedLogParameter*) maskEUII:(nullable id) parameter {
+    return MSID_EUII_ONLY_LOG_MASKABLE(parameter);
+}
+
++ (MSIDMaskedHashableLogParameter*) maskTrackablePII:(nullable id) parameter {
+    return MSID_PII_LOG_TRACKABLE(parameter);
+}
+
++ (MSIDMaskedUsernameLogParameter*) maskUsername:(nullable id) parameter {
+    return MSID_PII_LOG_EMAIL(parameter);
+}
+
+@end

--- a/MSAL/src/native_auth/logger/MSALNativeAuthLogging.swift
+++ b/MSAL/src/native_auth/logger/MSALNativeAuthLogging.swift
@@ -1,0 +1,150 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALLogging {
+    static func log(
+        level: MSIDLogLevel,
+        context: MSIDRequestContext?,
+        filename: String,
+        lineNumber: Int,
+        function: String,
+        format: String,
+        _ args: CVarArg...)
+    static func logPII(
+        level: MSIDLogLevel,
+        context: MSIDRequestContext?,
+        filename: String,
+        lineNumber: Int,
+        function: String,
+        format: String,
+        _ args: CVarArg...)
+    static func log(
+        level: MSIDLogLevel,
+        correlationId: UUID?,
+        filename: String,
+        lineNumber: Int,
+        function: String,
+        format: String,
+        _ args: CVarArg...)
+    static func logPII(
+        level: MSIDLogLevel,
+        correlationId: UUID?,
+        filename: String,
+        lineNumber: Int,
+        function: String,
+        format: String,
+        _ args: CVarArg...)
+}
+
+extension MSALLogger: MSALLogging {
+    private static func logCommon(level: MSIDLogLevel,
+                                  context: MSIDRequestContext? = nil,
+                                  correlationId: UUID? = nil,
+                                  containsPII: Bool,
+                                  filename: String = #fileID,
+                                  lineNumber: Int = #line,
+                                  function: String = #function,
+                                  format: String,
+                                  _ args: CVaListPointer) {
+        MSIDLogger.shared().log(with: level,
+                                context: context,
+                                correlationId: correlationId,
+                                containsPII: containsPII,
+                                filename: filename,
+                                lineNumber: UInt(lineNumber),
+                                function: function,
+                                format: format,
+                                formatArgs: args)
+    }
+
+    static func log(level: MSIDLogLevel,
+                    context: MSIDRequestContext?,
+                    filename: String = #fileID,
+                    lineNumber: Int = #line,
+                    function: String = #function,
+                    format: String,
+                    _ args: CVarArg...) {
+        logCommon(level: level,
+                  context: context,
+                  containsPII: false,
+                  filename: filename,
+                  lineNumber: lineNumber,
+                  function: function,
+                  format: format,
+                  getVaList(args))
+    }
+
+    static func logPII(level: MSIDLogLevel,
+                       context: MSIDRequestContext?,
+                       filename: String = #fileID,
+                       lineNumber: Int = #line,
+                       function: String = #function,
+                       format: String,
+                       _ args: CVarArg...) {
+        logCommon(level: level,
+                  context: context,
+                  containsPII: true,
+                  filename: filename,
+                  lineNumber: lineNumber,
+                  function: function,
+                  format: format,
+                  getVaList(args))
+    }
+
+    static func log(level: MSIDLogLevel,
+                    correlationId: UUID?,
+                    filename: String = #fileID,
+                    lineNumber: Int = #line,
+                    function: String = #function,
+                    format: String,
+                    _ args: CVarArg...) {
+        logCommon(level: level,
+                  correlationId: correlationId,
+                  containsPII: false,
+                  filename: filename,
+                  lineNumber: lineNumber,
+                  function: function,
+                  format: format,
+                  getVaList(args))
+    }
+
+    static func logPII(level: MSIDLogLevel,
+                       correlationId: UUID?,
+                       filename: String = #fileID,
+                       lineNumber: Int = #line,
+                       function: String = #function,
+                       format: String,
+                       _ args: CVarArg...) {
+        logCommon(level: level,
+                  correlationId: correlationId,
+                  containsPII: true,
+                  filename: filename,
+                  lineNumber: lineNumber,
+                  function: function,
+                  format: format,
+                  getVaList(args))
+    }
+}

--- a/MSAL/src/native_auth/telemetry/MSALNativeAuthCurrentRequestTelemetry.swift
+++ b/MSAL/src/native_auth/telemetry/MSALNativeAuthCurrentRequestTelemetry.swift
@@ -1,0 +1,59 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthCurrentRequestTelemetry: NSObject, MSIDTelemetryStringSerializable {
+    let apiId: MSALNativeAuthTelemetryApiId
+    let operationType: MSALNativeAuthOperationType
+    private let schemaVersion: Int
+    private let platformFields: [String]?
+
+    init(apiId: MSALNativeAuthTelemetryApiId,
+         operationType: MSALNativeAuthOperationType,
+         platformFields: [String]?) {
+        self.schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION
+        self.apiId = apiId
+        self.operationType = operationType
+        self.platformFields = platformFields
+    }
+
+    func telemetryString() -> String {
+        return serializeCurrentTelemetryString()
+    }
+
+    private func serializeCurrentTelemetryString() -> String {
+        let currentTelemetryFields = createSerializedItem()
+        return currentTelemetryFields.serialize() ?? ""
+    }
+
+    private func createSerializedItem() -> MSIDCurrentRequestTelemetrySerializedItem {
+        let defaultFields: [NSNumber] = [.init(value: apiId.rawValue),
+                                         .init(value: operationType)]
+        return .init(schemaVersion: .init(value: schemaVersion),
+                     defaultFields: defaultFields,
+                     platformFields: platformFields)
+    }
+}

--- a/MSAL/src/native_auth/telemetry/MSALNativeAuthOperationTypes.swift
+++ b/MSAL/src/native_auth/telemetry/MSALNativeAuthOperationTypes.swift
@@ -1,0 +1,78 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+typealias MSALNativeAuthOperationType = Int
+
+enum MSALNativeAuthSignUpType: MSALNativeAuthOperationType {
+    case signUpWithPassword = 0
+    case signUpWithOTP = 1
+    case signUpWithMFA = 2
+    case signUpStart = 3
+    case signUpChallenge = 4
+    case signUpContinue = 5
+}
+
+enum MSALNativeAuthSignInType: MSALNativeAuthOperationType {
+    case signInWithOTP = 0
+    case signInWithMFA = 1
+    case signInInitiate = 2
+    case signInChallenge = 3
+}
+
+enum MSALNativeAuthTokenType: MSALNativeAuthOperationType {
+    case signInWithPassword = 0
+    case refreshToken = 1
+
+}
+enum MSALNAtiveAuthResetPasswordType: MSALNativeAuthOperationType {
+    case resetPasswordStart = 0
+    case resetPasswordChallenge = 1
+    case resetPasswordContinue = 2
+    case resetPasswordSubmit = 3
+    case resetPasswordPollCompletion = 4
+}
+
+enum MSALNativeAuthResetPasswordStartType: MSALNativeAuthOperationType {
+    case resetPasswordStart = 0
+}
+
+enum MSALNativeAuthResetPasswordCompleteType: MSALNativeAuthOperationType {
+    case resetPasswordComplete = 0
+}
+
+enum MSALNativeAuthResendCodeType: MSALNativeAuthOperationType {
+    case resendCode = 0
+}
+
+enum MSALNativeAuthVerifyCodeType: MSALNativeAuthOperationType {
+    case verifyCode = 0
+}
+
+enum MSALNativeAuthSignOutType: MSALNativeAuthOperationType {
+    case signOutAction = 0
+    case signOutForced = 1
+}

--- a/MSAL/src/native_auth/telemetry/MSALNativeAuthServerTelemetry.swift
+++ b/MSAL/src/native_auth/telemetry/MSALNativeAuthServerTelemetry.swift
@@ -1,0 +1,67 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthServerTelemetry: NSObject, MSIDHttpRequestServerTelemetryHandling {
+
+    let currentRequestTelemetry: MSALNativeAuthCurrentRequestTelemetry
+    let context: MSIDRequestContext
+    private let lastRequestTelemetry: MSIDLastRequestTelemetry
+    init(currentRequestTelemetry: MSALNativeAuthCurrentRequestTelemetry,
+         context: MSIDRequestContext) {
+        self.currentRequestTelemetry = currentRequestTelemetry
+        self.context = context
+        self.lastRequestTelemetry = MSIDLastRequestTelemetry.sharedInstance()
+    }
+
+    func handleError(_ error: Error?, context: MSIDRequestContext) {
+        guard let error = error else { return }
+        let errorString = (error as NSError).msidServerTelemetryErrorString()
+        handleError(error, errorString: errorString, context: context)
+    }
+
+    func handleError(_ error: Error?, errorString: String, context: MSIDRequestContext) {
+        lastRequestTelemetry.update(withApiId: currentRequestTelemetry.apiId.rawValue,
+                                    errorString: errorString,
+                                    context: context)
+    }
+
+    func setTelemetryToRequest(_ request: MSIDHttpRequestProtocol) {
+
+        let currentRequestTelemetryString = currentRequestTelemetry.telemetryString()
+        let lastRequestTelemetryString = lastRequestTelemetry.telemetryString()
+
+        guard let mutableUrlRequest = (request.urlRequest as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Mutable copy of request could not be made for telemetry")
+            return
+        }
+        mutableUrlRequest.setValue(currentRequestTelemetryString, forHTTPHeaderField: "x-client-current-telemetry")
+        mutableUrlRequest.setValue(lastRequestTelemetryString, forHTTPHeaderField: "x-client-last-telemetry")
+        request.urlRequest = mutableUrlRequest as URLRequest
+    }
+}

--- a/MSAL/src/native_auth/validation/MSALNativeAuthAuthorityProvider.swift
+++ b/MSAL/src/native_auth/validation/MSALNativeAuthAuthorityProvider.swift
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthAuthorityProviding {
+    func authority(rawTenant: String) throws -> MSALCIAMAuthority
+}
+
+final class MSALNativeAuthAuthorityProvider: MSALNativeAuthAuthorityProviding {
+
+    func authority(rawTenant: String) throws -> MSALCIAMAuthority {
+        let ciamUrlString = "https://\(rawTenant).ciamlogin.com"
+        guard let url = URL(string: ciamUrlString) else {
+            assert(false, "URL for default CIAM Authority must be valid")
+            throw MSALNativeAuthInternalError.invalidAuthority
+        }
+
+        return try MSALCIAMAuthority(url: url)
+    }
+}

--- a/MSAL/test/unit/native_auth/cache/MSALNativeAuthCacheAccessorTest.swift
+++ b/MSAL/test/unit/native_auth/cache/MSALNativeAuthCacheAccessorTest.swift
@@ -1,0 +1,329 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE. 
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthCacheAccessorTest: XCTestCase {
+    private let cacheAccessor = MSALNativeAuthCacheAccessor()
+    private lazy var parameters = getParameters()
+    private lazy var contextStub = ContextStub()
+    
+    override func tearDownWithError() throws {
+        try cacheAccessor.clearCache(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, clientId: parameters.msidConfiguration.clientId, context: contextStub)
+    }
+    
+    // MARK: happy cases
+    
+    func testTokensStore_whenAllInfoPresent_shouldSaveTokensCorrectly() {
+        let tokenResponse = getTokenResponse()
+        let parameters = getParameters()
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        var tokens: MSALNativeAuthTokens? = nil
+        
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
+    }
+    
+    func testUpdateTokensAndAccount_whenAllInfoPresent_shouldUpdateDataCorrectly() {
+        let tokenResponse = getTokenResponse()
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        var tokens: MSALNativeAuthTokens? = nil
+        
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
+        
+        let newAccessToken = "newAccessToken"
+        let newRefreshToken = "newRefreshToken"
+        let newIdToken = "newIdToken"
+        tokenResponse.accessToken = newAccessToken
+        tokenResponse.refreshToken = newRefreshToken
+        tokenResponse.idToken = newIdToken
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, newAccessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, newRefreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, newIdToken)
+    }
+
+    func testGetAllAccounts_whenAllInfoPresent_shouldRetrieveDataCorrectly() {
+        clearCache()
+        let tokenResponse = getTokenResponse()
+        var tokens: MSALNativeAuthTokens? = nil
+        var account: MSALAccount? = nil
+
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertNoThrow(account = try cacheAccessor.getAllAccounts(configuration: parameters.msidConfiguration).first)
+        XCTAssertEqual(account?.username, parameters.accountIdentifier.displayableId)
+        XCTAssertEqual(account?.identifier, parameters.accountIdentifier.homeAccountId)
+        XCTAssertEqual(account?.environment, "contoso.com")
+        XCTAssertNil(account?.accountClaims)
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: account!, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
+        clearCache()
+    }
+
+    func testGetAllAccounts_whenAllInfoPresent_shouldRetrieveDataOnlyOnSameAuthority() {
+        clearCache()
+        let tokenResponse = getTokenResponse()
+        var tokens: MSALNativeAuthTokens? = nil
+        var account: MSALAccount? = nil
+
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertNoThrow(account = try cacheAccessor.getAllAccounts(configuration: parameters.msidConfiguration).first)
+        XCTAssertEqual(account?.username, parameters.accountIdentifier.displayableId)
+        XCTAssertEqual(account?.identifier, parameters.accountIdentifier.homeAccountId)
+        XCTAssertEqual(account?.environment, "contoso.com")
+        XCTAssertNil(account?.accountClaims)
+        parameters.msidConfiguration = getMSIDConfiguration(host: "https://contoso.com/tfp/tenantName")
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: account!, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
+        clearCache()
+    }
+
+    func testDataRetrieval_whenAccountIsOverwritten_shouldRetrieveLastAccount() {
+        clearCache()
+        let tokenResponse = getTokenResponse()
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        var tokens: MSALNativeAuthTokens? = nil
+        var account: MSALAccount? = nil
+
+        let newDisplayableId = "newDisplayableId"
+        let newAccessToken = "newAccessToken"
+        let newRefreshToken = "newRefreshToken"
+        let newIdToken = "eyJhbGciOiJIUzI1NiJ9.eyJ2ZXIiOiIyLjAiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vdGVzdC92Mi4wIiwic3ViIjoiQUFBQUFBQUFBQUFBQUFBQUFBQUFBUFdLdXZBcTQ3ZWZsc0o3TXdnaW1rVSIsImF1ZCI6IjA5ODRhN2I2LWJjMTMtNDE0MS04YjBkLThmNzY3ZTEzNmJiNyIsImV4cCI6MTY4MTQ2MzAyMywiaWF0IjoxNjgxMzc2MzIzLCJuYmYiOjE2ODEzNzYzMjMsIm5hbWUiOiJOZXcgVXNlciIsInByZWZlcnJlZF91c2VybmFtZSI6Im5ld0Rpc3BsYXlhYmxlSWQiLCJvaWQiOiJuZXdPaWQiLCJ0aWQiOiJuZXdUaWQiLCJhaW8iOiJEVGhGY3dSdFgwT0tqNXBTSEdOZUdVR1NVNGhaNFJoNU83TmhnUjYzMnpldEM5WmgzM3dWRypXeUJqIVFPM0twU0dXRVRla25sMDA1WE8qQWg0bXhRamVuR2VRZXIqakx3Nypkcmh1cDdTc0NJRThraUlsempYMDZuaWNWNFFFTGZxR3BoYkRuemI0RWtOZEZXTHBOTmhJJCJ9.A9K5OQgR3dUaexxosQg6FOMOteC9R96fI0sZtF-KwjU"
+        tokenResponse.accessToken = newAccessToken
+        tokenResponse.refreshToken = newRefreshToken
+        tokenResponse.idToken = newIdToken
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertNoThrow(account = try cacheAccessor.getAllAccounts(configuration: parameters.msidConfiguration).first)
+        XCTAssertEqual(account?.username, newDisplayableId)
+        XCTAssertEqual(account?.identifier, parameters.accountIdentifier.homeAccountId)
+        XCTAssertEqual(account?.environment, "contoso.com")
+        XCTAssertNil(account?.accountClaims)
+        XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: account!, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertEqual(tokens?.accessToken?.accessToken, newAccessToken)
+        XCTAssertEqual(tokens?.refreshToken?.refreshToken, newRefreshToken)
+        XCTAssertEqual(tokens?.rawIdToken, newIdToken)
+        clearCache()
+    }
+    
+    func testAccountStore_whenAllInfoPresent_shouldStoreAccountCorrectly() {
+        let tokenResponse = getTokenResponse()
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+
+        var account: MSIDAccount? = nil
+        XCTAssertNoThrow(account = try cacheAccessor.getAccount(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, context: contextStub))
+        XCTAssertEqual(account?.accountIdentifier.homeAccountId, parameters.accountIdentifier.homeAccountId)
+        // this information was took from the TokenResponse.IDToken (JWT format)
+        XCTAssertEqual(account?.accountIdentifier.displayableId, "1234567890")
+        XCTAssertEqual(account?.accountIdentifier.utid, parameters.accountIdentifier.utid)
+        XCTAssertEqual(account?.accountIdentifier.uid, parameters.accountIdentifier.uid)
+        XCTAssertEqual(account?.clientInfo, tokenResponse.clientInfo)
+    }
+    
+    func testTokensDeletion_whenAllInfoPresent_shouldRemoveTokensCorrectly() {
+        var tokens: MSALNativeAuthTokens? = nil
+        XCTAssertThrowsError(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertNil(tokens)
+        
+        let tokenResponse = getTokenResponse()
+        let _ = try? cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub)
+        
+        tokens = try? cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub)
+        XCTAssertNotNil(tokens)
+        
+        XCTAssertNoThrow(try cacheAccessor.removeTokens(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, clientId: parameters.msidConfiguration.clientId, context: contextStub))
+        
+        tokens = try? cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub)
+        XCTAssertNil(tokens)
+    }
+    
+    func testClearCache_whenAllInfoPresent_shouldRemoveTokensAndAccountCorrectly() {
+        var tokens: MSALNativeAuthTokens? = nil
+        var account: MSIDAccount? = nil
+        XCTAssertThrowsError(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertThrowsError(account = try cacheAccessor.getAccount(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, context: contextStub))
+        XCTAssertNil(tokens)
+        XCTAssertNil(account)
+        
+        let tokenResponse = getTokenResponse()
+        let _ = try? cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub)
+        
+        tokens = try? cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub)
+        account = try? cacheAccessor.getAccount(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, context: contextStub)
+        XCTAssertNotNil(tokens)
+        XCTAssertNotNil(account)
+        
+        XCTAssertNoThrow(try cacheAccessor.clearCache(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, clientId: parameters.msidConfiguration.clientId, context: contextStub))
+        
+        tokens = try? cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub)
+        account = try? cacheAccessor.getAccount(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, context: contextStub)
+        XCTAssertNil(tokens)
+        XCTAssertNil(account)
+    }
+    
+    // MARK: unhappy cases
+    
+    func testDataRetrieval_whenNoDataIsStored_shouldThrowsAnError() {
+        XCTAssertThrowsError(try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+        XCTAssertThrowsError(try cacheAccessor.getAccount(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, context: contextStub))
+    }
+
+    func testDataRetrieval_whenNoAccountStored_ShouldReturnNoAccount() {
+        clearCache()
+        var account: MSALAccount? = nil
+        XCTAssertNoThrow(account = try cacheAccessor.getAllAccounts(configuration: parameters.msidConfiguration).first)
+        XCTAssertNil(account)
+        clearCache()
+    }
+    
+    func testContentDeletion_whenNoDataIsStored_shouldNotThrowsAnError() {
+        XCTAssertNoThrow(try cacheAccessor.removeTokens(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, clientId: parameters.msidConfiguration.clientId, context: contextStub))
+        XCTAssertNoThrow(try cacheAccessor.clearCache(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, clientId: parameters.msidConfiguration.clientId, context: contextStub))
+    }
+    
+    func testRemoveTokens_whenInvalidInputIsUsed_shouldNotThrowsAnError() {
+        var authority: MSIDAuthority? = nil
+        XCTAssertNoThrow(authority = try MSIDCIAMAuthority(url: URL(string: "https://www.microsoft.com")!, validateFormat: false, context: nil))
+        XCTAssertNoThrow(try cacheAccessor.removeTokens(accountIdentifier: MSIDAccountIdentifier(), authority: authority!, clientId: "" , context: contextStub))
+    }
+    
+    func testStoreTokens_whenAccessAndRefreshTokensAreMissing_shouldThrowsAnErrorOnGetTokens() {
+        let tokenResponse = getTokenResponse()
+        tokenResponse.accessToken = nil
+        tokenResponse.refreshToken = nil
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        
+        XCTAssertThrowsError(try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+    }
+    
+    func testGetTokens_whenThereIsNoAuthScheme_shouldThrowsAnError() {
+        let tokenResponse = getTokenResponse()
+        XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
+        
+        let parameters = getParameters()
+        parameters.msidConfiguration.authScheme = nil
+        XCTAssertThrowsError(try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
+    }
+    
+    // MARK: private methods
+    
+    private func getParameters() -> ParametersStub {
+        ParametersStub(
+            account: getAccount(),
+            accountIdentifier: getAccountIdentifier(),
+            msidConfiguration: getMSIDConfiguration(host: "https://contoso.com/tfp/tenantName")
+        )
+    }
+    
+    private func getAccountIdentifier() -> MSIDAccountIdentifier {
+        return MSIDAccountIdentifier(displayableId: "1234567890", homeAccountId: "fedcba98-7654-3210-0000-000000000000.00000000-0000-1234-5678-90abcdefffff")
+    }
+
+    private func getAccount() -> MSALAccount {
+        let homeAccountId = MSALAccountId(accountIdentifier: "fedcba98-7654-3210-0000-000000000000.00000000-0000-1234-5678-90abcdefffff", objectId: "", tenantId: "https://contoso.com/tfp/tenantName")
+        let account = MSALAccount(username: "1234567890", homeAccountId: homeAccountId, environment: "contoso.com", tenantProfiles: [])
+        account?.lookupAccountIdentifier = getAccountIdentifier()
+        return account!
+    }
+    
+    private func getTokenResponse() -> MSIDCIAMTokenResponse {
+        let tokenResponse = MSIDCIAMTokenResponse()
+        tokenResponse.accessToken = "AccessToken"
+        tokenResponse.refreshToken = "refreshToken"
+        tokenResponse.idToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        tokenResponse.scope = "user.read"
+        let clientInfo = try? MSIDClientInfo(rawClientInfo: "eyAidWlkIiA6ImZlZGNiYTk4LTc2NTQtMzIxMC0wMDAwLTAwMDAwMDAwMDAwMCIsICJ1dGlkIiA6IjAwMDAwMDAwLTAwMDAtMTIzNC01Njc4LTkwYWJjZGVmZmZmZiJ9")
+        tokenResponse.clientInfo = clientInfo
+        return tokenResponse
+    }
+    
+    private func getMSIDConfiguration(host: String) -> MSIDConfiguration {
+        let configuration = MSIDConfiguration(authority: try? MSIDCIAMAuthority(url: URL(string: host)!, validateFormat: false, context: nil), redirectUri: "", clientId: "clientId", target: "user.read") ?? MSIDConfiguration()
+        let authSchema = MSIDAuthenticationScheme()
+        configuration.authScheme = authSchema
+        return configuration
+    }
+
+    private func clearCache() {
+        var accounts: [MSALAccount]!
+        XCTAssertNoThrow(accounts = try cacheAccessor.getAllAccounts(configuration: parameters.msidConfiguration))
+        for account in accounts {
+            let identifier = MSIDAccountIdentifier(displayableId: account.username, homeAccountId: account.homeAccountId.identifier)!
+            XCTAssertNoThrow(try cacheAccessor.clearCache(accountIdentifier: identifier,
+                                                          authority: parameters.msidConfiguration.authority,
+                                                          clientId: parameters.msidConfiguration.clientId,
+                                                          context: contextStub))
+        }
+    }
+}
+
+private struct ParametersStub {
+    var account: MSALAccount
+    var accountIdentifier: MSIDAccountIdentifier
+    var msidConfiguration: MSIDConfiguration
+}
+
+private class ContextStub: MSIDRequestContext {
+
+    var currentAppRequestMetadata = [AnyHashable : Any]()
+    var internalCorrelationId = UUID()
+    var telemetryId = UUID()
+
+    init() {
+        guard let metadata = Bundle.main.infoDictionary else { return }
+        let appName = metadata["CFBundleDisplayName"] ?? (metadata["CFBundleName"] ?? "")
+        let appVer = metadata["CFBundleShortVersionString"] ?? ""
+        currentAppRequestMetadata[MSID_VERSION_KEY] = MSIDVersion.sdkVersion()
+        currentAppRequestMetadata[MSID_APP_NAME_KEY] = appName
+        currentAppRequestMetadata[MSID_APP_VER_KEY] = appVer
+    }
+
+    func correlationId() -> UUID! {
+        internalCorrelationId
+    }
+
+    func logComponent() -> String! {
+        MSIDVersion.sdkName()
+    }
+
+    func telemetryRequestId() -> String! {
+        telemetryId.uuidString
+    }
+
+    func appRequestMetadata() -> [AnyHashable : Any]! {
+        currentAppRequestMetadata
+    }
+}

--- a/MSAL/test/unit/native_auth/cache/MSALNativeAuthCacheAccessorTest.swift
+++ b/MSAL/test/unit/native_auth/cache/MSALNativeAuthCacheAccessorTest.swift
@@ -31,8 +31,12 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
     private lazy var parameters = getParameters()
     private lazy var contextStub = ContextStub()
     
-    override func tearDownWithError() throws {
-        try cacheAccessor.clearCache(accountIdentifier: parameters.accountIdentifier, authority: parameters.msidConfiguration.authority, clientId: parameters.msidConfiguration.clientId, context: contextStub)
+    override func setUp() {
+        clearCache()
+    }
+    
+    override func tearDown() {
+        clearCache()
     }
     
     // MARK: happy cases
@@ -74,7 +78,6 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
     }
 
     func testGetAllAccounts_whenAllInfoPresent_shouldRetrieveDataCorrectly() {
-        clearCache()
         let tokenResponse = getTokenResponse()
         var tokens: MSALNativeAuthTokens? = nil
         var account: MSALAccount? = nil
@@ -89,11 +92,9 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
         XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
         XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
         XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
-        clearCache()
     }
 
     func testGetAllAccounts_whenAllInfoPresent_shouldRetrieveDataOnlyOnSameAuthority() {
-        clearCache()
         let tokenResponse = getTokenResponse()
         var tokens: MSALNativeAuthTokens? = nil
         var account: MSALAccount? = nil
@@ -109,11 +110,9 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
         XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
         XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
         XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
-        clearCache()
     }
 
     func testDataRetrieval_whenAccountIsOverwritten_shouldRetrieveLastAccount() {
-        clearCache()
         let tokenResponse = getTokenResponse()
         XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
         var tokens: MSALNativeAuthTokens? = nil
@@ -136,7 +135,6 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
         XCTAssertEqual(tokens?.accessToken?.accessToken, newAccessToken)
         XCTAssertEqual(tokens?.refreshToken?.refreshToken, newRefreshToken)
         XCTAssertEqual(tokens?.rawIdToken, newIdToken)
-        clearCache()
     }
     
     func testAccountStore_whenAllInfoPresent_shouldStoreAccountCorrectly() {
@@ -202,11 +200,9 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
     }
 
     func testDataRetrieval_whenNoAccountStored_ShouldReturnNoAccount() {
-        clearCache()
         var account: MSALAccount? = nil
         XCTAssertNoThrow(account = try cacheAccessor.getAllAccounts(configuration: parameters.msidConfiguration).first)
         XCTAssertNil(account)
-        clearCache()
     }
     
     func testContentDeletion_whenNoDataIsStored_shouldNotThrowsAnError() {

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthBaseControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthBaseControllerTests.swift
@@ -1,0 +1,269 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthBaseControllerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthBaseController!
+    private var contextMock: MSALNativeAuthRequestContextMock!
+    private var clientId: String!
+
+    override func setUp() {
+        super.setUp()
+
+        contextMock = MSALNativeAuthRequestContextMock()
+        contextMock.mockTelemetryRequestId = "mock_id"
+        clientId = DEFAULT_TEST_CLIENT_ID
+        dispatcher = MSALNativeAuthTelemetryTestDispatcher()
+
+        sut = MSALNativeAuthBaseController(
+            clientId: clientId
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        MSIDTelemetry.sharedInstance().remove(dispatcher)
+    }
+
+    func test_makeTelemetryApiEvent() {
+
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignUp, context: contextMock)!
+        let properties = event.getProperties()!
+
+        XCTAssertEqual(properties[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+
+        let expectedTelemetryApiId = String(MSALNativeAuthTelemetryApiId.telemetryApiIdSignUp.rawValue)
+        XCTAssertEqual(properties[MSID_TELEMETRY_KEY_API_ID] as? String, expectedTelemetryApiId)
+        XCTAssertEqual(properties[MSID_TELEMETRY_KEY_CORRELATION_ID] as? String, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(properties[MSID_TELEMETRY_KEY_CLIENT_ID] as? String, clientId)
+    }
+
+    func test_stopTelemetryEvent_with_no_error() {
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignInWithPasswordStart, context: contextMock)
+        let expectation = expectation(description: "Telemetry event test no error")
+
+        dispatcher.setTestCallback { event in
+            let dict = event.getProperties()!
+
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+            XCTAssertNil(dict[MSID_TELEMETRY_KEY_API_ERROR_CODE])
+            XCTAssertNil(dict[MSID_TELEMETRY_KEY_PROTOCOL_CODE])
+            XCTAssertNil(dict[MSID_TELEMETRY_KEY_ERROR_DOMAIN])
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_IS_SUCCESSFUL] as? String, "yes")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_RESULT_STATUS] as? String, "succeeded")
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_START_TIME])
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_END_TIME])
+
+            expectation.fulfill()
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+
+        sut.startTelemetryEvent(event, context: contextMock)
+        sut.stopTelemetryEvent(event, context: contextMock)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_stopTelemetryEvent_withNegativeErrorCode() {
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignInWithPasswordStart, context: contextMock)
+        let error = NSError(domain: "com.microsoft", code: -1)
+
+        let expectation = expectation(description: "Telemetry event test negative error code")
+
+        dispatcher.setTestCallback { event in
+            let dict = event.getProperties()!
+
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_API_ERROR_CODE] as? String, "-1")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_ERROR_DOMAIN] as? String, "com.microsoft")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_IS_SUCCESSFUL] as? String, "no")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_RESULT_STATUS] as? String, "failed")
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_START_TIME])
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_END_TIME])
+
+            expectation.fulfill()
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+
+        sut.startTelemetryEvent(event, context: contextMock)
+        sut.stopTelemetryEvent(event, context: contextMock, error: error)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_stopTelemetryEvent_withPositiveErrorCode() {
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignInWithPasswordStart, context: contextMock)
+        let error = NSError(domain: "com.microsoft", code: 12)
+
+        let expectation = expectation(description: "Telemetry event test positive error code")
+
+        dispatcher.setTestCallback { event in
+            let dict = event.getProperties()!
+
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_API_ERROR_CODE] as? String, "12")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_ERROR_DOMAIN] as? String, "com.microsoft")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_IS_SUCCESSFUL] as? String, "no")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_RESULT_STATUS] as? String, "failed")
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_START_TIME])
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_END_TIME])
+
+            expectation.fulfill()
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+
+        sut.startTelemetryEvent(event, context: contextMock)
+        sut.stopTelemetryEvent(event, context: contextMock, error: error)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_stopTelemetryEvent_with_OAuthErrorKey() {
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignInWithPasswordStart, context: contextMock)
+        let error = NSError(domain: "com.microsoft", code: 12, userInfo: ["MSIDOAuthErrorKey": "oauthErrorCode_mock"])
+
+        let expectation = expectation(description: "Telemetry event test OAuthErrorKey")
+
+        dispatcher.setTestCallback { event in
+            let dict = event.getProperties()!
+
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_API_ERROR_CODE] as? String, "12")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_PROTOCOL_CODE] as? String, "oauthErrorCode_mock")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_ERROR_DOMAIN] as? String, "com.microsoft")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_IS_SUCCESSFUL] as? String, "no")
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_RESULT_STATUS] as? String, "failed")
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_START_TIME])
+            XCTAssertNotNil(dict[MSID_TELEMETRY_KEY_END_TIME])
+
+            expectation.fulfill()
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+
+        sut.startTelemetryEvent(event, context: contextMock)
+        sut.stopTelemetryEvent(event, context: contextMock, error: error)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_completeWithTelemetry_withInvalidParameters_shouldComplete() {
+        let event = sut.makeLocalTelemetryApiEvent(name: "anEvent", telemetryApiId: .telemetryApiIdSignInWithPasswordStart, context: contextMock)
+
+        let exp1 = expectation(description: "Telemetry event")
+        let exp2 = expectation(description: "Completion event")
+
+        dispatcher.setTestCallback { event in
+            let dict = event.getProperties()!
+
+            XCTAssertEqual(dict[MSID_TELEMETRY_KEY_EVENT_NAME] as? String, "anEvent")
+            exp1.fulfill()
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+
+        sut.startTelemetryEvent(event, context: contextMock)
+
+        let responseNil: String? = nil
+
+        sut.complete(event, response: responseNil, error: nil, context: contextMock) { _, _ in
+            exp2.fulfill()
+        }
+
+        wait(for: [exp1, exp2], timeout: 1)
+    }
+
+    func test_performRequest_withError() async {
+        let baseUrl = URL(string: "https://www.contoso.com")!
+
+        let parameters = ["p1": "v1"]
+
+        let httpResponse = HTTPURLResponse(
+            url: baseUrl,
+            statusCode: 500,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        var urlRequest = URLRequest(url: baseUrl)
+        urlRequest.httpMethod = "POST"
+
+        let testUrlResponse = MSIDTestURLResponse.request(baseUrl, reponse: httpResponse)
+
+        testUrlResponse?.setError(ErrorMock.error)
+
+        testUrlResponse?.setUrlFormEncodedBody(parameters)
+        testUrlResponse?.setResponseJSON([""])
+        MSIDTestURLSession.add(testUrlResponse)
+
+        let request = MSIDHttpRequest()
+
+        request.urlRequest = urlRequest
+        request.parameters = parameters
+
+        let result: Result<String, Error> = await sut.performRequest(request, context: contextMock)
+
+        switch result {
+        case .failure(let error):
+            XCTAssertEqual(error as? ErrorMock, ErrorMock.error)
+        case .success:
+            XCTFail("Unexpected response")
+        }
+    }
+
+    func test_performRequest_withSuccess() async {
+        let request = MSIDHttpRequest()
+        HttpModuleMockConfigurator.configure(request: request, responseJson: ["response"])
+
+        let result: Result<[String], Error> = await sut.performRequest(request, context: contextMock)
+
+        switch result {
+        case .failure:
+            XCTFail("Unexpected response")
+        case .success(let response):
+            XCTAssertEqual(response.first, "response")
+        }
+    }
+
+    func test_performRequest_withUnexpectedError() async {
+        let request = MSIDHttpRequest()
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [nil] as [Any?])
+
+        let result: Result<[String], Error> = await sut.performRequest(request, context: contextMock)
+
+        switch result {
+        case .failure(let error):
+            XCTAssertEqual(error as? MSALNativeAuthInternalError, .invalidResponse)
+        case .success:
+            XCTFail("Unexpected response")
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
@@ -1,0 +1,214 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthCredentialsController!
+    private var requestProviderMock: MSALNativeAuthTokenRequestProviderMock!
+    private var cacheAccessorMock: MSALNativeAuthCacheAccessorMock!
+    private var contextMock: MSALNativeAuthRequestContextMock!
+    private var factory: MSALNativeAuthResultFactoryMock!
+    private var responseValidatorMock: MSALNativeAuthTokenResponseValidatorMock!
+    private var tokenResult = MSIDTokenResult()
+    private var tokenResponse = MSIDCIAMTokenResponse()
+    private var defaultUUID = UUID(uuidString: DEFAULT_TEST_UID)!
+
+    override func setUpWithError() throws {
+        requestProviderMock = .init()
+        cacheAccessorMock = .init()
+        contextMock = .init()
+        contextMock.mockTelemetryRequestId = "telemetry_request_id"
+        factory = .init()
+        responseValidatorMock = .init()
+        sut = .init(
+            clientId: DEFAULT_TEST_CLIENT_ID,
+            requestProvider: requestProviderMock,
+            cacheAccessor: cacheAccessorMock,
+            factory: factory,
+            responseValidator: responseValidatorMock
+        )
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+        
+        try super.setUpWithError()
+    }
+    
+    // MARK: get native user account tests
+
+    func test_whenNoAccountPresent_shouldReturnNoAccounts() {
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let accountResult = sut.retrieveUserAccountResult(context: expectedContext)
+        XCTAssertNil(accountResult)
+    }
+
+    func test_whenNoTokenPresent_shouldReturnNoAccounts() {
+        let account = MSALNativeAuthUserAccountResultStub.account
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
+        let userAccountResult = MSALNativeAuthUserAccountResult(
+            account: account,
+            authTokens: authTokens,
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: MSALNativeAuthCacheAccessorMock()
+        )
+        factory.mockMakeUserAccountResult(userAccountResult)
+        cacheAccessorMock.mockUserAccounts = [account]
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let accountResult = sut.retrieveUserAccountResult(context: expectedContext)
+        XCTAssertNil(accountResult)
+    }
+
+    func test_whenAccountSet_shouldReturnAccount() async {
+        let account = MSALNativeAuthUserAccountResultStub.account
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
+
+        let userAccountResult = MSALNativeAuthUserAccountResult(
+            account: account,
+            authTokens: authTokens,
+            configuration: MSALNativeAuthConfigStubs.configuration,
+            cacheAccessor: MSALNativeAuthCacheAccessorMock()
+        )
+
+        factory.mockMakeUserAccountResult(userAccountResult)
+        cacheAccessorMock.mockUserAccounts = [account]
+        cacheAccessorMock.mockAuthTokens = authTokens
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let accountResult = sut.retrieveUserAccountResult(context: expectedContext)
+        XCTAssertEqual(accountResult?.account.username, account.username)
+        XCTAssertEqual(accountResult?.idToken, authTokens.rawIdToken)
+        XCTAssertEqual(accountResult?.scopes, authTokens.accessToken?.scopes.array as? [String])
+        XCTAssertEqual(accountResult?.expiresOn, authTokens.accessToken?.expiresOn)
+        XCTAssertTrue(NSDictionary(dictionary: accountResult?.account.accountClaims ?? [:]).isEqual(to: account.accountClaims ?? [:]))
+    }
+
+    func test_whenCreateRequestFails_shouldReturnError() async throws {
+        let expectation = expectation(description: "CredentialsController")
+
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
+
+        requestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: nil, signInSLT: nil, grantType: MSALNativeAuthGrantType.refreshToken, scope: "" , password: nil, oobCode: nil, includeChallengeType: true, refreshToken: "refreshToken")
+        requestProviderMock.throwingTokenError = ErrorMock.error
+
+        let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .generalError))
+
+        let result = await sut.refreshToken(context: expectedContext, authTokens: authTokens)
+        helper.onAccessTokenRetrieveError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdRefreshToken, isSuccessful: false)
+    }
+
+    func test_whenAccountSet_shouldRefreshToken() async {
+        let expectation = expectation(description: "CredentialsController")
+
+        let account = MSALNativeAuthUserAccountResultStub.account
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
+        let userAccountResult = MSALNativeAuthUserAccountResult(account: account,
+                                                                authTokens: authTokens,
+                                                                configuration: MSALNativeAuthConfigStubs.configuration, cacheAccessor: MSALNativeAuthCacheAccessorMock())
+
+        let request = MSIDHttpRequest()
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        requestProviderMock.result = request
+
+        let expectedAccessToken = "accessToken"
+        let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedAccessToken: expectedAccessToken)
+
+        factory.mockMakeUserAccountResult(userAccountResult)
+        tokenResult.accessToken = MSIDAccessToken()
+        tokenResult.accessToken.accessToken = expectedAccessToken
+        responseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        cacheAccessorMock.mockUserAccounts = [account]
+        cacheAccessorMock.mockAuthTokens = authTokens
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+        let result = await sut.refreshToken(context: expectedContext, authTokens: authTokens)
+        helper.onAccessTokenRetrieveCompleted(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertEqual(expectedAccessToken, authTokens.accessToken?.accessToken)
+    }
+
+    func test_whenErrorIsReturnedFromValidator_itIsCorrectlyTranslatedToDelegateError() async  {
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError), validatorError: .generalError)
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError), validatorError: .expiredToken(message: nil))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError), validatorError: .authorizationPending(message: nil))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError), validatorError: .slowDown(message: nil))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError), validatorError: .invalidRequest(message: nil))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.invalidServerResponse), validatorError: .invalidServerResponse)
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, message: "Invalid Client ID"), validatorError: .invalidClient(message: "Invalid Client ID"))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, message: "Unsupported challenge type"), validatorError: .unsupportedChallengeType(message: "Unsupported challenge type"))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, message: "Invalid scope"), validatorError: .invalidScope(message: "Invalid scope"))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .refreshTokenExpired), validatorError: .expiredRefreshToken(message: nil))
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .browserRequired, message: "MFA currently not supported. Use the browser instead"), validatorError: .strongAuthRequired(message: "MFA currently not supported. Use the browser instead"))
+    }
+
+    private func checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError, validatorError: MSALNativeAuthTokenValidatedErrorType) async {
+        let request = MSIDHttpRequest()
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "CredentialsController")
+
+        requestProviderMock.result = request
+
+        let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedError: publicError)
+        responseValidatorMock.tokenValidatedResponse = .error(validatorError)
+
+        let result = await sut.refreshToken(context: expectedContext, authTokens: authTokens)
+        helper.onAccessTokenRetrieveError(result)
+
+        checkTelemetryEventResult(id: .telemetryApiIdRefreshToken, isSuccessful: false)
+        receivedEvents.removeAll()
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    private func checkTelemetryEventResult(id: MSALNativeAuthTelemetryApiId, isSuccessful: Bool) {
+        XCTAssertEqual(receivedEvents.count, 1)
+
+        guard let telemetryEventDict = receivedEvents.first else {
+            return XCTFail("Telemetry test fail")
+        }
+
+        let expectedApiId = String(id.rawValue)
+        XCTAssertEqual(telemetryEventDict["api_id"] as? String, expectedApiId)
+        XCTAssertEqual(telemetryEventDict["event_name"] as? String, "api_event" )
+        XCTAssertEqual(telemetryEventDict["correlation_id" ] as? String, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(telemetryEventDict["is_successfull"] as? String, isSuccessful ? "yes" : "no")
+        XCTAssertEqual(telemetryEventDict["status"] as? String, isSuccessful ? "succeeded" : "failed")
+        XCTAssertNotNil(telemetryEventDict["start_time"])
+        XCTAssertNotNil(telemetryEventDict["stop_time"])
+        XCTAssertNotNil(telemetryEventDict["response_time"])
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
@@ -1,0 +1,922 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthResetPasswordController!
+    private var contextMock: MSALNativeAuthRequestContext!
+    private var requestProviderMock: MSALNativeAuthResetPasswordRequestProviderMock!
+    private var validatorMock: MSALNativeAuthResetPasswordResponseValidatorMock!
+
+
+    private var resetPasswordStartParams: MSALNativeAuthResetPasswordStartRequestProviderParameters {
+        .init(
+            username: "user@contoso.com",
+            context: contextMock
+        )
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        contextMock = .init(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        requestProviderMock = .init()
+        validatorMock = .init()
+
+        sut = .init(config: MSALNativeAuthConfigStubs.configuration,
+                    requestProvider: requestProviderMock,
+                    responseValidator: validatorMock
+        )
+    }
+
+    // MARK: - ResetPasswordStart (/start request) tests
+
+    func test_whenResetPasswordStart_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordStart_returnsSuccess_it_callsChallenge() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.unexpectedError)
+        _ = prepareResetPasswordStartValidatorHelper()
+
+        _ = await sut.resetPassword(parameters: resetPasswordStartParams)
+
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+    }
+
+    func test_whenResetPasswordStartPassword_returns_redirect_it_returnsBrowserRequiredError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.redirect)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordStart_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.error(.userNotFound(message: nil)))
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .userNotFound)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInResetPasswordStart_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    // MARK: - ResetPasswordStart (/challenge request) tests
+
+    func test_whenResetPasswordStart_challenge_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordStart_challenge_succeeds_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "resetPasswordToken"))
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordCodeRequired(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "resetPasswordToken")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: true)
+    }
+
+    func test_whenResetPasswordStart_challenge_returns_redirect_it_returnsRedirectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.redirect)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordStart_challenge_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthResetPasswordChallengeValidatedResponse = .error(
+            MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken,
+                                                              errorDescription: "Expired Token",
+                                                              errorCodes: nil,
+                                                              errorURI: nil,
+                                                              innerErrors: nil,
+                                                              target: nil))
+        validatorMock.mockValidateResetPasswordChallengeFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertEqual(helper.error?.errorDescription, "Expired Token")
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInResetPasswordStart_challenge_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    // MARK: - ResendCode tests
+
+    func test_whenResetPasswordResendCode_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordResendCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordResendCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordResendCode_succeeds_it_returnsResetPasswordResendCodeRequired() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        validatorMock.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "flowToken response"))
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordResendCodeRequired(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordResendCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "flowToken response")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordResendCode, isSuccessful: true)
+    }
+
+    func test_whenResetPasswordResendCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthResetPasswordChallengeValidatedResponse = .error(
+            MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest,
+                                                              errorDescription: nil,
+                                                              errorCodes: nil,
+                                                              errorURI: nil,
+                                                              innerErrors: nil,
+                                                              target: nil))
+        validatorMock.mockValidateResetPasswordChallengeFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordResendCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordResendCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordResendCode_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.redirect)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordResendCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordResendCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordResendCode_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordResendCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordResendCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitCode tests
+
+    func test_whenResetPasswordSubmitCode_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode(code: "1234", passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordVerifyCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordSubmitCode_succeeds_it_returnsPasswordRequired() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateResetPasswordContinueFunc(.success(passwordSubmitToken: ""))
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode(code: "1234", passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onPasswordRequired(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onPasswordRequiredCalled)
+        XCTAssertNotNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmitCode, isSuccessful: true)
+    }
+
+    func test_whenResetPasswordSubmitCode_returns_invalidOOB_it_returnsInvalidCode() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateResetPasswordContinueFunc(.invalidOOB)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode(code: "1234", passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordVerifyCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordVerifyCodeErrorCalled)
+        XCTAssertEqual(helper.newCodeRequiredState?.flowToken, "passwordResetToken")
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .invalidCode)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordSubmitCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        let error : MSALNativeAuthResetPasswordContinueValidatedResponse = .error(
+            MSALNativeAuthResetPasswordContinueResponseError(error: .invalidRequest,
+                                                             errorDescription: nil,
+                                                             errorCodes: nil,
+                                                             errorURI: nil,
+                                                             innerErrors: nil,
+                                                             target: nil,
+                                                             passwordResetToken: nil))
+        validatorMock.mockValidateResetPasswordContinueFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode(code: "1234", passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordVerifyCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordSubmitCode_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateResetPasswordContinueFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode(code: "1234", passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordVerifyCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmitCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitPassword tests
+
+    func test_whenResetPasswordSubmitPassword_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockSubmitRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_succeeds_it_returnsCompleted() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded))
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordCompleted(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordCompletedCalled)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: true)
+    }
+
+    func test_whenResetPasswordSubmitPassword_returns_passwordError_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        let error : MSALNativeAuthResetPasswordSubmitValidatedResponse = .passwordError(error:
+            MSALNativeAuthResetPasswordSubmitResponseError(error: .passwordTooWeak,
+                                                           errorDescription: "Password too weak",
+                                                           errorCodes: nil,
+                                                           errorURI: nil,
+                                                           innerErrors: nil,
+                                                           target: nil))
+        validatorMock.mockValidateResetPasswordSubmitFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "passwordSubmitToken")
+        XCTAssertEqual(helper.error?.type, .invalidPassword)
+        XCTAssertEqual(helper.error?.errorDescription, "Password too weak")
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordSubmitPassword_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        let error : MSALNativeAuthResetPasswordSubmitValidatedResponse = .error(
+            MSALNativeAuthResetPasswordSubmitResponseError(error: .invalidRequest,
+                                                           errorDescription: nil,
+                                                           errorCodes: nil,
+                                                           errorURI: nil,
+                                                           innerErrors: nil,
+                                                           target: nil))
+        validatorMock.mockValidateResetPasswordSubmitFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordSubmitPassword_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    // MARK: - SubmitPassword - poll completion tests
+
+    func test_whenSubmitPassword_pollCompletion_returns_failed_it_returnsResetPasswordRequiredError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_passwordError_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        let error : MSALNativeAuthResetPasswordPollCompletionValidatedResponse =
+            .passwordError(error:
+                            MSALNativeAuthResetPasswordPollCompletionResponseError(error: .passwordBanned,
+                                                                                   errorDescription: "Password banned",
+                                                                                   errorCodes: nil,
+                                                                                   errorURI: nil,
+                                                                                   innerErrors: nil,
+                                                                                   target: nil))
+        
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "passwordResetToken")
+        XCTAssertEqual(helper.error?.type, .invalidPassword)
+        XCTAssertEqual(helper.error?.errorDescription, "Password banned")
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        let error : MSALNativeAuthResetPasswordPollCompletionValidatedResponse = .error(
+            MSALNativeAuthResetPasswordPollCompletionResponseError(error: .expiredToken,
+                                                             errorDescription: "Expired Token",
+                                                             errorCodes: nil,
+                                                             errorURI: nil,
+                                                             innerErrors: nil,
+                                                             target: nil))
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertEqual(helper.error?.errorDescription, "Expired Token")
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_notStarted_it_returnsCorrectErrorAfterRetries() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 1))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .notStarted))
+
+        prepareMockRequestsForPollCompletionRetries(5)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_failed_it_returnsError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .failed))
+
+        prepareMockRequestsForPollCompletionRetries(5)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_inProgress_it_returnsErrorAfterRetries() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .inProgress))
+
+        prepareMockRequestsForPollCompletionRetries(5)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+
+    // MARK: - Common Methods
+
+    private func checkTelemetryEventResult(id: MSALNativeAuthTelemetryApiId, isSuccessful: Bool) {
+        XCTAssertEqual(receivedEvents.count, 1)
+
+        guard let telemetryEventDict = receivedEvents.first else {
+            return XCTFail("Telemetry test fail")
+        }
+
+        let expectedApiId = String(id.rawValue)
+        XCTAssertEqual(telemetryEventDict["api_id"] as? String, expectedApiId)
+        XCTAssertEqual(telemetryEventDict["event_name"] as? String, "api_event" )
+        XCTAssertEqual(telemetryEventDict["correlation_id" ] as? String, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(telemetryEventDict["is_successfull"] as? String, isSuccessful ? "yes" : "no")
+        XCTAssertEqual(telemetryEventDict["status"] as? String, isSuccessful ? "succeeded" : "failed")
+        XCTAssertNotNil(telemetryEventDict["start_time"])
+        XCTAssertNotNil(telemetryEventDict["stop_time"])
+        XCTAssertNotNil(telemetryEventDict["response_time"])
+    }
+
+    private func prepareResetPasswordStartValidatorHelper(_ expectation: XCTestExpectation? = nil) -> ResetPasswordStartTestsValidatorHelper {
+        let helper = ResetPasswordStartTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onResetPasswordErrorCalled)
+        XCTAssertFalse(helper.onResetPasswordCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareResetPasswordResendCodeValidatorHelper(_ expectation: XCTestExpectation? = nil) -> ResetPasswordResendCodeTestsValidatorHelper {
+        let helper = ResetPasswordResendCodeTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onResetPasswordResendCodeErrorCalled)
+        XCTAssertFalse(helper.onResetPasswordResendCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareResetPasswordSubmitCodeValidatorHelper(_ expectation: XCTestExpectation? = nil) -> ResetPasswordVerifyCodeTestsValidatorHelper {
+        let helper = ResetPasswordVerifyCodeTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onPasswordRequiredCalled)
+        XCTAssertFalse(helper.onResetPasswordVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareResetPasswordSubmitPasswordValidatorHelper(_ expectation: XCTestExpectation? = nil) -> ResetPasswordRequiredTestsValidatorHelper {
+        let helper = ResetPasswordRequiredTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onResetPasswordCompletedCalled)
+        XCTAssertFalse(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func expectedChallengeParams(token: String = "passwordResetToken") -> (token: String, context: MSIDRequestContext) {
+        return (token: token, context: contextMock)
+    }
+
+    private func expectedContinueParams(
+        grantType: MSALNativeAuthGrantType = .oobCode,
+        token: String = "passwordResetToken",
+        oobCode: String? = "1234"
+    ) -> MSALNativeAuthResetPasswordContinueRequestParameters {
+        .init(
+            context: contextMock,
+            passwordResetToken: token,
+            grantType: grantType,
+            oobCode: oobCode
+        )
+    }
+
+    private func expectedSubmitParams(
+        token: String = "passwordSubmitToken",
+        password: String = "password"
+    ) -> MSALNativeAuthResetPasswordSubmitRequestParameters {
+        .init(
+            context: contextMock,
+            passwordSubmitToken: token,
+            newPassword: password)
+    }
+
+    private func expectedPollCompletionParameters(
+        token: String = "passwordResetToken"
+    ) -> MSALNativeAuthResetPasswordPollCompletionRequestParameters {
+        .init(
+            context: contextMock,
+            passwordResetToken: token)
+    }
+
+    private func prepareMockRequest() -> MSIDHttpRequest {
+        let request = MSIDHttpRequest()
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        return request
+    }
+
+    private func prepareMockRequestsForPollCompletionRetries(_ count: Int) {
+        for _ in 1...count {
+            _ = prepareMockRequest()
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -1,0 +1,1082 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthSignInController!
+    private var signInRequestProviderMock: MSALNativeAuthSignInRequestProviderMock!
+    private var tokenRequestProviderMock: MSALNativeAuthTokenRequestProviderMock!
+    private var cacheAccessorMock: MSALNativeAuthCacheAccessorMock!
+    private var signInResponseValidatorMock: MSALNativeAuthSignInResponseValidatorMock!
+    private var tokenResponseValidatorMock: MSALNativeAuthTokenResponseValidatorMock!
+    private var contextMock: MSALNativeAuthRequestContextMock!
+    private var tokenResult = MSIDTokenResult()
+    private var tokenResponse = MSIDCIAMTokenResponse()
+    private var defaultUUID = UUID(uuidString: DEFAULT_TEST_UID)!
+    private let defaultScopes = "openid profile offline_access"
+
+    override func setUpWithError() throws {
+        signInRequestProviderMock = .init()
+        tokenRequestProviderMock = .init()
+        cacheAccessorMock = .init()
+        signInResponseValidatorMock = .init()
+        tokenResponseValidatorMock = .init()
+        contextMock = .init()
+        contextMock.mockTelemetryRequestId = "telemetry_request_id"
+        
+        sut = .init(
+            clientId: DEFAULT_TEST_CLIENT_ID,
+            signInRequestProvider: signInRequestProviderMock,
+            tokenRequestProvider: tokenRequestProviderMock,
+            cacheAccessor: cacheAccessorMock,
+            factory: MSALNativeAuthResultFactoryMock(),
+            signInResponseValidator: signInResponseValidatorMock,
+            tokenResponseValidator: tokenResponseValidatorMock
+        )
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+        tokenResult.rawIdToken = "idToken"
+
+        try super.setUpWithError()
+    }
+    
+    // MARK: sign in with username and password tests
+
+    func test_whenCreateRequestFails_shouldReturnError() async throws {
+        let expectation = expectation(description: "SignInController")
+
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedContext = expectedContext
+        signInRequestProviderMock.throwingInitError = ErrorMock.error
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInPasswordStartError(type: .generalError))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenUserSpecifiesScope_defaultScopesShouldBeIncluded() async throws {
+        let expectation = expectation(description: "SignInController")
+
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let expectedScopes = "scope1 scope2 openid profile offline_access"
+        let credentialToken = "credentialToken"
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInPasswordStartError(type: .generalError))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "scope2"]))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenUserSpecifiesScopes_NoDuplicatedScopeShouldBeSent() async throws {
+        let expectation = expectation(description: "SignInController")
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let expectedScopes = "scope1 openid profile offline_access"
+        let credentialToken = "credentialToken"
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.throwingTokenError = ErrorMock.error
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInPasswordStartError(type: .generalError))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "openid", "profile"]))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+    
+    func test_successfulResponseAndValidation_shouldCompleteSignIn() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+
+        let expectation = expectation(description: "SignInController")
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedUsername = expectedUsername
+        tokenRequestProviderMock.expectedContext = expectedContext
+
+        let userAccountResult = MSALNativeAuthUserAccountResultStub.result
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedUserAccountResult: userAccountResult)
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInCompleted(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertTrue(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: true)
+    }
+
+    func test_successfulResponseAndUnsuccessfulValidation_shouldReturnError() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+
+        let expectation = expectation(description: "SignInController")
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedUsername = expectedUsername
+        tokenRequestProviderMock.expectedContext = expectedContext
+
+        let userAccountResult = MSALNativeAuthUserAccountResultStub.result
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedUserAccountResult: userAccountResult)
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+
+        cacheAccessorMock.expectedMSIDTokenResult = nil
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+
+    func test_errorResponse_shouldReturnError() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "invalid token"
+
+        let expectation = expectation(description: "SignInController")
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .error(.invalidToken(message: nil))
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedUsername = expectedUsername
+        tokenRequestProviderMock.expectedContext = expectedContext
+
+        let userAccountResult = MSALNativeAuthUserAccountResultStub.result
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedUserAccountResult: userAccountResult)
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+    
+    func test_whenErrorIsReturnedFromValidator_itIsCorrectlyTranslatedToDelegateError() async  {
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError), validatorError: .generalError)
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError), validatorError: .expiredToken(message: nil))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError), validatorError: .authorizationPending(message: nil))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError), validatorError: .slowDown(message: nil))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError, message: "Invalid server response"), validatorError: .invalidServerResponse)
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError, message: "Invalid Client ID"), validatorError: .invalidClient(message: "Invalid Client ID"))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError, message: "Unsupported challenge type"), validatorError: .unsupportedChallengeType(message: "Unsupported challenge type"))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError, message: "Invalid scope"), validatorError: .invalidScope(message: "Invalid scope"))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .invalidPassword), validatorError: .invalidPassword(message: nil))
+    }
+    
+    func test_whenCredentialsAreRequired_browserRequiredErrorIsReturned() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedCredentialToken = credentialToken
+
+        let expectation = expectation(description: "SignInController")
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: .init(type: .browserRequired, message: MSALNativeAuthErrorMessage.unsupportedMFA))
+
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(.strongAuthRequired(message: "MFA currently not supported. Use the browser instead"))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInPasswordError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignInUsingPassword_apiReturnsChallengeTypeOOB_codeRequiredShouldBeCalled() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedSentTo = "sentTo"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+
+        let expectation = expectation(description: "SignInController")
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation)
+        helper.expectedSentTo = expectedSentTo
+        helper.expectedChannelTargetType = expectedChannelTargetType
+        helper.expectedCodeLength = expectedCodeLength
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignInCodeRequired(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: true)
+    }
+
+    func test_whenSignInUsingPassword_apiReturnsChallengeTypeOOB__butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedSentTo = "sentTo"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+
+        let expectation = expectation(description: "SignInController")
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation)
+        helper.expectedSentTo = expectedSentTo
+        helper.expectedChannelTargetType = expectedChannelTargetType
+        helper.expectedCodeLength = expectedCodeLength
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignInCodeRequired(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+    }
+    
+    // MARK: sign in with username and code
+    
+    func test_whenSignInWithCodeStartWithValidInfo_codeRequiredShouldBeCalled() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let sentTo = "sentTo"
+        let channelTargetType = MSALNativeAuthChannelType.email
+        let codeLength = 4
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedSentTo: sentTo, expectedChannelTargetType: channelTargetType, expectedCodeLength: codeLength)
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+
+        helper.onSignInCodeRequired(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: true)
+    }
+
+    func test_afterSignInWithCodeSubmitCode_signInShouldCompleteSuccessfully() {
+        let request = MSIDHttpRequest()
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: defaultScopes, password: nil, oobCode: "code", includeChallengeType: false, refreshToken: nil)
+
+        let userAccountResult = MSALNativeAuthUserAccountResultStub.result
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        cacheAccessorMock.mockUserAccounts = [MSALNativeAuthUserAccountResultStub.account]
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+
+        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), flowToken: credentialToken)
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedUserAccountResult: userAccountResult), correlationId: defaultUUID)
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(cacheAccessorMock.clearCacheWasCalled)
+        XCTAssertTrue(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitCode, isSuccessful: true)
+    }
+
+    func test_afterSignInWithCodeSubmitCode_whenTokenCacheIsNotValid_it_shouldReturnCorrectError() {
+        let request = MSIDHttpRequest()
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: defaultScopes, password: nil, oobCode: "code", includeChallengeType: false, refreshToken: nil)
+
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        cacheAccessorMock.expectedMSIDTokenResult = nil
+
+        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), flowToken: credentialToken)
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)), correlationId: defaultUUID)
+
+        wait(for: [expectation], timeout: 1)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitCode, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithCodeStartAndInitiateRequestCreationFail_errorShouldBeReturned() async {
+        let expectedUsername = "username"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedContext = expectedContext
+        signInRequestProviderMock.throwingInitError = MSALNativeAuthError()
+
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+
+        helper.onSignInError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithCodeStartAndInitiateReturnError_properErrorShouldBeReturned() async {
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .browserRequired), validatorError: .redirect)
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .invalidClient(message: nil))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .unsupportedChallengeType(message: nil))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidServerResponse)
+    }
+    
+    func test_whenSignInWithCodeChallengeRequestCreationFail_errorShouldBeReturned() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError()
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: "credentialToken")
+        
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+
+        helper.onSignInError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithCodeChallengeReturnsError_properErrorShouldBeReturned() async {
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .browserRequired), validatorError: .redirect)
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .expiredToken(message: nil))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidToken(message: nil))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidServerResponse)
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .invalidClient(message: nil))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .unsupportedChallengeType(message: nil))
+    }
+    
+    func test_whenSignInWithCodePasswordIsRequired_newStateIsPropagatedToUser() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: expectedCredentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: expectedCredentialToken)
+        
+        let helper = SignInCodeStartWithPasswordRequiredTestsValidatorHelper(expectation: expectation)
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignInPasswordRequired(result.result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: true)
+        XCTAssertEqual(helper.passwordRequiredState?.flowToken, expectedCredentialToken)
+    }
+
+    func test_whenSignInWithCodePasswordIsRequired_newStateIsPropagatedToUser_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: expectedCredentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: expectedCredentialToken)
+
+        let helper = SignInCodeStartWithPasswordRequiredTestsValidatorHelper(expectation: expectation)
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignInPasswordRequired(result.result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
+        XCTAssertEqual(helper.passwordRequiredState?.flowToken, expectedCredentialToken)
+    }
+    
+    func test_whenSignInWithCodeSubmitPassword_signInIsCompletedSuccessfully() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let exp = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedUserAccountResult: MSALNativeAuthUserAccountResultStub.result)
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+        cacheAccessorMock.mockUserAccounts = [MSALNativeAuthUserAccountResultStub.account]
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate, correlationId: defaultUUID)
+
+        await fulfillment(of: [exp], timeout: 1)
+
+        XCTAssertTrue(cacheAccessorMock.clearCacheWasCalled)
+        XCTAssertTrue(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitPassword, isSuccessful: true)
+    }
+
+    func test_whenSignInWithCodeSubmitPassword_whenTokenCacheIsNotValid_it_shouldReturnCorrectError() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let exp = expectation(description: "SignInController")
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+        cacheAccessorMock.expectedMSIDTokenResult = nil
+
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate, correlationId: defaultUUID)
+
+        await fulfillment(of: [exp], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitPassword, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithCodeSubmitPasswordTokenRequestCreationFail_errorShouldBeReturned() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let exp = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
+        signInRequestProviderMock.expectedContext = expectedContext
+        
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
+
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate, correlationId: defaultUUID)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertNotNil(mockDelegate.newPasswordRequiredState)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitPassword, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithCodeSubmitPasswordTokenAPIReturnError_correctErrorShouldBeReturned() async {
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .generalError)
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .expiredToken(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidClient(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidRequest(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidServerResponse)
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .userNotFound(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidOOBCode(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .unsupportedChallengeType(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .browserRequired), validatorError: .strongAuthRequired(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidScope(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .authorizationPending(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .slowDown(message: nil))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .invalidPassword), validatorError: .invalidPassword(message: nil))
+    }
+    
+    func test_signInWithCodeSubmitCodeTokenRequestFailCreation_errorShouldBeReturned() {
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
+
+        let state = SignInCodeRequiredState(scopes: [], controller: sut, flowToken: credentialToken)
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)), correlationId: defaultUUID)
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitCode, isSuccessful: false)
+    }
+    
+    func test_signInWithCodeSubmitCodeReturnError_correctResultShouldReturned() {
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .generalError)
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .expiredToken(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidClient(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidRequest(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidServerResponse)
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .userNotFound(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .invalidCode, validatorError: .invalidOOBCode(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unsupportedChallengeType(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .browserRequired, validatorError: .strongAuthRequired(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidScope(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .authorizationPending(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .slowDown(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidPassword(message: nil))
+    }
+        
+    func test_signInWithCodeResendCode_shouldSendNewCode() async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let sentTo = "sentTo"
+        let channelTargetType = MSALNativeAuthChannelType.email
+        let codeLength = 4
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation, expectedSentTo: sentTo, expectedChannelTargetType: channelTargetType, expectedCodeLength: codeLength)
+
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
+
+        let result = await sut.resendCode(credentialToken: credentialToken, context: expectedContext, scopes: [])
+
+        helper.onSignInResendCodeCodeRequired(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInResendCode, isSuccessful: true)
+    }
+    
+    func test_signInWithCodeResendCodeChallengeCreationFail_errorShouldBeReturned() async {
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError()
+
+        let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
+
+        let result = await sut.resendCode(credentialToken: "credentialToken", context: expectedContext, scopes: [])
+
+        helper.onSignInResendCodeError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertNotNil(helper.newSignInCodeRequiredState)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInResendCode, isSuccessful: false)
+    }
+    
+    func test_signInWithCodeResendCodePasswordRequired_shouldReturnAnError() async {
+        let request = MSIDHttpRequest()
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
+
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+
+        let result = await sut.resendCode(credentialToken: credentialToken, context: expectedContext, scopes: [])
+
+        helper.onSignInResendCodeError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertNil(helper.newSignInCodeRequiredState)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInResendCode, isSuccessful: false)
+    }
+    
+    func test_signInWithCodeResendCodeChallengeReturnError_shouldReturnAnError() async {
+        let request = MSIDHttpRequest()
+        let credentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
+
+        signInResponseValidatorMock.challengeValidatedResponse = .error(.userNotFound(message: nil))
+
+        let result = await sut.resendCode(credentialToken: credentialToken, context: expectedContext, scopes: [])
+
+        helper.onSignInResendCodeError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertNotNil(helper.newSignInCodeRequiredState)
+        XCTAssertEqual(helper.newSignInCodeRequiredState?.flowToken, credentialToken)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInResendCode, isSuccessful: false)
+    }
+    
+    // MARK: signIn using SLT
+    
+    func test_whenSignInWithSLT_signInIsCompletedSuccessfully() {
+        let request = MSIDHttpRequest()
+        let slt = "signInSLT"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let expectation = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: "", credentialToken: nil, signInSLT: slt, grantType: .slt, scope: defaultScopes, password: nil, oobCode: nil, includeChallengeType: false, refreshToken: nil)
+
+        let userAccountResult = MSALNativeAuthUserAccountResultStub.result
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedUserAccountResult: userAccountResult)
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
+
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+        
+        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt)
+        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInAfterSignUp, isSuccessful: true)
+    }
+    
+    func test_whenSignInWithSLTTokenRequestCreationFail_errorShouldBeReturned() {
+        let request = MSIDHttpRequest()
+        let slt = "signInSLT"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let exp = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
+        signInRequestProviderMock.expectedContext = expectedContext
+        
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: exp, expectedError: SignInAfterSignUpError())
+
+        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt)
+        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+        
+        wait(for: [exp], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInAfterSignUp, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithSLTTokenReturnError_shouldReturnAnError() {
+        let request = MSIDHttpRequest()
+        let slt = "signInSLT"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Invalid Client ID"))
+
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(.invalidClient(message: "Invalid Client ID"))
+
+        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt)
+        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInAfterSignUp, isSuccessful: false)
+    }
+    
+    func test_whenSignInWithSLTHaveTokenNil_shouldReturnAnError() {        
+        let expectation = expectation(description: "SignInController")
+
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Sign In is not available at this point, please use the standalone sign in methods"))
+
+        let state = SignInAfterSignUpState(controller: sut, username: "username", slt: nil)
+        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInAfterSignUp, isSuccessful: false)
+    }
+
+    
+    // MARK: private methods
+
+    private func checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: VerifyCodeErrorType, validatorError: MSALNativeAuthTokenValidatedErrorType) {
+        let request = MSIDHttpRequest()
+        let expectedCredentialToken = "credentialToken"
+        let expectedOOBCode = "code"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let exp = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: "", password: nil, oobCode: expectedOOBCode, includeChallengeType: true, refreshToken: nil)
+        let mockDelegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedError: VerifyCodeError(type: delegateError))
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
+        
+        let state = SignInCodeRequiredState(scopes: [], controller: sut, flowToken: expectedCredentialToken)
+        state.submitCode(code: expectedOOBCode, delegate: mockDelegate, correlationId: defaultUUID)
+
+        wait(for: [exp], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitCode, isSuccessful: false)
+        receivedEvents.removeAll()
+    }
+    
+    private func checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError, validatorError: MSALNativeAuthTokenValidatedErrorType) async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedCredentialToken = "credentialToken"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        let exp = expectation(description: "SignInController")
+        
+        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.expectedContext = expectedContext
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: publicError)
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
+
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate, correlationId: defaultUUID)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitPassword, isSuccessful: false)
+        receivedEvents.removeAll()
+    }
+    
+    private func checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError, validatorError: MSALNativeAuthSignInChallengeValidatedErrorType) async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.result = request
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: "credentialToken")
+        signInResponseValidatorMock.challengeValidatedResponse = .error(validatorError)
+        
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+
+        helper.onSignInError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
+        receivedEvents.removeAll()
+    }
+    
+    private func checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError, validatorError: MSALNativeAuthSignInInitiateValidatedErrorType) async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        let expectation = expectation(description: "SignInController")
+
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedContext = expectedContext
+        signInRequestProviderMock.result = request
+        signInResponseValidatorMock.initiateValidatedResponse = .error(validatorError)
+
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
+
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+
+        helper.onSignInError(result)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
+        receivedEvents.removeAll()
+    }
+    
+    private func checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError, validatorError: MSALNativeAuthTokenValidatedErrorType) async {
+        let request = MSIDHttpRequest()
+        let expectedUsername = "username"
+        let expectedPassword = "password"
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+        
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+        
+        signInRequestProviderMock.result = request
+        signInRequestProviderMock.expectedUsername = expectedUsername
+        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedContext = expectedContext
+
+        let expectation = expectation(description: "SignInController")
+
+        tokenRequestProviderMock.result = request
+        
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
+        
+        let result = await sut.signIn(params: MSALNativeAuthSignInWithPasswordParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+
+        helper.onSignInPasswordError(result)
+        
+        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
+        receivedEvents.removeAll()
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+    
+    private func checkTelemetryEventResult(id: MSALNativeAuthTelemetryApiId, isSuccessful: Bool) {
+        XCTAssertEqual(receivedEvents.count, 1)
+
+        guard let telemetryEventDict = receivedEvents.first else {
+            return XCTFail("Telemetry test fail")
+        }
+
+        let expectedApiId = String(id.rawValue)
+        XCTAssertEqual(telemetryEventDict["api_id"] as? String, expectedApiId)
+        XCTAssertEqual(telemetryEventDict["event_name"] as? String, "api_event" )
+        XCTAssertEqual(telemetryEventDict["correlation_id" ] as? String, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(telemetryEventDict["is_successfull"] as? String, isSuccessful ? "yes" : "no")
+        XCTAssertEqual(telemetryEventDict["status"] as? String, isSuccessful ? "succeeded" : "failed")
+        XCTAssertNotNil(telemetryEventDict["start_time"])
+        XCTAssertNotNil(telemetryEventDict["stop_time"])
+        XCTAssertNotNil(telemetryEventDict["response_time"])
+    }
+
+}

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
@@ -1784,7 +1784,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
     }
 
-    // MARK: - Sign-in with SLT
+    // MARK: - Sign-in with SLT (Short-Lived Token)
 
     func test_whenSignUpSucceeds_and_userCallsSignInWithSLT_signUpControllerPassesCorrectParams() async {
         let username = "username"

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
@@ -1,0 +1,1948 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthSignUpController!
+    private var contextMock: MSALNativeAuthRequestContext!
+    private var requestProviderMock: MSALNativeAuthSignUpRequestProviderMock!
+    private var validatorMock: MSALNativeAuthSignUpResponseValidatorMock!
+    private var signInControllerMock: MSALNativeAuthSignInControllerMock!
+
+    private var signUpStartPasswordParams: MSALNativeAuthSignUpStartRequestProviderParameters {
+        .init(
+            username: "user@contoso.com",
+            password: "password",
+            attributes: ["key": "value"],
+            context: contextMock
+        )
+    }
+
+    private var signUpStartCodeParams: MSALNativeAuthSignUpStartRequestProviderParameters {
+        .init(
+            username: "user@contoso.com",
+            password: nil,
+            attributes: ["key": "value"],
+            context: contextMock
+        )
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        contextMock = .init(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        requestProviderMock = .init()
+        validatorMock = .init()
+        signInControllerMock = .init()
+
+        sut = MSALNativeAuthSignUpController(
+            config: MSALNativeAuthConfigStubs.configuration,
+            requestProvider: requestProviderMock,
+            responseValidator: validatorMock,
+            signInController: signInControllerMock
+        )
+    }
+
+    // MARK: - SignUpPasswordStart (/start request) tests
+
+    func test_whenSignUpStartPassword_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returnsVerificationRequired_it_returnsChallenge() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let helper = prepareSignUpPasswordStartValidatorHelper()
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returnsAttributeValidationFailed_it_returnsChallenge() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_telemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        let error : MSALNativeAuthSignUpStartValidatedResponse = .error(
+            MSALNativeAuthSignUpStartResponseError(error: .passwordTooLong,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(error)
+        
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+        
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+        
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .invalidPassword)
+        
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_returns_invalidUsername_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        let invalidUsername : MSALNativeAuthSignUpStartValidatedResponse = .invalidUsername(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidUsername)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .invalidUsername)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+    
+    func test_whenSignUpStartPassword_returns_invalidClientId_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        let invalidClientId : MSALNativeAuthSignUpStartValidatedResponse = .invalidClientId(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidClientId)
+        
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+        
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartPassword_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    // MARK: - SignUpPasswordStart (/challenge request) tests
+
+    func test_whenSignUpStartPassword_challenge_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_challenge_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpCodeRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: true)
+    }
+
+    func test_whenSignUpStartPassword_challenge_returns_passwordRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired(""))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_challenge_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartPassword_challenge_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
+                                                       errorDescription: "Expired Token",
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertEqual(helper.error?.errorDescription, "Expired Token")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartPassword_challenge_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpPasswordStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        helper.onSignUpPasswordError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpPasswordStart, isSuccessful: false)
+    }
+
+    // MARK: - SignUpCodeStart (/start request) tests
+
+    func test_whenSignUpStartCode_cantCreateRequest_returns_it_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returnsVerificationRequired_it_returnsChallenge() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let helper = prepareSignUpCodeStartValidatorHelper()
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returnsAttributeValidationFailed_it_returnsCorrectError() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        result.telemetryUpdate?(.success(()))
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_telemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        let invalidAttributes = ["name"]
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+        helper.onSignUpAttributesInvalid(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesInvalidCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.attributeNames, invalidAttributes)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        let error : MSALNativeAuthSignUpStartValidatedResponse = .error(
+            MSALNativeAuthSignUpStartResponseError(error: .userAlreadyExists,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .userAlreadyExists)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_returns_invalidUsername_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        let invalidUsername : MSALNativeAuthSignUpStartValidatedResponse = .invalidUsername(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidUsername)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .invalidUsername)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+    
+    func test_whenSignUpStartCode_returns_invalidClientId_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        let invalidClientId : MSALNativeAuthSignUpStartValidatedResponse = .invalidClientId(
+            MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
+                                                   errorDescription: nil,
+                                                   errorCodes: nil,
+                                                   errorURI: nil,
+                                                   innerErrors: nil,
+                                                   signUpToken: nil,
+                                                   unverifiedAttributes: nil,
+                                                   invalidAttributes: nil))
+        validatorMock.mockValidateSignUpStartFunc(invalidClientId)
+        
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+        
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartCode_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    // MARK: - SignUpCodeStart (/challenge request) tests
+
+    func test_whenSignUpStartCode_challenge_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_challenge_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken 1", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 1")
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpCodeRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: true)
+    }
+
+    func test_whenSignUpStartCode_challenge_succeedsPassword_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired(""))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_challenge_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenSignUpStartCode_challenge_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
+                                                       errorDescription: "Expired Token",
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertEqual(helper.error?.errorDescription, "Expired Token")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInSignUpStartCode_challenge_it_returns_unexpectedError_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpCodeStartValidatorHelper(exp)
+
+        let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        helper.onSignUpError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpCodeStart, isSuccessful: false)
+    }
+
+    // MARK: - ResendCode tests
+
+    func test_whenSignUpResendCode_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeCodeRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpResendCode_succeedsPassword_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 1"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken 2")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .invalidRequest,
+                                                       errorDescription: nil,
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpResendCode_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        helper.onSignUpResendCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNotNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpResendCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitCode tests
+
+    func test_whenSignUpSubmitCode_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSubmitCode_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.success(""))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitCode_returns_invalidUserInput_it_returnsInvalidCode() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .invalidUserInput(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidOOBValue,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertEqual(helper.newCodeRequiredState?.flowToken, "signUpToken")
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .invalidCode)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_attributesRequired_it_returnsAttributesRequired() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken", requiredAttributes: []))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken")
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitCode_returns_attributesRequired_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken", requiredAttributes: []))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken")
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_attributeValidationFailed_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["name"]))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+        
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .error(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidRequest,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitCode + credential_required error tests
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andCantCreateRequest() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andSucceeds() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 3"))
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpPasswordRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken 3")
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 3"))
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpPasswordRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken 3")
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andSucceedOOB_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("", .email, 4, "signUpToken 3"))
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andRedirects() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.redirect)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andReturnsError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
+            MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
+                                                       errorDescription: nil,
+                                                       errorCodes: nil,
+                                                       errorURI: nil,
+                                                       innerErrors: nil))
+        validatorMock.mockValidateSignUpChallengeFunc(error)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andReturnsUnexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
+
+        XCTAssertFalse(requestProviderMock.challengeCalled)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpVerifyCodeError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitPassword tests
+
+    func test_whenSignUpSubmitPassword_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.success("signInSLT"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_invalidUserInput_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .invalidUserInput(
+            MSALNativeAuthSignUpContinueResponseError(error: .passwordTooWeak,
+                                                      errorDescription: "Password too weak",
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken")
+        XCTAssertEqual(helper.error?.type, .invalidPassword)
+        XCTAssertEqual(helper.error?.errorDescription, "Password too weak")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_attributesRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken 2")
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_attributesRequired_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.failure(.init(message: "error")))
+
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken 2")
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .error(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidRequest,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_credentialRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitPassword_returns_attributeValidationFailed_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["key"]))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
+
+        helper.onSignUpPasswordRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: false)
+    }
+
+    // MARK: - SubmitAttributes tests
+
+    func test_whenSignUpSubmitAttributes_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSubmitAttributes_succeeds_it_continuesTheFlow() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.success(""))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: true)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_invalidUserInput_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .invalidUserInput(
+            MSALNativeAuthSignUpContinueResponseError(error: .attributeValidationFailed,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        let error : MSALNativeAuthSignUpContinueValidatedResponse = .error(
+            MSALNativeAuthSignUpContinueResponseError(error: .invalidRequest,
+                                                      errorDescription: nil,
+                                                      errorCodes: nil,
+                                                      errorURI: nil,
+                                                      innerErrors: nil,
+                                                      signUpToken: nil,
+                                                      requiredAttributes: nil,
+                                                      unverifiedAttributes: nil,
+                                                      invalidAttributes: nil))
+        validatorMock.mockValidateSignUpContinueFunc(error)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_attributesRequired_it_returnsAttributesRequiredError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequired(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_credentialRequired_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.unexpectedError)
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesRequiredError(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    func test_whenSignUpSubmitAttributes_returns_attributeValidationFailed_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
+            grantType: .attributes,
+            oobCode: nil,
+            attributes: ["key": "value"]
+        )
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["attribute"]))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
+
+        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpAttributesValidationFailed(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpInvalidAttributesCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.invalidAttributes, ["attribute"])
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
+    }
+
+    // MARK: - Sign-in with SLT
+
+    func test_whenSignUpSucceeds_and_userCallsSignInWithSLT_signUpControllerPassesCorrectParams() async {
+        let username = "username"
+        let slt = "signInSLT"
+
+        class SignInAfterSignUpDelegateStub: SignInAfterSignUpDelegate {
+            func onSignInAfterSignUpError(error: MSAL.SignInAfterSignUpError) {}
+            func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {}
+        }
+
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
+        validatorMock.mockValidateSignUpContinueFunc(.success(slt))
+
+        let exp = expectation(description: "SignUpController expectation")
+        let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword("password", username: username, signUpToken: "signUpToken", context: contextMock)
+        helper.onSignUpCompleted(result)
+
+        await fulfillment(of: [exp], timeout: 1)
+        XCTAssertTrue(helper.onSignUpCompletedCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitPassword, isSuccessful: true)
+
+        let exp2 = expectation(description: "SignInAfterSignUp expectation")
+        signInControllerMock.expectation = exp2
+        signInControllerMock.signInSLTResult = .failure(.init())
+        helper.signInAfterSignUpState?.signIn(delegate: SignInAfterSignUpDelegateStub())
+        await fulfillment(of: [exp2], timeout: 1)
+
+        XCTAssertEqual(signInControllerMock.username, username)
+        XCTAssertEqual(signInControllerMock.slt, slt)
+    }
+
+    // MARK: - Common Methods
+
+    private func checkTelemetryEventResult(id: MSALNativeAuthTelemetryApiId, isSuccessful: Bool) {
+        XCTAssertEqual(receivedEvents.count, 1)
+
+        guard let telemetryEventDict = receivedEvents.first else {
+            return XCTFail("Telemetry test fail")
+        }
+
+        let expectedApiId = String(id.rawValue)
+        XCTAssertEqual(telemetryEventDict["api_id"] as? String, expectedApiId)
+        XCTAssertEqual(telemetryEventDict["event_name"] as? String, "api_event" )
+        XCTAssertEqual(telemetryEventDict["correlation_id" ] as? String, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(telemetryEventDict["is_successfull"] as? String, isSuccessful ? "yes" : "no")
+        XCTAssertEqual(telemetryEventDict["status"] as? String, isSuccessful ? "succeeded" : "failed")
+        XCTAssertNotNil(telemetryEventDict["start_time"])
+        XCTAssertNotNil(telemetryEventDict["stop_time"])
+        XCTAssertNotNil(telemetryEventDict["response_time"])
+    }
+
+    private func prepareSignUpPasswordStartValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpPasswordStartTestsValidatorHelper {
+        let helper = SignUpPasswordStartTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpPasswordErrorCalled)
+        XCTAssertFalse(helper.onSignUpCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpCodeStartValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpCodeStartTestsValidatorHelper {
+        let helper = SignUpCodeStartTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCodeErrorCalled)
+        XCTAssertFalse(helper.onSignUpCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpResendCodeValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpResendCodeTestsValidatorHelper {
+        let helper = SignUpResendCodeTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpResendCodeErrorCalled)
+        XCTAssertFalse(helper.onSignUpResendCodeCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpSubmitCodeValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpVerifyCodeTestsValidatorHelper {
+        let helper = SignUpVerifyCodeTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCompletedCalled)
+        XCTAssertFalse(helper.onSignUpPasswordRequiredCalled)
+        XCTAssertFalse(helper.onSignUpVerifyCodeErrorCalled)
+        XCTAssertFalse(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpSubmitPasswordValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpPasswordRequiredTestsValidatorHelper {
+        let helper = SignUpPasswordRequiredTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCompletedCalled)
+        XCTAssertFalse(helper.onSignUpPasswordRequiredErrorCalled)
+        XCTAssertFalse(helper.onSignUpAttributesRequiredCalled)
+        XCTAssertNil(helper.newAttributesRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareSignUpSubmitAttributesValidatorHelper(_ expectation: XCTestExpectation? = nil) -> SignUpAttributesRequiredTestsValidatorHelper {
+        let helper = SignUpAttributesRequiredTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onSignUpCompletedCalled)
+        XCTAssertFalse(helper.onSignUpAttributesRequiredErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareMockRequest() -> MSIDHttpRequest {
+        let request = MSIDHttpRequest()
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+        
+        return request
+    }
+
+    private func expectedChallengeParams(token: String = "signUpToken") -> (token: String, context: MSIDRequestContext) {
+        return (token: token, context: contextMock)
+    }
+
+    private func expectedContinueParams(
+        grantType: MSALNativeAuthGrantType = .oobCode,
+        token: String = "signUpToken",
+        password: String? = nil,
+        oobCode: String? = "1234",
+        attributes: [String: Any]? = nil
+    ) -> MSALNativeAuthSignUpContinueRequestProviderParams {
+        .init(
+            grantType: grantType,
+            signUpToken: token,
+            password: password,
+            oobCode: oobCode,
+            attributes: attributes,
+            context: contextMock
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
@@ -1,0 +1,85 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResultFactoryTests: XCTestCase {
+
+    private var sut: MSALNativeAuthResultFactory!
+
+    private let tokenResponseDict: [String: Any] = [
+        "token_type": "Bearer",
+        "scope": "openid profile email",
+        "expires_in": 4141,
+        "ext_expires_in": 4141,
+        "access_token": "accessToken",
+        "refresh_token": "refreshToken",
+        "id_token": "idToken"
+    ]
+
+    override func setUpWithError() throws {
+        sut = .init(config: MSALNativeAuthConfigStubs.configuration)
+    }
+
+    func test_makeMsidConfiguration() {
+        let result = sut.makeMSIDConfiguration(scopes: ["<scope_1>", "<scope_2>"])
+
+        XCTAssertEqual(result.authority, MSALNativeAuthNetworkStubs.msidAuthority)
+        XCTAssertNil(result.redirectUri)
+        XCTAssertEqual(result.clientId, DEFAULT_TEST_CLIENT_ID)
+        XCTAssertEqual(result.target, "<scope_1> <scope_2>")
+    }
+    
+    func test_makeUserAccount_returnExpectedResult() {
+        let accessTokenString = "accessToken"
+        let idToken = "idToken"
+        let username = "username"
+        let scopes = ["scope1", "scope2"]
+        let expiresOn = Date()
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = accessTokenString
+        accessToken.accountIdentifier = MSIDAccountIdentifier(displayableId: username, homeAccountId: "")
+        accessToken.expiresOn = expiresOn
+        accessToken.scopes = NSOrderedSet(array: scopes)
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.refreshToken = "refreshToken"
+        let msidAccount = MSIDAccount()
+        msidAccount.username = username
+        guard let tokenResult = MSIDTokenResult(accessToken: accessToken, refreshToken: refreshToken, idToken: idToken, account: msidAccount, authority: MSALNativeAuthNetworkStubs.msidAuthority, correlationId: UUID(), tokenResponse: nil) else {
+            XCTFail("Unexpected nil token")
+            return
+        }
+        let context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        guard let accountResult = sut.makeUserAccountResult(tokenResult: tokenResult, context: context) else {
+            XCTFail("Unexpected nil account")
+            return
+        }
+        XCTAssertEqual(accountResult.account.username, username)
+        XCTAssertEqual(accountResult.idToken, idToken)
+        XCTAssertEqual(accountResult.expiresOn, expiresOn)
+        XCTAssertEqual(accountResult.scopes, scopes)
+    }
+}

--- a/MSAL/test/unit/native_auth/input_validator/MSALNativeAuthInputValidatorTest.swift
+++ b/MSAL/test/unit/native_auth/input_validator/MSALNativeAuthInputValidatorTest.swift
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthInputValidatorTest: XCTestCase {
+    
+    private let validator = MSALNativeAuthInputValidator()
+    
+    func testInput_whenValidInputIsUsed_resultShouldBeValid() {
+        XCTAssertTrue(validator.isInputValid("email@contoso.com"))
+        XCTAssertTrue(validator.isInputValid("password"))
+        XCTAssertTrue(validator.isInputValid("1"))
+    }
+    
+    func testInput_whenInvalidStringInputIsUsed_resultShouldBeInvalid() {
+        XCTAssertFalse(validator.isInputValid(""))
+    }
+}

--- a/MSAL/test/unit/native_auth/logger/MSALNativeLoggingTests.swift
+++ b/MSAL/test/unit/native_auth/logger/MSALNativeLoggingTests.swift
@@ -1,0 +1,342 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthTestLogger : NSObject {
+    static var instanceCreated = false
+
+    @objc dynamic var containsPII = false
+    @objc dynamic var messages = NSMutableArray()
+    @objc dynamic var level: MSALLogLevel = .nothing
+    var expectation = XCTestExpectation()
+    private var queue = DispatchQueue(label: "test", qos: .default)
+    
+    override init () {
+        super.init()
+        guard Self.instanceCreated == false else {
+            fatalError("Only one instance allowed, inherit the MSALNativeAuthTestCase class and use the Self.logger property there")
+        }
+        Self.instanceCreated = true
+        MSALGlobalConfig.loggerConfig.setLogCallback { [weak self] level, message, containsPII in
+            self?.queue.sync {
+                self?.messages.add(message as Any)
+                self?.containsPII = containsPII
+                self?.level = level
+                // Making sure expectation has been set in the test case
+                if self?.expectation.description != "" {
+                    self?.expectation.fulfill()
+                }
+            }
+        }
+    }
+    
+    func reset() {
+        queue.sync {
+            expectation = XCTestExpectation(description: "")
+            containsPII = false
+            messages.removeAllObjects()
+            MSALGlobalConfig.loggerConfig.logLevel = .last
+        }
+    }
+}
+
+final class MSALNativeLoggingTests: MSALNativeAuthTestCase {
+    // Used for clarity of code. The static object is needed because MSALGlobalConfig.loggerConfig.setLogCallback
+    // must be set only once per execution of test
+
+    let context = MSIDBasicContext()
+    var correlationId = UUID()
+    let messageRegexFormat = "\\[\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} - %@\\] %@"
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskAllPII
+        context.correlationId = UUID()
+        correlationId = UUID()
+    }
+    
+    // MARK: Log With Context
+    
+    func testLogWithContext_noMaskNonNil() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", "String")
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test String"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+
+    
+    func testLogWithContext_andMasked() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(not-null\\)"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+    
+    func testLogWithContext_maskedAndNull() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(null\\)"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+    
+    // MARK: Log PII With Context
+    
+    func testLogPIIWithContext_andMaskAll() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskAllPII
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(not\\-null\\)"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertFalse(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithContext_andMaskEUII() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskEUIIOnly
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test String"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertTrue(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithContext_nilString() throws {
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(null\\)"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertFalse(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithContext_nilStringNotMasked() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskEUIIOnly
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, context: context, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test \\(null\\)"
+            let correlationId = context.correlationId?.uuidString ?? "Wrong Correlation Id"
+            if string.range(of: String(format:messageRegexFormat, correlationId, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertTrue(Self.logger.containsPII)
+    }
+    
+    // MARK: Log With Correlation Id
+    
+    func testLogWithCorrelationId_noMaskNonNil() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", "String")
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test String"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+    
+    func testLogWithCorrelationId_andMasked() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(not\\-null\\)"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+    
+    func testLogWithCorrelationId_maskedAndNull() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.log(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(null\\)"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+    }
+    
+    // MARK: Log PII With CorrelationId
+    
+    func testLogPIIWithCorrelationId_andMaskAll() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskAllPII
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(not\\-null\\)"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertFalse(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithCorrelationId_andMaskEUII() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskEUIIOnly
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII("String"))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test String"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertTrue(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithCorrelationId_nilString() throws {
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test Masked\\(null\\)"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertFalse(Self.logger.containsPII)
+    }
+    
+    func testLogPIIWithCorrelationId_nilStringNotMasked() throws {
+        MSALGlobalConfig.loggerConfig.logMaskingLevel = .settingsMaskEUIIOnly
+        
+        Self.logger.expectation = XCTestExpectation(description: "Callback Invoked")
+        MSALLogger.logPII(level: .error, correlationId: correlationId, filename: #file, lineNumber: #line, function: #function, format: "Test %@", MSALLogMask.maskPII(nil))
+        XCTWaiter().wait(for: [Self.logger.expectation], timeout: 1)
+        
+        XCTAssertNotNil(Self.logger.messages.object(at: 0));
+        if let string = Self.logger.messages.object(at: 0) as? String {
+            let correctString = "Test \\(null\\)"
+            if string.range(of: String(format:messageRegexFormat, correlationId.uuidString, correctString), options: .regularExpression, range: nil, locale: nil) == nil {
+                XCTFail("Message doesn't contain proper data or has incorrect format")
+            }
+        } else {
+            XCTFail("Message is not string")
+        }
+        XCTAssertTrue(Self.logger.containsPII)
+    }
+}

--- a/MSAL/test/unit/native_auth/telemetry/MSALNativeAuthCurrentRequestTelemetryTests.swift
+++ b/MSAL/test/unit/native_auth/telemetry/MSALNativeAuthCurrentRequestTelemetryTests.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthCurrentRequestTelemetryTests: XCTestCase {
+    
+    func testSerialization_whenValidProperties_shouldCreateString() {
+        let telemetry = MSALNativeAuthCurrentRequestTelemetry(apiId: .telemetryApiIdSignUp,
+                                                              operationType: MSALNativeAuthSignUpType.signUpWithPassword.rawValue,
+                                                              platformFields: nil)
+        let result = telemetry.telemetryString()
+        XCTAssertEqual(result, "4|75001,0|")
+    }
+    
+    func testSerialization_whenSignUpType_SignUpOTP_shouldCreateString() {
+        let telemetry = MSALNativeAuthCurrentRequestTelemetry(apiId: .telemetryApiIdSignUp,
+                                                              operationType: MSALNativeAuthSignUpType.signUpWithOTP.rawValue,
+                                                              platformFields: nil)
+        let result = telemetry.telemetryString()
+        XCTAssertEqual(result, "4|75001,1|")
+    }
+    
+    func testSerialization_withOnePlatfomField_shouldCreateString() {
+        let telemetry = MSALNativeAuthCurrentRequestTelemetry(apiId: .telemetryApiIdSignUp,
+                                                              operationType: MSALNativeAuthSignUpType.signUpWithPassword.rawValue,
+                                                              platformFields: ["iPhone14,5"])
+        let result = telemetry.telemetryString()
+        XCTAssertEqual(result, "4|75001,0|iPhone14,5")
+    }
+    
+    func testSerialization_withMultiplePlatfomField_shouldCreateString() {
+        let telemetry = MSALNativeAuthCurrentRequestTelemetry(apiId: .telemetryApiIdSignUp,
+                                                              operationType: MSALNativeAuthSignUpType.signUpWithPassword.rawValue,
+                                                              platformFields: ["iPhone14,5","iOS 16.0"])
+        let result = telemetry.telemetryString()
+        XCTAssertEqual(result, "4|75001,0|iPhone14,5,iOS 16.0")
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR shows the SDK that the CIAM team had developed. It is based on the Native Auth merge into MSAL plan here: https://microsofteur.sharepoint.com/:w:/t/DevExDublin/EdfT2AmlFZFIsTtr-EaoSBIBPqcOlRo1MJ1USbEsfjfEcQ

To comply with the design changes made by our API team, we have created a more dynamic SDK. This means that we make different API requests for each authentication flow. There is also some logic involved in each of the responses we get from each request.

We have created a state machine for each flow (check this [Figma](https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0%3A1&t=VUyK4gIoyUChTXWF-1) to see all the possible states), and we are making it external to developers by using delegates instead of completion blocks, as @Serhii Demchenko suggested. In this way we can guide the developer through the authentication process offering a discovering interface. We think that this approach will improve the overall developer experience.

**This PR is focused in the Native Auth base classes that interact with MSAL Objective-C, and their unit tests for:**
**- cache**
**- configuration**
**- controllers**
**- validation**
**- telemetry**
**- logger**
 **It is not compilable, so tests are not going to run. To build and test this code, please use the `ciam-master-snapshot` branch.**

The IdentityCore changes can be found in this PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1294

**For context, this is the Native Auth technical overview:** https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview?path=/%5BiOS%5D%20Native%20authentication/technical_overview.md&version=GBdanilo/native-authentication&_a=preview

State Machine:
https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0-1&mode=design&t=80VUxa1RvxMn4rnl-0

## Native Auth general high level overview

**MSALNativeAuthPublicClientApplication.swift**
The public interface is the entry point of the SDK. Here is where all the supported authentication flows begin.
Regarding the sign-up flow, developers can call either `signUp(...)` or `signUpUsingPassword(...)`.
Notice that in those methods they must pass a class that conforms to `SignUpStartDelegate`. or `SignUpPasswordStartDelegate`, respectively.


**MSALNativeAuthSignUpController.swift**
The controller handles most of the logic. Each of the methods inside the MARK: - Internal can be called from the public interfaces, that are:
    - MSALNativeAuthPublicClientApplication
    - One of the States (located in the file SignUpDelegates.swift). These States are returned through the delegates, as we will see.

For each of these methods, the controller:
    - Creates a request (`MSIDHttpRequest`) using its requestProvider (`MSALNativeAuthSignUpRequestProviding`).
    - Executes the request.
    - Passes the result to its responseValidator (`MSALNativeAuthSignUpResponseValidating`)
    - Handles the validated result and returns it to the public interface, which uses the delegate to communicate back to the developer.
    - Creates and handle the local telemetry events.

The controller decides what to do with the ValidatedResponse given by the ResponseValidator.

Every validated response usually has:
**A success:** it means that the SDK moves on to the next state, which usually involves making another request or returning back to the user via the delegate.
Redirect: when the backend detects an error and wants the SDK to fallback to the WebView-based flow.
**A known error:** in some cases, these errors put the user in a recoverable state (for example, an error that requires the user to provide more attributes). In other cases, the error means the end of the flow.
**An unexpected error:** these errors are likely bugs, they happen when we there are missing attributes from the response, etc.
(Please keep in mind that not every ValidatedResponse falls into the same categories, this is just an approximation)


**MSALNativeAuthRequestConfigurator.swift**
Each of the requestProviders from the Controllers uses the RequestConfigurator to create and configure the requests. Although there are different RequestProviders (one per flow), there's only one RequestConfigurator.

The RequestConfigurator injects a custom ErrorHandler (`MSALNativeAuthResponseErrorHandler`) to every request. This is needed in order to decode the errors from the API.
These errors follow a structure that you can see in `MSALNativeAuth(SignUp/SignIn/PasswordReset)StartResponseError` for example. In the directory native_auth/network/errors/ you can see all the files used.


**MSALNativeAuth(SignUp/SignIn/PasswordReset)ResponseValidator.swift**
The ResponseValidator is in charge of analysing the api response and returning to the Controller a validated response (for instance, for the response of the (SignUp/SignIn/PasswordReset)/start endpoint, it returns a `MSALNativeAuth(SignUp/SignIn/PasswordReset)StartValidatedResponse`).


**SignUp/SignIn/PasswordReset)States.swift**
In this file there are the different States that the Controller can return to the developer through the delegate.

This is how the developer will use them. For more examples of how developers can use the SDK you can check the Sample App (located in /Samples/ios-native-auth-simple in the branch `ciam-master-snapshot`). We will include it in a separate PR:

extension EmailAndPasswordViewController: SignUpPasswordStartDelegate {

    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState,
                                                      sentTo _: String,
                                                      channelTargetType _: MSAL.MSALNativeAuthChannelType,
                                                      codeLength _: Int) {

           // show UI to get the user's email OOB code, and wait for user's input
           // then, use the newState to send it to the SDK.
           newState.submitCode(code: code, delegate: self)
    }
}

Each of these states then calls one of the Controller's internal functions, and it follows the same process that we just described in the previous steps.

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

