### PR TITLE
Native Auth network classes that interact with MSAL

### DIFF
--- a/MSAL/src/native_auth/network/MSALNativeAuthRequestConfigurator.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthRequestConfigurator.swift
@@ -1,0 +1,271 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@_implementationOnly import MSAL_Private
+
+enum MSALNativeAuthRequestConfiguratorType {
+    enum SignUp {
+        case start(MSALNativeAuthSignUpStartRequestParameters)
+        case challenge(MSALNativeAuthSignUpChallengeRequestParameters)
+        case `continue`(MSALNativeAuthSignUpContinueRequestParameters)
+    }
+
+    enum SignIn {
+        case initiate(MSALNativeAuthSignInInitiateRequestParameters)
+        case challenge(MSALNativeAuthSignInChallengeRequestParameters)
+    }
+
+    enum ResetPassword {
+        case start(MSALNativeAuthResetPasswordStartRequestParameters)
+        case challenge(MSALNativeAuthResetPasswordChallengeRequestParameters)
+        case `continue`(MSALNativeAuthResetPasswordContinueRequestParameters)
+        case submit(MSALNativeAuthResetPasswordSubmitRequestParameters)
+        case pollCompletion(MSALNativeAuthResetPasswordPollCompletionRequestParameters)
+    }
+
+    enum Token {
+        case signInWithPassword(MSALNativeAuthTokenRequestParameters)
+        case refreshToken(MSALNativeAuthTokenRequestParameters)
+    }
+
+    case signUp(SignUp)
+    case signIn(SignIn)
+    case resetPassword(ResetPassword)
+    case token(Token)
+}
+
+class MSALNativeAuthRequestConfigurator: MSIDAADRequestConfigurator {
+    let config: MSALNativeAuthConfiguration
+
+    init(config: MSALNativeAuthConfiguration) {
+        self.config = config
+    }
+
+    func configure(configuratorType: MSALNativeAuthRequestConfiguratorType,
+                   request: MSIDHttpRequest,
+                   telemetryProvider: MSALNativeAuthTelemetryProviding) throws {
+        switch configuratorType {
+        case .signUp(let subType):
+            try signUpConfigure(subType, request, telemetryProvider)
+        case .signIn(let subType):
+            try signInConfigure(subType, request, telemetryProvider)
+        case .resetPassword(let subType):
+            try resetPasswordConfigure(subType, request, telemetryProvider)
+        case .token(let subType):
+            try tokenConfigure(subType, request, telemetryProvider)
+        }
+    }
+
+    private func signUpConfigure(_ subType: MSALNativeAuthRequestConfiguratorType.SignUp,
+                                 _ request: MSIDHttpRequest,
+                                 _ telemetryProvider: MSALNativeAuthTelemetryProviding) throws {
+        switch subType {
+        case .start(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignUpStartResponse>()
+            let telemetry = telemetryProvider.telemetryForSignUp(type: .signUpStart)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignUpStartResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .challenge(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignUpChallengeResponse>()
+            let telemetry = telemetryProvider.telemetryForSignUp(type: .signUpChallenge)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignUpChallengeResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .continue(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignUpContinueResponse>()
+            let telemetry = telemetryProvider.telemetryForSignUp(type: .signUpContinue)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignUpContinueResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        }
+    }
+
+    private func signInConfigure(_ subType: MSALNativeAuthRequestConfiguratorType.SignIn,
+                                 _ request: MSIDHttpRequest,
+                                 _ telemetryProvider: MSALNativeAuthTelemetryProviding) throws {
+        switch subType {
+        case .initiate(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignInInitiateResponse>()
+            let telemetry = telemetryProvider.telemetryForSignIn(type: .signInInitiate)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInInitiateResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .challenge(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignInChallengeResponse>()
+            let telemetry = telemetryProvider.telemetryForSignIn(type: .signInChallenge)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInChallengeResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        }
+    }
+
+    private func resetPasswordConfigure(_ subType: MSALNativeAuthRequestConfiguratorType.ResetPassword,
+                                        _ request: MSIDHttpRequest,
+                                        _ telemetryProvider: MSALNativeAuthTelemetryProviding) throws {
+        switch subType {
+        case .start(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthResetPasswordStartResponse>()
+            let telemetry = telemetryProvider.telemetryForResetPassword(type: .resetPasswordStart)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthResetPasswordStartResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .challenge(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthResetPasswordChallengeResponse>()
+            let telemetry = telemetryProvider.telemetryForResetPassword(type: .resetPasswordChallenge)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthResetPasswordChallengeResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .continue(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthResetPasswordContinueResponse>()
+            let telemetry = telemetryProvider.telemetryForResetPassword(type: .resetPasswordContinue)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthResetPasswordContinueResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .submit(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthResetPasswordSubmitResponse>()
+            let telemetry = telemetryProvider.telemetryForResetPassword(type: .resetPasswordSubmit)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthResetPasswordSubmitResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .pollCompletion(let parameters):
+            let responseSerializer =
+            MSALNativeAuthResponseSerializer<MSALNativeAuthResetPasswordPollCompletionResponse>()
+            let telemetry = telemetryProvider.telemetryForResetPassword(type: .resetPasswordPollCompletion)
+            let errorHandler =
+            MSALNativeAuthResponseErrorHandler<MSALNativeAuthResetPasswordPollCompletionResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        }
+    }
+
+    private func tokenConfigure(_ subType: MSALNativeAuthRequestConfiguratorType.Token,
+                                _ request: MSIDHttpRequest,
+                                _ telemetryProvider: MSALNativeAuthTelemetryProviding) throws {
+        switch subType {
+        case .signInWithPassword(let parameters):
+            let telemetry = telemetryProvider.telemetryForToken(type: .signInWithPassword)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthTokenResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .refreshToken(let parameters):
+            let telemetry = telemetryProvider.telemetryForToken(type: .refreshToken)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthTokenResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        }
+    }
+
+    private func configure<R: Decodable, E: Decodable & Error>(
+        request: MSIDHttpRequest,
+        parameters: MSALNativeAuthRequestable,
+        responseSerializer: MSALNativeAuthResponseSerializer<R>,
+        telemetry: MSALNativeAuthCurrentRequestTelemetry,
+        errorHandler: MSALNativeAuthResponseErrorHandler<E>
+    ) throws {
+        try configure(request: request,
+                      parameters: parameters,
+                      telemetry: telemetry,
+                      errorHandler: errorHandler)
+        request.responseSerializer = responseSerializer
+    }
+
+    // For the SignInToken endpoint the Response serialiser should not be set
+    // Because we cannot have optional Generic Types parameters at call time
+    // especially with Decodable we have to have another method name
+    // This might be removed in the future if the response from the /token endpoint changes
+    private func configure<E: Decodable & Error>(
+        request: MSIDHttpRequest,
+        parameters: MSALNativeAuthRequestable,
+        telemetry: MSALNativeAuthCurrentRequestTelemetry,
+        errorHandler: MSALNativeAuthResponseErrorHandler<E>
+    ) throws {
+        try configureAllRequests(request: request, parameters: parameters)
+        request.requestSerializer = MSALNativeAuthUrlRequestSerializer(
+            context: parameters.context,
+            encoding: .wwwFormUrlEncoded
+        )
+        request.serverTelemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetry,
+            context: parameters.context
+        )
+        request.errorHandler = errorHandler
+    }
+
+    private func configureAllRequests(request: MSIDHttpRequest,
+                                      parameters: MSALNativeAuthRequestable) throws {
+        request.context = parameters.context
+        request.parameters = parameters.makeRequestBody(config: config)
+
+        do {
+            let endpointUrl = try parameters.makeEndpointUrl(config: config)
+            request.urlRequest = URLRequest(url: endpointUrl)
+            request.urlRequest?.httpMethod = MSALParameterStringForHttpMethod(.POST)
+        } catch {
+            MSALLogger.log(
+                level: .error,
+                context: parameters.context,
+                format: "Endpoint could not be created: \(error)"
+            )
+            throw MSALNativeAuthInternalError.invalidRequest
+        }
+        configure(request)
+    }
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseErrorHandler.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseErrorHandler.swift
@@ -1,0 +1,193 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResponseErrorHandler<T: Decodable & Error>: NSObject, MSIDHttpRequestErrorHandling {
+    private var customError: T?
+
+    // swiftlint:disable:next function_parameter_count
+    func handleError(
+        _ error: Error?,
+        httpResponse: HTTPURLResponse?,
+        data: Data?,
+        httpRequest: MSIDHttpRequestProtocol?,
+        responseSerializer: MSIDResponseSerialization?,
+        externalSSOContext ssoContext: MSIDExternalSSOContext?,
+        context: MSIDRequestContext?,
+        completionBlock: MSIDHttpRequestDidCompleteBlock?
+    ) {
+        guard let httpResponse = httpResponse else {
+            completionBlock?(nil, error)
+            return
+        }
+
+        if shouldRetry(httpResponse: httpResponse, httpRequest: httpRequest) {
+            retryRequest(httpRequest: httpRequest,
+                         context: context,
+                         completionBlock: completionBlock)
+            return
+        }
+
+        if httpResponse.statusCode == 400 || httpResponse.statusCode == 401 {
+            // PKeyAuth challenge
+            if let authValue = wwwAuthValue(httpResponse: httpResponse) {
+                handleAuthenticateHeader(wwwAuthValue: authValue,
+                                         httpRequest: httpRequest,
+                                         context: context,
+                                         ssoContext: ssoContext,
+                                         completionBlock: completionBlock)
+                return
+            }
+
+            handleAPIError(data: data, completionBlock: completionBlock)
+            return
+        }
+
+        handleHTTPError(httpResponse: httpResponse,
+                        context: context,
+                        completionBlock: completionBlock)
+    }
+
+    private func shouldRetry(httpResponse: HTTPURLResponse,
+                             httpRequest: MSIDHttpRequestProtocol?) -> Bool {
+        guard let httpRequest = httpRequest, httpRequest.retryCounter > 0 else {
+            return false
+        }
+        return httpResponse.statusCode >= 500 && httpResponse.statusCode <= 599
+    }
+
+    private func retryRequest(
+        httpRequest: MSIDHttpRequestProtocol?,
+        context: MSIDRequestContext?,
+        completionBlock: MSIDHttpRequestDidCompleteBlock?
+    ) {
+        httpRequest?.retryCounter -= 1
+        if let context = context {
+            MSALLogger.log(level: .verbose,
+                           context: context,
+                           format: "Retrying network request, retryCounter: %d", httpRequest?.retryCounter ?? 0)
+        }
+        let deadline = DispatchTime.now() + Double(UInt64(httpRequest?.retryInterval ?? 0) * NSEC_PER_SEC )
+        DispatchQueue.global().asyncAfter(deadline: deadline) {
+            httpRequest?.send(completionBlock)
+        }
+    }
+
+    private func wwwAuthValue(httpResponse: HTTPURLResponse) -> String? {
+        let wwwAuthKey = httpResponse.allHeaderFields.keys.first(where: {
+            if let keyNameUppercased = ($0 as? String)?.uppercased() {
+                return keyNameUppercased == kMSIDWwwAuthenticateHeader.uppercased()
+            }
+            return false
+        })
+        let wwwAuthValue = httpResponse
+                            .allHeaderFields[wwwAuthKey ?? "" as Dictionary<AnyHashable, Any>.Keys.Element] as? String
+
+        if !NSString.msidIsStringNilOrBlank(wwwAuthValue),
+            let wwwAuthValue = wwwAuthValue,
+            wwwAuthValue.contains(kMSIDPKeyAuthName) {
+            return wwwAuthValue
+        }
+        return nil
+    }
+
+    private func handleAuthenticateHeader(
+        wwwAuthValue: String,
+        httpRequest: MSIDHttpRequestProtocol?,
+        context: MSIDRequestContext?,
+        ssoContext: MSIDExternalSSOContext?,
+        completionBlock: MSIDHttpRequestDidCompleteBlock?
+    ) {
+        MSIDPKeyAuthHandler.handleWwwAuthenticateHeader(
+            wwwAuthValue,
+            request: httpRequest?.urlRequest.url,
+            externalSSOContext: ssoContext,
+            context: context) { authHeader, completionError in
+            if !NSString.msidIsStringNilOrBlank(authHeader) {
+                // Append Auth Header
+                if var newRequest = httpRequest?.urlRequest {
+                    newRequest.setValue(authHeader, forHTTPHeaderField: "Authorization")
+                    httpRequest?.urlRequest = newRequest as URLRequest
+
+                    DispatchQueue.global().async {
+                        httpRequest?.send(completionBlock)
+                    }
+                }
+                return
+            }
+            completionBlock?(nil, completionError)
+        }
+    }
+
+    private func handleAPIError(
+        data: Data?,
+        completionBlock: MSIDHttpRequestDidCompleteBlock?
+    ) {
+        do {
+            customError = try JSONDecoder().decode(T.self, from: data ?? Data())
+            completionBlock?(nil, customError)
+        } catch {
+            completionBlock?(nil, error)
+        }
+    }
+
+    private func handleHTTPError(
+        httpResponse: HTTPURLResponse,
+        context: MSIDRequestContext?,
+        completionBlock: MSIDHttpRequestDidCompleteBlock?
+    ) {
+        let statusCode = httpResponse.statusCode
+        let errorDescription = HTTPURLResponse.localizedString(forStatusCode: statusCode)
+        if let context = context {
+            MSALLogger.log(level: .warning,
+                           context: context,
+                           format: "HTTP error raised. HTTP Code: %d Description %@", statusCode,
+                           MSALLogMask.maskPII(errorDescription))
+        }
+
+        var additionalInfo = [AnyHashable: Any]()
+        additionalInfo[MSIDHTTPHeadersKey] = httpResponse.allHeaderFields
+        additionalInfo[MSIDHTTPResponseCodeKey] = String(httpResponse.statusCode)
+
+        if statusCode >= 500 && statusCode <= 599 {
+            additionalInfo[MSIDServerUnavailableStatusKey] = NSNumber(value: 1)
+        }
+
+        if let context = context {
+            let httpError  = MSIDCreateError(MSIDHttpErrorCodeDomain,
+                                             MSIDErrorCode.serverUnhandledResponse.rawValue,
+                                             errorDescription,
+                                             nil,
+                                             nil,
+                                             nil,
+                                             context.correlationId(),
+                                             additionalInfo,
+                                             true)
+            completionBlock?(nil, httpError)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseSerializer.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResponseSerializer<T: Decodable>: NSObject, MSIDResponseSerialization {
+
+    func responseObject(for httpResponse: HTTPURLResponse?, data: Data?, context: MSIDRequestContext?) throws -> Any {
+        guard let data = data else {
+            throw MSALNativeAuthInternalError.responseSerializationError
+        }
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        return try decoder.decode(T.self, from: data)
+    }
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthUrlRequestSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthUrlRequestSerializer.swift
@@ -1,0 +1,94 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+enum MSALNativeAuthUrlRequestEncoding: String {
+    case wwwFormUrlEncoded = "application/x-www-form-urlencoded"
+    case json = "application/json"
+}
+
+final class MSALNativeAuthUrlRequestSerializer: NSObject, MSIDRequestSerialization {
+
+    private let context: MSIDRequestContext
+    private let encoding: MSALNativeAuthUrlRequestEncoding
+
+    init(context: MSIDRequestContext, encoding: MSALNativeAuthUrlRequestEncoding) {
+        self.context = context
+        self.encoding = encoding
+    }
+
+    func serialize(
+        with request: URLRequest,
+        parameters: [AnyHashable: Any],
+        headers: [AnyHashable: Any]
+    ) -> URLRequest {
+
+        var request = request
+        var requestHeaders: [String: String] = [:]
+
+        // Convert entries from `headers` to a dictionary [String: String]
+
+        headers.forEach {
+            if let key = $0.key as? String, let value = $0.value as? String {
+                requestHeaders[key] = value
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Header serialization failed")
+            }
+        }
+
+        if encoding == .json {
+            if JSONSerialization.isValidJSONObject(parameters) {
+                do {
+                    let jsonData = try JSONSerialization.data(withJSONObject: parameters)
+                    request.httpBody = jsonData
+                } catch {
+                    MSALLogger.log(
+                        level: .error,
+                        context: context,
+                        format: "HTTP body request serialization failed with error: \(error.localizedDescription)"
+                    )
+                }
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "HTTP body request serialization failed")
+            }
+        } else {
+            let encodedBody = formUrlEncode(parameters)
+            request.httpBody = encodedBody.data(using: .utf8)
+        }
+
+        requestHeaders["Content-Type"] = encoding.rawValue
+        request.allHTTPHeaderFields = requestHeaders
+
+        return request
+    }
+
+    private func formUrlEncode(_ parameters: [AnyHashable: Any]) -> String {
+        parameters.map {
+            let encodedKey = (($0.key as? String) ?? "").msidWWWFormURLEncode() ?? ""
+            let encodedValue = (($0.value as? String) ?? "").msidWWWFormURLEncode() ?? ""
+            return "\(encodedKey)=\(encodedValue)"
+        }.joined(separator: "&")
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestContext.swift
+++ b/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestContext.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthRequestContext: MSIDRequestContext {
+
+    private let _correlationId: UUID
+    private let _telemetryRequestId: String = MSIDTelemetry.sharedInstance().generateRequestId()
+
+    init(correlationId: UUID? = nil) {
+        _correlationId = correlationId ?? UUID()
+    }
+
+    func correlationId() -> UUID {
+        _correlationId
+    }
+
+    func logComponent() -> String {
+        MSIDVersion.sdkName()
+    }
+
+    func telemetryRequestId() -> String {
+        _telemetryRequestId
+    }
+
+    func appRequestMetadata() -> [AnyHashable: Any] {
+        guard let metadata = Bundle.main.infoDictionary else {
+            return [:]
+        }
+
+        let appName = metadata["CFBundleDisplayName"] ?? (metadata["CFBundleName"] ?? "")
+        let appVersion = metadata["CFBundleShortVersionString"] ?? ""
+
+        return [
+            MSID_VERSION_KEY: MSIDVersion.sdkVersion() ?? "",
+            MSID_APP_NAME_KEY: appName,
+            MSID_APP_VER_KEY: appVersion
+        ]
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestable.swift
+++ b/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestable.swift
@@ -1,0 +1,51 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthRequestable {
+    var endpoint: MSALNativeAuthEndpoint { get }
+    var context: MSIDRequestContext { get }
+
+    func makeEndpointUrl(config: MSALNativeAuthConfiguration) throws -> URL
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String]
+}
+
+extension MSALNativeAuthRequestable {
+
+    func makeEndpointUrl(config: MSALNativeAuthConfiguration) throws -> URL {
+        var components = URLComponents(url: config.authority.url, resolvingAgainstBaseURL: true)
+        components?.path += endpoint.rawValue
+
+        if let dataCenter = config.sliceConfig?.dc {
+            components?.queryItems = [URLQueryItem(name: "dc", value: dataCenter)]
+        }
+
+        guard let url = components?.url else {
+            throw MSALNativeAuthInternalError.invalidUrl
+        }
+
+        return url
+    }
+}

--- a/MSAL/src/native_auth/network/reset_password/MSALNativeAuthResetPasswordRequestProvider.swift
+++ b/MSAL/src/native_auth/network/reset_password/MSALNativeAuthResetPasswordRequestProvider.swift
@@ -1,0 +1,137 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthResetPasswordRequestProviding {
+    func start(
+        parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters
+    ) throws -> MSIDHttpRequest
+
+    func challenge(
+        token: String,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest
+
+    func `continue`(
+        parameters: MSALNativeAuthResetPasswordContinueRequestParameters
+    ) throws -> MSIDHttpRequest
+
+    func submit(
+        parameters: MSALNativeAuthResetPasswordSubmitRequestParameters
+    ) throws -> MSIDHttpRequest
+
+    func pollCompletion(
+        parameters: MSALNativeAuthResetPasswordPollCompletionRequestParameters
+    ) throws -> MSIDHttpRequest
+}
+
+final class MSALNativeAuthResetPasswordRequestProvider: MSALNativeAuthResetPasswordRequestProviding {
+
+    // MARK: - Variables
+    private let requestConfigurator: MSALNativeAuthRequestConfigurator
+    private let telemetryProvider: MSALNativeAuthTelemetryProviding
+
+    // MARK: - Init
+
+    init(
+        requestConfigurator: MSALNativeAuthRequestConfigurator,
+        telemetryProvider: MSALNativeAuthTelemetryProviding = MSALNativeAuthTelemetryProvider()
+    ) {
+        self.requestConfigurator = requestConfigurator
+        self.telemetryProvider = telemetryProvider
+    }
+
+    // MARK: - Reset Password Start
+
+    func start(
+        parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters
+    ) throws -> MSIDHttpRequest {
+
+        let requestParams = MSALNativeAuthResetPasswordStartRequestParameters(
+            context: parameters.context,
+            username: parameters.username
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .resetPassword(.start(requestParams)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    // MARK: - Reset Password Challenge
+
+    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        let requestParams = MSALNativeAuthResetPasswordChallengeRequestParameters(
+            context: context,
+            passwordResetToken: token
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .resetPassword(.challenge(requestParams)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    // MARK: - Reset Password Continue
+
+    func `continue`(
+        parameters: MSALNativeAuthResetPasswordContinueRequestParameters
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .resetPassword(.continue(parameters)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    // MARK: - Reset Password Submit
+
+    func submit(
+        parameters: MSALNativeAuthResetPasswordSubmitRequestParameters
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .resetPassword(.submit(parameters)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    // MARK: - Reset Password Poll Completion
+
+    func pollCompletion(
+        parameters: MSALNativeAuthResetPasswordPollCompletionRequestParameters
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .resetPassword(.pollCompletion(parameters)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+}

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
@@ -1,0 +1,273 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthResetPasswordResponseValidating {
+    func validate(_ result: Result<MSALNativeAuthResetPasswordStartResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordStartValidatedResponse
+    func validate(_ result: Result<MSALNativeAuthResetPasswordChallengeResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordChallengeValidatedResponse
+    func validate(_ result: Result<MSALNativeAuthResetPasswordContinueResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordContinueValidatedResponse
+    func validate(_ result: Result<MSALNativeAuthResetPasswordSubmitResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordSubmitValidatedResponse
+    func validate(_ result: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse
+}
+
+final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPasswordResponseValidating {
+
+    // MARK: - Start Request
+
+    func validate(_ result: Result<MSALNativeAuthResetPasswordStartResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordStartValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleStartSuccess(response, with: context)
+        case .failure(let error):
+            return handleStartFailed(error, with: context)
+        }
+    }
+
+    private func handleStartSuccess(_ response: MSALNativeAuthResetPasswordStartResponse,
+                                    with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordStartValidatedResponse {
+        if response.challengeType == .redirect {
+            return .redirect
+        } else if let passwordResetToken = response.passwordResetToken {
+            return .success(passwordResetToken: passwordResetToken)
+        } else {
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "resetpassword/start returned success with unexpected response body")
+
+            return .unexpectedError
+        }
+    }
+
+    private func handleStartFailed(_ error: Error,
+                                   with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordStartValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthResetPasswordStartResponseError else {
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error type not expected")
+
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .invalidRequest:
+            if apiError.errorCodes?.first == MSALNativeAuthESTSApiErrorCodes.userNotHaveAPassword.rawValue {
+                return .error(.userDoesNotHavePassword)
+            } else {
+                return .error(.invalidRequest(message: apiError.errorDescription))
+            }
+        case .invalidClient:
+            return .error(.invalidClient(message: apiError.errorDescription))
+        case .userNotFound:
+            return .error(.userNotFound(message: apiError.errorDescription))
+        case .unsupportedChallengeType:
+            return .error(.unsupportedChallengeType(message: apiError.errorDescription))
+        }
+    }
+
+    // MARK: - Challenge Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthResetPasswordChallengeResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordChallengeValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleChallengeSuccess(response, with: context)
+        case .failure(let error):
+            return handleChallengeError(error, with: context)
+        }
+    }
+
+    private func handleChallengeSuccess(
+        _ response: MSALNativeAuthResetPasswordChallengeResponse,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordChallengeValidatedResponse {
+        switch response.challengeType {
+        case .redirect:
+            return .redirect
+        case .oob:
+            if let sentTo = response.challengeTargetLabel,
+               let channelTargetType = response.challengeChannel?.toPublicChannelType(),
+               let codeLength = response.codeLength,
+               let passwordResetToken = response.passwordResetToken {
+                return .success(
+                    sentTo,
+                    channelTargetType,
+                    codeLength,
+                    passwordResetToken
+                )
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields from backend")
+                return .unexpectedError
+            }
+        case .password,
+             .otp:
+            MSALLogger.log(level: .error, context: context, format: "ChallengeType not expected")
+            return .unexpectedError
+        }
+    }
+
+    private func handleChallengeError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordChallengeValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthResetPasswordChallengeResponseError else {
+            MSALLogger.log(level: .info, context: context, format: "Error type not expected")
+            return .unexpectedError
+        }
+
+        return .error(apiError)
+    }
+
+    // MARK: - Continue Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthResetPasswordContinueResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleContinueSuccess(response)
+        case .failure(let error):
+            return handleContinueError(error, with: context)
+        }
+    }
+
+    private func handleContinueSuccess(
+        _ response: MSALNativeAuthResetPasswordContinueResponse
+    ) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
+        return .success(passwordSubmitToken: response.passwordSubmitToken)
+    }
+
+    private func handleContinueError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthResetPasswordContinueResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "continue returned unexpected error type")
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .invalidOOBValue:
+            return .invalidOOB
+        case .invalidClient,
+             .invalidGrant,
+             .expiredToken,
+             .invalidRequest:
+            return .error(apiError)
+        case .verificationRequired:
+            MSALLogger.log(level: .error, context: context, format: "verificationRequired is not supported yet")
+            return .unexpectedError
+        }
+    }
+
+    // MARK: - Submit Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthResetPasswordSubmitResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleSubmitSuccess(response)
+        case .failure(let error):
+            return handleSubmitError(error, with: context)
+        }
+    }
+
+    private func handleSubmitSuccess(
+        _ response: MSALNativeAuthResetPasswordSubmitResponse
+    ) -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
+        return .success(
+            passwordResetToken: response.passwordResetToken,
+            pollInterval: response.pollInterval
+        )
+    }
+
+    private func handleSubmitError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthResetPasswordSubmitResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "submit returned unexpected error type")
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .passwordError(error: apiError)
+        case .invalidRequest,
+             .invalidClient,
+             .expiredToken:
+            return .error(apiError)
+        }
+    }
+
+    // MARK: - Poll Completion Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handlePollCompletionSuccess(response)
+        case .failure(let error):
+            return handlePollCompletionError(error, with: context)
+        }
+    }
+
+    private func handlePollCompletionSuccess(
+        _ response: MSALNativeAuthResetPasswordPollCompletionResponse
+    ) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
+        return .success(status: response.status)
+    }
+
+    private func handlePollCompletionError(
+        _ error: Error,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthResetPasswordPollCompletionResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "Poll Completion returned unexpected error type")
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .passwordError(error: apiError)
+        case .userNotFound,
+             .invalidRequest,
+             .invalidClient,
+             .expiredToken:
+            return .error(apiError)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -1,0 +1,160 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignInResponseValidating {
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        result: Result<MSALNativeAuthSignInChallengeResponse, Error>
+    ) -> MSALNativeAuthSignInChallengeValidatedResponse
+
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        result: Result<MSALNativeAuthSignInInitiateResponse, Error>
+    ) -> MSALNativeAuthSignInInitiateValidatedResponse
+}
+
+final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseValidating {
+
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        result: Result<MSALNativeAuthSignInChallengeResponse, Error>
+    ) -> MSALNativeAuthSignInChallengeValidatedResponse {
+        switch result {
+        case .success(let challengeResponse):
+            return handleSuccessfulSignInChallengeResult(context, response: challengeResponse)
+        case .failure(let signInChallengeResponseError):
+            guard let signInChallengeResponseError =
+                    signInChallengeResponseError as? MSALNativeAuthSignInChallengeResponseError else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "SignIn Challenge: Error type not expected, error: \(signInChallengeResponseError)")
+                return .error(.invalidServerResponse)
+            }
+            return handleFailedSignInChallengeResult(context, error: signInChallengeResponseError)
+        }
+    }
+
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        result: Result<MSALNativeAuthSignInInitiateResponse, Error>
+    ) -> MSALNativeAuthSignInInitiateValidatedResponse {
+        switch result {
+        case .success(let initiateResponse):
+            if initiateResponse.challengeType == .redirect {
+                return .error(.redirect)
+            }
+            if let credentialToken = initiateResponse.credentialToken {
+                return .success(credentialToken: credentialToken)
+            }
+            MSALLogger.log(level: .error, context: context, format: "SignIn Initiate: challengeType and credential token empty")
+            return .error(.invalidServerResponse)
+        case .failure(let responseError):
+            guard let initiateResponseError = responseError as? MSALNativeAuthSignInInitiateResponseError else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "SignIn Initiate: Error type not expected, error: \(responseError)")
+                return .error(.invalidServerResponse)
+            }
+            return handleFailedSignInInitiateResult(context, error: initiateResponseError)
+        }
+    }
+
+    // MARK: private methods
+
+    private func handleSuccessfulSignInChallengeResult(
+        _ context: MSALNativeAuthRequestContext,
+        response: MSALNativeAuthSignInChallengeResponse) -> MSALNativeAuthSignInChallengeValidatedResponse {
+        switch response.challengeType {
+        case .otp:
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "SignIn Challenge: Received unexpected challenge type: \(response.challengeType)")
+            return .error(.invalidServerResponse)
+        case .oob:
+            guard let credentialToken = response.credentialToken,
+                    let targetLabel = response.challengeTargetLabel,
+                    let codeLength = response.codeLength,
+                    let channelType = response.challengeChannel else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "SignIn Challenge: Invalid response with challenge type oob, response: \(response)")
+                return .error(.invalidServerResponse)
+            }
+            return .codeRequired(
+                credentialToken: credentialToken,
+                sentTo: targetLabel,
+                channelType: channelType.toPublicChannelType(),
+                codeLength: codeLength)
+        case .password:
+            guard let credentialToken = response.credentialToken else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "SignIn Challenge: Expected credential token not nil with credential type password")
+                return .error(.invalidServerResponse)
+            }
+            return .passwordRequired(credentialToken: credentialToken)
+        case .redirect:
+            return .error(.redirect)
+        }
+    }
+
+    private func handleFailedSignInChallengeResult(
+        _ context: MSALNativeAuthRequestContext,
+        error: MSALNativeAuthSignInChallengeResponseError) -> MSALNativeAuthSignInChallengeValidatedResponse {
+            switch error.error {
+            case .invalidRequest:
+                return .error(.invalidRequest(message: error.errorDescription))
+            case .unauthorizedClient:
+                return .error(.invalidClient(message: error.errorDescription))
+            case .invalidGrant:
+                return .error(.invalidToken(message: error.errorDescription))
+            case .expiredToken:
+                return .error(.expiredToken(message: error.errorDescription))
+            case .unsupportedChallengeType:
+                return .error(.unsupportedChallengeType(message: error.errorDescription))
+            }
+    }
+
+    private func handleFailedSignInInitiateResult(
+        _ context: MSALNativeAuthRequestContext,
+        error: MSALNativeAuthSignInInitiateResponseError) -> MSALNativeAuthSignInInitiateValidatedResponse {
+            switch error.error {
+            case .invalidRequest:
+                return .error(.invalidRequest(message: error.errorDescription))
+            case .unauthorizedClient:
+                return .error(.invalidClient(message: error.errorDescription))
+            case .unsupportedChallengeType:
+                return .error(.unsupportedChallengeType(message: error.errorDescription))
+            case .invalidGrant:
+                return .error(.userNotFound(message: error.errorDescription))
+            }
+    }
+}

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -1,0 +1,274 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignUpResponseValidating {
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpStartResponse, Error>, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpStartValidatedResponse
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpChallengeResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpChallengeValidatedResponse
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpContinueResponse, Error>, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpContinueValidatedResponse
+}
+
+final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseValidating {
+
+    // MARK: - Start Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpStartResponse, Error>, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpStartValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleStartSuccess(response, with: context)
+        case .failure(let error):
+            return handleStartFailed(error, with: context)
+        }
+    }
+
+    private func handleStartSuccess(
+        _ response: MSALNativeAuthSignUpStartResponse, with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpStartValidatedResponse {
+        if response.challengeType == .redirect {
+            return .redirect
+        } else {
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "Unexpected response in signup/start. SDK expects only 200 with redirect challenge_type"
+            )
+            return .unexpectedError
+        }
+    }
+
+    private func handleStartFailed(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpStartValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthSignUpStartResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "Error type not expected")
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .verificationRequired:
+            if let signUpToken = apiError.signUpToken, let unverifiedAttributes = apiError.unverifiedAttributes, !unverifiedAttributes.isEmpty {
+                return .verificationRequired(signUpToken: signUpToken, unverifiedAttributes: extractAttributeNames(from: unverifiedAttributes))
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/start for verification_required error")
+                return .unexpectedError
+            }
+        case .attributeValidationFailed:
+            if let invalidAttributes = apiError.invalidAttributes, !invalidAttributes.isEmpty {
+                return .attributeValidationFailed(invalidAttributes: extractAttributeNames(from: invalidAttributes))
+            } else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "Missing expected fields in signup/start for attribute_validation_failed error"
+                )
+                return .unexpectedError
+            }
+        case .invalidRequest where isSignUpStartInvalidRequestParameter(
+            apiError,
+            knownErrorDescription: MSALNativeAuthESTSApiErrorDescriptions.usernameParameterIsEmptyOrNotValid.rawValue):
+            return .invalidUsername(apiError)
+        case .invalidRequest where isSignUpStartInvalidRequestParameter(
+            apiError,
+            knownErrorDescription: MSALNativeAuthESTSApiErrorDescriptions.clientIdParameterIsEmptyOrNotValid.rawValue):
+            return .invalidClientId(apiError)
+        default:
+            return .error(apiError)
+        }
+    }
+
+    // MARK: - Challenge Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpChallengeResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleChallengeSuccess(response, with: context)
+        case .failure(let error):
+            return handleChallengeError(error, with: context)
+        }
+    }
+
+    private func handleChallengeSuccess(
+        _ response: MSALNativeAuthSignUpChallengeResponse,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        guard let challengeTypeIssued = response.challengeType else {
+            MSALLogger.log(level: .error, context: context, format: "Missing ChallengeType from backend in signup/challenge response")
+            return .unexpectedError
+        }
+
+        switch challengeTypeIssued {
+        case .redirect:
+            return .redirect
+        case .oob:
+            if let sentTo = response.challengeTargetLabel,
+               let channelType = response.challengeChannel?.toPublicChannelType(),
+               let codeLength = response.codeLength,
+               let signUpChallengeToken = response.signUpToken {
+                return .codeRequired(sentTo, channelType, codeLength, signUpChallengeToken)
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/challenge with challenge_type = oob")
+                return .unexpectedError
+            }
+        case .password:
+            if let signUpToken = response.signUpToken {
+                return .passwordRequired(signUpToken)
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/challenge with challenge_type = password")
+                return .unexpectedError
+            }
+        case .otp:
+            MSALLogger.log(level: .error, context: context, format: "ChallengeType OTP not expected for signup/challenge")
+            return .unexpectedError
+        }
+    }
+
+    private func handleChallengeError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpChallengeValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthSignUpChallengeResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "Error type not expected")
+            return .unexpectedError
+        }
+
+        return .error(apiError)
+    }
+
+    // MARK: - Continue Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthSignUpContinueResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        switch result {
+        case .success(let response):
+            // Even if the `signInSLT` is nil, the signUp flow is considered successfully completed
+            return .success(response.signinSLT)
+        case .failure(let error):
+            return handleContinueError(error, with: context)
+        }
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private func handleContinueError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthSignUpContinueResponseError else {
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .invalidOOBValue,
+             .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .invalidUserInput(apiError)
+        case .attributeValidationFailed:
+            if let signUpToken = apiError.signUpToken, let invalidAttributes = apiError.invalidAttributes, !invalidAttributes.isEmpty {
+                return .attributeValidationFailed(signUpToken: signUpToken, invalidAttributes: extractAttributeNames(from: invalidAttributes))
+            } else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "Missing expected fields in signup/continue for attribute_validation_failed error"
+                )
+                return .unexpectedError
+            }
+        case .credentialRequired:
+            if let signUpToken = apiError.signUpToken {
+                return .credentialRequired(signUpToken: signUpToken)
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/continue for credential_required error")
+                return .unexpectedError
+            }
+        case .attributesRequired:
+            if let signUpToken = apiError.signUpToken, let requiredAttributes = apiError.requiredAttributes, !requiredAttributes.isEmpty {
+                return .attributesRequired(signUpToken: signUpToken, requiredAttributes: requiredAttributes.map { $0.toRequiredAttributesPublic() })
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/continue for attributes_required error")
+                return .unexpectedError
+            }
+        // TODO: .verificationRequired is not supported by the API team yet. We treat it as an unexpectedError
+        case .verificationRequired:
+            MSALLogger.log(level: .error, context: context, format: "verificationRequired is not supported yet")
+            return .unexpectedError
+        case .unauthorizedClient,
+             .invalidGrant,
+             .expiredToken,
+             .userAlreadyExists:
+            return .error(apiError)
+        case .invalidRequest:
+            return handleInvalidRequestError(apiError)
+        }
+    }
+
+    private func handleInvalidRequestError(_ error: MSALNativeAuthSignUpContinueResponseError) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        guard let errorCode = error.errorCodes?.first, let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: errorCode) else {
+            return .error(error)
+        }
+        switch knownErrorCode {
+        case .invalidOTP,
+            .incorrectOTP,
+            .OTPNoCacheEntryForUser:
+            return .invalidUserInput(
+                MSALNativeAuthSignUpContinueResponseError(
+                    error: .invalidOOBValue,
+                    errorDescription: error.errorDescription,
+                    errorCodes: error.errorCodes,
+                    errorURI: error.errorURI,
+                    innerErrors: error.innerErrors,
+                    signUpToken: error.signUpToken,
+                    requiredAttributes: error.requiredAttributes,
+                    unverifiedAttributes: error.unverifiedAttributes,
+                    invalidAttributes: error.invalidAttributes))
+        case .userNotFound,
+            .invalidCredentials,
+            .strongAuthRequired,
+            .userNotHaveAPassword,
+            .invalidRequestParameter:
+            return .error(error)
+        }
+    }
+
+    private func isSignUpStartInvalidRequestParameter(_ apiError: MSALNativeAuthSignUpStartResponseError, knownErrorDescription: String) -> Bool {
+        guard let errorCode = apiError.errorCodes?.first,
+              let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: errorCode),
+              let errorDescription = apiError.errorDescription else {
+            return false
+        }
+        return knownErrorCode == .invalidRequestParameter && errorDescription.contains(knownErrorDescription)
+    }
+
+    private func extractAttributeNames(from attributes: [MSALNativeAuthErrorBasicAttributes]) -> [String] {
+        return attributes.map { $0.name }
+    }
+}

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -1,0 +1,222 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthTokenResponseValidating {
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        msidConfiguration: MSIDConfiguration,
+        result: Result<MSIDCIAMTokenResponse, Error>
+    ) -> MSALNativeAuthTokenValidatedResponse
+
+    func validateAccount(
+        with tokenResult: MSIDTokenResult,
+        context: MSIDRequestContext,
+        accountIdentifier: MSIDAccountIdentifier
+    ) throws -> Bool
+}
+
+final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseValidating {
+    private let factory: MSALNativeAuthResultBuildable
+    private let msidValidator: MSIDTokenResponseValidator
+
+    init(
+        factory: MSALNativeAuthResultBuildable,
+        msidValidator: MSIDTokenResponseValidator
+    ) {
+        self.factory = factory
+        self.msidValidator = msidValidator
+    }
+
+    func validate(
+        context: MSALNativeAuthRequestContext,
+        msidConfiguration: MSIDConfiguration,
+        result: Result<MSIDCIAMTokenResponse, Error>
+    ) -> MSALNativeAuthTokenValidatedResponse {
+        switch result {
+        case .success(let tokenResponse):
+            return .success(tokenResponse)
+        case .failure(let tokenResponseError):
+            guard let tokenResponseError =
+                    tokenResponseError as? MSALNativeAuthTokenResponseError else {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "Token: Error type not expected, error: \(tokenResponseError)")
+                return .error(.invalidServerResponse)
+            }
+            return handleFailedTokenResult(context, tokenResponseError)
+        }
+    }
+
+    func validateAccount(
+        with tokenResult: MSIDTokenResult,
+        context: MSIDRequestContext,
+        accountIdentifier: MSIDAccountIdentifier
+    ) throws -> Bool {
+        var error: NSError?
+        let validAccount = msidValidator.validateAccount(
+            accountIdentifier,
+            tokenResult: tokenResult,
+            correlationID: context.correlationId(),
+            error: &error
+        )
+        if let error = error {
+            throw error
+        }
+        return validAccount
+    }
+
+    private func handleFailedTokenResult(
+        _ context: MSALNativeAuthRequestContext,
+        _ responseError: MSALNativeAuthTokenResponseError) -> MSALNativeAuthTokenValidatedResponse {
+            switch responseError.error {
+            case .invalidRequest:
+                return handleInvalidRequestErrorCodes(responseError.errorCodes, errorDescription: responseError.errorDescription, context: context)
+            case .invalidClient,
+                .unauthorizedClient:
+                return .error(.invalidClient(message: responseError.errorDescription))
+            case .invalidGrant:
+                return handleInvalidGrantErrorCodes(responseError.errorCodes, errorDescription: responseError.errorDescription, context: context)
+            case .expiredToken:
+                return .error(.expiredToken(message: responseError.errorDescription))
+            case .expiredRefreshToken:
+                return .error(.expiredRefreshToken(message: responseError.errorDescription))
+            case .unsupportedChallengeType:
+                return .error(.unsupportedChallengeType(message: responseError.errorDescription))
+            case .invalidScope:
+                return .error(.invalidScope(message: responseError.errorDescription))
+            case .authorizationPending:
+                return .error(.authorizationPending(message: responseError.errorDescription))
+            case .slowDown:
+                return .error(.slowDown(message: responseError.errorDescription))
+            }
+        }
+
+    private func handleInvalidRequestErrorCodes(
+        _ errorCodes: [Int]?,
+        errorDescription: String?,
+        context: MSALNativeAuthRequestContext
+    ) -> MSALNativeAuthTokenValidatedResponse {
+        return handleInvalidResponseErrorCodes(
+            errorCodes,
+            errorDescription: errorDescription,
+            context: context,
+            useInvalidRequestAsDefaultResult: true,
+            errorCodesConverterFunction: convertInvalidRequestErrorCodeToErrorType
+        )
+    }
+
+    private func handleInvalidGrantErrorCodes(
+        _ errorCodes: [Int]?,
+        errorDescription: String?,
+        context: MSALNativeAuthRequestContext
+    ) -> MSALNativeAuthTokenValidatedResponse {
+        return handleInvalidResponseErrorCodes(
+            errorCodes,
+            errorDescription: errorDescription,
+            context: context,
+            errorCodesConverterFunction: convertInvalidGrantErrorCodeToErrorType
+        )
+    }
+
+    private func handleInvalidResponseErrorCodes(
+        _ errorCodes: [Int]?,
+        errorDescription: String?,
+        context: MSALNativeAuthRequestContext,
+        useInvalidRequestAsDefaultResult: Bool = false,
+        errorCodesConverterFunction: (MSALNativeAuthESTSApiErrorCodes, String?) -> MSALNativeAuthTokenValidatedErrorType
+    ) -> MSALNativeAuthTokenValidatedResponse {
+        guard var errorCodes = errorCodes, !errorCodes.isEmpty else {
+            MSALLogger.log(level: .error, context: context, format: "/token error - Empty error_codes received")
+            return useInvalidRequestAsDefaultResult ? .error(.invalidRequest(message: errorDescription)) : .error(.generalError)
+        }
+
+        let validatedResponse: MSALNativeAuthTokenValidatedResponse
+        let firstErrorCode = errorCodes.removeFirst()
+
+        if let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: firstErrorCode) {
+            validatedResponse = .error(errorCodesConverterFunction(knownErrorCode, errorDescription))
+        } else {
+            MSALLogger.log(level: .error, context: context, format: "/token error - Unknown code received in error_codes: \(firstErrorCode)")
+            validatedResponse = useInvalidRequestAsDefaultResult ? .error(.invalidRequest(message: errorDescription)) : .error(.generalError)
+        }
+
+        // Log the rest of error_codes
+
+        errorCodes.forEach { errorCode in
+            let errorMessage: String
+
+            if let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: errorCode) {
+                errorMessage = "/token error - ESTS error received in error_codes: \(knownErrorCode) (ignoring)"
+            } else {
+                errorMessage = "/token error - Unknown ESTS received in error_codes with code: \(errorCode) (ignoring)"
+            }
+
+            MSALLogger.log(level: .verbose, context: context, format: errorMessage)
+        }
+
+        return validatedResponse
+    }
+
+    private func convertInvalidGrantErrorCodeToErrorType(
+        _ errorCode: MSALNativeAuthESTSApiErrorCodes,
+        errorDescription: String?
+    ) -> MSALNativeAuthTokenValidatedErrorType {
+        switch errorCode {
+        case .userNotFound:
+            return .userNotFound(message: errorDescription)
+        case .invalidCredentials:
+            return .invalidPassword(message: errorDescription)
+        case .invalidOTP,
+            .incorrectOTP,
+            .OTPNoCacheEntryForUser:
+            return .invalidOOBCode(message: errorDescription)
+        case .strongAuthRequired:
+            return .strongAuthRequired(message: errorDescription)
+        case .userNotHaveAPassword,
+             .invalidRequestParameter:
+            return .generalError
+        }
+    }
+
+    private func convertInvalidRequestErrorCodeToErrorType(
+        _ errorCode: MSALNativeAuthESTSApiErrorCodes,
+        errorDescription: String?
+    ) -> MSALNativeAuthTokenValidatedErrorType {
+        switch errorCode {
+        case .invalidOTP,
+            .incorrectOTP,
+            .OTPNoCacheEntryForUser:
+            return .invalidOOBCode(message: errorDescription)
+        case .userNotFound,
+            .invalidCredentials,
+            .strongAuthRequired,
+            .userNotHaveAPassword,
+            .invalidRequestParameter:
+            return .invalidRequest(message: errorDescription)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/sign_in/MSALNativeAuthSignInRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_in/MSALNativeAuthSignInRequestProvider.swift
@@ -1,0 +1,83 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignInRequestProviding {
+    func inititate(
+        parameters: MSALNativeAuthSignInInitiateRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest
+
+    func challenge(
+        parameters: MSALNativeAuthSignInChallengeRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest
+}
+
+final class MSALNativeAuthSignInRequestProvider: MSALNativeAuthSignInRequestProviding {
+
+    // MARK: - Variables
+    private let requestConfigurator: MSALNativeAuthRequestConfigurator
+    private let telemetryProvider: MSALNativeAuthTelemetryProviding
+
+    // MARK: - Init
+
+    init(
+        requestConfigurator: MSALNativeAuthRequestConfigurator,
+        telemetryProvider: MSALNativeAuthTelemetryProviding = MSALNativeAuthTelemetryProvider()
+    ) {
+        self.requestConfigurator = requestConfigurator
+        self.telemetryProvider = telemetryProvider
+    }
+
+    // MARK: - SignIn Initiate
+
+    func inititate(
+        parameters: MSALNativeAuthSignInInitiateRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signIn(.initiate(parameters)),
+                                          request: request,
+                                          telemetryProvider: telemetryProvider)
+
+        return request
+    }
+
+    // MARK: - SignIn Challenge
+
+    func challenge(
+        parameters: MSALNativeAuthSignInChallengeRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signIn(.challenge(parameters)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+}

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
@@ -1,0 +1,99 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthSignUpRequestProviding {
+    func start(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) throws -> MSIDHttpRequest
+    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest
+    func `continue`(parameters: MSALNativeAuthSignUpContinueRequestProviderParams) throws -> MSIDHttpRequest
+}
+
+final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProviding {
+
+    private let requestConfigurator: MSALNativeAuthRequestConfigurator
+    private let telemetryProvider: MSALNativeAuthTelemetryProviding
+
+    init(requestConfigurator: MSALNativeAuthRequestConfigurator,
+         telemetryProvider: MSALNativeAuthTelemetryProviding) {
+        self.requestConfigurator = requestConfigurator
+        self.telemetryProvider = telemetryProvider
+    }
+
+    func start(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) throws -> MSIDHttpRequest {
+        guard let attributes = try formatAttributes(parameters.attributes) else {
+            throw MSALNativeAuthInternalError.invalidAttributes
+        }
+
+        let params = MSALNativeAuthSignUpStartRequestParameters(
+            username: parameters.username,
+            password: parameters.password,
+            attributes: attributes,
+            context: parameters.context
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signUp(.start(params)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        let params = MSALNativeAuthSignUpChallengeRequestParameters(
+            signUpToken: token,
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signUp(.challenge(params)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    func `continue`(parameters: MSALNativeAuthSignUpContinueRequestProviderParams) throws -> MSIDHttpRequest {
+        let attributesFormatted = try parameters.attributes.map { try formatAttributes($0) } ?? nil
+
+        let params = MSALNativeAuthSignUpContinueRequestParameters(
+            grantType: parameters.grantType,
+            signUpToken: parameters.signUpToken,
+            password: parameters.password,
+            oobCode: parameters.oobCode,
+            attributes: attributesFormatted,
+            context: parameters.context
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signUp(.continue(params)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    private func formatAttributes(_ attributes: [String: Any]) throws -> String? {
+        let data = try JSONSerialization.data(withJSONObject: attributes)
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/MSAL/src/native_auth/network/token/MSALNativeAuthTokenRequestProvider.swift
+++ b/MSAL/src/native_auth/network/token/MSALNativeAuthTokenRequestProvider.swift
@@ -1,0 +1,80 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthTokenRequestProviding {
+    func signInWithPassword(
+        parameters: MSALNativeAuthTokenRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest
+
+    func refreshToken(
+        parameters: MSALNativeAuthTokenRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest
+}
+
+final class MSALNativeAuthTokenRequestProvider: MSALNativeAuthTokenRequestProviding {
+
+    // MARK: - Variables
+    private let requestConfigurator: MSALNativeAuthRequestConfigurator
+    private let telemetryProvider: MSALNativeAuthTelemetryProviding
+
+    // MARK: - Init
+
+    init(
+        requestConfigurator: MSALNativeAuthRequestConfigurator,
+        telemetryProvider: MSALNativeAuthTelemetryProviding = MSALNativeAuthTelemetryProvider()
+    ) {
+        self.requestConfigurator = requestConfigurator
+        self.telemetryProvider = telemetryProvider
+    }
+
+    // MARK: - Token
+
+    func signInWithPassword(
+        parameters: MSALNativeAuthTokenRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .token(.signInWithPassword(parameters)),
+                                          request: request,
+                                          telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    func refreshToken(
+        parameters: MSALNativeAuthTokenRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .token(.refreshToken(parameters)),
+                                          request: request,
+                                          telemetryProvider: telemetryProvider)
+        return request
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
@@ -1,0 +1,451 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
+
+    let telemetryProvider = MSALNativeAuthTelemetryProvider()
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+    
+    let context = MSALNativeAuthRequestContext(
+        correlationId: .init(
+            UUID(uuidString: DEFAULT_TEST_UID)!
+        )
+    )
+
+    func test_signInInititate_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForSignIn(type: .signInInitiate),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthSignInInitiateRequestParameters(context: context,
+                                                                   username: DEFAULT_TEST_ID_TOKEN_USERNAME)
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .signIn(.initiate(params)),
+                      request: request,
+                      telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "challenge_type": "password",
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .signInInitiate)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_signInChallenge_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.otp]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForSignIn(type: .signInChallenge),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthSignInChallengeRequestParameters(context: context,
+                                                                    credentialToken: "Test Credential Token")
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .signIn(.challenge(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "credential_token": "Test Credential Token",
+            "challenge_type": "otp"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .signInChallenge)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_signInToken_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForToken(type: .signInWithPassword),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthTokenRequestParameters(context: context,
+                                                          username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+                                                          credentialToken: "Test Credential Token",
+                                                          signInSLT: "Test SignIn SLT",
+                                                          grantType: .password,
+                                                          scope: "<scope-1>",
+                                                          password: "password",
+                                                          oobCode: "oob",
+                                                          includeChallengeType: true,
+                                                          refreshToken: nil)
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .token(.signInWithPassword(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "credential_token": "Test Credential Token",
+            "signin_slt": "Test SignIn SLT",
+            "grant_type": "password",
+            "challenge_type": "password",
+            "scope": "<scope-1>",
+            "password": "password",
+            "oob": "oob",
+            "client_info" : "true"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .token)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_signUpStartRequest_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForSignUp(type: .signUpStart),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthSignUpStartRequestParameters(username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+                                                                password: "strong-password",
+                                                                attributes: "<attribute1: value1>",
+                                                                context: context)
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .signUp(.start(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "password": "strong-password",
+            "attributes": "<attribute1: value1>",
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .signUpStart)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_signUpChallengeRequest_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForSignUp(type: .signUpChallenge),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthSignUpChallengeRequestParameters(signUpToken: "<sign-up-token>",
+                                                                    context: context)
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .signUp(.challenge(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "signup_token": "<sign-up-token>",
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .signUpChallenge)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_signUpContinueRequest_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForSignUp(type: .signUpContinue),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthSignUpContinueRequestParameters(grantType: .oobCode,
+                                                                   signUpToken: "<sign-up-token>",
+                                                                   password: "<strong-password>",
+                                                                   oobCode: "0000",
+                                                                   attributes: "<attributes>",
+                                                                   context: context)
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .signUp(.continue(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "signup_token": "<sign-up-token>",
+            "password": "<strong-password>",
+            "oob": "0000",
+            "grant_type": "oob",
+            "attributes": "<attributes>"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .signUpContinue)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+
+    func test_resetPasswordStart_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordStart),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthResetPasswordStartRequestParameters(context: context,
+                                                                       username: DEFAULT_TEST_ID_TOKEN_USERNAME)
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .resetPassword(.start(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .resetPasswordStart)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_resetPasswordChallenge_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordChallenge),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthResetPasswordChallengeRequestParameters(context: context,
+                                                                           passwordResetToken: "<password-reset-token>")
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .resetPassword(.challenge(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_reset_token": "<password-reset-token>",
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .resetPasswordChallenge)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_resetPasswordContinue_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordContinue),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthResetPasswordContinueRequestParameters(context: context,
+                                                                          passwordResetToken: "<password-reset-token>",
+                                                                          grantType: .oobCode,
+                                                                          oobCode: "0000")
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .resetPassword(.continue(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_reset_token": "<password-reset-token>",
+            "grant_type": "oob",
+            "oob": "0000"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .resetPasswordContinue)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_resetPasswordSubmit_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordSubmit),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthResetPasswordSubmitRequestParameters(context: context,
+                                                                        passwordSubmitToken: "<password-submit-token>",
+                                                                        newPassword:"new-password")
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .resetPassword(.submit(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_submit_token": "<password-submit-token>",
+            "new_password": "new-password"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .resetPasswordSubmit)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_resetPasswordPollCompletion_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordPollCompletion),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthResetPasswordPollCompletionRequestParameters(context: context,
+                                                                                passwordResetToken: "<password-reset-token")
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .resetPassword(.pollCompletion(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_reset_token": "<password-reset-token"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .resetpasswordPollCompletion)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+    func test_refreshToken_getsConfiguredSuccessfully() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
+        let telemetry = MSALNativeAuthServerTelemetry(
+            currentRequestTelemetry: telemetryProvider.telemetryForToken(type: .refreshToken),
+            context: context
+        )
+
+        let request = MSIDHttpRequest()
+        let params = MSALNativeAuthTokenRequestParameters(context: context,
+                                                          username: nil,
+                                                          credentialToken: nil,
+                                                          signInSLT: nil,
+                                                          grantType: .refreshToken,
+                                                          scope: "<scope-1>",
+                                                          password: nil,
+                                                          oobCode: nil,
+                                                          includeChallengeType: false,
+                                                          refreshToken: "refreshToken")
+
+        let sut = MSALNativeAuthRequestConfigurator(config: config)
+        try sut.configure(configuratorType: .token(.refreshToken(params)),
+                          request: request,
+                          telemetryProvider: telemetryProvider)
+
+        let expectedBodyParams = [
+            "client_id" : DEFAULT_TEST_CLIENT_ID,
+            "grant_type" : "refresh_token",
+            "scope" : "<scope-1>",
+            "refresh_token" : "refreshToken",
+            "client_info" : "true"
+        ]
+
+        XCTAssertEqual(request.parameters, expectedBodyParams)
+        checkUrlRequest(request.urlRequest, endpoint: .token)
+        checkHeaders(request: request)
+        checkTelemetry(request.serverTelemetry, telemetry)
+    }
+
+
+    private func checkUrlRequest(_ result: URLRequest?, endpoint: MSALNativeAuthEndpoint) {
+        XCTAssertEqual(result?.httpMethod, MSALParameterStringForHttpMethod(.POST))
+
+        let expectedUrl = URL(string: MSALNativeAuthNetworkStubs.authority.url.absoluteString + endpoint.rawValue)!
+        XCTAssertEqual(result?.url, expectedUrl)
+    }
+
+    private func checkHeaders(request: MSIDHttpRequest) {
+        let headers = request.urlRequest?.allHTTPHeaderFields!
+        XCTAssertEqual(headers!["Accept"], "application/json")
+        XCTAssertEqual(headers!["return-client-request-id"], "true")
+        XCTAssertEqual(headers!["x-ms-PkeyAuth+"], "1.0")
+        XCTAssertNotNil("client-request-id")
+        XCTAssertNotNil("x-client-CPU")
+        XCTAssertNotNil("x-client-SKU")
+        XCTAssertNotNil("x-app-name")
+        XCTAssertNotNil("x-app-ver")
+        XCTAssertNotNil("x-client-OS")
+        XCTAssertNotNil("x-client-Ver")
+#if TARGET_OS_IPHONE
+        XCTAssertNotNil("x-client-DM")
+#endif
+    }
+
+    private func checkTelemetry(_ result: MSIDHttpRequestServerTelemetryHandling?, _ expected: MSALNativeAuthServerTelemetry) {
+
+        guard let resultTelemetry = (result as? MSALNativeAuthServerTelemetry)?.currentRequestTelemetry else {
+            return XCTFail()
+        }
+
+        let expectedTelemetry = expected.currentRequestTelemetry
+
+        XCTAssertEqual(resultTelemetry.apiId, expectedTelemetry.apiId)
+        XCTAssertEqual(resultTelemetry.operationType, expectedTelemetry.operationType)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestErrorHandlerTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestErrorHandlerTests.swift
@@ -1,0 +1,281 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
+    // MARK: - Variables
+
+    private var sut: MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInInitiateResponseError>!
+    private let error = NSError(domain:"Test Error Domain", code:400, userInfo:nil)
+    private var httpRequest: MSIDHttpRequest!
+    private let context = MSALNativeAuthRequestContextMock(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+
+    override func setUpWithError() throws {
+        sut = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInInitiateResponseError>()
+        httpRequest = MSIDHttpRequest()
+        try super.setUpWithError()
+    }
+
+    func test_completeWithError_whenBodyMissing() {
+        let expectation = expectation(description: "Handle Error Body Missing")
+        sut.handleError(
+            error,
+            httpResponse: nil,
+            data: nil,
+            httpRequest: nil,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: nil
+        ) { result, error in
+            XCTAssertEqual(self.error.domain, (error! as NSError).domain)
+            XCTAssertEqual(self.error.code, (error! as NSError).code)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldRetry_whenRetryCountGreaterThanZeroAndRetryStatusCode() {
+        let expectation = expectation(description: "Handle Error Retry Success")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 500,
+            httpVersion: nil,
+            headerFields: nil
+        )
+        HttpModuleMockConfigurator.configure(request: httpRequest, response: httpResponse, responseJson: [])
+        httpRequest.retryCounter = 5
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: nil,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual(self.httpRequest.retryCounter, 4)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldNotRetry_whenRetryCountZeroAndRetryStatusCode() {
+        let expectation = expectation(description: "Handle Error No Retries Left")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 500,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        HttpModuleMockConfigurator.configure(request: httpRequest, response: httpResponse, responseJson: [])
+        httpRequest.retryCounter = 0
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: nil,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((error! as NSError).code, MSIDErrorCode.serverUnhandledResponse.rawValue)
+            XCTAssertEqual((error! as NSError).userInfo[MSIDHTTPResponseCodeKey] as! String, "500")
+            XCTAssertEqual((error! as NSError).userInfo[MSIDServerUnavailableStatusKey] as! Int, 1)
+            XCTAssertEqual((error! as NSError).userInfo[MSIDErrorDescriptionKey] as! String, "internal server error")
+            XCTAssertEqual(((error! as NSError).userInfo[MSIDHTTPHeadersKey] as! [String: String]).count, 0)
+            MSIDTestURLSession.clearResponses()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldCompleteAndResend_whenResponseContainsPkeyHeader() {
+        let expectation = expectation(description: "Handle Error Response Pkey Header")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 400,
+            httpVersion: nil,
+            headerFields: [kMSIDWwwAuthenticateHeader: "PKeyAuth Context=TestContext,Version=1.0"]
+        )
+
+        HttpModuleMockConfigurator.configure(request: httpRequest, response: httpResponse, responseJson: [])
+
+        let secondHttpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Authorization": "PKeyAuth  Context=\"TestContext\", Version=\"1.0\"",
+                           "Content-Type": "application/x-www-form-urlencoded"]
+        )
+        let testUrlResponse = MSIDTestURLResponse.request(HttpModuleMockConfigurator.baseUrl, reponse: secondHttpResponse)
+        testUrlResponse?.setRequestHeaders(secondHttpResponse?.allHeaderFields)
+        testUrlResponse?.setResponseJSON(["Test":"Response"])
+        MSIDTestURLSession.add(testUrlResponse)
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: nil,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((result as! NSDictionary)["Test"] as! String, "Response")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldCompleteWithAPIError_whenStatusCode400() {
+        let expectation = expectation(description: "Handle Error Retry Success")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 400,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        var dictionary = [String: Any]()
+        dictionary["error"] = "invalid_request"
+        dictionary["error_description"] = "Request parameter validation failed"
+        dictionary["error_uri"] = HttpModuleMockConfigurator.baseUrl.absoluteString
+        dictionary["inner_errors"] = [["error": "invalid_username", "error_description":"Username was invalid"]]
+
+        let data = try! JSONSerialization.data(withJSONObject: dictionary)
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: data,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((error as! MSALNativeAuthSignInInitiateResponseError).error, MSALNativeAuthSignInInitiateOauth2ErrorCode.invalidRequest)
+            XCTAssertEqual((error as! MSALNativeAuthSignInInitiateResponseError).errorDescription, "Request parameter validation failed")
+            XCTAssertEqual((error as! MSALNativeAuthSignInInitiateResponseError).errorURI, HttpModuleMockConfigurator.baseUrl.absoluteString)
+            XCTAssertEqual((error as! MSALNativeAuthSignInInitiateResponseError).innerErrors![0].error, "invalid_username")
+            XCTAssertEqual((error as! MSALNativeAuthSignInInitiateResponseError).innerErrors![0].errorDescription, "Username was invalid")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldFailWithDecodeError_whenStatusCode400AndJSONMissing() {
+        let expectation = expectation(description: "Handle Error Retry Success")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 400,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        let dictionary = [String: Any]()
+        let data = try! JSONSerialization.data(withJSONObject: dictionary)
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: data,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((error as! DecodingError).localizedDescription,"The data couldn’t be read because it is missing.")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldFailWithDecodeError_whenStatusCode400AndJSONInvalid() {
+        let expectation = expectation(description: "Handle Error Retry Success")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 400,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        var dictionary = [String: Any]()
+        dictionary["error_key_incorrect"] = "invalid_request"
+        let data = try! JSONSerialization.data(withJSONObject: dictionary)
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: data,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((error as! DecodingError).localizedDescription,"The data couldn’t be read because it is missing.")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func test_shouldCompleteWithHTTPError_whenStatusCodeNotHandled() {
+        let expectation = expectation(description: "Handle Error Retry Success")
+
+        let httpResponse = HTTPURLResponse(
+            url: HttpModuleMockConfigurator.baseUrl,
+            statusCode: 600,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        sut.handleError(
+            error,
+            httpResponse: httpResponse,
+            data: nil,
+            httpRequest: httpRequest,
+            responseSerializer: nil,
+            externalSSOContext: nil,
+            context: context
+        ) { result, error in
+            XCTAssertEqual((error! as NSError).code, MSIDErrorCode.serverUnhandledResponse.rawValue)
+            XCTAssertEqual((error! as NSError).userInfo[MSIDHTTPResponseCodeKey] as! String, "600")
+            XCTAssertEqual((error! as NSError).userInfo[MSIDErrorDescriptionKey] as! String, "")
+            XCTAssertEqual(((error! as NSError).userInfo[MSIDHTTPHeadersKey] as! [String: String]).count, 0)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
@@ -1,0 +1,79 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthRequestableTests: XCTestCase {
+    
+    var request: MSALNativeAuthResetPasswordStartRequestParameters! = nil
+
+    override func setUpWithError() throws {
+        let context = MSALNativeAuthRequestContext(
+                correlationId: .init(
+                UUID(uuidString: DEFAULT_TEST_UID)!
+            )
+        )
+        
+        request = MSALNativeAuthResetPasswordStartRequestParameters(context: context, username: DEFAULT_TEST_ID_TOKEN_USERNAME)
+    }
+    
+    func test_whenSliceConfigIsUsed_CorrectURLIsGenerated() throws {
+        let sliceDc = "TEST-SLICE-IDENTIFIER"
+        
+        guard let authorityUrl = URL(string: DEFAULT_TEST_AUTHORITY) else {
+            XCTFail()
+            return
+        }
+        
+        let authority = try MSALCIAMAuthority(url: authorityUrl)
+        var config = try MSALNativeAuthConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
+                                                      authority: authority,
+                                                      challengeTypes: [.redirect])
+        
+        config.sliceConfig = MSALSliceConfig(slice: nil, dc: sliceDc)
+        let url = try request.makeEndpointUrl(config: config)
+        
+        let expectedUrlString = config.authority.url.absoluteString + request.endpoint.rawValue + "?dc=\(sliceDc)"
+        XCTAssertEqual(url.absoluteString, expectedUrlString)
+    }
+    
+    func test_whenSliceConfigIsNotUsed_CorrectURLIsGenerated() throws {
+        guard let authorityUrl = URL(string: DEFAULT_TEST_AUTHORITY) else {
+            XCTFail()
+            return
+        }
+        
+        let authority = try MSALCIAMAuthority(url: authorityUrl)
+        var config = try MSALNativeAuthConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
+                                                      authority: authority,
+                                                      challengeTypes: [.redirect])
+        
+        let url = try request.makeEndpointUrl(config: config)
+        
+        let expectedUrlString = config.authority.url.absoluteString + request.endpoint.rawValue
+        XCTAssertEqual(url.absoluteString, expectedUrlString)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseSerializerTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseSerializerTests.swift
@@ -1,0 +1,80 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResponseSerializerTests: XCTestCase {
+
+    func testSerialize_correctResponse_shouldReturnSuccess() {
+        let serializer = MSALNativeAuthResponseSerializer<ResponseStub>()
+        let responseString = """
+        {
+          "token_type": "Bearer",
+          "scope": "scope",
+          "expires_in": 4141,
+          "extended_expires_in": 4141,
+          "access_token": "access",
+          "refresh_token": "refresh",
+          "id_token": "id"
+        }
+        """
+        var response: ResponseStub? = nil
+        XCTAssertNoThrow(response = try serializer.responseObject(for: nil, data:responseString.data(using: .utf8) , context: nil) as? ResponseStub)
+        XCTAssertEqual(response?.idToken, "id")
+        XCTAssertEqual(response?.tokenType, "Bearer")
+        XCTAssertEqual(response?.scope, "scope")
+        XCTAssertEqual(response?.expiresIn, 4141)
+        XCTAssertEqual(response?.extendedExpiresIn, 4141)
+        XCTAssertEqual(response?.refreshToken, "refresh")
+        XCTAssertEqual(response?.accessToken, "access")
+    }
+
+    func testSerialize_wrongResponse_shouldFail() throws {
+        let serializer = MSALNativeAuthResponseSerializer<ResponseStub>()
+        let wrongResponseString = """
+        {
+          "tokenType": "Bearer",
+          "spe": "scope",
+          "expiresIn": 4141,
+          "ext_expires_in": 4141,
+          "access_token": "access",
+          "refresh_token": "refresh",
+          "id_token": "id"
+        }
+        """
+        XCTAssertThrowsError(try serializer.responseObject(for: nil, data: wrongResponseString.data(using: .utf8) , context: nil))
+    }
+}
+
+private struct ResponseStub: Decodable {
+    let tokenType: String
+    let scope: String
+    let expiresIn: Int
+    let extendedExpiresIn: Int
+    let accessToken: String
+    let refreshToken: String
+    let idToken: String
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
@@ -1,0 +1,141 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
+
+    private var sut: MSALNativeAuthSignUpRequestProvider!
+    private var telemetryProvider: MSALNativeAuthTelemetryProvider!
+    private var context: MSIDRequestContext!
+
+    override func setUpWithError() throws {
+        telemetryProvider = MSALNativeAuthTelemetryProvider()
+        context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+
+        sut = .init(requestConfigurator: MSALNativeAuthRequestConfigurator(config: MSALNativeAuthConfigStubs.configuration),
+                    telemetryProvider: telemetryProvider)
+    }
+
+    func test_signUpStartRequest_is_created_successfully() throws {
+        let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            password: "1234",
+            attributes: ["city": "dublin"],
+            context: MSALNativeAuthRequestContext(correlationId: context.correlationId())
+        )
+
+        let request = try sut.start(parameters: parameters)
+
+        checkBodyParams(request.parameters, for: .signUpStart)
+        checkUrlRequest(request.urlRequest!, for: .signUpStart)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpStart).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+
+    func test_signUpChallengeRequest_is_created_successfully() throws {
+        let request = try sut.challenge(token: "sign-up-token", context: context)
+
+        checkBodyParams(request.parameters, for: .signUpChallenge)
+        checkUrlRequest(request.urlRequest!, for: .signUpChallenge)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpChallenge).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+
+    func test_signUpContinueRequest_is_created_successfully() throws {
+        let parameters = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: "sign-up-token",
+            password: "1234",
+            oobCode: nil,
+            attributes: nil,
+            context: context
+        )
+
+        let request = try sut.continue(parameters: parameters)
+
+        checkBodyParams(request.parameters, for: .signUpContinue)
+        checkUrlRequest(request.urlRequest!, for: .signUpContinue)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpContinue).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+
+    private func checkBodyParams(_ bodyParams: [String: String]?, for endpoint: MSALNativeAuthEndpoint) {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        var expectedBodyParams: [String: String]!
+
+        switch endpoint {
+        case .signUpStart:
+            expectedBodyParams = [
+                Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
+                Key.username.rawValue: DEFAULT_TEST_ID_TOKEN_USERNAME,
+                Key.challengeType.rawValue: "redirect",
+                Key.attributes.rawValue: "{\"city\":\"dublin\"}",
+                Key.password.rawValue: "1234"
+            ]
+        case .signUpChallenge:
+            expectedBodyParams = [
+                Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
+                Key.signUpToken.rawValue: "sign-up-token",
+                Key.challengeType.rawValue: "redirect"
+            ]
+        case .signUpContinue:
+            expectedBodyParams = [
+                Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
+                Key.grantType.rawValue: "password",
+                Key.signUpToken.rawValue: "sign-up-token",
+                Key.password.rawValue: "1234"
+            ]
+        default:
+            XCTFail("Case not tested")
+        }
+
+        XCTAssertEqual(bodyParams, expectedBodyParams)
+    }
+
+    private func checkUrlRequest(_ result: URLRequest?, for endpoint: MSALNativeAuthEndpoint) {
+        XCTAssertEqual(result?.httpMethod, MSALParameterStringForHttpMethod(.POST))
+
+        let expectedUrl = URL(string: MSALNativeAuthNetworkStubs.authority.url.absoluteString + endpoint.rawValue)!
+        XCTAssertEqual(result?.url, expectedUrl)
+
+        XCTAssertEqual(result?.allHTTPHeaderFields?["return-client-request-id"], "true")
+        XCTAssertEqual(result?.allHTTPHeaderFields?["Accept"], "application/json")
+    }
+
+    private func checkServerTelemetry(_ result: MSIDHttpRequestServerTelemetryHandling?, expectedTelemetryResult: String) {
+        guard let serverTelemetry = result as? MSALNativeAuthServerTelemetry else {
+            return XCTFail("Server telemetry should be of kind MSALNativeAuthServerTelemetry")
+        }
+
+        XCTAssertEqual(serverTelemetry.context.correlationId().uuidString, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(serverTelemetry.currentRequestTelemetry.telemetryString(), expectedTelemetryResult)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthUrlRequestSerializerTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthUrlRequestSerializerTests.swift
@@ -1,0 +1,196 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthUrlRequestSerializerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthUrlRequestSerializer!
+    private var request: URLRequest!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let url = URL(string: DEFAULT_TEST_RESOURCE)!
+        request = URLRequest(url: url)
+
+        sut = MSALNativeAuthUrlRequestSerializer(context: MSALNativeAuthRequestContext(), encoding: .json)
+    }
+
+    func test_serialize_successfully() throws {
+        let parameters = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "grant_type": "passwordless_otp",
+            "email": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "password": "12345",
+            "scope": DEFAULT_TEST_SCOPE
+        ]
+
+        let headers = [
+            "custom-header": "value"
+        ]
+
+        let result = sut.serialize(with: request, parameters: parameters, headers: headers)
+
+        let bodyParametersResult = try JSONDecoder().decode([String: String].self, from: result.httpBody!)
+
+        XCTAssertEqual(bodyParametersResult.count, 5)
+        XCTAssertEqual(bodyParametersResult["client_id"], DEFAULT_TEST_CLIENT_ID)
+        XCTAssertEqual(bodyParametersResult["grant_type"], "passwordless_otp")
+        XCTAssertEqual(bodyParametersResult["email"], DEFAULT_TEST_ID_TOKEN_USERNAME)
+        XCTAssertEqual(bodyParametersResult["password"], "12345")
+        XCTAssertEqual(bodyParametersResult["scope"], DEFAULT_TEST_SCOPE)
+
+        let httpHeadersResult = result.allHTTPHeaderFields!
+
+        XCTAssertEqual(httpHeadersResult.count, 2)
+        XCTAssertEqual(httpHeadersResult["Content-Type"], "application/json")
+        XCTAssertEqual(httpHeadersResult["custom-header"], "value")
+    }
+
+    func test_serialize_with_dict_in_body() throws {
+        let customAttributes: [String: Codable] = [
+            "name": "John",
+            "surname": "Smith",
+            "age": "37"
+        ]
+
+        let parameters = [
+            "customAttributes": customAttributes
+        ]
+
+        let result = sut.serialize(with: request, parameters: parameters, headers: [:])
+
+        let bodyParametersResult = try JSONDecoder().decode([String: [String: String]].self, from: result.httpBody!)
+
+        XCTAssertEqual(bodyParametersResult.count, 1)
+        let resultCustomAttributes = bodyParametersResult["customAttributes"]!
+
+        XCTAssertEqual(resultCustomAttributes["name"], "John")
+        XCTAssertEqual(resultCustomAttributes["surname"], "Smith")
+        XCTAssertEqual(resultCustomAttributes["age"], "37")
+
+        let httpHeadersResult = result.allHTTPHeaderFields!
+
+        XCTAssertEqual(httpHeadersResult.count, 1)
+        XCTAssertEqual(httpHeadersResult["Content-Type"], "application/json")
+    }
+
+    func test_when_passingEmptyBodyParams_it_still_succeeds() throws {
+        let expectation = expectation(description: "Body request serialization error")
+        expectation.isInverted = true
+
+        Self.logger.expectation = expectation
+
+        let result = sut.serialize(with: request, parameters: [:], headers: [:])
+
+        wait(for: [expectation], timeout: 1)
+
+        let bodyParametersResult = try JSONDecoder().decode([String: [String: String]].self, from: result.httpBody!)
+        XCTAssertEqual(bodyParametersResult.count, 0)
+    }
+
+    func test_when_error_happens_in_headerSerialization_it_logs_it() throws {
+        let expectation = expectation(description: "Header serialization error")
+
+        Self.logger.expectation = expectation
+
+        _ = sut.serialize(with: request, parameters: [:], headers: ["header": 1])
+
+        wait(for: [expectation], timeout: 1)
+
+        let resultingLog = Self.logger.messages[0] as! String
+        XCTAssertTrue(resultingLog.contains("Header serialization failed"))
+    }
+
+    func test_when_error_happens_in_bodySerialization_it_logs_it() throws {
+        let expectation = expectation(description: "Body request serialization error")
+
+        Self.logger.expectation = expectation
+
+        let impossibleToEncode = [
+            "param": UIView()
+        ]
+
+        _ = sut.serialize(with: request, parameters: impossibleToEncode, headers: [:])
+
+        wait(for: [expectation], timeout: 1)
+
+        let resultingLog = Self.logger.messages[0] as! String
+        XCTAssertTrue(resultingLog.contains("HTTP body request serialization failed"))
+    }
+
+    func test_serializeUrlForm_successfully() {
+        let parameters = [
+            "clientId": DEFAULT_TEST_CLIENT_ID,
+            "grantType": "oob",
+            "email": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "password": "12345",
+            "scope": DEFAULT_TEST_SCOPE
+        ]
+
+        let headers = [
+            "custom-header": "value"
+        ]
+
+        sut = MSALNativeAuthUrlRequestSerializer(context: MSALNativeAuthRequestContext(), encoding: .wwwFormUrlEncoded)
+
+        let result = sut.serialize(with: request, parameters: parameters, headers: headers)
+        let bodyResultFormUrlEncoded = String(data: result.httpBody!, encoding: .utf8)
+
+        let expectedScope = "scope=https%3A%2F%2Fgraph.microsoft.com%2Fmail.read"
+        let expectedClientId = "clientId=\(DEFAULT_TEST_CLIENT_ID)"
+        let expectedGrantType = "grantType=oob"
+        let expectedEmail = "email=user%40contoso.com"
+        let expectedPassword = "password=12345"
+
+        let expectedBodyResult = "\(expectedScope)&\(expectedClientId)&\(expectedGrantType)&\(expectedEmail)&\(expectedPassword)"
+
+        XCTAssertEqual(bodyResultFormUrlEncoded?.sorted(), expectedBodyResult.sorted())
+
+        let httpHeadersResult = result.allHTTPHeaderFields!
+
+        XCTAssertEqual(httpHeadersResult.count, 2)
+        XCTAssertEqual(httpHeadersResult["Content-Type"], "application/x-www-form-urlencoded")
+        XCTAssertEqual(httpHeadersResult["custom-header"], "value")
+    }
+
+    func test_when_passingEmptyBodyParamsUsingUrlForm_it_still_succeeds() throws {
+        let expectation = expectation(description: "Body request serialization error")
+        expectation.isInverted = true
+
+        Self.logger.expectation = expectation
+
+        sut = MSALNativeAuthUrlRequestSerializer(context: MSALNativeAuthRequestContext(), encoding: .wwwFormUrlEncoded)
+
+        let result = sut.serialize(with: request, parameters: [:], headers: [:])
+
+        wait(for: [expectation], timeout: 1)
+
+        let bodyResultFormUrlEncoded = String(data: result.httpBody!, encoding: .utf8)!
+        XCTAssertTrue(bodyResultFormUrlEncoded.isEmpty)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
@@ -1,0 +1,662 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthResetPasswordResponseValidator!
+    private var context: MSIDRequestContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        sut = MSALNativeAuthResetPasswordResponseValidator()
+        context = MSALNativeAuthRequestContextMock()
+    }
+
+    // MARK: - Start Response
+
+    func test_whenResetPasswordStartSuccessResponseContainsRedirect_itReturnsRedirect() {
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .success(
+            .init(passwordResetToken: nil, challengeType: .redirect)
+        )
+
+        let result = sut.validate(response, with: context)
+        if case .redirect = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+
+    func test_whenResetPasswordStartSuccessResponseDoesNotContainsTokenOrRedirect_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .success(
+            .init(passwordResetToken: nil, challengeType: .otp)
+        )
+
+        let result = sut.validate(response, with: context)
+        if case .unexpectedError = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+
+    func test_whenResetPasswordStartSuccessResponseContainsToken_itReturnsSuccess() {
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .success(
+            .init(passwordResetToken: "passwordResetToken", challengeType: .otp)
+        )
+
+        let result = sut.validate(response, with: context)
+
+        guard case .success(let passwordResetToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(passwordResetToken, "passwordResetToken")
+    }
+
+    func test_whenResetPasswordStartErrorResponseIsNotExpected_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        if case .unexpectedError = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+
+    func test_whenResetPasswordStartErrorResponseUserNotFound_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .userNotFound)
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.userNotFound) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenResetPasswordStartErrorResponseInvalidClient_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .invalidClient)
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.invalidClient) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenResetPasswordStartErrorResponseUnsupportedChallengeType_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .unsupportedChallengeType)
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.unsupportedChallengeType) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenResetPasswordStartInvalidRequestUserDoesntHaveAPwd_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .invalidRequest, errorCodes: [500222])
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.userDoesNotHavePassword) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenResetPasswordStartInvalidRequestGenericErrorCode_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .invalidRequest, errorCodes: [90023])
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.invalidRequest) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenResetPasswordStartInvalidRequestNoErrorCode_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .invalidRequest)
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.invalidRequest) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+
+    // MARK: - Challenge Response
+
+    func test_whenResetPasswordChallengeSuccessResponseContainsRedirect_itReturnsRedirect() {
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .success(.init(
+            challengeType: .redirect,
+            bindingMethod: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            passwordResetToken: "token",
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .redirect)
+    }
+
+    func test_whenResetPasswordChallengeSuccessResponseContainsValidAttributesAndOOB_itReturnsSuccess() {
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .success(.init(
+            challengeType: .oob,
+            bindingMethod: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            passwordResetToken: "token",
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+
+        guard case .success(let sentTo, let channelTargetType, let codeLength, let passwordResetToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(sentTo, "challenge-type-label")
+        XCTAssertEqual(channelTargetType, .email)
+        XCTAssertEqual(codeLength, 6)
+        XCTAssertEqual(passwordResetToken, "token")
+    }
+
+    func test_whenResetPasswordChallengeSuccessResponseOmitsSomeAttributes_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .success(.init(
+            challengeType: .oob,
+            bindingMethod: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            passwordResetToken: nil,
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenResetPasswordChallengeSuccessResponseHasInvalidChallengeChannel_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .success(.init(
+            challengeType: .otp,
+            bindingMethod: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .none,
+            passwordResetToken: nil,
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenResetPasswordChallengeErrorResponseIsNotExpected_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenResetPasswordChallengeErrorResponseIsExpected_itReturnsError() {
+        let error = createResetPasswordChallengeError(error: .expiredToken)
+
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    // MARK: - Continue Response
+
+    func test_whenResetPasswordContinueSuccessResponseContainsValidAttributesAndOOB_itReturnsSuccess() {
+        let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .success(.init(passwordSubmitToken: "passwordSubmitToken", expiresIn: 300))
+
+        let result = sut.validate(response, with: context)
+
+        guard case .success(let passwordSubmitToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(passwordSubmitToken, "passwordSubmitToken")
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIsNotExpected_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_invalidOOBValue_itReturnsExpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidOOBValue)
+
+        XCTAssertEqual(result, .invalidOOB)
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_verificationRequired_itReturnsUnexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .verificationRequired)
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_invalidClient_itReturnsExpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidClient)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidClient = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_invalidGrant_itReturnsExpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidGrant)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidGrant = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_expiredToken_itReturnsExpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .expiredToken)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_invalidRequest_itReturnsExpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidRequest)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidRequest = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    // MARK: - Submit Response
+
+    func test_whenResetPasswordSubmitSuccessResponseContainsToken_itReturnsSuccess() {
+        let response: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = .success(.init(passwordResetToken: "passwordResetToken", pollInterval: 1))
+
+        let result = sut.validate(response, with: context)
+
+        guard case .success(let passwordResetToken, let pollInterval) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(passwordResetToken, "passwordResetToken")
+        XCTAssertEqual(pollInterval, 1)
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_passwordTooWeak_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .passwordTooWeak)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooWeak = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_passwordTooShort_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .passwordTooShort)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooShort = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_passwordTooLong_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .passwordTooLong)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooLong = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_passwordRecentlyUsed_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .passwordRecentlyUsed)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordRecentlyUsed = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_passwordBanned_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .passwordBanned)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordBanned = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_invalidRequest_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .invalidRequest)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidRequest = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_invalidClient_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .invalidClient)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidClient = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_expiredToken_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .expiredToken)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIsNotExpected_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    // MARK: - Poll Completion Response
+
+    func test_whenResetPasswordPollCompletionSuccessResponse_itReturnsSuccess() {
+        let response: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = .success(.init(status: .succeeded, signInSLT: nil, expiresIn: nil))
+
+        let result = sut.validate(response, with: context)
+
+        guard case .success(let status) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(status, .succeeded)
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsPasswordTooWeak_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .passwordTooWeak)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooWeak = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsPasswordTooShort_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .passwordTooShort)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooShort = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsPasswordTooLong_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .passwordTooLong)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooLong = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsPasswordRecentlyUsed_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .passwordRecentlyUsed)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordRecentlyUsed = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsPasswordBanned_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .passwordBanned)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordBanned = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsInvalidRequest_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .invalidRequest)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidRequest = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsInvalidClient_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .invalidClient)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidClient = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsExpiredToken_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .expiredToken)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsNotExpected_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    // MARK: - Helper methods
+
+    private func buildContinueErrorResponse(
+        expectedError: MSALNativeAuthResetPasswordContinueOauth2ErrorCode,
+        expectedPasswordResetToken: String? = nil
+    ) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
+        let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .failure(
+            createResetPasswordContinueError(
+                error: expectedError,
+                passwordResetToken: expectedPasswordResetToken
+            )
+        )
+
+        return sut.validate(response, with: context)
+    }
+
+    private func buildSubmitErrorResponse(
+        expectedError: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode
+    ) -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
+        let response: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = .failure(
+            createResetPasswordSubmitError(
+                error: expectedError
+            )
+        )
+
+        return sut.validate(response, with: context)
+    }
+
+    private func buildPollCompletionErrorResponse(
+        expectedError: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode
+    ) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
+        let response: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = .failure(
+            createResetPasswordPollCompletionError(
+                error: expectedError
+            )
+        )
+
+        return sut.validate(response, with: context)
+    }
+
+    private func createResetPasswordStartError(
+        error: MSALNativeAuthResetPasswordStartOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil
+    ) -> MSALNativeAuthResetPasswordStartResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target
+        )
+    }
+
+    private func createResetPasswordChallengeError(
+        error: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil
+    ) -> MSALNativeAuthResetPasswordChallengeResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target
+        )
+    }
+
+    private func createResetPasswordContinueError(
+        error: MSALNativeAuthResetPasswordContinueOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil,
+        passwordResetToken: String? = nil
+    ) -> MSALNativeAuthResetPasswordContinueResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target,
+            passwordResetToken: passwordResetToken
+        )
+    }
+
+    private func createResetPasswordSubmitError(
+        error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil
+    ) -> MSALNativeAuthResetPasswordSubmitResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target
+        )
+    }
+
+    private func createResetPasswordPollCompletionError(
+        error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil
+    ) -> MSALNativeAuthResetPasswordPollCompletionResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
@@ -1,0 +1,172 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
+
+    private let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    private var sut: MSALNativeAuthSignInResponseValidator!
+    private var defaultUUID = UUID(uuidString: DEFAULT_TEST_UID)!
+    private var factory: MSALNativeAuthResultFactoryMock!
+
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        factory =  MSALNativeAuthResultFactoryMock()
+        sut = MSALNativeAuthSignInResponseValidator()
+    }
+    
+    // MARK: challenge API tests
+    
+    func test_whenChallengeTypeRedirect_validationShouldReturnRedirectError() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: nil, challengeType: .redirect, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
+        let result = sut.validate(context: context, result: .success(challengeResponse))
+        if case .error(.redirect) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenChallengeTypePassword_validationShouldReturnPasswordRequired() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
+        let result = sut.validate(context: context, result: .success(challengeResponse))
+        if case .passwordRequired(credentialToken: credentialToken) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenChallengeTypePasswordAndNoCredentialToken_validationShouldFail() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: nil, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
+        let result = sut.validate(context: context, result: .success(challengeResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenChallengeTypeOOB_validationShouldReturnCodeRequired() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+        let targetLabel = "targetLabel"
+        let codeLength = 4
+        let channelType = MSALNativeAuthInternalChannelType.email
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
+        let result = sut.validate(context: context, result: .success(challengeResponse))
+        if case .codeRequired(credentialToken: credentialToken, sentTo: targetLabel, channelType: .email, codeLength: codeLength) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenChallengeTypeOOBButMissingAttributes_validationShouldFail() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+        let targetLabel = "targetLabel"
+        let codeLength = 4
+        let channelType = MSALNativeAuthInternalChannelType.email
+        let missingCredentialToken = MSALNativeAuthSignInChallengeResponse(credentialToken: nil, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
+        var result = sut.validate(context: context, result: .success(missingCredentialToken))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+        let missingTargetLabel = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: channelType, codeLength: codeLength, interval: nil)
+        result = sut.validate(context: context, result: .success(missingTargetLabel))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+        let missingChannelType = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: nil, codeLength: codeLength, interval: nil)
+        result = sut.validate(context: context, result: .success(missingChannelType))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+        let missingCodeLength = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: nil, interval: nil)
+        result = sut.validate(context: context, result: .success(missingCodeLength))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenChallengeTypeOTP_validationShouldFail() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: "something", challengeType: .otp, bindingMethod: nil, challengeTargetLabel: "some", challengeChannel: .email, codeLength: 2, interval: nil)
+        let result = sut.validate(context: context, result: .success(challengeResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    // MARK: initiate API tests
+    
+    func test_whenInitiateResponseIsValid_validationShouldBeSuccessful() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let credentialToken = "credentialToken"
+        let initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: credentialToken, challengeType: nil)
+        let result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .success(credentialToken: credentialToken) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenInitiateResponseIsInvalid_validationShouldFail() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: nil)
+        let result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenInitiateChallengeTypeIsRedirect_validationShouldReturnRedirectError() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .redirect)
+        let result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .error(.redirect) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenInitiateChallengeTypeIsInvalid_validationShouldFail() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        var initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .oob)
+        var result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+        initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .otp)
+        result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+        initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .password)
+        result = sut.validate(context: context, result: .success(initiateResponse))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
@@ -1,0 +1,742 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthSignUpResponseValidator!
+    private var context: MSIDRequestContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        sut = MSALNativeAuthSignUpResponseValidator()
+        context = MSALNativeAuthRequestContextMock()
+    }
+
+    // MARK: - Start Response
+
+    func test_whenSignUpStartSuccessResponseContainsRedirect_it_returns_redirect() {
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .success(
+            .init(signupToken: nil, challengeType: .redirect)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .redirect)
+    }
+
+    func test_whenSignUpStartSuccessResponseDoesNotContainsTokenOrRedirect_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .success(
+            .init(signupToken: nil, challengeType: .otp)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStartErrorResponseIsNotExpected_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_verificationRequiredErrorWithSignUpTokenAndUnverifiedAttributes_it_returns_verificationRequired() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            signUpToken: "sign-up token",
+            unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes(name: "username")]
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+
+        guard case .verificationRequired(let signUpToken, let unverifiedAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up token")
+        XCTAssertEqual(unverifiedAttributes.first, "username")
+    }
+
+    func test_whenSignUpStart_verificationRequiredErrorWithSignUpToken_but_unverifiedAttributesIsEmpty_it_returns_unexpectedError() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            signUpToken: "sign-up token",
+            unverifiedAttributes: []
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_verificationRequiredErrorWithSignUpToken_but_unverifiedAttributesIsNil_it_returns_unexpectedError() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            signUpToken: "sign-up token",
+            unverifiedAttributes: nil
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_attributeValidationFailedWithSignUpTokenAndInvalidAttributes_it_returns_attributeValidationFailed() {
+        let error = createSignUpStartError(
+            error: .attributeValidationFailed,
+            invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "city")]
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+
+        guard case .attributeValidationFailed(let invalidAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(invalidAttributes.first, "city")
+    }
+
+    func test_whenSignUpStart_attributeValidationFailedWithSignUpToken_but_invalidAttributesIsEmpty_it_returns_attributeValidationFailed() {
+        let error = createSignUpStartError(
+            error: .attributeValidationFailed,
+            invalidAttributes: []
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_attributeValidationFailedWithSignUpToken_but_invalidAttributesIsNil_it_returns_attributeValidationFailed() {
+        let error = createSignUpStartError(
+            error: .verificationRequired,
+            invalidAttributes: nil
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStart_expectedVerificationRequiredErrorWithoutSignUpToken_it_returns_unexpectedError() {
+        let error = createSignUpStartError(error: .verificationRequired, signUpToken: nil)
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpStartErrorResponseIsExpected_it_returns_error() {
+        let error = createSignUpStartError(error: .userAlreadyExists)
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .userAlreadyExists = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpStartErrorResponseIs_invalidRequestWithInvalidUsernameErrorDescription_it_returns_expectedError() {
+        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidRequestParameter.rawValue, Int.max]
+
+        let apiError = createSignUpStartError(
+            error: .invalidRequest,
+            errorDescription: "username parameter is empty or not valid",
+            errorCodes: errorCodes,
+            errorURI: "aURI",
+            signUpToken: "aToken",
+            unverifiedAttributes: attributes,
+            invalidAttributes: attributes
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(apiError)
+
+        let result = sut.validate(response, with: context)
+        guard case .invalidUsername(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(error as MSALNativeAuthSignUpStartResponseError, apiError)
+    }
+    
+    func test_whenSignUpStartErrorResponseIs_invalidRequestWithInvalidClientIdErrorDescription_it_returns_expectedError() {
+        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidRequestParameter.rawValue, Int.max]
+        
+        let apiError = createSignUpStartError(
+            error: .invalidRequest,
+            errorDescription: "client_id parameter is empty or not valid",
+            errorCodes: errorCodes,
+            errorURI: "aURI",
+            signUpToken: "aToken",
+            unverifiedAttributes: attributes,
+            invalidAttributes: attributes
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(apiError)
+        
+        let result = sut.validate(response, with: context)
+        guard case .invalidClientId(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        
+        XCTAssertEqual(error as MSALNativeAuthSignUpStartResponseError, apiError)
+    }
+
+    func test_whenSignUpStartErrorResponseIs_invalidRequestWithGenericErrorCode_it_returns_expectedError() {
+        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let errorCodes = [Int.max]
+
+        let apiError = createSignUpStartError(
+            error: .invalidRequest,
+            errorDescription: "aDescription",
+            errorCodes: errorCodes,
+            errorURI: "aURI",
+            signUpToken: "aToken",
+            unverifiedAttributes: attributes,
+            invalidAttributes: attributes
+        )
+        let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(apiError)
+
+        let result = sut.validate(response, with: context)
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        let resultError = error as MSALNativeAuthSignUpStartResponseError
+        XCTAssertEqual(resultError.error, .invalidRequest)
+        XCTAssertEqual(resultError.errorDescription, "aDescription")
+        XCTAssertEqual(resultError.errorCodes, errorCodes)
+        XCTAssertEqual(resultError.errorURI, "aURI")
+        XCTAssertEqual(resultError.signUpToken, "aToken")
+        XCTAssertEqual(resultError.unverifiedAttributes, attributes)
+        XCTAssertEqual(resultError.invalidAttributes, attributes)
+    }
+
+    // MARK: - Challenge Response
+
+    func test_whenSignUpChallengeSuccessResponseDoesNotContainChallengeType_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: nil,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: "token",
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsRedirect_it_returns_redirect() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .redirect,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: "token",
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .redirect)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndOOB_it_returns_success() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .oob,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            signUpToken: "token",
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+
+        guard case .codeRequired(let displayName, let displayType, let codeLength, let signUpToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(displayName, "challenge-type-label")
+        XCTAssertEqual(displayType, .email)
+        XCTAssertEqual(codeLength, 6)
+        XCTAssertEqual(signUpToken, "token")
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndPassword_it_returns_success() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .password,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            signUpToken: "token",
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+
+        guard case .passwordRequired(let signUpToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "token")
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsPassword_but_noToken_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .password,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            signUpToken: nil,
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndOTP_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .otp,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: "token",
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeSuccessResponseOmitsSomeAttributes_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
+            challengeType: .oob,
+            bindingMethod: nil,
+            interval: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: nil,
+            signUpToken: nil,
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeErrorResponseIsNotExpected_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpChallengeErrorResponseIsExpected_it_returns_error() {
+        let error = createSignUpChallengeError(error: .expiredToken)
+
+        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    // MARK: - Continue Response
+
+    func test_whenSignUpStartSuccessResponseContainsSLT_it_returns_success() {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .success(
+            .init(signinSLT: "<signin_slt>", expiresIn: nil, signupToken: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .success("<signin_slt>"))
+    }
+
+    func test_whenSignUpStartSuccessResponseButDoesNotContainSLT_it_returns_successWithNoSLT() throws {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .success(
+            .init(signinSLT: nil, expiresIn: nil, signupToken: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .success(nil))
+    }
+
+    func test_whenSignUpContinueErrorResponseIsNotExpected_it_returns_unexpectedError() {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_invalidOOBValue_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidOOBValue, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidOOBValue = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordTooWeak_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordTooWeak, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooWeak = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordTooShort_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordTooShort, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooShort = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordTooLong_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordTooLong, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooLong = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordRecentlyUsed_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordRecentlyUsed, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordRecentlyUsed = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_passwordBanned_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .passwordBanned, expectedSignUpToken: "sign-up-token")
+
+        guard case .invalidUserInput(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordBanned = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, expectedSignUpToken: "sign-up-token", invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "email")])
+
+        guard case .attributeValidationFailed(let signUpToken, let invalidAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up-token")
+        XCTAssertEqual(invalidAttributes.first, "email")
+    }
+    
+    func test_whenSignUpContinueErrorResponseIs_invalidRequestWithInvalidOTPErrorCode_it_returns_expectedError() {
+        let signUpToken = "sign-up-token"
+        var errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidOTP.rawValue, Int.max]
+        var result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        checkInvalidOOBValue()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.incorrectOTP.rawValue]
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        checkInvalidOOBValue()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.OTPNoCacheEntryForUser.rawValue]
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        checkInvalidOOBValue()
+        func checkInvalidOOBValue() {
+            guard case .invalidUserInput(let error) = result else {
+                return XCTFail("Unexpected response")
+            }
+            if case .invalidOOBValue = error.error {} else {
+                XCTFail("Unexpected error: \(error.error)")
+            }
+            XCTAssertNil(error.errorDescription)
+            XCTAssertNil(error.errorURI)
+            XCTAssertNil(error.innerErrors)
+            XCTAssertEqual(error.signUpToken, signUpToken)
+            XCTAssertNil(error.requiredAttributes)
+            XCTAssertNil(error.unverifiedAttributes)
+            XCTAssertNil(error.invalidAttributes)
+            XCTAssertEqual(error.errorCodes, errorCodes)
+        }
+    }
+    
+    func test_whenSignUpContinueErrorResponseIs_invalidRequestWithGenericErrorCode_it_returns_expectedError() {
+        var result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue])
+        checkValidatedErrorResult()
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [Int.max])
+        checkValidatedErrorResult()
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [MSALNativeAuthESTSApiErrorCodes.userNotHaveAPassword.rawValue])
+        checkValidatedErrorResult()
+        func checkValidatedErrorResult() {
+            guard case .error(let error) = result else {
+                return XCTFail("Unexpected response")
+            }
+            if case .invalidRequest = error.error {} else {
+                XCTFail("Unexpected error: \(error.error)")
+            }
+        }
+    }
+    
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_signUpTokenIsNil_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, expectedSignUpToken: nil, invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "email")])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_invalidAttributesIsNil_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, invalidAttributes: nil)
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_invalidAttributesIsEmpty_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, invalidAttributes: [])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_credentialRequired_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedSignUpToken: "sign-up-token")
+
+        guard case .credentialRequired(let signUpToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up-token")
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_credentialRequired_but_signUpToken_isNil_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedSignUpToken: nil)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
+
+        guard case .attributesRequired(let signUpToken, let requiredAttributes) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(signUpToken, "sign-up-token")
+        XCTAssertEqual(requiredAttributes.count, 2)
+        XCTAssertEqual(requiredAttributes[0].name, "email")
+        XCTAssertEqual(requiredAttributes[1].name, "city")
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_signUpToken_IsNil_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: nil, requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_requiredAttributesIsNil_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: nil)
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_requiredAttributes_IsEmpty_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: [])
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_verificationRequired_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_unauthorizedClient_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .unauthorizedClient)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .unauthorizedClient = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_invalidGrant_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidGrant)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidGrant = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_expiredToken_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .expiredToken)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_invalidRequest_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidRequest)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidRequest = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenSignUpContinueErrorResponseIs_userAlreadyExists_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .userAlreadyExists)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .userAlreadyExists = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    private func buildContinueErrorResponse(
+        expectedError: MSALNativeAuthSignUpContinueOauth2ErrorCode,
+        expectedSignUpToken: String? = nil,
+        requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
+        errorCodes: [Int]? = nil
+    ) -> MSALNativeAuthSignUpContinueValidatedResponse {
+        let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .failure(
+            createSignUpContinueError(
+                error: expectedError,
+                errorCodes: errorCodes,
+                signUpToken: expectedSignUpToken,
+                requiredAttributes: requiredAttributes,
+                invalidAttributes: invalidAttributes
+            )
+        )
+
+        return sut.validate(response, with: context)
+    }
+
+    private func createSignUpStartError(
+        error: MSALNativeAuthSignUpStartOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        signUpToken: String? = nil,
+        unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil
+    ) -> MSALNativeAuthSignUpStartResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            signUpToken: signUpToken,
+            unverifiedAttributes: unverifiedAttributes,
+            invalidAttributes: invalidAttributes
+        )
+    }
+
+    private func createSignUpChallengeError(
+        error: MSALNativeAuthSignUpChallengeOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil
+    ) -> MSALNativeAuthSignUpChallengeResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors
+        )
+    }
+
+    private func createSignUpContinueError(
+        error: MSALNativeAuthSignUpContinueOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        signUpToken: String? = nil,
+        requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]? = nil,
+        unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil
+    ) -> MSALNativeAuthSignUpContinueResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            signUpToken: signUpToken,
+            requiredAttributes: requiredAttributes,
+            unverifiedAttributes: unverifiedAttributes,
+            invalidAttributes: invalidAttributes
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
@@ -1,0 +1,255 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
+
+    private let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    private var sut: MSALNativeAuthTokenResponseValidator!
+    private var defaultUUID = UUID(uuidString: DEFAULT_TEST_UID)!
+    private var tokenResponse = MSIDTokenResponse()
+    private var factory: MSALNativeAuthResultFactoryMock!
+    private var context: MSALNativeAuthRequestContext!
+
+    private let accountIdentifier = MSIDAccountIdentifier(displayableId: "aDisplayableId", homeAccountId: "home.account.id")!
+    private let configuration = MSIDConfiguration()
+
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        factory =  MSALNativeAuthResultFactoryMock()
+        sut = MSALNativeAuthTokenResponseValidator(factory: factory, msidValidator: MSIDDefaultTokenResponseValidator())
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+    }
+    
+    // MARK: token API tests
+
+    func test_whenValidTokenResponse_validationIsSuccessful() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let userAccountResult = MSALNativeAuthUserAccountResult(account:
+                                                                    MSALNativeAuthUserAccountResultStub.account,
+                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
+                                                                                                 refreshToken: nil,
+                                                                                                 rawIdToken: nil),
+                                                                configuration: MSALNativeAuthConfigStubs.configuration,
+                                                                cacheAccessor: MSALNativeAuthCacheAccessorMock())
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.familyId = "familyId"
+        refreshToken.refreshToken = "refreshToken"
+        let tokenResponse = MSIDCIAMTokenResponse()
+        factory.mockMakeUserAccountResult(userAccountResult)
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .success(tokenResponse))
+        if case .success(tokenResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenInvalidErrorTokenResponse_anErrorIsReturned() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(MSALNativeAuthInternalError.headerNotSerialized))
+        if case .error(.invalidServerResponse) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+
+    func test_invalidGrantTokenResponse_withSeveralUnknownErrorCodes_isProperlyHandled() {
+        let unknownErrorCode1 = Int.max
+        let unknownErrorCode2 = unknownErrorCode1 - 1
+
+        let errorCodes: [Int] = [unknownErrorCode1, unknownErrorCode2]
+
+        let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: nil, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+        
+        guard case .error(let innerError) = result else {
+            return XCTFail("Unexpected response")
+        }
+        
+        if case .generalError = innerError {} else {
+            XCTFail("Unexpected Error")
+        }
+    }
+    
+    func test_invalidClient_isProperlyHandled() {
+        let error = MSALNativeAuthTokenResponseError(error: .invalidClient, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+        
+        guard case .error(let innerError) = result else {
+            return XCTFail("Unexpected response")
+        }
+        
+        if case .invalidClient(message: nil) = innerError {} else {
+            XCTFail("Unexpected Error")
+        }
+    }
+    
+    func test_unauthorizedClient_isProperlyHandled() {
+        let error = MSALNativeAuthTokenResponseError(error: .unauthorizedClient, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+        
+        guard case .error(let innerError) = result else {
+            return XCTFail("Unexpected response")
+        }
+        
+        if case .invalidClient(message: nil) = innerError {} else {
+            XCTFail("Unexpected Error")
+        }
+    }
+    
+
+    func test_invalidGrantTokenResponse_withKnownError_andSeveralUnknownErrorCodes_isProperlyHandled() {
+        let description = "description"
+        let unknownErrorCode1 = Int.max
+        let unknownErrorCode2 = unknownErrorCode1 - 1
+
+        var errorCodes: [Int] = [MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .userNotFound(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidOTP.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .invalidOOBCode(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.incorrectOTP.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .invalidOOBCode(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.OTPNoCacheEntryForUser.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .invalidOOBCode(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .strongAuthRequired(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .strongAuthRequired(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidCredentials.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .invalidPassword(message: description) = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.userNotHaveAPassword.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .generalError = checkErrorCodes() else {
+            return XCTFail("Unexpected Error")
+        }
+        func checkErrorCodes() -> MSALNativeAuthTokenValidatedErrorType? {
+            let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+            
+            let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+            
+            guard case .error(let innerError) = result else {
+                return nil
+            }
+            return innerError
+        }
+    }
+
+    func test_invalidGrantTokenResponse_withUnknownErrorCode_andKnownErrorCodes_isProperlyHandled() {
+        let knownErrorCode = MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue
+        let unknownErrorCode1 = Int.max
+        let unknownErrorCode2 = unknownErrorCode1 - 1
+
+        // We only check for the first error, if it's unknown, we return .generalError
+
+        let errorCodes: [Int] = [unknownErrorCode1, knownErrorCode, unknownErrorCode2]
+
+        let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: nil, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+        
+        guard case .error(let innerError) = result else {
+            return XCTFail("Unexpected response")
+        }
+        
+        if case .generalError = innerError {} else {
+            XCTFail("Unexpected Error")
+        }
+    }
+    
+    func test_invalidRequesTokenResponse_withOTPErrorCodes_isTranslatedToInvalidCode() {
+        let unknownErrorCode1 = Int.max
+        var errorCodes: [Int] = [MSALNativeAuthESTSApiErrorCodes.invalidOTP.rawValue, unknownErrorCode1]
+        checkErrorCodes()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.incorrectOTP.rawValue, unknownErrorCode1]
+        checkErrorCodes()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.OTPNoCacheEntryForUser.rawValue, unknownErrorCode1]
+        checkErrorCodes()
+        func checkErrorCodes() {
+            let description = "description"
+            let error = MSALNativeAuthTokenResponseError(error: .invalidRequest, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+            
+            let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+            let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+            
+            guard case .error(let innerError) = result else {
+                return XCTFail("Unexpected response")
+            }
+            
+            guard case .invalidOOBCode(message: description) = innerError else {
+                return XCTFail("Unexpected Error")
+            }
+        }
+    }
+    
+    func test_invalidRequesTokenResponse_withGenericErrorCode_isTranslatedToGeneralError() {
+        let description = "description"
+        let unknownErrorCode1 = Int.max
+        var errorCodes: [Int] = [unknownErrorCode1]
+        checkErrorCodes()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue]
+        checkErrorCodes()
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue]
+        checkErrorCodes()
+        func checkErrorCodes() {
+            let error = MSALNativeAuthTokenResponseError(error: .invalidRequest, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+            
+            let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+            let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+            
+            guard case .error(let innerError) = result else {
+                return XCTFail("Unexpected response")
+            }
+            
+            guard case .invalidRequest(message: description) = innerError else {
+                return XCTFail("Unexpected Error")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR shows the SDK that the CIAM team had developed. It is based on the Native Auth merge into MSAL plan here: https://microsofteur.sharepoint.com/:w:/t/DevExDublin/EdfT2AmlFZFIsTtr-EaoSBIBPqcOlRo1MJ1USbEsfjfEcQ

To comply with the design changes made by our API team, we have created a more dynamic SDK. This means that we make different API requests for each authentication flow. There is also some logic involved in each of the responses we get from each request.

We have created a state machine for each flow (check this [Figma](https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0%3A1&t=VUyK4gIoyUChTXWF-1) to see all the possible states), and we are making it external to developers by using delegates instead of completion blocks, as @Serhii Demchenko suggested. In this way we can guide the developer through the authentication process offering a discovering interface. We think that this approach will improve the overall developer experience.

**This PR is focused in the Native Auth base classes that interact with MSAL Objective-C, and their unit tests for:**
**- network**
 **It is not compilable, so tests are not going to run. To build and test this code, please use the `ciam-master-snapshot` branch.**

The IdentityCore changes can be found in this PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1294

**For context, this is the Native Auth technical overview:** https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview?path=/%5BiOS%5D%20Native%20authentication/technical_overview.md&version=GBdanilo/native-authentication&_a=preview

State Machine:
https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0-1&mode=design&t=80VUxa1RvxMn4rnl-0

## Native Auth general high level overview

**MSALNativeAuthPublicClientApplication.swift**
The public interface is the entry point of the SDK. Here is where all the supported authentication flows begin.
Regarding the sign-up flow, developers can call either `signUp(...)` or `signUpUsingPassword(...)`.
Notice that in those methods they must pass a class that conforms to `SignUpStartDelegate`. or `SignUpPasswordStartDelegate`, respectively.


**MSALNativeAuthSignUpController.swift**
The controller handles most of the logic. Each of the methods inside the MARK: - Internal can be called from the public interfaces, that are:
    - MSALNativeAuthPublicClientApplication
    - One of the States (located in the file SignUpDelegates.swift). These States are returned through the delegates, as we will see.

For each of these methods, the controller:
    - Creates a request (`MSIDHttpRequest`) using its requestProvider (`MSALNativeAuthSignUpRequestProviding`).
    - Executes the request.
    - Passes the result to its responseValidator (`MSALNativeAuthSignUpResponseValidating`)
    - Handles the validated result and returns it to the public interface, which uses the delegate to communicate back to the developer.
    - Creates and handle the local telemetry events.

The controller decides what to do with the ValidatedResponse given by the ResponseValidator.

Every validated response usually has:
**A success:** it means that the SDK moves on to the next state, which usually involves making another request or returning back to the user via the delegate.
Redirect: when the backend detects an error and wants the SDK to fallback to the WebView-based flow.
**A known error:** in some cases, these errors put the user in a recoverable state (for example, an error that requires the user to provide more attributes). In other cases, the error means the end of the flow.
**An unexpected error:** these errors are likely bugs, they happen when we there are missing attributes from the response, etc.
(Please keep in mind that not every ValidatedResponse falls into the same categories, this is just an approximation)


**MSALNativeAuthRequestConfigurator.swift**
Each of the requestProviders from the Controllers uses the RequestConfigurator to create and configure the requests. Although there are different RequestProviders (one per flow), there's only one RequestConfigurator.

The RequestConfigurator injects a custom ErrorHandler (`MSALNativeAuthResponseErrorHandler`) to every request. This is needed in order to decode the errors from the API.
These errors follow a structure that you can see in `MSALNativeAuth(SignUp/SignIn/PasswordReset)StartResponseError` for example. In the directory native_auth/network/errors/ you can see all the files used.


**MSALNativeAuth(SignUp/SignIn/PasswordReset)ResponseValidator.swift**
The ResponseValidator is in charge of analysing the api response and returning to the Controller a validated response (for instance, for the response of the (SignUp/SignIn/PasswordReset)/start endpoint, it returns a `MSALNativeAuth(SignUp/SignIn/PasswordReset)StartValidatedResponse`).


**SignUp/SignIn/PasswordReset)States.swift**
In this file there are the different States that the Controller can return to the developer through the delegate.

This is how the developer will use them. For more examples of how developers can use the SDK you can check the Sample App (located in /Samples/ios-native-auth-simple in the branch `ciam-master-snapshot`). We will include it in a separate PR:

extension EmailAndPasswordViewController: SignUpPasswordStartDelegate {

    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState,
                                                      sentTo _: String,
                                                      channelTargetType _: MSAL.MSALNativeAuthChannelType,
                                                      codeLength _: Int) {

           // show UI to get the user's email OOB code, and wait for user's input
           // then, use the newState to send it to the SDK.
           newState.submitCode(code: code, delegate: self)
    }
}

Each of these states then calls one of the Controller's internal functions, and it follows the same process that we just described in the previous steps.

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

