### PR TITLE
Native Auth Password Reset

### DIFF
--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -1,0 +1,537 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
+final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController, MSALNativeAuthResetPasswordControlling {
+    private let kNumberOfTimesToRetryPollCompletionCall = 5
+
+    private let requestProvider: MSALNativeAuthResetPasswordRequestProviding
+    private let responseValidator: MSALNativeAuthResetPasswordResponseValidating
+
+    init(
+        config: MSALNativeAuthConfiguration,
+        requestProvider: MSALNativeAuthResetPasswordRequestProviding,
+        responseValidator: MSALNativeAuthResetPasswordResponseValidating
+    ) {
+        self.requestProvider = requestProvider
+        self.responseValidator = responseValidator
+
+        super.init(clientId: config.clientId)
+    }
+
+    convenience init(config: MSALNativeAuthConfiguration) {
+        self.init(
+            config: config,
+            requestProvider: MSALNativeAuthResetPasswordRequestProvider(
+                requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+                telemetryProvider: MSALNativeAuthTelemetryProvider()
+            ),
+            responseValidator: MSALNativeAuthResetPasswordResponseValidator()
+        )
+    }
+
+    // MARK: - Internal interface methods
+
+    func resetPassword(parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordStart, context: parameters.context)
+        let response = await performStartRequest(parameters: parameters)
+        return await handleStartResponse(response, event: event, context: parameters.context)
+    }
+
+    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordResendCode, context: context)
+        let response = await performChallengeRequest(passwordResetToken: passwordResetToken, context: context)
+        return await handleResendCodeChallengeResponse(response, event: event, context: context)
+    }
+
+    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordVerifyCodeResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordSubmitCode, context: context)
+
+        let params = MSALNativeAuthResetPasswordContinueRequestParameters(
+            context: context,
+            passwordResetToken: passwordResetToken,
+            grantType: .oobCode,
+            oobCode: code
+        )
+
+        let response = await performContinueRequest(parameters: params)
+        return await handleSubmitCodeResponse(response, passwordResetToken: passwordResetToken, event: event, context: context)
+    }
+
+    func submitPassword(
+        password: String,
+        passwordSubmitToken: String,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult {
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordSubmit, context: context)
+
+        let params = MSALNativeAuthResetPasswordSubmitRequestParameters(
+            context: context,
+            passwordSubmitToken: passwordSubmitToken,
+            newPassword: password
+        )
+        let submitRequestResponse = await performSubmitRequest(parameters: params)
+        return await handleSubmitPasswordResponse(submitRequestResponse, passwordSubmitToken: passwordSubmitToken, event: event, context: context)
+    }
+
+    // MARK: - Start Request handling
+
+    private func performStartRequest(
+        parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters
+    ) async -> MSALNativeAuthResetPasswordStartValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.start(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error creating resetpassword/start request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing resetpassword/start request")
+
+        let result: Result<MSALNativeAuthResetPasswordStartResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(result, with: parameters.context)
+    }
+
+    private func handleStartResponse(_ response: MSALNativeAuthResetPasswordStartValidatedResponse,
+                                     event: MSIDTelemetryAPIEvent?,
+                                     context: MSIDRequestContext) async -> ResetPasswordStartResult {
+
+        MSALLogger.log(level: .verbose, context: context, format: "Finished resetpassword/start request")
+
+        switch response {
+        case .success(let passwordResetToken):
+            let challengeResponse = await performChallengeRequest(passwordResetToken: passwordResetToken, context: context)
+            return await handleChallengeResponse(challengeResponse, event: event, context: context)
+        case .redirect:
+            let error = ResetPasswordStartError(type: .browserRequired, message: MSALNativeAuthErrorMessage.browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "redirect error in resetpassword/start request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        case .error(let apiError):
+            let error = apiError.toResetPasswordStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in resetpassword/start request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        case .unexpectedError:
+            let error = ResetPasswordStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in resetpassword/start request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        }
+    }
+
+    // MARK: - Challenge Request handling
+
+    private func performChallengeRequest(
+        passwordResetToken: String,
+        context: MSIDRequestContext
+    ) async -> MSALNativeAuthResetPasswordChallengeValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.challenge(token: passwordResetToken, context: context)
+        } catch {
+            MSALLogger.log(level: .error, context: context, format: "Error creating Challenge Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: context, format: "Performing resetpassword/challenge request")
+
+        let result: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = await performRequest(request, context: context)
+        return responseValidator.validate(result, with: context)
+    }
+
+    private func handleChallengeResponse(
+        _ response: MSALNativeAuthResetPasswordChallengeValidatedResponse,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordStartResult {
+        switch response {
+        case .success(let sentTo, let channelTargetType, let codeLength, let challengeToken):
+            MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/challenge request")
+            stopTelemetryEvent(event, context: context)
+
+            return .codeRequired(
+                newState: ResetPasswordCodeRequiredState(controller: self, flowToken: challengeToken),
+                sentTo: sentTo,
+                channelTargetType: channelTargetType,
+                codeLength: codeLength
+            )
+        case .error(let apiError):
+            let error = apiError.toResetPasswordStartPublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        case .redirect:
+            let error = ResetPasswordStartError(type: .browserRequired, message: MSALNativeAuthErrorMessage.browserRequired)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Redirect error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        case .unexpectedError:
+            let error = ResetPasswordStartError(type: .generalError)
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Unexpected error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
+            return .error(error)
+        }
+    }
+
+    private func handleResendCodeChallengeResponse(
+        _ response: MSALNativeAuthResetPasswordChallengeValidatedResponse,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordResendCodeResult {
+        switch response {
+        case .success(let sentTo, let channelTargetType, let codeLength, let challengeToken):
+            stopTelemetryEvent(event, context: context)
+            MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/challenge (resend code) request")
+            return .codeRequired(
+                newState: ResetPasswordCodeRequiredState(controller: self, flowToken: challengeToken),
+                sentTo: sentTo,
+                channelTargetType: channelTargetType,
+                codeLength: codeLength
+            )
+        case .error(let apiError):
+            let error = apiError.toResendCodePublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in resetpassword/challenge request (resend code) \(error.errorDescription ?? "No error description")")
+            return .error(error: error, newState: nil)
+        case .redirect,
+                .unexpectedError:
+            let error = ResendCodeError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in resetpassword/challenge request (resend code) \(error.errorDescription ?? "No error description")")
+            return .error(error: error, newState: nil)
+        }
+    }
+
+    // MARK: - Continue Request handling
+
+    private func performContinueRequest(
+        parameters: MSALNativeAuthResetPasswordContinueRequestParameters
+    ) async -> MSALNativeAuthResetPasswordContinueValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.continue(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error creating Continue Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing resetpassword/continue request")
+
+        let result: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(result, with: parameters.context)
+    }
+
+    private func handleSubmitCodeResponse(
+        _ response: MSALNativeAuthResetPasswordContinueValidatedResponse,
+        passwordResetToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordVerifyCodeResult {
+        switch response {
+        case .success(let passwordSubmitToken):
+            stopTelemetryEvent(event, context: context)
+            MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/continue request")
+            return .passwordRequired(newState: ResetPasswordRequiredState(controller: self, flowToken: passwordSubmitToken))
+        case .error(let apiError):
+            let error = apiError.toVerifyCodePublicError()
+            stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error in resetpassword/continue request \(error.errorDescription ?? "No error description")")
+            return .error(error: error, newState: nil)
+        case .unexpectedError:
+            let error = VerifyCodeError(type: .generalError)
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error calling resetpassword/continue \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: nil)
+        case .invalidOOB:
+            let error = VerifyCodeError(type: .invalidCode)
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Invalid code error calling resetpassword/continue \(error.errorDescription ?? "No error description")")
+
+            let state = ResetPasswordCodeRequiredState(controller: self, flowToken: passwordResetToken)
+            return .error(error: error, newState: state)
+        }
+    }
+
+    // MARK: - Submit Request handling
+
+    private func performSubmitRequest(
+        parameters: MSALNativeAuthResetPasswordSubmitRequestParameters
+    ) async -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.submit(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error creating Submit Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing resetpassword/submit request")
+
+        let result: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = await performRequest(request, context: parameters.context)
+        return responseValidator.validate(result, with: parameters.context)
+    }
+
+    private func handleSubmitPasswordResponse(
+        _ response: MSALNativeAuthResetPasswordSubmitValidatedResponse,
+        passwordSubmitToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult {
+        MSALLogger.log(level: .info, context: context, format: "Finished resetpassword/submit request")
+
+        switch response {
+        case .success(let passwordResetToken, let pollInterval):
+            return await doPollCompletionLoop(
+                passwordResetToken: passwordResetToken,
+                pollInterval: pollInterval,
+                retriesRemaining: kNumberOfTimesToRetryPollCompletionCall,
+                event: event,
+                context: context
+            )
+        case .passwordError(let apiError):
+            let error = apiError.toPasswordRequiredPublicError()
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Password error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: ResetPasswordRequiredState(controller: self, flowToken: passwordSubmitToken))
+        case .error(let apiError):
+            let error = apiError.toPasswordRequiredPublicError()
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: nil)
+        case .unexpectedError:
+            let error = PasswordRequiredError(type: .generalError)
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: nil)
+        }
+    }
+
+    // MARK: - Poll Completion Request handling
+
+    private func doPollCompletionLoop(
+        passwordResetToken: String,
+        pollInterval: Int,
+        retriesRemaining: Int,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult {
+        MSALLogger.log(level: .verbose, context: context, format: "performing poll completion request...")
+
+        let pollCompletionResponse = await performPollCompletionRequest(
+            passwordResetToken: passwordResetToken,
+            context: context
+        )
+
+        MSALLogger.log(level: .verbose, context: context, format: "handling poll completion response...")
+
+        return await handlePollCompletionResponse(
+            pollCompletionResponse,
+            pollInterval: pollInterval,
+            retriesRemaining: retriesRemaining,
+            passwordResetToken: passwordResetToken,
+            event: event,
+            context: context
+        )
+    }
+
+    private func performPollCompletionRequest(
+        passwordResetToken: String,
+        context: MSIDRequestContext
+    ) async -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
+        let parameters = MSALNativeAuthResetPasswordPollCompletionRequestParameters(
+            context: context,
+            passwordResetToken: passwordResetToken
+        )
+        let request: MSIDHttpRequest
+
+        do {
+            request = try requestProvider.pollCompletion(parameters: parameters)
+        } catch {
+            MSALLogger.log(level: .error, context: parameters.context, format: "Error creating Poll Completion Request: \(error)")
+            return .unexpectedError
+        }
+
+        MSALLogger.log(level: .info, context: parameters.context, format: "Performing resetpassword/poll_completion request")
+
+        let result: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = await performRequest(
+            request,
+            context: parameters.context
+        )
+        return responseValidator.validate(result, with: parameters.context)
+    }
+
+    private func handlePollCompletionResponse(
+        _ response: MSALNativeAuthResetPasswordPollCompletionValidatedResponse,
+        pollInterval: Int,
+        retriesRemaining: Int,
+        passwordResetToken: String,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult {
+        MSALLogger.log(level: .info, context: context, format: "Finished resetpassword/poll_completion")
+
+        switch response {
+        case .success(let status):
+            switch status {
+            case .inProgress,
+                 .notStarted:
+
+                return await retryPollCompletion(
+                    passwordResetToken: passwordResetToken,
+                    pollInterval: pollInterval,
+                    retriesRemaining: retriesRemaining,
+                    event: event,
+                    context: context
+                )
+            case .succeeded:
+                stopTelemetryEvent(event, context: context)
+
+                return .completed
+            case .failed:
+                let error = PasswordRequiredError(type: .generalError)
+                self.stopTelemetryEvent(event, context: context, error: error)
+                MSALLogger.log(level: .error, context: context, format: "password poll success returned status 'failed'")
+
+                return .error(error: error, newState: nil)
+            }
+        case .passwordError(let apiError):
+            let error = apiError.toPasswordRequiredPublicError()
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Password error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: ResetPasswordRequiredState(controller: self, flowToken: passwordResetToken))
+        case .error(let apiError):
+            let error = apiError.toPasswordRequiredPublicError()
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: nil)
+        case .unexpectedError:
+            let error = PasswordRequiredError(type: .generalError)
+            self.stopTelemetryEvent(event, context: context, error: error)
+
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
+
+            return .error(error: error, newState: nil)
+        }
+    }
+
+    private func retryPollCompletion(
+        passwordResetToken: String,
+        pollInterval: Int,
+        retriesRemaining: Int,
+        event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult {
+        guard retriesRemaining > 0 else {
+            let error = PasswordRequiredError(type: .generalError)
+            self.stopTelemetryEvent(event, context: context, error: error)
+            MSALLogger.log(level: .error, context: context, format: "password poll completion did not complete in time")
+
+            return .error(error: error, newState: nil)
+        }
+
+        MSALLogger.log(
+            level: .info,
+            context: context,
+            format: "resetpassword: waiting for \(pollInterval) seconds before retrying"
+        )
+
+        do {
+            try await Task.sleep(nanoseconds: 1_000_000_000 * UInt64(pollInterval))
+        } catch {
+            // Task.sleep can throw a CancellationError if the Task is cancelled.
+            // We don't expect that to ever happen here so we just log it and carry on
+
+            MSALLogger.log(
+                level: .error,
+                context: context,
+                format: "resetpassword: Task.sleep unexpectedly threw an error: \(error). Ignoring..."
+            )
+        }
+
+        return await doPollCompletionLoop(
+            passwordResetToken: passwordResetToken,
+            pollInterval: pollInterval,
+            retriesRemaining: retriesRemaining - 1,
+            event: event,
+            context: context
+        )
+    }
+}
+// swiftlint:enable file_length

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordControlling.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordControlling.swift
@@ -1,0 +1,40 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthResetPasswordControlling: AnyObject {
+
+    func resetPassword(parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartResult
+
+    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeResult
+
+    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordVerifyCodeResult
+
+    func submitPassword(
+        password: String,
+        passwordSubmitToken: String,
+        context: MSIDRequestContext
+    ) async -> ResetPasswordRequiredResult
+}

--- a/MSAL/src/native_auth/controllers/responses/ResetPasswordResults.swift
+++ b/MSAL/src/native_auth/controllers/responses/ResetPasswordResults.swift
@@ -1,0 +1,61 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/// Represents the result of starting the reset password process.
+enum ResetPasswordStartResult {
+    /// Returned if a user has received an email with code.
+    ///
+    /// - newState: An object representing the new state of the flow with follow on methods.
+    /// - sentTo: The email/phone number that the code was sent to.
+    /// - channelTargetType: The channel (email/phone) the code was sent through.
+    /// - codeLength: The length of the code required.
+    case codeRequired(newState: ResetPasswordCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
+
+    /// An error object indicating why the operation failed.
+    case error(ResetPasswordStartError)
+}
+
+/// Result type that contains information about the code sent, the next state of the reset password process and possible errors.
+/// See ``CodeRequiredGenericResult`` for more information.
+typealias ResetPasswordResendCodeResult = CodeRequiredGenericResult<ResetPasswordCodeRequiredState, ResendCodeError>
+
+/// Represents the result of verifying a reset password verification code.
+enum ResetPasswordVerifyCodeResult {
+    /// Returned when a password is required.
+    case passwordRequired(newState: ResetPasswordRequiredState)
+
+    /// An error object indicating why the operation failed.
+    case error(error: VerifyCodeError, newState: ResetPasswordCodeRequiredState?)
+}
+
+/// Represents the result of verifying a reset password verification code.
+enum ResetPasswordRequiredResult {
+    /// Returned after the reset password operation completed successfully.
+    case completed
+
+    /// An error object indicating why the operation failed.
+    case error(error: PasswordRequiredError, newState: ResetPasswordRequiredState?)
+}

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCode.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthResetPasswordChallengeOauth2ErrorCode: String, Decodable, CaseIterable {
+    case invalidRequest = "invalid_request"
+    case invalidClient = "invalid_client"
+    case expiredToken = "expired_token"
+    case unsupportedChallengeType = "unsupported_challenge_type"
+}

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseError.swift
@@ -1,0 +1,67 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResetPasswordChallengeResponseError: MSALNativeAuthResponseError {
+
+    let error: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+    let target: String?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+        case target
+    }
+}
+
+extension MSALNativeAuthResetPasswordChallengeResponseError {
+
+    func toResetPasswordStartPublicError() -> ResetPasswordStartError {
+        switch error {
+        case .invalidRequest,
+             .invalidClient,
+             .unsupportedChallengeType,
+             .expiredToken:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+
+    func toResendCodePublicError() -> ResendCodeError {
+        switch error {
+        case .invalidClient,
+             .unsupportedChallengeType,
+             .expiredToken,
+             .invalidRequest:
+            return .init(message: errorDescription)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCode.swift
@@ -1,0 +1,34 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthResetPasswordContinueOauth2ErrorCode: String, Decodable, CaseIterable {
+    case invalidRequest = "invalid_request"
+    case invalidClient = "invalid_client"
+    case invalidGrant = "invalid_grant"
+    case expiredToken = "expired_token"
+    case verificationRequired = "verification_required"
+    case invalidOOBValue = "invalid_oob_value"
+}

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResetPasswordContinueResponseError: MSALNativeAuthResponseError {
+
+    let error: MSALNativeAuthResetPasswordContinueOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+    let target: String?
+    let passwordResetToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+        case target
+        case passwordResetToken = "password_reset_token"
+    }
+}
+
+extension MSALNativeAuthResetPasswordContinueResponseError {
+
+    func toVerifyCodePublicError() -> VerifyCodeError {
+        switch error {
+        case .invalidOOBValue:
+            return .init(type: .invalidCode, message: errorDescription)
+        case .invalidClient,
+             .expiredToken,
+             .invalidRequest,
+             .invalidGrant,
+             .verificationRequired:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode: String, Decodable, CaseIterable {
+    case invalidRequest = "invalid_request"
+    case invalidClient = "invalid_client"
+    case expiredToken = "expired_token"
+    case passwordTooWeak = "password_too_weak"
+    case passwordTooShort = "password_too_short"
+    case passwordTooLong = "password_too_long"
+    case passwordRecentlyUsed = "password_recently_used"
+    case passwordBanned = "password_banned"
+    case userNotFound = "user_not_found"
+}

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
@@ -1,0 +1,63 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthResponseError {
+
+    let error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+    let target: String?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+        case target
+    }
+}
+
+extension MSALNativeAuthResetPasswordPollCompletionResponseError {
+
+    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+        switch error {
+        case .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .init(type: .invalidPassword, message: errorDescription)
+        case .invalidClient,
+             .expiredToken,
+             .invalidRequest,
+             .userNotFound:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCode.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthResetPasswordStartOauth2ErrorCode: String, Decodable, CaseIterable {
+    case invalidRequest = "invalid_request"
+    case invalidClient = "invalid_client"
+    case userNotFound = "user_not_found"
+    case unsupportedChallengeType = "unsupported_challenge_type"
+}

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartResponseError.swift
@@ -1,0 +1,44 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResetPasswordStartResponseError: MSALNativeAuthResponseError {
+
+    let error: MSALNativeAuthResetPasswordStartOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+    let target: String?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+        case target
+    }
+}

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitOauth2ErrorCode.swift
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthResetPasswordSubmitOauth2ErrorCode: String, Decodable, CaseIterable {
+    case invalidRequest = "invalid_request"
+    case invalidClient = "invalid_client"
+    case expiredToken = "expired_token"
+    case passwordTooWeak = "password_too_weak"
+    case passwordTooShort = "password_too_short"
+    case passwordTooLong = "password_too_long"
+    case passwordRecentlyUsed = "password_recently_used"
+    case passwordBanned = "password_banned"
+}

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResetPasswordSubmitResponseError: MSALNativeAuthResponseError {
+
+    let error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+    let target: String?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+        case target
+    }
+}
+
+extension MSALNativeAuthResetPasswordSubmitResponseError {
+
+    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+        switch error {
+        case .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .init(type: .invalidPassword, message: errorDescription)
+        case .invalidClient,
+             .expiredToken,
+             .invalidRequest:
+            return .init(type: .generalError, message: errorDescription)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParameters.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthResetPasswordChallengeRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .resetPasswordChallenge
+    let context: MSIDRequestContext
+    let passwordResetToken: String
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.passwordResetToken.rawValue: passwordResetToken,
+            Key.challengeType.rawValue: config.challengeTypesString
+        ].compactMapValues { $0 }
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParameters.swift
@@ -1,0 +1,44 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthResetPasswordContinueRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .resetPasswordContinue
+    let context: MSIDRequestContext
+    let passwordResetToken: String
+    let grantType: MSALNativeAuthGrantType
+    let oobCode: String?
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.passwordResetToken.rawValue: passwordResetToken,
+            Key.grantType.rawValue: grantType.rawValue,
+            Key.oobCode.rawValue: oobCode
+        ].compactMapValues { $0 }
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParameters.swift
@@ -1,0 +1,40 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthResetPasswordPollCompletionRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .resetpasswordPollCompletion
+    let context: MSIDRequestContext
+    let passwordResetToken: String
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.passwordResetToken.rawValue: passwordResetToken
+        ]
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParameters.swift
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthResetPasswordStartRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .resetPasswordStart
+    let context: MSIDRequestContext
+    let username: String
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.username.rawValue: username,
+            Key.challengeType.rawValue: config.challengeTypesString
+        ]
+
+    }
+}

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParameters.swift
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthResetPasswordSubmitRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .resetPasswordSubmit
+    let context: MSIDRequestContext
+    let passwordSubmitToken: String
+    let newPassword: String
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.passwordSubmitToken.rawValue: passwordSubmitToken,
+            Key.newPassword.rawValue: newPassword
+        ]
+    }
+}

