### PR TITLE
Fix duplicated values for error JIT codes

### DIFF
--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -386,11 +386,6 @@ typedef NS_ENUM(NSInteger, MSALInternalError)
     MSALInternalBrokerNotAvailable                      = -42714,
     
     /**
-     JIT - Link - Timeout while waiting for server confirmation.
-    */
-    MSALInternalErrorJITLinkServerConfirmationTimeout   = -42714,
-    
-    /**
      JIT - Link - Error while waiting for server confirmation
      */
     MSALInternalErrorJITLinkServerConfirmationError     =   -42715,
@@ -471,23 +466,28 @@ typedef NS_ENUM(NSInteger, MSALInternalError)
     MSALErrorJITUnknownStatusWebCP                      = -42730,
 
     /**
-     JIT - Troubleshooting flow needed
-     */
-    MSALErrorJITTroubleshootingRequired                 = -42730,
-
-    /**
      JIT - Troubleshooting - Could not create web view controller
      */
     MSALErrorJITTroubleshootingCreateController         = -42731,
-
-    /**
-     JIT - Troubleshooting - Result unknown
-     */
-    MSALErrorJITTroubleshootingResultUnknown         = -42731,
     
     /**
      JIT - Troubleshooting - Acquire token error
      */
     MSALErrorJITTroubleshootingAcquireToken          = -42732,
+    
+    /**
+     JIT - Link - Timeout while waiting for server confirmation.
+    */
+    MSALInternalErrorJITLinkServerConfirmationTimeout   = -42733,
+    
+    /**
+     JIT - Troubleshooting flow needed
+     */
+    MSALErrorJITTroubleshootingRequired                 = -42734,
+    
+    /**
+     JIT - Troubleshooting - Result unknown
+     */
+    MSALErrorJITTroubleshootingResultUnknown         = -42735,
     
 };


### PR DESCRIPTION
## Proposed changes

Fix duplicated values for error JIT codes, as reported here: https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/1892

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