--- a/MSAL/src/native_auth/network/reset_password/MSALNativeAuthResetPasswordRequestProvider.swift
+++ b/MSAL/src/native_auth/network/reset_password/MSALNativeAuthResetPasswordRequestProvider.swift
@@ -1,0 +1,137 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthResetPasswordRequestProviding {
+    func start(
+        parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters
+    ) throws -> MSIDHttpRequest
+
+    func challenge(
+        token: String,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest
+
+    func `continue`(
+        parameters: MSALNativeAuthResetPasswordContinueRequestParameters
+    ) throws -> MSIDHttpRequest
+
+    func submit(
+        parameters: MSALNativeAuthResetPasswordSubmitRequestParameters
+    ) throws -> MSIDHttpRequest
+
+    func pollCompletion(
+        parameters: MSALNativeAuthResetPasswordPollCompletionRequestParameters
+    ) throws -> MSIDHttpRequest
+}
+
+final class MSALNativeAuthResetPasswordRequestProvider: MSALNativeAuthResetPasswordRequestProviding {
+
+    // MARK: - Variables
+    private let requestConfigurator: MSALNativeAuthRequestConfigurator
+    private let telemetryProvider: MSALNativeAuthTelemetryProviding
+
+    // MARK: - Init
+
+    init(
+        requestConfigurator: MSALNativeAuthRequestConfigurator,
+        telemetryProvider: MSALNativeAuthTelemetryProviding = MSALNativeAuthTelemetryProvider()
+    ) {
+        self.requestConfigurator = requestConfigurator
+        self.telemetryProvider = telemetryProvider
+    }
+
+    // MARK: - Reset Password Start
+
+    func start(
+        parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters
+    ) throws -> MSIDHttpRequest {
+
+        let requestParams = MSALNativeAuthResetPasswordStartRequestParameters(
+            context: parameters.context,
+            username: parameters.username
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .resetPassword(.start(requestParams)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    // MARK: - Reset Password Challenge
+
+    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        let requestParams = MSALNativeAuthResetPasswordChallengeRequestParameters(
+            context: context,
+            passwordResetToken: token
+        )
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .resetPassword(.challenge(requestParams)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    // MARK: - Reset Password Continue
+
+    func `continue`(
+        parameters: MSALNativeAuthResetPasswordContinueRequestParameters
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .resetPassword(.continue(parameters)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    // MARK: - Reset Password Submit
+
+    func submit(
+        parameters: MSALNativeAuthResetPasswordSubmitRequestParameters
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .resetPassword(.submit(parameters)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+
+    // MARK: - Reset Password Poll Completion
+
+    func pollCompletion(
+        parameters: MSALNativeAuthResetPasswordPollCompletionRequestParameters
+    ) throws -> MSIDHttpRequest {
+
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .resetPassword(.pollCompletion(parameters)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+}

--- a/MSAL/src/native_auth/network/reset_password/MSALNativeAuthResetPasswordStartRequestProviderParameters.swift
+++ b/MSAL/src/native_auth/network/reset_password/MSALNativeAuthResetPasswordStartRequestProviderParameters.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResetPasswordStartRequestProviderParameters {
+    let username: String
+    let context: MSALNativeAuthRequestContext
+}

--- a/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
+++ b/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResendCodeRequestResponse: Decodable {
+
+    // MARK: - Variables
+    let credentialToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case credentialToken = "flowToken"
+    }
+}

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordChallengeResponse.swift
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResetPasswordChallengeResponse: Decodable {
+
+    // MARK: - Variables
+    let challengeType: MSALNativeAuthInternalChallengeType
+    let bindingMethod: String?
+    let challengeTargetLabel: String?
+    let challengeChannel: MSALNativeAuthInternalChannelType?
+    let passwordResetToken: String?
+    let codeLength: Int?
+}

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordContinueResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordContinueResponse.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResetPasswordContinueResponse: Decodable {
+
+    // MARK: - Variables
+    let passwordSubmitToken: String
+    let expiresIn: Int
+}

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordPollCompletionResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordPollCompletionResponse.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResetPasswordPollCompletionResponse: Decodable {
+
+    // MARK: - Variables
+    let status: MSALNativeAuthResetPasswordPollCompletionStatus
+    let signInSLT: String?
+    let expiresIn: Int?
+}

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordPollCompletionStatus.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordPollCompletionStatus.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+enum MSALNativeAuthResetPasswordPollCompletionStatus: String, Decodable {
+    case succeeded
+    case inProgress = "in_progress"
+    case failed
+    case notStarted = "not_started"
+}

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResetPasswordStartResponse: Decodable {
+
+    // MARK: - Variables
+    let passwordResetToken: String?
+    let challengeType: MSALNativeAuthInternalChallengeType?
+
+    enum CodingKeys: String, CodingKey {
+        case passwordResetToken
+        case challengeType
+    }
+
+    init(passwordResetToken: String?, challengeType: MSALNativeAuthInternalChallengeType?) {
+        self.passwordResetToken = passwordResetToken
+        self.challengeType = challengeType
+    }
+}

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordSubmitResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordSubmitResponse.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct MSALNativeAuthResetPasswordSubmitResponse: Decodable {
+
+    // MARK: - Variables
+    let passwordResetToken: String
+    let pollInterval: Int
+}

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
@@ -1,0 +1,273 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+protocol MSALNativeAuthResetPasswordResponseValidating {
+    func validate(_ result: Result<MSALNativeAuthResetPasswordStartResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordStartValidatedResponse
+    func validate(_ result: Result<MSALNativeAuthResetPasswordChallengeResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordChallengeValidatedResponse
+    func validate(_ result: Result<MSALNativeAuthResetPasswordContinueResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordContinueValidatedResponse
+    func validate(_ result: Result<MSALNativeAuthResetPasswordSubmitResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordSubmitValidatedResponse
+    func validate(_ result: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse
+}
+
+final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPasswordResponseValidating {
+
+    // MARK: - Start Request
+
+    func validate(_ result: Result<MSALNativeAuthResetPasswordStartResponse, Error>,
+                  with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordStartValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleStartSuccess(response, with: context)
+        case .failure(let error):
+            return handleStartFailed(error, with: context)
+        }
+    }
+
+    private func handleStartSuccess(_ response: MSALNativeAuthResetPasswordStartResponse,
+                                    with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordStartValidatedResponse {
+        if response.challengeType == .redirect {
+            return .redirect
+        } else if let passwordResetToken = response.passwordResetToken {
+            return .success(passwordResetToken: passwordResetToken)
+        } else {
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "resetpassword/start returned success with unexpected response body")
+
+            return .unexpectedError
+        }
+    }
+
+    private func handleStartFailed(_ error: Error,
+                                   with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordStartValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthResetPasswordStartResponseError else {
+            MSALLogger.log(level: .error,
+                           context: context,
+                           format: "Error type not expected")
+
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .invalidRequest:
+            if apiError.errorCodes?.first == MSALNativeAuthESTSApiErrorCodes.userNotHaveAPassword.rawValue {
+                return .error(.userDoesNotHavePassword)
+            } else {
+                return .error(.invalidRequest(message: apiError.errorDescription))
+            }
+        case .invalidClient:
+            return .error(.invalidClient(message: apiError.errorDescription))
+        case .userNotFound:
+            return .error(.userNotFound(message: apiError.errorDescription))
+        case .unsupportedChallengeType:
+            return .error(.unsupportedChallengeType(message: apiError.errorDescription))
+        }
+    }
+
+    // MARK: - Challenge Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthResetPasswordChallengeResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordChallengeValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleChallengeSuccess(response, with: context)
+        case .failure(let error):
+            return handleChallengeError(error, with: context)
+        }
+    }
+
+    private func handleChallengeSuccess(
+        _ response: MSALNativeAuthResetPasswordChallengeResponse,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordChallengeValidatedResponse {
+        switch response.challengeType {
+        case .redirect:
+            return .redirect
+        case .oob:
+            if let sentTo = response.challengeTargetLabel,
+               let channelTargetType = response.challengeChannel?.toPublicChannelType(),
+               let codeLength = response.codeLength,
+               let passwordResetToken = response.passwordResetToken {
+                return .success(
+                    sentTo,
+                    channelTargetType,
+                    codeLength,
+                    passwordResetToken
+                )
+            } else {
+                MSALLogger.log(level: .error, context: context, format: "Missing expected fields from backend")
+                return .unexpectedError
+            }
+        case .password,
+             .otp:
+            MSALLogger.log(level: .error, context: context, format: "ChallengeType not expected")
+            return .unexpectedError
+        }
+    }
+
+    private func handleChallengeError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordChallengeValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthResetPasswordChallengeResponseError else {
+            MSALLogger.log(level: .info, context: context, format: "Error type not expected")
+            return .unexpectedError
+        }
+
+        return .error(apiError)
+    }
+
+    // MARK: - Continue Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthResetPasswordContinueResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleContinueSuccess(response)
+        case .failure(let error):
+            return handleContinueError(error, with: context)
+        }
+    }
+
+    private func handleContinueSuccess(
+        _ response: MSALNativeAuthResetPasswordContinueResponse
+    ) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
+        return .success(passwordSubmitToken: response.passwordSubmitToken)
+    }
+
+    private func handleContinueError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthResetPasswordContinueResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "continue returned unexpected error type")
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .invalidOOBValue:
+            return .invalidOOB
+        case .invalidClient,
+             .invalidGrant,
+             .expiredToken,
+             .invalidRequest:
+            return .error(apiError)
+        case .verificationRequired:
+            MSALLogger.log(level: .error, context: context, format: "verificationRequired is not supported yet")
+            return .unexpectedError
+        }
+    }
+
+    // MARK: - Submit Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthResetPasswordSubmitResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handleSubmitSuccess(response)
+        case .failure(let error):
+            return handleSubmitError(error, with: context)
+        }
+    }
+
+    private func handleSubmitSuccess(
+        _ response: MSALNativeAuthResetPasswordSubmitResponse
+    ) -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
+        return .success(
+            passwordResetToken: response.passwordResetToken,
+            pollInterval: response.pollInterval
+        )
+    }
+
+    private func handleSubmitError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthResetPasswordSubmitResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "submit returned unexpected error type")
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .passwordError(error: apiError)
+        case .invalidRequest,
+             .invalidClient,
+             .expiredToken:
+            return .error(apiError)
+        }
+    }
+
+    // MARK: - Poll Completion Request
+
+    func validate(
+        _ result: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error>,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
+        switch result {
+        case .success(let response):
+            return handlePollCompletionSuccess(response)
+        case .failure(let error):
+            return handlePollCompletionError(error, with: context)
+        }
+    }
+
+    private func handlePollCompletionSuccess(
+        _ response: MSALNativeAuthResetPasswordPollCompletionResponse
+    ) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
+        return .success(status: response.status)
+    }
+
+    private func handlePollCompletionError(
+        _ error: Error,
+        with context: MSIDRequestContext
+    ) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
+        guard let apiError = error as? MSALNativeAuthResetPasswordPollCompletionResponseError else {
+            MSALLogger.log(level: .error, context: context, format: "Poll Completion returned unexpected error type")
+            return .unexpectedError
+        }
+
+        switch apiError.error {
+        case .passwordTooWeak,
+             .passwordTooShort,
+             .passwordTooLong,
+             .passwordRecentlyUsed,
+             .passwordBanned:
+            return .passwordError(error: apiError)
+        case .userNotFound,
+             .invalidRequest,
+             .invalidClient,
+             .expiredToken:
+            return .error(apiError)
+        }
+    }
+}

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordValidatedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordValidatedResponses.swift
@@ -1,0 +1,79 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+enum MSALNativeAuthResetPasswordStartValidatedResponse {
+    case success(passwordResetToken: String)
+    case redirect
+    case error(MSALNativeAuthResetPasswordStartValidatedErrorType)
+    case unexpectedError
+}
+
+enum MSALNativeAuthResetPasswordStartValidatedErrorType: Error {
+    case invalidRequest(message: String?)
+    case invalidClient(message: String?)
+    case userNotFound(message: String?)
+    case unsupportedChallengeType(message: String?)
+    case userDoesNotHavePassword
+
+    func toResetPasswordStartPublicError() -> ResetPasswordStartError {
+        switch self {
+        case .userNotFound(let message):
+            return .init(type: .userNotFound, message: message)
+        case .unsupportedChallengeType(let message),
+             .invalidRequest(let message),
+             .invalidClient(let message):
+            return .init(type: .generalError, message: message)
+        case .userDoesNotHavePassword:
+            return .init(type: .userDoesNotHavePassword, message: MSALNativeAuthErrorMessage.userDoesNotHavePassword)
+        }
+    }
+}
+
+enum MSALNativeAuthResetPasswordChallengeValidatedResponse: Equatable {
+    case success(_ sentTo: String, _ channelTargetType: MSALNativeAuthChannelType, _ codeLength: Int, _ resetPasswordChallengeToken: String)
+    case redirect
+    case error(MSALNativeAuthResetPasswordChallengeResponseError)
+    case unexpectedError
+}
+
+enum MSALNativeAuthResetPasswordContinueValidatedResponse: Equatable {
+    case success(passwordSubmitToken: String)
+    case invalidOOB
+    case error(MSALNativeAuthResetPasswordContinueResponseError)
+    case unexpectedError
+}
+
+enum MSALNativeAuthResetPasswordSubmitValidatedResponse: Equatable {
+    case success(passwordResetToken: String, pollInterval: Int)
+    case passwordError(error: MSALNativeAuthResetPasswordSubmitResponseError)
+    case error(MSALNativeAuthResetPasswordSubmitResponseError)
+    case unexpectedError
+}
+
+enum MSALNativeAuthResetPasswordPollCompletionValidatedResponse: Equatable {
+    case success(status: MSALNativeAuthResetPasswordPollCompletionStatus)
+    case passwordError(error: MSALNativeAuthResetPasswordPollCompletionResponseError)
+    case error(MSALNativeAuthResetPasswordPollCompletionResponseError)
+    case unexpectedError
+}

--- a/MSAL/src/native_auth/public/state_machine/MSALNativeAuthRequiredAttributes.swift
+++ b/MSAL/src/native_auth/public/state_machine/MSALNativeAuthRequiredAttributes.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class MSALNativeAuthRequiredAttributes: NSObject {
+    public let name: String
+    public let type: String
+    public let required: Bool
+    public let regex: String?
+
+    init(name: String, type: String, required: Bool, regex: String? = nil) {
+        self.name = name
+        self.type = type
+        self.required = required
+        self.regex = regex
+        super.init()
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/delegate/ResetPasswordDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/ResetPasswordDelegates.swift
@@ -1,0 +1,86 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public protocol ResetPasswordStartDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onResetPasswordError(error: ResetPasswordStartError)
+
+    /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Parameters:
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    ///   - sentTo: The email/phone number that the code was sent to.
+    ///   - channelTargetType: The channel (email/phone) the code was sent through.
+    ///   - codeLength: The length of the code required.
+    @MainActor func onResetPasswordCodeRequired(
+        newState: ResetPasswordCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    )
+}
+
+@objc
+public protocol ResetPasswordVerifyCodeDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onResetPasswordVerifyCodeError(error: VerifyCodeError, newState: ResetPasswordCodeRequiredState?)
+
+    /// Notifies the delegate that a password is required from the user to continue.
+    /// - Parameter newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onPasswordRequired(newState: ResetPasswordRequiredState)
+}
+
+@objc
+public protocol ResetPasswordResendCodeDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onResetPasswordResendCodeError(error: ResendCodeError, newState: ResetPasswordCodeRequiredState?)
+
+    /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Parameters:
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    ///   - sentTo: The email/phone number that the code was sent to.
+    ///   - channelTargetType: The channel (email/phone) the code was sent through.
+    ///   - codeLength: The length of the code required.
+    @MainActor func onResetPasswordResendCodeRequired(
+        newState: ResetPasswordCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    )
+}
+
+@objc
+public protocol ResetPasswordRequiredDelegate {
+    /// Notifies the delegate that the operation resulted in an error.
+    /// - Parameter error: An error object indicating why the operation failed.
+    @MainActor func onResetPasswordRequiredError(error: PasswordRequiredError, newState: ResetPasswordRequiredState?)
+
+    /// Notifies the delegate that the reset password operation completed successfully.
+    @MainActor func onResetPasswordCompleted()
+}

--- a/MSAL/src/native_auth/public/state_machine/error/ResetPasswordStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/ResetPasswordStartError.swift
@@ -1,0 +1,64 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objc
+public class ResetPasswordStartError: MSALNativeAuthError {
+    /// An error type indicating the type of error that occurred
+    @objc public let type: ResetPasswordStartErrorType
+
+    init(type: ResetPasswordStartErrorType, message: String? = nil) {
+        self.type = type
+        super.init(message: message)
+    }
+
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        switch type {
+        case .browserRequired:
+            return "Browser required"
+        case .generalError:
+            return "General error"
+        case .userDoesNotHavePassword:
+            return "User does not have a password"
+        case .userNotFound:
+            return "User not found"
+        case .invalidUsername:
+            return "Invalid username"
+        }
+    }
+}
+
+@objc
+public enum ResetPasswordStartErrorType: Int {
+    case browserRequired
+    case generalError
+    case userDoesNotHavePassword
+    case userNotFound
+    case invalidUsername
+}

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
@@ -1,0 +1,58 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+extension ResetPasswordCodeRequiredState {
+
+    func resendCodeInternal(correlationId: UUID?) async -> ResetPasswordResendCodeResult {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        return await controller.resendCode(passwordResetToken: flowToken, context: context)
+    }
+
+    func submitCodeInternal(code: String, correlationId: UUID?) async -> ResetPasswordVerifyCodeResult {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        guard inputValidator.isInputValid(code) else {
+            MSALLogger.log(level: .error, context: context, format: "ResetPassword flow, invalid code")
+            return .error(error: VerifyCodeError(type: .invalidCode), newState: self)
+        }
+
+        return await controller.submitCode(code: code, passwordResetToken: flowToken, context: context)
+    }
+}
+
+extension ResetPasswordRequiredState {
+
+    func submitPasswordInternal(password: String, correlationId: UUID?) async -> ResetPasswordRequiredResult {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        guard inputValidator.isInputValid(password) else {
+            MSALLogger.log(level: .error, context: context, format: "ResetPassword flow, invalid password")
+            return .error(error: PasswordRequiredError(type: .invalidPassword), newState: self)
+        }
+
+        return await controller.submitPassword(password: password, passwordSubmitToken: flowToken, context: context)
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates.swift
@@ -1,0 +1,105 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+@objcMembers
+public class ResetPasswordBaseState: MSALNativeAuthBaseState {
+    let controller: MSALNativeAuthResetPasswordControlling
+    let inputValidator: MSALNativeAuthInputValidating
+
+    init(
+        controller: MSALNativeAuthResetPasswordControlling,
+        flowToken: String,
+        inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator()
+    ) {
+        self.controller = controller
+        self.inputValidator = inputValidator
+        super.init(flowToken: flowToken)
+    }
+}
+
+/// An object of this type is created when a user is required to supply a verification code to continue a reset password flow.
+@objcMembers public class ResetPasswordCodeRequiredState: ResetPasswordBaseState {
+    /// Requests the server to resend the verification code to the user.
+    /// - Parameters:
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func resendCode(delegate: ResetPasswordResendCodeDelegate, correlationId: UUID? = nil) {
+        Task {
+            let result = await resendCodeInternal(correlationId: correlationId)
+
+            switch result {
+            case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
+                await delegate.onResetPasswordResendCodeRequired(
+                    newState: newState,
+                    sentTo: sentTo,
+                    channelTargetType: channelTargetType,
+                    codeLength: codeLength
+                )
+            case .error(let error, let newState):
+                await delegate.onResetPasswordResendCodeError(error: error, newState: newState)
+            }
+        }
+    }
+
+    /// Submits the code to the server for verification.
+    /// - Parameters:
+    ///   - code: Verification code that the user supplied.
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func submitCode(code: String, delegate: ResetPasswordVerifyCodeDelegate, correlationId: UUID? = nil) {
+        Task {
+            let result = await submitCodeInternal(code: code, correlationId: correlationId)
+
+            switch result {
+            case .passwordRequired(let newState):
+                await delegate.onPasswordRequired(newState: newState)
+            case .error(let error, let newState):
+                await delegate.onResetPasswordVerifyCodeError(error: error, newState: newState)
+            }
+        }
+    }
+}
+
+/// An object of this type is created when a user is required to supply a password to continue a reset password flow.
+@objcMembers public class ResetPasswordRequiredState: ResetPasswordBaseState {
+    /// Submits the password to the server for verification.
+    /// - Parameters:
+    ///   - password: Password that the user supplied.
+    ///   - delegate: Delegate that receives callbacks for the operation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    public func submitPassword(password: String, delegate: ResetPasswordRequiredDelegate, correlationId: UUID? = nil) {
+        Task {
+            let result = await submitPasswordInternal(password: password, correlationId: correlationId)
+
+            switch result {
+            case .completed:
+                await delegate.onResetPasswordCompleted()
+            case .error(let error, let newState):
+                await delegate.onResetPasswordRequiredError(error: error, newState: newState)
+            }
+        }
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
@@ -1,0 +1,82 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import XCTest
+
+final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBaseTestCase {
+
+    private let usernameOTP = ProcessInfo.processInfo.environment["existingOTPUserEmail"] ?? "<existingOTPUserEmail not set>"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipIf(!usingMockAPI)
+    }
+    
+    // Hero Scenario 2.3.1. SSPR – without automatic sign in
+    func test_resetPassword_withoutAutomaticSignIn_succeeds() async throws {
+        let codeRequiredExp = expectation(description: "code required")
+        let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.ssprStartSuccess, endpoint: .resetPasswordStart)
+        }
+
+        sut.resetPassword(username: usernameOTP, delegate: resetPasswordStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp], timeout: defaultTimeout)
+        XCTAssertTrue(resetPasswordStartDelegate.onResetPasswordCodeRequiredCalled)
+        XCTAssertEqual(resetPasswordStartDelegate.channelTargetType, .email)
+        XCTAssertFalse(resetPasswordStartDelegate.sentTo?.isEmpty ?? true)
+        XCTAssertNotNil(resetPasswordStartDelegate.codeLength)
+
+        // Now submit the code...
+
+        let passwordRequiredExp = expectation(description: "password required")
+        let resetPasswordVerifyDelegate = ResetPasswordVerifyCodeDelegateSpy(expectation: passwordRequiredExp)
+
+        if usingMockAPI {
+            try await mockResponse(.ssprContinueSuccess, endpoint: .resetPasswordContinue)
+        }
+
+        resetPasswordStartDelegate.newState?.submitCode(code: "1234", delegate: resetPasswordVerifyDelegate)
+
+        await fulfillment(of: [passwordRequiredExp], timeout: defaultTimeout)
+        XCTAssertTrue(resetPasswordVerifyDelegate.onPasswordRequiredCalled)
+
+        // Now submit the password...
+        let resetPasswordCompletedExp = expectation(description: "reset password completed")
+        let resetPasswordRequiredDelegate = ResetPasswordRequiredDelegateSpy(expectation: resetPasswordCompletedExp)
+
+        if usingMockAPI {
+            try await mockResponse(.ssprSubmitSuccess, endpoint: .resetPasswordSubmit)
+        }
+
+        resetPasswordVerifyDelegate.newPasswordRequiredState?.submitPassword(password: "password", delegate: resetPasswordRequiredDelegate)
+
+        await fulfillment(of: [resetPasswordCompletedExp], timeout: defaultTimeout)
+        XCTAssertTrue(resetPasswordRequiredDelegate.onResetPasswordCompletedCalled)
+    }
+
+}

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/ResetPasswordDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/ResetPasswordDelegateSpies.swift
@@ -1,0 +1,119 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import XCTest
+import MSAL
+
+class ResetPasswordStartDelegateSpy: ResetPasswordStartDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onResetPasswordErrorCalled = false
+    private(set) var onResetPasswordCodeRequiredCalled = false
+    private(set) var error: MSAL.ResetPasswordStartError?
+    private(set) var newState: MSAL.ResetPasswordCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSAL.MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordError(error: MSAL.ResetPasswordStartError) {
+        onResetPasswordErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+
+    func onResetPasswordCodeRequired(
+        newState: MSAL.ResetPasswordCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSAL.MSALNativeAuthChannelType,
+        codeLength: Int
+    ) {
+        onResetPasswordCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        expectation.fulfill()
+    }
+}
+
+class ResetPasswordVerifyCodeDelegateSpy: ResetPasswordVerifyCodeDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onResetPasswordVerifyCodeErrorCalled = false
+    private(set) var onPasswordRequiredCalled = false
+    private(set) var error: MSAL.VerifyCodeError?
+    private(set) var newCodeRequiredState: MSAL.ResetPasswordCodeRequiredState?
+    private(set) var newPasswordRequiredState: MSAL.ResetPasswordRequiredState?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordVerifyCodeError(error: MSAL.VerifyCodeError, newState: MSAL.ResetPasswordCodeRequiredState?) {
+        onResetPasswordVerifyCodeErrorCalled = true
+        self.error = error
+        newCodeRequiredState = newState
+
+        expectation.fulfill()
+    }
+
+    func onPasswordRequired(newState: MSAL.ResetPasswordRequiredState) {
+        onPasswordRequiredCalled = true
+        newPasswordRequiredState = newState
+
+        expectation.fulfill()
+    }
+}
+
+class ResetPasswordRequiredDelegateSpy: ResetPasswordRequiredDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onResetPasswordRequiredErrorCalled = false
+    private(set) var onResetPasswordCompletedCalled = false
+    private(set) var error: MSAL.PasswordRequiredError?
+    private(set) var newPasswordRequiredState: MSAL.ResetPasswordRequiredState?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordRequiredError(error: MSAL.PasswordRequiredError, newState: MSAL.ResetPasswordRequiredState?) {
+        onResetPasswordRequiredErrorCalled = true
+
+        self.error = error
+        newPasswordRequiredState = newState
+
+        expectation.fulfill()
+    }
+
+    func onResetPasswordCompleted() {
+        onResetPasswordCompletedCalled = true
+
+        expectation.fulfill()
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordChallengeIntegrationTests.swift
@@ -1,0 +1,119 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordChallengeIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+
+    private var provider: MSALNativeAuthResetPasswordRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        provider = MSALNativeAuthResetPasswordRequestProvider(
+            requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+            telemetryProvider: MSALNativeAuthTelemetryProvider()
+        )
+
+        sut = try provider.challenge(
+            token: "<password-reset-token>",
+            context: MSALNativeAuthRequestContext(correlationId: correlationId)
+        )
+    }
+
+    func test_whenResetPasswordChallenge_succeeds() async throws {
+        try await mockAPIHandler.addResponse(
+            endpoint: .resetPasswordChallenge,
+            correlationId: correlationId,
+            responses: [.challengeTypeOOB]
+        )
+
+        let response: MSALNativeAuthResetPasswordChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?.challengeType)
+        XCTAssertNotNil(response?.bindingMethod)
+        XCTAssertNotNil(response?.challengeTargetLabel)
+        XCTAssertNotNil(response?.challengeChannel)
+        XCTAssertNotNil(response?.passwordResetToken)
+        XCTAssertNotNil(response?.codeLength)
+    }
+
+    func test_whenResetPasswordChallenge_redirects() async throws {
+        try await mockResponse(.challengeTypeRedirect, endpoint: .resetPasswordChallenge)
+        let response: MSALNativeAuthResetPasswordChallengeResponse? = try await performTestSucceed()
+
+
+        XCTAssertEqual(response?.challengeType, .redirect)
+        XCTAssertNil(response?.bindingMethod)
+        XCTAssertNil(response?.challengeTargetLabel)
+        XCTAssertNil(response?.challengeChannel)
+        XCTAssertNil(response?.passwordResetToken)
+        XCTAssertNil(response?.codeLength)
+    }
+
+    func test_resetPasswordChallenge_invalidClient() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordChallenge,
+            response: .invalidClient,
+            expectedError: createError(.invalidClient)
+        )
+    }
+
+    func test_resetPasswordChallenge_expiredToken() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordChallenge,
+            response: .expiredToken,
+            expectedError: createError(.expiredToken)
+        )
+    }
+
+    func test_resetPasswordChallenge_invalidPasswordResetToken() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordChallenge,
+            response: .invalidPasswordResetToken,
+            expectedError: createError(.invalidRequest)
+        )
+    }
+
+    func test_resetPasswordChallenge_unsupportedChallengeType() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordChallenge,
+            response: .unsupportedChallengeType,
+            expectedError: createError(.unsupportedChallengeType)
+        )
+    }
+
+    private func createError(_ error: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode) -> MSALNativeAuthResetPasswordChallengeResponseError {
+        .init(
+            error: error,
+            errorDescription: nil,
+            errorCodes: nil,
+            errorURI: nil,
+            innerErrors: nil,
+            target: nil
+        )
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordContinueIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordContinueIntegrationTests.swift
@@ -1,0 +1,131 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordContinueIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+
+    private var provider: MSALNativeAuthResetPasswordRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        provider = MSALNativeAuthResetPasswordRequestProvider(
+            requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+            telemetryProvider: MSALNativeAuthTelemetryProvider()
+        )
+
+        sut = try provider.continue(
+            parameters: MSALNativeAuthResetPasswordContinueRequestParameters(context: context,
+                                                                             passwordResetToken: "<password-reset-token>",
+                                                                             grantType: .oobCode,
+                                                                             oobCode: "0000")
+        )
+    }
+
+    func test_whenResetPasswordContinue_succeeds() async throws {
+        try await mockAPIHandler.addResponse(
+            endpoint: .resetPasswordContinue,
+            correlationId: correlationId,
+            responses: [.ssprContinueSuccess]
+        )
+
+        let response: MSALNativeAuthResetPasswordContinueResponse? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?.passwordSubmitToken)
+        XCTAssertNotNil(response?.expiresIn)
+    }
+
+    func test_resetPasswordContinue_invalidClient() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordContinue,
+            response: .invalidClient,
+            expectedError: createResetPasswordContinueError(error: .invalidClient)
+        )
+    }
+
+    func test_resetPasswordContinue_expiredToken() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordContinue,
+            response: .expiredToken,
+            expectedError: createResetPasswordContinueError(error: .expiredToken)
+        )
+    }
+
+    func test_resetPasswordContinue_invalidPasswordResetToken() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordContinue,
+            response: .invalidPasswordResetToken,
+            expectedError: createResetPasswordContinueError(error: .invalidRequest)
+        )
+    }
+
+    func test_resetPasswordContinue_invalidPassword() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordContinue,
+            response: .invalidPassword,
+            expectedError: createResetPasswordContinueError(error: .invalidGrant, errorCodes: [MSALNativeAuthESTSApiErrorCodes.invalidCredentials.rawValue])
+        )
+    }
+
+    func test_resetPasswordContinue_invalidOOB() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordContinue,
+            response: .explicitInvalidOOBValue,
+            expectedError: createResetPasswordContinueError(error: .invalidOOBValue)
+        )
+    }
+
+    func test_resetPasswordContinue_verificationRequired() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordContinue,
+            response: .verificationRequired,
+            expectedError: createResetPasswordContinueError(error: .verificationRequired)
+        )
+    }
+
+    private func createResetPasswordContinueError(
+        error: MSALNativeAuthResetPasswordContinueOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil,
+        passwordResetToken: String? = nil
+    ) -> MSALNativeAuthResetPasswordContinueResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target,
+            passwordResetToken: passwordResetToken
+        )
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordPollCompletionIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordPollCompletionIntegrationTests.swift
@@ -1,0 +1,195 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordPollCompletionIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+
+    private var provider: MSALNativeAuthResetPasswordRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        provider = MSALNativeAuthResetPasswordRequestProvider(
+            requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+            telemetryProvider: MSALNativeAuthTelemetryProvider()
+        )
+
+        sut = try provider.pollCompletion(
+            parameters: MSALNativeAuthResetPasswordPollCompletionRequestParameters(context: context,
+                                                                                   passwordResetToken: "<password-reset-token")
+
+        )
+    }
+
+    func test_whenResetPasswordPollCompletion_succeeds() async throws {
+        try await mockAPIHandler.addResponse(
+            endpoint: .resetPasswordPollCompletion,
+            correlationId: correlationId,
+            responses: [.ssprPollSuccess]
+        )
+
+        let response: MSALNativeAuthResetPasswordPollCompletionResponse? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?.status)
+        XCTAssertNil(response?.signInSLT)
+        XCTAssertNil(response?.expiresIn)
+    }
+
+    func test_whenResetPasswordPollCompletion_inProgress() async throws {
+        try await mockAPIHandler.addResponse(
+            endpoint: .resetPasswordPollCompletion,
+            correlationId: correlationId,
+            responses: [.ssprPollInProgress]
+        )
+
+        let response: MSALNativeAuthResetPasswordPollCompletionResponse? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?.status)
+        XCTAssertNil(response?.signInSLT)
+        XCTAssertNil(response?.expiresIn)
+    }
+
+    func test_whenResetPasswordPollCompletion_failed() async throws {
+        try await mockAPIHandler.addResponse(
+            endpoint: .resetPasswordPollCompletion,
+            correlationId: correlationId,
+            responses: [.ssprPollFailed]
+        )
+
+        let response: MSALNativeAuthResetPasswordPollCompletionResponse? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?.status)
+        XCTAssertNil(response?.signInSLT)
+        XCTAssertNil(response?.expiresIn)
+    }
+
+    func test_whenResetPasswordPollCompletion_notStarted() async throws {
+        try await mockAPIHandler.addResponse(
+            endpoint: .resetPasswordPollCompletion,
+            correlationId: correlationId,
+            responses: [.ssprPollNotStarted]
+        )
+
+        let response: MSALNativeAuthResetPasswordPollCompletionResponse? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?.status)
+        XCTAssertNil(response?.signInSLT)
+        XCTAssertNil(response?.expiresIn)
+    }
+
+    func test_resetPasswordPollCompletion_invalidClient() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordPollCompletion,
+            response: .invalidClient,
+            expectedError: createResetPasswordPollCompletionError(error: .invalidClient)
+        )
+    }
+
+    func test_resetPasswordPollCompletion_invalidPasswordResetToken() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordPollCompletion,
+            response: .invalidPasswordResetToken,
+            expectedError: createResetPasswordPollCompletionError(error: .invalidRequest)
+        )
+    }
+
+    func test_resetPasswordPollCompletion_expiredToken() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordPollCompletion,
+            response: .expiredToken,
+            expectedError: createResetPasswordPollCompletionError(error: .expiredToken)
+        )
+    }
+
+    func test_resetPasswordPollCompletion_passwordTooWeak() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordPollCompletion,
+            response: .passwordTooWeak,
+            expectedError: createResetPasswordPollCompletionError(error: .passwordTooWeak)
+        )
+    }
+
+    func test_resetPasswordPollCompletion_passwordTooShort() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordPollCompletion,
+            response: .passwordTooShort,
+            expectedError: createResetPasswordPollCompletionError(error: .passwordTooShort)
+        )
+    }
+
+    func test_resetPasswordPollCompletion_passwordTooLong() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordPollCompletion,
+            response: .passwordTooLong,
+            expectedError: createResetPasswordPollCompletionError(error: .passwordTooLong)
+        )
+    }
+
+    func test_resetPasswordPollCompletion_passwordRecentlyUsed() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordPollCompletion,
+            response: .passwordRecentlyUsed,
+            expectedError: createResetPasswordPollCompletionError(error: .passwordRecentlyUsed)
+        )
+    }
+
+    func test_resetPasswordPollCompletion_passwordBanned() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordPollCompletion,
+            response: .passwordBanned,
+            expectedError: createResetPasswordPollCompletionError(error: .passwordBanned)
+        )
+    }
+
+    func test_resetPasswordPollCompletion_userNotFound() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordPollCompletion,
+            response: .explicityUserNotFound,
+            expectedError: createResetPasswordPollCompletionError(error: .userNotFound)
+        )
+    }
+
+    private func createResetPasswordPollCompletionError(
+        error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil
+    ) -> MSALNativeAuthResetPasswordPollCompletionResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target
+        )
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordStartIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordStartIntegrationTests.swift
@@ -1,0 +1,113 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordStartIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+
+    private var provider: MSALNativeAuthResetPasswordRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        provider = MSALNativeAuthResetPasswordRequestProvider(
+            requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+            telemetryProvider: MSALNativeAuthTelemetryProvider()
+        )
+
+        sut = try provider.start(
+            parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters(
+                username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+                context: context
+            )
+        )
+    }
+
+    func test_whenResetPasswordStart_succeeds() async throws {
+        try await mockAPIHandler.addResponse(
+            endpoint: .resetPasswordStart,
+            correlationId: correlationId,
+            responses: []
+        )
+
+        let response: MSALNativeAuthResetPasswordStartResponse? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?.passwordResetToken)
+        XCTAssertNil(response?.challengeType)
+    }
+
+    func test_whenResetPasswordStart_redirects() async throws {
+        try await mockResponse(.challengeTypeRedirect, endpoint: .resetPasswordStart)
+        let response: MSALNativeAuthResetPasswordStartResponse? = try await performTestSucceed()
+
+        XCTAssertNil(response?.passwordResetToken)
+        XCTAssertEqual(response?.challengeType, .redirect)
+    }
+
+    func test_resetPasswordStart_invalidClient() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordStart,
+            response: .invalidClient,
+            expectedError: createResetPasswordStartError(error: .invalidClient)
+        )
+    }
+
+    func test_resetPasswordStart_userNotFound() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordStart,
+            response: .explicityUserNotFound,
+            expectedError: createResetPasswordStartError(error: .userNotFound)
+        )
+    }
+
+    func test_resetPasswordStart_unsupportedChallengeType() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordStart,
+            response: .unsupportedChallengeType,
+            expectedError: createResetPasswordStartError(error: .unsupportedChallengeType)
+        )
+    }
+
+    private func createResetPasswordStartError(
+        error: MSALNativeAuthResetPasswordStartOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil
+    ) -> MSALNativeAuthResetPasswordStartResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target
+        )
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordSubmitIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordSubmitIntegrationTests.swift
@@ -1,0 +1,137 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordSubmitIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+
+    private var provider: MSALNativeAuthResetPasswordRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        provider = MSALNativeAuthResetPasswordRequestProvider(
+            requestConfigurator: MSALNativeAuthRequestConfigurator(config: config),
+            telemetryProvider: MSALNativeAuthTelemetryProvider()
+        )
+
+        sut = try provider.submit(
+            parameters: MSALNativeAuthResetPasswordSubmitRequestParameters(context: context,
+                                                                           passwordSubmitToken: "<password-submit-token>",
+                                                                           newPassword:"new-password")
+        )
+    }
+
+    func test_whenResetPasswordSubmit_succeeds() async throws {
+        try await mockAPIHandler.addResponse(
+            endpoint: .resetPasswordSubmit,
+            correlationId: correlationId,
+            responses: [.ssprSubmitSuccess]
+        )
+
+        let response: MSALNativeAuthResetPasswordSubmitResponse? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?.passwordResetToken)
+        XCTAssertNotNil(response?.pollInterval)
+    }
+
+    func test_resetPasswordSubmit_invalidClient() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordSubmit,
+            response: .invalidClient,
+            expectedError: createError(.invalidClient)
+        )
+    }
+
+    func test_resetPasswordSubmit_invalidPasswordResetToken() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordSubmit,
+            response: .invalidPasswordResetToken,
+            expectedError: createError(.invalidRequest)
+        )
+    }
+
+    func test_resetPasswordSubmit_expiredToken() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordSubmit,
+            response: .expiredToken,
+            expectedError: createError(.expiredToken)
+        )
+    }
+
+    func test_resetPasswordSubmit_passwordTooWeak() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordSubmit,
+            response: .passwordTooWeak,
+            expectedError: createError(.passwordTooWeak)
+        )
+    }
+
+    func test_resetPasswordSubmit_passwordTooShort() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordSubmit,
+            response: .passwordTooShort,
+            expectedError: createError(.passwordTooShort)
+        )
+    }
+
+    func test_resetPasswordSubmit_passwordTooLong() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordSubmit,
+            response: .passwordTooLong,
+            expectedError: createError(.passwordTooLong)
+        )
+    }
+
+    func test_resetPasswordSubmit_passwordRecentlyUsed() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordSubmit,
+            response: .passwordRecentlyUsed,
+            expectedError: createError(.passwordRecentlyUsed)
+        )
+    }
+
+    func test_resetPasswordSubmit_passwordBanned() async throws {
+        try await perform_testFail(
+            endpoint: .resetPasswordSubmit,
+            response: .passwordBanned,
+            expectedError: createError(.passwordBanned)
+        )
+    }
+
+    private func createError(_ error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode) -> MSALNativeAuthResetPasswordSubmitResponseError {
+        .init(
+            error: error,
+            errorDescription: nil,
+            errorCodes: nil,
+            errorURI: nil,
+            innerErrors: nil,
+            target: nil
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/MSALNativeAuthTestCase.swift
+++ b/MSAL/test/unit/native_auth/MSALNativeAuthTestCase.swift
@@ -1,0 +1,56 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthTestCase: XCTestCase {
+    //Do not create more than one instance of this variable, inherit this class instead
+    static let logger = MSALNativeAuthTestLogger()
+    var dispatcher: MSALNativeAuthTelemetryTestDispatcher!
+    var receivedEvents: [[AnyHashable: Any]] = []
+
+    override func setUpWithError() throws {
+        // Logger needs to reset so the expectation name and count resets from the previous test
+        // The previous test could be across class
+        Self.logger.reset()
+
+        dispatcher = MSALNativeAuthTelemetryTestDispatcher()
+
+        dispatcher.setTestCallback { event in
+            self.receivedEvents.append(event.propertyMap)
+        }
+
+        MSIDTelemetry.sharedInstance().add(dispatcher)
+    }
+
+    override func tearDown() {
+        // Logger needs to reset so the expectation name and count resets for the next test.
+        // The next test could be across classes
+        Self.logger.reset()
+
+        receivedEvents.removeAll()
+        MSIDTelemetry.sharedInstance().remove(dispatcher)
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
@@ -1,0 +1,922 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthResetPasswordController!
+    private var contextMock: MSALNativeAuthRequestContext!
+    private var requestProviderMock: MSALNativeAuthResetPasswordRequestProviderMock!
+    private var validatorMock: MSALNativeAuthResetPasswordResponseValidatorMock!
+
+
+    private var resetPasswordStartParams: MSALNativeAuthResetPasswordStartRequestProviderParameters {
+        .init(
+            username: "user@contoso.com",
+            context: contextMock
+        )
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        contextMock = .init(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        requestProviderMock = .init()
+        validatorMock = .init()
+
+        sut = .init(config: MSALNativeAuthConfigStubs.configuration,
+                    requestProvider: requestProviderMock,
+                    responseValidator: validatorMock
+        )
+    }
+
+    // MARK: - ResetPasswordStart (/start request) tests
+
+    func test_whenResetPasswordStart_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordStart_returnsSuccess_it_callsChallenge() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.unexpectedError)
+        _ = prepareResetPasswordStartValidatorHelper()
+
+        _ = await sut.resetPassword(parameters: resetPasswordStartParams)
+
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+    }
+
+    func test_whenResetPasswordStartPassword_returns_redirect_it_returnsBrowserRequiredError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.redirect)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordStart_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.error(.userNotFound(message: nil)))
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .userNotFound)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInResetPasswordStart_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    // MARK: - ResetPasswordStart (/challenge request) tests
+
+    func test_whenResetPasswordStart_challenge_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordStart_challenge_succeeds_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "resetPasswordToken"))
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordCodeRequired(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "resetPasswordToken")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: true)
+    }
+
+    func test_whenResetPasswordStart_challenge_returns_redirect_it_returnsRedirectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.redirect)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .browserRequired)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordStart_challenge_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthResetPasswordChallengeValidatedResponse = .error(
+            MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken,
+                                                              errorDescription: "Expired Token",
+                                                              errorCodes: nil,
+                                                              errorURI: nil,
+                                                              innerErrors: nil,
+                                                              target: nil))
+        validatorMock.mockValidateResetPasswordChallengeFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertEqual(helper.error?.errorDescription, "Expired Token")
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    func test_whenValidatorInResetPasswordStart_challenge_returns_unexpectedError_it_returnsGeneralError() async {
+        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
+        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordStartValidatorHelper(exp)
+
+        let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        helper.onResetPasswordError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordStart, isSuccessful: false)
+    }
+
+    // MARK: - ResendCode tests
+
+    func test_whenResetPasswordResendCode_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordResendCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordResendCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordResendCode_succeeds_it_returnsResetPasswordResendCodeRequired() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+
+        validatorMock.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "flowToken response"))
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordResendCodeRequired(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordResendCodeRequiredCalled)
+        XCTAssertEqual(helper.newState?.flowToken, "flowToken response")
+        XCTAssertEqual(helper.sentTo, "sentTo")
+        XCTAssertEqual(helper.channelTargetType, .email)
+        XCTAssertEqual(helper.codeLength, 4)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordResendCode, isSuccessful: true)
+    }
+
+    func test_whenResetPasswordResendCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        let error : MSALNativeAuthResetPasswordChallengeValidatedResponse = .error(
+            MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest,
+                                                              errorDescription: nil,
+                                                              errorCodes: nil,
+                                                              errorURI: nil,
+                                                              innerErrors: nil,
+                                                              target: nil))
+        validatorMock.mockValidateResetPasswordChallengeFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordResendCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordResendCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordResendCode_returns_redirect_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.redirect)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordResendCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordResendCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordResendCode_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
+        validatorMock.mockValidateResetPasswordChallengeFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
+
+        let result = await sut.resendCode(passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordResendCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordResendCodeErrorCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordResendCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitCode tests
+
+    func test_whenResetPasswordSubmitCode_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockContinueRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode(code: "1234", passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordVerifyCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordSubmitCode_succeeds_it_returnsPasswordRequired() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateResetPasswordContinueFunc(.success(passwordSubmitToken: ""))
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode(code: "1234", passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onPasswordRequired(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onPasswordRequiredCalled)
+        XCTAssertNotNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmitCode, isSuccessful: true)
+    }
+
+    func test_whenResetPasswordSubmitCode_returns_invalidOOB_it_returnsInvalidCode() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateResetPasswordContinueFunc(.invalidOOB)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode(code: "1234", passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordVerifyCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordVerifyCodeErrorCalled)
+        XCTAssertEqual(helper.newCodeRequiredState?.flowToken, "passwordResetToken")
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .invalidCode)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordSubmitCode_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        let error : MSALNativeAuthResetPasswordContinueValidatedResponse = .error(
+            MSALNativeAuthResetPasswordContinueResponseError(error: .invalidRequest,
+                                                             errorDescription: nil,
+                                                             errorCodes: nil,
+                                                             errorURI: nil,
+                                                             innerErrors: nil,
+                                                             target: nil,
+                                                             passwordResetToken: nil))
+        validatorMock.mockValidateResetPasswordContinueFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode(code: "1234", passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordVerifyCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmitCode, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordSubmitCode_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
+        validatorMock.mockValidateResetPasswordContinueFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
+
+        let result = await sut.submitCode(code: "1234", passwordResetToken: "passwordResetToken", context: contextMock)
+        helper.onResetPasswordVerifyCodeError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmitCode, isSuccessful: false)
+    }
+
+    // MARK: - SubmitPassword tests
+
+    func test_whenResetPasswordSubmitPassword_cantCreateRequest_it_returns_unexpectedError() async {
+        requestProviderMock.mockSubmitRequestFunc(nil, throwError: true)
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_succeeds_it_returnsCompleted() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded))
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordCompleted(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordCompletedCalled)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: true)
+    }
+
+    func test_whenResetPasswordSubmitPassword_returns_passwordError_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        let error : MSALNativeAuthResetPasswordSubmitValidatedResponse = .passwordError(error:
+            MSALNativeAuthResetPasswordSubmitResponseError(error: .passwordTooWeak,
+                                                           errorDescription: "Password too weak",
+                                                           errorCodes: nil,
+                                                           errorURI: nil,
+                                                           innerErrors: nil,
+                                                           target: nil))
+        validatorMock.mockValidateResetPasswordSubmitFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "passwordSubmitToken")
+        XCTAssertEqual(helper.error?.type, .invalidPassword)
+        XCTAssertEqual(helper.error?.errorDescription, "Password too weak")
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordSubmitPassword_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        let error : MSALNativeAuthResetPasswordSubmitValidatedResponse = .error(
+            MSALNativeAuthResetPasswordSubmitResponseError(error: .invalidRequest,
+                                                           errorDescription: nil,
+                                                           errorCodes: nil,
+                                                           errorURI: nil,
+                                                           innerErrors: nil,
+                                                           target: nil))
+        validatorMock.mockValidateResetPasswordSubmitFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenResetPasswordSubmitPassword_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    // MARK: - SubmitPassword - poll completion tests
+
+    func test_whenSubmitPassword_pollCompletion_returns_failed_it_returnsResetPasswordRequiredError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_unexpectedError_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.unexpectedError)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_passwordError_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        let error : MSALNativeAuthResetPasswordPollCompletionValidatedResponse =
+            .passwordError(error:
+                            MSALNativeAuthResetPasswordPollCompletionResponseError(error: .passwordBanned,
+                                                                                   errorDescription: "Password banned",
+                                                                                   errorCodes: nil,
+                                                                                   errorURI: nil,
+                                                                                   innerErrors: nil,
+                                                                                   target: nil))
+        
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "passwordResetToken")
+        XCTAssertEqual(helper.error?.type, .invalidPassword)
+        XCTAssertEqual(helper.error?.errorDescription, "Password banned")
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_error_it_returnsCorrectError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        let error : MSALNativeAuthResetPasswordPollCompletionValidatedResponse = .error(
+            MSALNativeAuthResetPasswordPollCompletionResponseError(error: .expiredToken,
+                                                             errorDescription: "Expired Token",
+                                                             errorCodes: nil,
+                                                             errorURI: nil,
+                                                             innerErrors: nil,
+                                                             target: nil))
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(error)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+        XCTAssertEqual(helper.error?.errorDescription, "Expired Token")
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_notStarted_it_returnsCorrectErrorAfterRetries() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 1))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .notStarted))
+
+        prepareMockRequestsForPollCompletionRetries(5)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_failed_it_returnsError() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .failed))
+
+        prepareMockRequestsForPollCompletionRetries(5)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+    func test_whenSubmitPassword_pollCompletion_returns_inProgress_it_returnsErrorAfterRetries() async {
+        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .inProgress))
+
+        prepareMockRequestsForPollCompletionRetries(5)
+
+        let exp = expectation(description: "ResetPasswordController expectation")
+        let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
+
+        let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        helper.onResetPasswordRequiredError(result)
+
+        await fulfillment(of: [exp])
+        XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertEqual(helper.error?.type, .generalError)
+
+        checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
+    }
+
+
+    // MARK: - Common Methods
+
+    private func checkTelemetryEventResult(id: MSALNativeAuthTelemetryApiId, isSuccessful: Bool) {
+        XCTAssertEqual(receivedEvents.count, 1)
+
+        guard let telemetryEventDict = receivedEvents.first else {
+            return XCTFail("Telemetry test fail")
+        }
+
+        let expectedApiId = String(id.rawValue)
+        XCTAssertEqual(telemetryEventDict["api_id"] as? String, expectedApiId)
+        XCTAssertEqual(telemetryEventDict["event_name"] as? String, "api_event" )
+        XCTAssertEqual(telemetryEventDict["correlation_id" ] as? String, DEFAULT_TEST_UID.uppercased())
+        XCTAssertEqual(telemetryEventDict["is_successfull"] as? String, isSuccessful ? "yes" : "no")
+        XCTAssertEqual(telemetryEventDict["status"] as? String, isSuccessful ? "succeeded" : "failed")
+        XCTAssertNotNil(telemetryEventDict["start_time"])
+        XCTAssertNotNil(telemetryEventDict["stop_time"])
+        XCTAssertNotNil(telemetryEventDict["response_time"])
+    }
+
+    private func prepareResetPasswordStartValidatorHelper(_ expectation: XCTestExpectation? = nil) -> ResetPasswordStartTestsValidatorHelper {
+        let helper = ResetPasswordStartTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onResetPasswordErrorCalled)
+        XCTAssertFalse(helper.onResetPasswordCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareResetPasswordResendCodeValidatorHelper(_ expectation: XCTestExpectation? = nil) -> ResetPasswordResendCodeTestsValidatorHelper {
+        let helper = ResetPasswordResendCodeTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onResetPasswordResendCodeErrorCalled)
+        XCTAssertFalse(helper.onResetPasswordResendCodeRequiredCalled)
+        XCTAssertNil(helper.newState)
+        XCTAssertNil(helper.sentTo)
+        XCTAssertNil(helper.channelTargetType)
+        XCTAssertNil(helper.codeLength)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareResetPasswordSubmitCodeValidatorHelper(_ expectation: XCTestExpectation? = nil) -> ResetPasswordVerifyCodeTestsValidatorHelper {
+        let helper = ResetPasswordVerifyCodeTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onPasswordRequiredCalled)
+        XCTAssertFalse(helper.onResetPasswordVerifyCodeErrorCalled)
+        XCTAssertNil(helper.newCodeRequiredState)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func prepareResetPasswordSubmitPasswordValidatorHelper(_ expectation: XCTestExpectation? = nil) -> ResetPasswordRequiredTestsValidatorHelper {
+        let helper = ResetPasswordRequiredTestsValidatorHelper(expectation: expectation)
+        XCTAssertFalse(helper.onResetPasswordCompletedCalled)
+        XCTAssertFalse(helper.onResetPasswordRequiredErrorCalled)
+        XCTAssertNil(helper.newPasswordRequiredState)
+        XCTAssertNil(helper.error)
+
+        return helper
+    }
+
+    private func expectedChallengeParams(token: String = "passwordResetToken") -> (token: String, context: MSIDRequestContext) {
+        return (token: token, context: contextMock)
+    }
+
+    private func expectedContinueParams(
+        grantType: MSALNativeAuthGrantType = .oobCode,
+        token: String = "passwordResetToken",
+        oobCode: String? = "1234"
+    ) -> MSALNativeAuthResetPasswordContinueRequestParameters {
+        .init(
+            context: contextMock,
+            passwordResetToken: token,
+            grantType: grantType,
+            oobCode: oobCode
+        )
+    }
+
+    private func expectedSubmitParams(
+        token: String = "passwordSubmitToken",
+        password: String = "password"
+    ) -> MSALNativeAuthResetPasswordSubmitRequestParameters {
+        .init(
+            context: contextMock,
+            passwordSubmitToken: token,
+            newPassword: password)
+    }
+
+    private func expectedPollCompletionParameters(
+        token: String = "passwordResetToken"
+    ) -> MSALNativeAuthResetPasswordPollCompletionRequestParameters {
+        .init(
+            context: contextMock,
+            passwordResetToken: token)
+    }
+
+    private func prepareMockRequest() -> MSIDHttpRequest {
+        let request = MSIDHttpRequest()
+        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
+
+        return request
+    }
+
+    private func prepareMockRequestsForPollCompletionRetries(_ count: Int) {
+        for _ in 1...count {
+            _ = prepareMockRequest()
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthResetPasswordControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthResetPasswordControllerMock.swift
@@ -1,0 +1,51 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthResetPasswordControllerMock: MSALNativeAuthResetPasswordControlling {
+
+    var resetPasswordResult: ResetPasswordStartResult!
+    var resendCodeResult: ResetPasswordResendCodeResult!
+    var submitCodeResult: ResetPasswordVerifyCodeResult!
+    var submitPasswordResult: ResetPasswordRequiredResult!
+
+    func resetPassword(parameters: MSAL.MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartResult {
+        return resetPasswordResult
+    }
+
+    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeResult {
+        return resendCodeResult
+    }
+
+    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordVerifyCodeResult {
+        return submitCodeResult
+    }
+
+    func submitPassword(password: String, passwordSubmitToken: String, context: MSIDRequestContext) async -> ResetPasswordRequiredResult {
+        return submitPasswordResult
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/ResetPasswordDelegateSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/ResetPasswordDelegateSpies.swift
@@ -1,0 +1,161 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+class ResetPasswordStartDelegateSpy: ResetPasswordStartDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onResetPasswordErrorCalled = false
+    private(set) var onResetPasswordCodeRequiredCalled = false
+    private(set) var error: ResetPasswordStartError?
+    private(set) var newState: ResetPasswordCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordError(error: MSAL.ResetPasswordStartError) {
+        onResetPasswordErrorCalled = true
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onResetPasswordCodeRequired(
+        newState: ResetPasswordCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    ) {
+        onResetPasswordCodeRequiredCalled = true
+        self.newState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class ResetPasswordResendCodeDelegateSpy: ResetPasswordResendCodeDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onResetPasswordResendCodeErrorCalled = false
+    private(set) var onResetPasswordResendCodeRequiredCalled = false
+    private(set) var error: ResendCodeError?
+    private(set) var newState: ResetPasswordCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordResendCodeError(error: ResendCodeError, newState: ResetPasswordCodeRequiredState?) {
+        onResetPasswordResendCodeErrorCalled = true
+
+        self.error = error
+        self.newState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onResetPasswordResendCodeRequired(newState: MSAL.ResetPasswordCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
+        onResetPasswordResendCodeRequiredCalled = true
+
+        self.newState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class ResetPasswordVerifyCodeDelegateSpy: ResetPasswordVerifyCodeDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onResetPasswordVerifyCodeErrorCalled = false
+    private(set) var onPasswordRequiredCalled = false
+    private(set) var error: VerifyCodeError?
+    private(set) var newCodeRequiredState: ResetPasswordCodeRequiredState?
+    private(set) var newPasswordRequiredState: ResetPasswordRequiredState?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordVerifyCodeError(error: VerifyCodeError, newState: ResetPasswordCodeRequiredState?) {
+        onResetPasswordVerifyCodeErrorCalled = true
+        self.error = error
+        newCodeRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onPasswordRequired(newState: ResetPasswordRequiredState) {
+        onPasswordRequiredCalled = true
+        newPasswordRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class ResetPasswordRequiredDelegateSpy: ResetPasswordRequiredDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var onResetPasswordRequiredErrorCalled = false
+    private(set) var onResetPasswordCompletedCalled = false
+    private(set) var error: PasswordRequiredError?
+    private(set) var newPasswordRequiredState: ResetPasswordRequiredState?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordRequiredError(error: PasswordRequiredError, newState: ResetPasswordRequiredState?) {
+        onResetPasswordRequiredErrorCalled = true
+
+        self.error = error
+        newPasswordRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+
+    func onResetPasswordCompleted() {
+        onResetPasswordCompletedCalled = true
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/ResetPasswordTestValidatorHelpers.swift
+++ b/MSAL/test/unit/native_auth/mock/ResetPasswordTestValidatorHelpers.swift
@@ -1,0 +1,114 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+class ResetPasswordStartTestsValidatorHelper: ResetPasswordStartDelegateSpy {
+
+    func onResetPasswordError(_ input: ResetPasswordStartResult) {
+        guard case let .error(error) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be an .error")
+        }
+
+        Task { await self.onResetPasswordError(error: error) }
+    }
+
+    func onResetPasswordCodeRequired(_ input: ResetPasswordStartResult) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be .codeRequired")
+        }
+
+        Task {
+            await self.onResetPasswordCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength)
+        }
+    }
+}
+
+class ResetPasswordResendCodeTestsValidatorHelper: ResetPasswordResendCodeDelegateSpy {
+
+    func onResetPasswordResendCodeError(_ input: ResetPasswordResendCodeResult) {
+        guard case let .error(error, newState) = input else {
+            expectation?.fulfill()
+            return XCTFail("should be .error")
+        }
+
+        Task { await self.onResetPasswordResendCodeError(error: error, newState: newState) }
+    }
+
+    func onResetPasswordResendCodeRequired(_ input: ResetPasswordResendCodeResult) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input else {
+            expectation?.fulfill()
+            return XCTFail("Should be .codeRequired")
+        }
+
+        Task {
+            await self.onResetPasswordResendCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength)
+        }
+    }
+}
+
+class ResetPasswordVerifyCodeTestsValidatorHelper: ResetPasswordVerifyCodeDelegateSpy {
+
+    func onResetPasswordVerifyCodeError(_ input: ResetPasswordVerifyCodeResult) {
+        guard case let .error(error, newState) = input else {
+            expectation?.fulfill()
+            return XCTFail("should be .error")
+        }
+
+        Task { await self.onResetPasswordVerifyCodeError(error: error, newState: newState) }
+    }
+
+    func onPasswordRequired(_ input: ResetPasswordVerifyCodeResult) {
+        guard case let .passwordRequired(newState) = input else {
+            expectation?.fulfill()
+            return XCTFail("should be .success")
+        }
+
+        Task { await self.onPasswordRequired(newState: newState) }
+    }
+}
+
+class ResetPasswordRequiredTestsValidatorHelper: ResetPasswordRequiredDelegateSpy {
+
+    func onResetPasswordRequiredError(_ input: ResetPasswordRequiredResult) {
+        guard case let .error(error, newState) = input else {
+            expectation?.fulfill()
+            return XCTFail("should be .error")
+        }
+
+        Task { await self.onResetPasswordRequiredError(error: error, newState: newState) }
+    }
+
+    func onResetPasswordCompleted(_ input: ResetPasswordRequiredResult) {
+        guard case .completed = input else {
+            expectation?.fulfill()
+            return XCTFail("should be .success")
+        }
+
+        Task { await self.onResetPasswordCompleted() }
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
@@ -1,0 +1,76 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordControlling {
+    private let expectation: XCTestExpectation
+    private(set) var context: MSIDRequestContext?
+    private(set) var flowToken: String?
+    private(set) var resetPasswordCalled = false
+    private(set) var resendCodeCalled = false
+    private(set) var submitCodeCalled = false
+    private(set) var submitPasswordCalled = false
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func resetPassword(parameters: MSAL.MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartResult {
+        self.context = parameters.context
+        resetPasswordCalled = true
+        expectation.fulfill()
+
+        return .error(.init(type: .generalError))
+    }
+
+    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeResult {
+        self.flowToken = passwordResetToken
+        self.context = context
+        resendCodeCalled = true
+        expectation.fulfill()
+
+        return .error(error: .init(), newState: nil)
+    }
+
+    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordVerifyCodeResult {
+        self.flowToken = passwordResetToken
+        self.context = context
+        submitCodeCalled = true
+        expectation.fulfill()
+
+        return .error(error: .init(type: .generalError), newState: nil)
+    }
+
+    func submitPassword(password: String, passwordSubmitToken: String, context: MSIDRequestContext) async -> ResetPasswordRequiredResult {
+        self.flowToken = passwordSubmitToken
+        self.context = context
+        submitPasswordCalled = true
+        expectation.fulfill()
+
+        return .error(error: .init(type: .generalError), newState: nil)
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordRequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordRequestProviderMock.swift
@@ -1,0 +1,182 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthResetPasswordRequestProviderMock: MSALNativeAuthResetPasswordRequestProviding {
+    // MARK: Start
+
+    var requestStart: MSIDHttpRequest?
+    var throwErrorStart = false
+    private(set) var startCalled = false
+    var expectedStartRequestParameters: MSALNativeAuthResetPasswordStartRequestProviderParameters!
+
+    func mockStartRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {
+        requestStart = request
+        throwErrorStart = throwError
+    }
+
+    func start(parameters: MSAL.MSALNativeAuthResetPasswordStartRequestProviderParameters) throws -> MSIDHttpRequest {
+        startCalled = true
+        checkParameters(params: parameters)
+
+        if let request = requestStart {
+            return request
+        } else if throwErrorStart {
+            throw ErrorMock.error
+        } else {
+            fatalError("Make sure to use mockStartRequestFunc()")
+        }
+    }
+
+    private func checkParameters(params: MSALNativeAuthResetPasswordStartRequestProviderParameters) {
+        XCTAssertEqual(params.username, expectedStartRequestParameters.username)
+        XCTAssertEqual(params.context.correlationId(), expectedStartRequestParameters.context.correlationId())
+    }
+
+    // MARK: Challenge
+
+    var requestChallenge: MSIDHttpRequest?
+    var throwErrorChallenge = false
+    private(set) var challengeCalled = false
+    var expectedChallengeRequestParameters: (token: String, context: MSIDRequestContext)!
+
+    func mockChallengeRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {
+        requestChallenge = request
+        throwErrorChallenge = throwError
+    }
+
+    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+        challengeCalled = true
+        checkParameters(token: token, context: context)
+
+        if let request = requestChallenge {
+            return request
+        } else if throwErrorChallenge {
+            throw ErrorMock.error
+        } else {
+            fatalError("Make sure to use mockChallengeRequestFunc()")
+        }
+    }
+
+    private func checkParameters(token: String, context: MSIDRequestContext) {
+        XCTAssertEqual(token, expectedChallengeRequestParameters.token)
+        XCTAssertEqual(context.correlationId(), expectedChallengeRequestParameters.context.correlationId())
+    }
+
+    // MARK: Continue
+
+    var requestContinue: MSIDHttpRequest?
+    var throwErrorContinue = false
+    private(set) var continueCalled = false
+    var expectedContinueRequestParameters: MSALNativeAuthResetPasswordContinueRequestParameters!
+
+    func mockContinueRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {
+        requestContinue = request
+        throwErrorContinue = throwError
+    }
+
+    func `continue`(parameters: MSAL.MSALNativeAuthResetPasswordContinueRequestParameters) throws -> MSIDHttpRequest {
+        continueCalled = true
+        checkParameters(parameters)
+
+        if let request = requestContinue {
+            return request
+        } else if throwErrorContinue {
+            throw ErrorMock.error
+        } else {
+            fatalError("Make sure to use mockContinueRequestFunc()")
+        }
+    }
+
+    private func checkParameters(_ params: MSALNativeAuthResetPasswordContinueRequestParameters) {
+        XCTAssertEqual(params.grantType, expectedContinueRequestParameters.grantType)
+        XCTAssertEqual(params.passwordResetToken, expectedContinueRequestParameters.passwordResetToken)
+        XCTAssertEqual(params.oobCode, expectedContinueRequestParameters.oobCode)
+        XCTAssertEqual(params.context.correlationId(), expectedContinueRequestParameters.context.correlationId())
+    }
+
+    // MARK: Submit
+
+    var requestSubmit: MSIDHttpRequest?
+    var throwErrorSubmit = false
+    private(set) var submitCalled = false
+    var expectedSubmitRequestParameters: MSALNativeAuthResetPasswordSubmitRequestParameters!
+
+    func mockSubmitRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {
+        requestSubmit = request
+        throwErrorSubmit = throwError
+    }
+
+    func submit(parameters: MSAL.MSALNativeAuthResetPasswordSubmitRequestParameters) throws -> MSIDHttpRequest {
+        submitCalled = true
+        checkParameters(parameters)
+
+        if let request = requestSubmit {
+            return request
+        } else if throwErrorSubmit {
+            throw ErrorMock.error
+        } else {
+            fatalError("Make sure to use mockSubmitRequestFunc()")
+        }
+    }
+
+    private func checkParameters(_ params: MSALNativeAuthResetPasswordSubmitRequestParameters) {
+        XCTAssertEqual(params.passwordSubmitToken, expectedSubmitRequestParameters.passwordSubmitToken)
+        XCTAssertEqual(params.newPassword, expectedSubmitRequestParameters.newPassword)
+        XCTAssertEqual(params.context.correlationId(), expectedSubmitRequestParameters.context.correlationId())
+    }
+
+    // MARK: PollCompletion
+
+    var requestPollCompletion: MSIDHttpRequest?
+    var throwErrorPollCompletion = false
+    private(set) var pollCompletionCalled = false
+    var expectedPollCompletionParameters: MSALNativeAuthResetPasswordPollCompletionRequestParameters!
+
+    func mockPollCompletionRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {
+        requestPollCompletion = request
+        throwErrorPollCompletion = throwError
+    }
+
+    func pollCompletion(parameters: MSAL.MSALNativeAuthResetPasswordPollCompletionRequestParameters) throws -> MSIDHttpRequest {
+        pollCompletionCalled = true
+        checkParameters(parameters)
+
+        if let request = requestPollCompletion {
+            return request
+        } else if throwErrorPollCompletion {
+            throw ErrorMock.error
+        } else {
+            fatalError("Make sure to use mockPollCompletionRequestFunc()")
+        }
+    }
+
+    private func checkParameters(_ params: MSALNativeAuthResetPasswordPollCompletionRequestParameters) {
+        XCTAssertEqual(params.passwordResetToken, expectedPollCompletionParameters.passwordResetToken)
+        XCTAssertEqual(params.context.correlationId(), expectedPollCompletionParameters.context.correlationId())
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordResponseValidatorMock.swift
+++ b/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordResponseValidatorMock.swift
@@ -1,0 +1,110 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthResetPasswordResponseValidatorMock: MSALNativeAuthResetPasswordResponseValidating {
+
+    // MARK: Start
+
+    private var resetPasswordStartValidatedResponse: MSALNativeAuthResetPasswordStartValidatedResponse?
+
+    func mockValidateResetPasswordStartFunc(_ response: MSALNativeAuthResetPasswordStartValidatedResponse) {
+        self.resetPasswordStartValidatedResponse = response
+    }
+
+    func validate(_ result: Result<MSAL.MSALNativeAuthResetPasswordStartResponse, Error>, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordStartValidatedResponse {
+
+        if let resetPasswordStartValidatedResponse = resetPasswordStartValidatedResponse {
+            return resetPasswordStartValidatedResponse
+        } else {
+            fatalError("Make sure you call mockValidateResetPasswordStartFunc()")
+        }
+    }
+
+    // MARK: Challenge
+
+    private var resetPasswordChallengeValidatedResponse: MSALNativeAuthResetPasswordChallengeValidatedResponse?
+
+    func mockValidateResetPasswordChallengeFunc(_ response: MSALNativeAuthResetPasswordChallengeValidatedResponse) {
+        self.resetPasswordChallengeValidatedResponse = response
+    }
+
+    func validate(_ result: Result<MSAL.MSALNativeAuthResetPasswordChallengeResponse, Error>, with context: MSIDRequestContext) -> MSAL.MSALNativeAuthResetPasswordChallengeValidatedResponse {
+        if let resetPasswordChallengeValidatedResponse = resetPasswordChallengeValidatedResponse {
+            return resetPasswordChallengeValidatedResponse
+        } else {
+            fatalError("Make sure you call mockValidateResetPasswordChallengeFunc()")
+        }
+    }
+
+    // MARK: Continue
+
+    private var resetPasswordContinueValidatedResponse: MSALNativeAuthResetPasswordContinueValidatedResponse?
+
+    func mockValidateResetPasswordContinueFunc(_ response: MSALNativeAuthResetPasswordContinueValidatedResponse) {
+        self.resetPasswordContinueValidatedResponse = response
+    }
+
+    func validate(_ result: Result<MSAL.MSALNativeAuthResetPasswordContinueResponse, Error>, with context: MSIDRequestContext) -> MSAL.MSALNativeAuthResetPasswordContinueValidatedResponse {
+        if let resetPasswordContinueValidatedResponse = resetPasswordContinueValidatedResponse {
+            return resetPasswordContinueValidatedResponse
+        } else {
+            fatalError("Make sure you call mockValidateResetPasswordContinueFunc()")
+        }
+    }
+
+    // MARK: Submit
+
+    private var resetPasswordSubmitValidatedResponse: MSALNativeAuthResetPasswordSubmitValidatedResponse?
+
+    func mockValidateResetPasswordSubmitFunc(_ response: MSALNativeAuthResetPasswordSubmitValidatedResponse) {
+        self.resetPasswordSubmitValidatedResponse = response
+    }
+
+    func validate(_ result: Result<MSAL.MSALNativeAuthResetPasswordSubmitResponse, Error>, with context: MSIDRequestContext) -> MSAL.MSALNativeAuthResetPasswordSubmitValidatedResponse {
+        if let resetPasswordSubmitValidatedResponse = resetPasswordSubmitValidatedResponse {
+            return resetPasswordSubmitValidatedResponse
+        } else {
+            fatalError("Make sure you call mockValidateResetPasswordSubmitFunc()")
+        }
+    }
+
+    // MARK: PollCompletion
+
+    private var resetPasswordPollCompletionValidatedResponse: MSALNativeAuthResetPasswordPollCompletionValidatedResponse?
+
+    func mockValidateResetPasswordPollCompletionFunc(_ response: MSALNativeAuthResetPasswordPollCompletionValidatedResponse) {
+        self.resetPasswordPollCompletionValidatedResponse = response
+    }
+
+    func validate(_ result: Result<MSAL.MSALNativeAuthResetPasswordPollCompletionResponse, Error>, with context: MSIDRequestContext) -> MSAL.MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
+        if let resetPasswordPollCompletionValidatedResponse = resetPasswordPollCompletionValidatedResponse {
+            return resetPasswordPollCompletionValidatedResponse
+        } else {
+            fatalError("Make sure you call mockValidateResetPasswordPollCompletionFunc()")
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCodeTests.swift
@@ -1,0 +1,51 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthResetPasswordChallengeOauth2ErrorCodeTests: XCTestCase {
+    
+    private typealias sut = MSALNativeAuthResetPasswordChallengeOauth2ErrorCode
+    
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 4)
+    }
+    
+    func test_invalidRequest() {
+        XCTAssertEqual(sut.invalidRequest.rawValue, "invalid_request")
+    }
+    
+    func test_invalidClient() {
+        XCTAssertEqual(sut.invalidClient.rawValue, "invalid_client")
+    }
+    
+    func test_expiredToken() {
+        XCTAssertEqual(sut.expiredToken.rawValue, "expired_token")
+    }
+    
+    func test_unsupportedChallengeType() {
+        XCTAssertEqual(sut.unsupportedChallengeType.rawValue, "unsupported_challenge_type")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
@@ -1,0 +1,88 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthResetPasswordChallengeResponseErrorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthResetPasswordChallengeResponseError!
+    private let testDescription = "testDescription"
+
+    // MARK: - to ResetPasswordStartError tests
+
+    func test_toResetPasswordStartPublicError_invalidClient() {
+        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
+        let error = sut.toResetPasswordStartPublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+
+    func test_toResetPasswordStartPublicError_invalidRequest() {
+        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
+        let error = sut.toResetPasswordStartPublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertNotNil(error.errorDescription)
+    }
+
+    func test_toResetPasswordStartPublicError_expiredToken() {
+        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
+        let error = sut.toResetPasswordStartPublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+
+    func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
+        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unsupportedChallengeType, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
+        let error = sut.toResetPasswordStartPublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertNotNil(error.errorDescription)
+    }
+
+    // MARK: - to ResendCodePublicError tests
+
+    func test_toResendCodePublicError_invalidClient() {
+        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
+        let error = sut.toResendCodePublicError()
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+
+    func test_toResendCodePublicError_invalidRequest() {
+        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
+        let error = sut.toResendCodePublicError()
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+
+    func test_toResendCodePublicError_expiredToken() {
+        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
+        let error = sut.toResendCodePublicError()
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+
+    func test_toResendCodePublicError_unsupportedChallengeType() {
+        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unsupportedChallengeType, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
+        let error = sut.toResendCodePublicError()
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCodeTests.swift
@@ -1,0 +1,59 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthResetPasswordContinueOauth2ErrorCodeTests: XCTestCase {
+
+    private typealias sut = MSALNativeAuthResetPasswordContinueOauth2ErrorCode
+
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 6)
+    }
+    
+    func test_invalidRequest() {
+        XCTAssertEqual(sut.invalidRequest.rawValue, "invalid_request")
+    }
+
+    func test_invalidClient() {
+        XCTAssertEqual(sut.invalidClient.rawValue, "invalid_client")
+    }
+
+    func test_invalidGrant() {
+        XCTAssertEqual(sut.invalidGrant.rawValue, "invalid_grant")
+    }
+
+    func test_expiredToken() {
+        XCTAssertEqual(sut.expiredToken.rawValue, "expired_token")
+    }
+
+    func test_verificationRequired() {
+        XCTAssertEqual(sut.verificationRequired.rawValue, "verification_required")
+    }
+
+    func test_invalidOOBValue() {
+        XCTAssertEqual(sut.invalidOOBValue.rawValue, "invalid_oob_value")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
@@ -1,0 +1,76 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthResetPasswordContinueResponseErrorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthResetPasswordContinueResponseError!
+    private let testDescription = "testDescription"
+
+    // MARK: - to toVerifyCodePublicError tests
+    
+    func test_toResetPasswordStartPublicError_invalidRequest() {
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        let error = sut.toVerifyCodePublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertNotNil(error.errorDescription)
+    }
+    
+    func test_toResetPasswordStartPublicError_invalidClient() {
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        let error = sut.toVerifyCodePublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+
+    func test_toResetPasswordStartPublicError_invalidGrant() {
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidGrant, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        let error = sut.toVerifyCodePublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+    
+    func test_toResetPasswordStartPublicError_expiredToken() {
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        let error = sut.toVerifyCodePublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+
+    func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .verificationRequired, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        let error = sut.toVerifyCodePublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertNotNil(error.errorDescription)
+    }
+    
+    func test_toResetPasswordStartPublicError_invalidOOBValue() {
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidOOBValue, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        let error = sut.toVerifyCodePublicError()
+        XCTAssertEqual(error.type, .invalidCode)
+        XCTAssertNotNil(error.errorDescription)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCodeTests.swift
@@ -1,0 +1,71 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCodeTests: XCTestCase {
+
+    private typealias sut = MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode
+
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 9)
+    }
+
+    func test_invalidRequest() {
+        XCTAssertEqual(sut.invalidRequest.rawValue, "invalid_request")
+    }
+    
+    func test_invalidClient() {
+        XCTAssertEqual(sut.invalidClient.rawValue, "invalid_client")
+    }
+    
+    func test_expiredToken() {
+        XCTAssertEqual(sut.expiredToken.rawValue, "expired_token")
+    }
+    
+    func test_passwordTooWeak() {
+        XCTAssertEqual(sut.passwordTooWeak.rawValue, "password_too_weak")
+    }
+    
+    func test_passwordTooShort() {
+        XCTAssertEqual(sut.passwordTooShort.rawValue, "password_too_short")
+    }
+    
+    func test_passwordTooLong() {
+        XCTAssertEqual(sut.passwordTooLong.rawValue, "password_too_long")
+    }
+    
+    func test_passwordRecentlyUsed() {
+        XCTAssertEqual(sut.passwordRecentlyUsed.rawValue, "password_recently_used")
+    }
+    
+    func test_passwordBanned() {
+        XCTAssertEqual(sut.passwordBanned.rawValue, "password_banned")
+    }
+    
+    func test_userNotFound() {
+        XCTAssertEqual(sut.userNotFound.rawValue, "user_not_found")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
@@ -1,0 +1,79 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthResetPasswordPollCompletionResponseErrorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthResetPasswordPollCompletionResponseError!
+    private let testDescription = "testDescription"
+
+    // MARK: - toPasswordRequiredPublicError tests
+    
+    func test_toPasswordRequiredPublicError_invalidRequest() {
+        testPasswordRequiredError(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_invalidClient() {
+        testPasswordRequiredError(code: .invalidClient, description: "General error", expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_expiredToken() {
+        testPasswordRequiredError(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_passwordTooWeak() {
+        testPasswordRequiredError(code: .passwordTooWeak, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+
+    func test_toPasswordRequiredPublicError_passwordTooShort() {
+        testPasswordRequiredError(code: .passwordTooShort, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+
+    func test_toPasswordRequiredPublicError_passwordTooLong() {
+        testPasswordRequiredError(code: .passwordTooLong, description: "General error", expectedErrorType: .invalidPassword)
+    }
+
+    func test_toPasswordRequiredPublicError_passwordRecentlyUsed() {
+        testPasswordRequiredError(code: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+
+    func test_toPasswordRequiredPublicError_passwordBanned() {
+        testPasswordRequiredError(code: .passwordBanned, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    func test_toPasswordRequiredPublicError_userNotFound() {
+        testPasswordRequiredError(code: .userNotFound, description: testDescription, expectedErrorType: .generalError)
+    }
+    
+    // MARK: private methods
+    
+    private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredErrorType) {
+        sut = MSALNativeAuthResetPasswordPollCompletionResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
+        let error = sut.toPasswordRequiredPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCodeTests.swift
@@ -1,0 +1,51 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthResetPasswordStartOauth2ErrorCodeTests: XCTestCase {
+
+    private typealias sut = MSALNativeAuthResetPasswordStartOauth2ErrorCode
+
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 4)
+    }
+    
+    func test_invalidRequest() {
+        XCTAssertEqual(sut.invalidRequest.rawValue, "invalid_request")
+    }
+
+    func test_invalidClient() {
+        XCTAssertEqual(sut.invalidClient.rawValue, "invalid_client")
+    }
+
+    func test_userNotFound() {
+        XCTAssertEqual(sut.userNotFound.rawValue, "user_not_found")
+    }
+
+    func test_unsupportedChallengeType() {
+        XCTAssertEqual(sut.unsupportedChallengeType.rawValue, "unsupported_challenge_type")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitOauth2ErrorCodeTests.swift
@@ -1,0 +1,67 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthResetPasswordSubmitOauth2ErrorCodeTests: XCTestCase {
+    
+    private typealias sut = MSALNativeAuthResetPasswordSubmitOauth2ErrorCode
+    
+    func test_allCases() {
+        XCTAssertEqual(sut.allCases.count, 8)
+    }
+    
+    func test_invalidRequest() {
+        XCTAssertEqual(sut.invalidRequest.rawValue, "invalid_request")
+    }
+    
+    func test_invalidClient() {
+        XCTAssertEqual(sut.invalidClient.rawValue, "invalid_client")
+    }
+    
+    func test_expiredToken() {
+        XCTAssertEqual(sut.expiredToken.rawValue, "expired_token")
+    }
+    
+    func test_passwordTooWeak() {
+        XCTAssertEqual(sut.passwordTooWeak.rawValue, "password_too_weak")
+    }
+    
+    func test_passwordTooShort() {
+        XCTAssertEqual(sut.passwordTooShort.rawValue, "password_too_short")
+    }
+    
+    func test_passwordTooLong() {
+        XCTAssertEqual(sut.passwordTooLong.rawValue, "password_too_long")
+    }
+    
+    func test_passwordRecentlyUsed() {
+        XCTAssertEqual(sut.passwordRecentlyUsed.rawValue, "password_recently_used")
+    }
+    
+    func test_passwordBanned() {
+        XCTAssertEqual(sut.passwordBanned.rawValue, "password_banned")
+    }
+}

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
@@ -1,0 +1,75 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthResetPasswordSubmitResponseErrorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthResetPasswordSubmitResponseError!
+    private let testDescription = "testDescription"
+
+    // MARK: - toPasswordRequiredPublicError tests
+
+    func test_toPasswordRequiredPublicError_invalidRequest() {
+        testPasswordRequiredError(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_invalidClient() {
+        testPasswordRequiredError(code: .invalidClient, description: "General error", expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_expiredToken() {
+        testPasswordRequiredError(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_passwordTooWeak() {
+        testPasswordRequiredError(code: .passwordTooWeak, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+
+    func test_toPasswordRequiredPublicError_passwordTooShort() {
+        testPasswordRequiredError(code: .passwordTooShort, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+
+    func test_toPasswordRequiredPublicError_passwordTooLong() {
+        testPasswordRequiredError(code: .passwordTooLong, description: "General error", expectedErrorType: .invalidPassword)
+    }
+
+    func test_toPasswordRequiredPublicError_passwordRecentlyUsed() {
+        testPasswordRequiredError(code: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+
+    func test_toPasswordRequiredPublicError_passwordBanned() {
+        testPasswordRequiredError(code: .passwordBanned, description: testDescription, expectedErrorType: .invalidPassword)
+    }
+    
+    // MARK: private methods
+    
+    private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredErrorType) {
+        sut = MSALNativeAuthResetPasswordSubmitResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
+        let error = sut.toPasswordRequiredPublicError()
+        XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.errorDescription, description)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift
@@ -1,0 +1,86 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordChallengeRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let parameters = MSALNativeAuthResetPasswordChallengeRequestParameters(
+            context: MSALNativeAuthRequestContextMock(),
+            passwordResetToken: "<password-reset-token>"
+        )
+
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/resetpassword/v1.0/challenge")
+    }
+
+    func test_allParametersFilled_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let params = MSALNativeAuthResetPasswordChallengeRequestParameters(
+            context: MSALNativeAuthRequestContextMock(),
+            passwordResetToken: "<password-reset-token>"
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_reset_token": "<password-reset-token>",
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+
+    func test_allOptionalNil_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .redirect]))
+        let params = MSALNativeAuthResetPasswordChallengeRequestParameters(
+            context: MSALNativeAuthRequestContextMock(),
+            passwordResetToken: "<password-reset-token>"
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_reset_token": "<password-reset-token>",
+            "challenge_type": "password redirect"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParametersTest.swift
@@ -1,0 +1,93 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordContinueRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let parameters = MSALNativeAuthResetPasswordContinueRequestParameters(
+            context: context,
+            passwordResetToken: "<password-reset-token>",
+            grantType: .oobCode,
+            oobCode: "0000"
+        )
+
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/resetpassword/v1.0/continue")
+    }
+
+    func test_allParametersFilled_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let params = MSALNativeAuthResetPasswordContinueRequestParameters(
+            context: context,
+            passwordResetToken: "<password-reset-token>",
+            grantType: .oobCode,
+            oobCode: "0000"
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_reset_token": "<password-reset-token>",
+            "grant_type": "oob",
+            "oob": "0000"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+
+    func test_allOptionalNil_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let params = MSALNativeAuthResetPasswordContinueRequestParameters(
+            context: context,
+            passwordResetToken: "<password-reset-token>",
+            grantType: .oobCode,
+            oobCode: nil
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_reset_token": "<password-reset-token>",
+            "grant_type": "oob"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParametersTest.swift
@@ -1,0 +1,67 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordPollCompletionRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let parameters = MSALNativeAuthResetPasswordPollCompletionRequestParameters(
+            context: context,
+            passwordResetToken: "<password-reset-token"
+        )
+
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/resetpassword/v1.0/poll_completion")
+    }
+
+    func test_allParametersFilled_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let params = MSALNativeAuthResetPasswordPollCompletionRequestParameters(
+            context: context,
+            passwordResetToken: "<password-reset-token"
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_reset_token": "<password-reset-token"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParametersTest.swift
@@ -1,0 +1,67 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordStartRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.redirect]))
+        let parameters = MSALNativeAuthResetPasswordStartRequestParameters(
+            context: MSALNativeAuthRequestContextMock(),
+            username: "username"
+        )
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/resetpassword/v1.0/start")
+    }
+
+    func test_allParametersFilled_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
+        let params = MSALNativeAuthResetPasswordStartRequestParameters(
+            context: MSALNativeAuthRequestContextMock(),
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "challenge_type": "password oob redirect"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParametersTest.swift
@@ -1,0 +1,70 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordSubmitRequestParametersTest: XCTestCase {
+    let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
+    var config: MSALNativeAuthConfiguration! = nil
+
+    private let context = MSALNativeAuthRequestContextMock(
+        correlationId: .init(uuidString: DEFAULT_TEST_UID)!
+    )
+
+    func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let parameters = MSALNativeAuthResetPasswordSubmitRequestParameters(
+            context: context,
+            passwordSubmitToken: "<password-submit-token>",
+            newPassword:"new-password"
+        )
+
+        var resultUrl: URL? = nil
+        XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
+        XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/resetpassword/v1.0/submit")
+    }
+
+    func test_allParametersFilled_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
+        let params = MSALNativeAuthResetPasswordSubmitRequestParameters(
+            context: context,
+            passwordSubmitToken: "<password-submit-token>",
+            newPassword:"new-password"
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "password_submit_token": "<password-submit-token>",
+            "new_password": "new-password"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
@@ -1,0 +1,662 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
+
+    private var sut: MSALNativeAuthResetPasswordResponseValidator!
+    private var context: MSIDRequestContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        sut = MSALNativeAuthResetPasswordResponseValidator()
+        context = MSALNativeAuthRequestContextMock()
+    }
+
+    // MARK: - Start Response
+
+    func test_whenResetPasswordStartSuccessResponseContainsRedirect_itReturnsRedirect() {
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .success(
+            .init(passwordResetToken: nil, challengeType: .redirect)
+        )
+
+        let result = sut.validate(response, with: context)
+        if case .redirect = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+
+    func test_whenResetPasswordStartSuccessResponseDoesNotContainsTokenOrRedirect_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .success(
+            .init(passwordResetToken: nil, challengeType: .otp)
+        )
+
+        let result = sut.validate(response, with: context)
+        if case .unexpectedError = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+
+    func test_whenResetPasswordStartSuccessResponseContainsToken_itReturnsSuccess() {
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .success(
+            .init(passwordResetToken: "passwordResetToken", challengeType: .otp)
+        )
+
+        let result = sut.validate(response, with: context)
+
+        guard case .success(let passwordResetToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(passwordResetToken, "passwordResetToken")
+    }
+
+    func test_whenResetPasswordStartErrorResponseIsNotExpected_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        if case .unexpectedError = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+
+    func test_whenResetPasswordStartErrorResponseUserNotFound_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .userNotFound)
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.userNotFound) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenResetPasswordStartErrorResponseInvalidClient_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .invalidClient)
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.invalidClient) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenResetPasswordStartErrorResponseUnsupportedChallengeType_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .unsupportedChallengeType)
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.unsupportedChallengeType) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenResetPasswordStartInvalidRequestUserDoesntHaveAPwd_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .invalidRequest, errorCodes: [500222])
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.userDoesNotHavePassword) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenResetPasswordStartInvalidRequestGenericErrorCode_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .invalidRequest, errorCodes: [90023])
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.invalidRequest) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenResetPasswordStartInvalidRequestNoErrorCode_itReturnsRelatedError() {
+        let error = createResetPasswordStartError(error: .invalidRequest)
+        let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        if case .error(.invalidRequest) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+
+    // MARK: - Challenge Response
+
+    func test_whenResetPasswordChallengeSuccessResponseContainsRedirect_itReturnsRedirect() {
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .success(.init(
+            challengeType: .redirect,
+            bindingMethod: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            passwordResetToken: "token",
+            codeLength: nil)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .redirect)
+    }
+
+    func test_whenResetPasswordChallengeSuccessResponseContainsValidAttributesAndOOB_itReturnsSuccess() {
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .success(.init(
+            challengeType: .oob,
+            bindingMethod: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            passwordResetToken: "token",
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+
+        guard case .success(let sentTo, let channelTargetType, let codeLength, let passwordResetToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(sentTo, "challenge-type-label")
+        XCTAssertEqual(channelTargetType, .email)
+        XCTAssertEqual(codeLength, 6)
+        XCTAssertEqual(passwordResetToken, "token")
+    }
+
+    func test_whenResetPasswordChallengeSuccessResponseOmitsSomeAttributes_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .success(.init(
+            challengeType: .oob,
+            bindingMethod: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .email,
+            passwordResetToken: nil,
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenResetPasswordChallengeSuccessResponseHasInvalidChallengeChannel_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .success(.init(
+            challengeType: .otp,
+            bindingMethod: nil,
+            challengeTargetLabel: "challenge-type-label",
+            challengeChannel: .none,
+            passwordResetToken: nil,
+            codeLength: 6)
+        )
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenResetPasswordChallengeErrorResponseIsNotExpected_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenResetPasswordChallengeErrorResponseIsExpected_itReturnsError() {
+        let error = createResetPasswordChallengeError(error: .expiredToken)
+
+        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .failure(error)
+
+        let result = sut.validate(response, with: context)
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    // MARK: - Continue Response
+
+    func test_whenResetPasswordContinueSuccessResponseContainsValidAttributesAndOOB_itReturnsSuccess() {
+        let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .success(.init(passwordSubmitToken: "passwordSubmitToken", expiresIn: 300))
+
+        let result = sut.validate(response, with: context)
+
+        guard case .success(let passwordSubmitToken) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(passwordSubmitToken, "passwordSubmitToken")
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIsNotExpected_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_invalidOOBValue_itReturnsExpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidOOBValue)
+
+        XCTAssertEqual(result, .invalidOOB)
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_verificationRequired_itReturnsUnexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .verificationRequired)
+
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_invalidClient_itReturnsExpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidClient)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidClient = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_invalidGrant_itReturnsExpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidGrant)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidGrant = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_expiredToken_itReturnsExpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .expiredToken)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordContinueErrorResponseIs_invalidRequest_itReturnsExpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .invalidRequest)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidRequest = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    // MARK: - Submit Response
+
+    func test_whenResetPasswordSubmitSuccessResponseContainsToken_itReturnsSuccess() {
+        let response: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = .success(.init(passwordResetToken: "passwordResetToken", pollInterval: 1))
+
+        let result = sut.validate(response, with: context)
+
+        guard case .success(let passwordResetToken, let pollInterval) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(passwordResetToken, "passwordResetToken")
+        XCTAssertEqual(pollInterval, 1)
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_passwordTooWeak_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .passwordTooWeak)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooWeak = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_passwordTooShort_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .passwordTooShort)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooShort = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_passwordTooLong_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .passwordTooLong)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooLong = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_passwordRecentlyUsed_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .passwordRecentlyUsed)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordRecentlyUsed = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_passwordBanned_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .passwordBanned)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordBanned = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_invalidRequest_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .invalidRequest)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidRequest = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_invalidClient_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .invalidClient)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidClient = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIs_expiredToken_itReturnsExpectedError() {
+        let result = buildSubmitErrorResponse(expectedError: .expiredToken)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordSubmitErrorResponseIsNotExpected_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    // MARK: - Poll Completion Response
+
+    func test_whenResetPasswordPollCompletionSuccessResponse_itReturnsSuccess() {
+        let response: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = .success(.init(status: .succeeded, signInSLT: nil, expiresIn: nil))
+
+        let result = sut.validate(response, with: context)
+
+        guard case .success(let status) = result else {
+            return XCTFail("Unexpected response")
+        }
+
+        XCTAssertEqual(status, .succeeded)
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsPasswordTooWeak_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .passwordTooWeak)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooWeak = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsPasswordTooShort_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .passwordTooShort)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooShort = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsPasswordTooLong_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .passwordTooLong)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordTooLong = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsPasswordRecentlyUsed_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .passwordRecentlyUsed)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordRecentlyUsed = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsPasswordBanned_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .passwordBanned)
+
+        guard case .passwordError(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .passwordBanned = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsInvalidRequest_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .invalidRequest)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidRequest = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsInvalidClient_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .invalidClient)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .invalidClient = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsExpiredToken_itReturnsExpectedError() {
+        let result = buildPollCompletionErrorResponse(expectedError: .expiredToken)
+
+        guard case .error(let error) = result else {
+            return XCTFail("Unexpected response")
+        }
+        if case .expiredToken = error.error {} else {
+            XCTFail("Unexpected error: \(error.error)")
+        }
+    }
+
+    func test_whenResetPasswordPollCompletionErrorResponseIsNotExpected_itReturnsUnexpectedError() {
+        let response: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = .failure(NSError())
+
+        let result = sut.validate(response, with: context)
+        XCTAssertEqual(result, .unexpectedError)
+    }
+
+    // MARK: - Helper methods
+
+    private func buildContinueErrorResponse(
+        expectedError: MSALNativeAuthResetPasswordContinueOauth2ErrorCode,
+        expectedPasswordResetToken: String? = nil
+    ) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
+        let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .failure(
+            createResetPasswordContinueError(
+                error: expectedError,
+                passwordResetToken: expectedPasswordResetToken
+            )
+        )
+
+        return sut.validate(response, with: context)
+    }
+
+    private func buildSubmitErrorResponse(
+        expectedError: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode
+    ) -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
+        let response: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = .failure(
+            createResetPasswordSubmitError(
+                error: expectedError
+            )
+        )
+
+        return sut.validate(response, with: context)
+    }
+
+    private func buildPollCompletionErrorResponse(
+        expectedError: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode
+    ) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
+        let response: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = .failure(
+            createResetPasswordPollCompletionError(
+                error: expectedError
+            )
+        )
+
+        return sut.validate(response, with: context)
+    }
+
+    private func createResetPasswordStartError(
+        error: MSALNativeAuthResetPasswordStartOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil
+    ) -> MSALNativeAuthResetPasswordStartResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target
+        )
+    }
+
+    private func createResetPasswordChallengeError(
+        error: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil
+    ) -> MSALNativeAuthResetPasswordChallengeResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target
+        )
+    }
+
+    private func createResetPasswordContinueError(
+        error: MSALNativeAuthResetPasswordContinueOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil,
+        passwordResetToken: String? = nil
+    ) -> MSALNativeAuthResetPasswordContinueResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target,
+            passwordResetToken: passwordResetToken
+        )
+    }
+
+    private func createResetPasswordSubmitError(
+        error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil
+    ) -> MSALNativeAuthResetPasswordSubmitResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target
+        )
+    }
+
+    private func createResetPasswordPollCompletionError(
+        error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil
+    ) -> MSALNativeAuthResetPasswordPollCompletionResponseError {
+        .init(
+            error: error,
+            errorDescription: errorDescription,
+            errorCodes: errorCodes,
+            errorURI: errorURI,
+            innerErrors: innerErrors,
+            target: target
+        )
+    }
+}

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordStartValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordStartValidatedErrorTypeTests.swift
@@ -1,0 +1,64 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthResetPasswordStartValidatedErrorTypeTests: XCTestCase {
+
+    private typealias sut = MSALNativeAuthResetPasswordStartValidatedErrorType
+    private let testDescription = "testDescription"
+
+    // MARK: - to ResetPasswordStartError tests
+
+    func test_toResetPasswordStartPublicError_invalidClient() {
+        let error = sut.invalidClient(message: testDescription).toResetPasswordStartPublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+
+    func test_toResetPasswordStartPublicError_invalidRequest() {
+        let error = sut.invalidRequest(message: "General error").toResetPasswordStartPublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, "General error")
+    }
+    
+    func test_toResetPasswordStartPublicError_userDoesNotHavePassword() {
+        let error = sut.userDoesNotHavePassword.toResetPasswordStartPublicError()
+        XCTAssertEqual(error.type, .userDoesNotHavePassword)
+        XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.userDoesNotHavePassword)
+    }
+
+    func test_toResetPasswordStartPublicError_userNotFound() {
+        let error = sut.userNotFound(message: testDescription).toResetPasswordStartPublicError()
+        XCTAssertEqual(error.type, .userNotFound)
+        XCTAssertEqual(error.errorDescription, testDescription)
+    }
+
+    func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
+        let error = sut.unsupportedChallengeType(message: nil).toResetPasswordStartPublicError()
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, "General error")
+    }
+}

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
@@ -1,0 +1,118 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+final class ResetPasswordCodeRequiredStateTests: XCTestCase {
+
+    private var controller: MSALNativeAuthResetPasswordControllerMock!
+    private var sut: ResetPasswordCodeRequiredState!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        controller = .init()
+        sut = ResetPasswordCodeRequiredState(controller: controller, flowToken: "<token>")
+    }
+
+    // MARK: - Delegates
+
+    // ResendCode
+
+    func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
+        let expectedError = ResendCodeError(message: "test error")
+        let expectedState = ResetPasswordCodeRequiredState(controller: controller, flowToken: "flowToken")
+
+        let expectedResult: ResetPasswordResendCodeResult = .error(error: expectedError, newState: expectedState)
+        controller.resendCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "reset password states")
+        let delegate = ResetPasswordResendCodeDelegateSpy(expectation: exp)
+
+        sut.resendCode(delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error, expectedError)
+        XCTAssertEqual(delegate.newState, expectedState)
+    }
+
+    func test_resendCode_delegate_success_shouldReturnCodeRequired() {
+        let expectedState = ResetPasswordCodeRequiredState(controller: controller, flowToken: "flowToken 2")
+
+        let expectedResult: ResetPasswordResendCodeResult = .codeRequired(
+            newState: expectedState,
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controller.resendCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-in states")
+        let delegate = ResetPasswordResendCodeDelegateSpy(expectation: exp)
+
+        sut.resendCode(delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newState?.flowToken, expectedState.flowToken)
+        XCTAssertEqual(delegate.sentTo, "sentTo")
+        XCTAssertEqual(delegate.channelTargetType, .email)
+        XCTAssertEqual(delegate.codeLength, 1)
+    }
+
+    // SubmitCode
+
+    func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
+        let expectedError = VerifyCodeError(type: .invalidCode)
+        let expectedState = ResetPasswordCodeRequiredState(controller: controller, flowToken: "flowToken")
+
+        let expectedResult: ResetPasswordVerifyCodeResult = .error(error: expectedError, newState: expectedState)
+        controller.submitCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "reset password states")
+        let delegate = ResetPasswordVerifyCodeDelegateSpy(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error, expectedError)
+        XCTAssertEqual(delegate.newCodeRequiredState, expectedState)
+    }
+
+    func test_submitCode_delegate_success_shouldReturnPasswordRequired() {
+        let expectedState = ResetPasswordRequiredState(controller: controller, flowToken: "flowToken 2")
+
+        let expectedResult: ResetPasswordVerifyCodeResult = .passwordRequired(newState: expectedState)
+        controller.submitCodeResult = .init(expectedResult)
+
+        let exp = expectation(description: "sign-in states")
+        let delegate = ResetPasswordVerifyCodeDelegateSpy(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.newPasswordRequiredState, expectedState)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
@@ -1,0 +1,56 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+
+final class ResetPasswordRequiredStateTests: XCTestCase {
+
+    private var correlationId: UUID!
+    private var exp: XCTestExpectation!
+    private var controller: MSALNativeAuthResetPasswordControllerSpy!
+    private var sut: ResetPasswordRequiredState!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        correlationId = UUID()
+        exp = expectation(description: "ResetPasswordRequiredState expectation")
+        controller = MSALNativeAuthResetPasswordControllerSpy(expectation: exp)
+        sut = ResetPasswordRequiredState(controller: controller, flowToken: "<token>")
+    }
+
+    func test_submitPassword_usesControllerSuccessfully() {
+        XCTAssertNil(controller.context)
+        XCTAssertFalse(controller.submitPasswordCalled)
+
+        sut.submitPassword(password: "1234", delegate: ResetPasswordRequiredDelegateSpy(), correlationId: correlationId)
+
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(controller.context?.correlationId(), correlationId)
+        XCTAssertTrue(controller.submitPasswordCalled)
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR shows the SDK that the CIAM team had developed. it is base on the Native Auth merge into MSAL plan here: https://microsofteur.sharepoint.com/:w:/t/DevExDublin/EdfT2AmlFZFIsTtr-EaoSBIBPqcOlRo1MJ1USbEsfjfEcQ

To comply with the design changes made by our API team, we have created a more dynamic SDK. This means that we make different API requests for each authentication flow. There is also some logic involved in each of the responses we get from each request.

We have created a state machine for each flow (check this [Figma](https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0%3A1&t=VUyK4gIoyUChTXWF-1) to see all the possible states), and we are making it external to developers by using delegates instead of completion blocks, as @Serhii Demchenko suggested. In this way we can guide the developer through the authentication process offering a discovering interface. We think that this approach will improve the overall developer experience.

**This PR is focused in the SSPR (password reset).**
**It is not compilable, so tests are not going to run. To build and test this code, please use the ciam-master-snapshot branch.**

The IdentityCore changes can be found in this PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1294

**For context, this is the Native Auth technical overview:** https://dev.azure.com/IdentityDivision/DevEx/_git/AuthLibrariesApiReview?path=/%5BiOS%5D%20Native%20authentication/technical_overview.md&version=GBdanilo/native-authentication&_a=preview

State Machine:
https://www.figma.com/file/2I4zEwwLREDKQOluQ8tgQs/Native-Auth-State-Models?type=design&node-id=0-1&mode=design&t=80VUxa1RvxMn4rnl-0

## High level overview

**MSALNativeAuthPublicClientApplication.swift**
The public interface is the entry point of the SDK. Here is where all the supported authentication flows begin.
Regarding the sign-up flow, developers can call `resetPassword(...)`.
Notice that in those methods they must pass a class that conforms to `ResetPasswordStartDelegate`.

**MSALNativeAuthResetPasswordController.swift**
The controller handles most of the logic. Each of the methods inside the MARK: - Internal can be called from the public interfaces, that are:
    - MSALNativeAuthPublicClientApplication
    - One of the States (located in the file ResetPasswordDelegates.swift). These States are returned through the delegates, as we will see.

For each of these methods, the controller:
    - Creates a request (`MSIDHttpRequest`) using its requestProvider (`MSALNativeAuthResetPasswordRequestProviding`).
    - Executes the request.
    - Passes the result to its responseValidator (`MSALNativeAuthResetPasswordResponseValidating`)
    - Handles the validated result and communicates back to the developer using the passed delegate.
    - Creates and handle the local telemetry events.

The controller decides what to do with the ValidatedResponse given by the ResponseValidator.

Every validated response usually has:
**A success:** it means that the SDK moves on to the next state, which usually involves making another request or returning back to the user via the delegate.
Redirect: when the backend detects an error and wants the SDK to fallback to the WebView-based flow.
**A known error:** in some cases, these errors put the user in a recoverable state (for example, an error that requires the user to provide more attributes). In other cases, the error means the end of the flow.
**An unexpected error:** these errors are likely bugs, they happen when we there are missing attributes from the response, etc.
(Please keep in mind that not every ValidatedResponse falls into the same categories, this is just an approximation)


**MSALNativeAuthRequestConfigurator.swift**
Each of the requestProviders from the Controllers uses the RequestConfigurator to create and configure the requests. Although there are different RequestProviders (one per flow), there's only one RequestConfigurator.

The RequestConfigurator injects a custom ErrorHandler (`MSALNativeAuthResponseErrorHandler`) to every request. This is needed in order to decode the errors from the API.
These errors follow a structure that you can see in `MSALNativeAuthResetPasswordStartResponseError` for example. In the directory native_auth/network/errors/ you can see all the files used.


**MSALNativeAuthResetPasswordResponseValidator.swift**
The ResponseValidator is in charge of analysing the api response and returning to the Controller a validated response (for instance, for the response of the resetpassword/start endpoint, it returns a `MSALNativeAuthResetPasswordStartValidatedResponse`).


**ResetPasswordStates.swift**
In this file there are the different States that the Controller can return to the developer through the delegate.

This is how the developer will use them. For more examples of how developers can use the SDK you can check the Sample App (located in /Samples/ios-native-auth-simple in the branch `ciam-master-snapshot`). We will include it in a separate PR:


## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

