### PR TITLE
CODEOWNERS file update

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,9 +4,9 @@
 *       @AzureAD/AppleIdentityTeam
 # @AzureAD/AppleCIAMTeam owns any files in the */native_auth
 # directories and any of its subdirectories.
-/MSAL/src/native_auth/ @AzureAD/AppleCIAMTeam
-/MSAL/test/unit/native_auth/ @AzureAD/AppleCIAMTeam
-/MSAL/test/integration/native_auth/ @AzureAD/AppleCIAMTeam
+/MSAL/src/native_auth/ @AzureAD/MSAL-ObjC-CIAM
+/MSAL/test/unit/native_auth/ @AzureAD/MSAL-ObjC-CIAM
+/MSAL/test/integration/native_auth/ @AzureAD/MSAL-ObjC-CIAM
 # For more details about inheritance patterns, or to assign different
 # owners for individual file extensions, see:
 # https://help.github.com/articles/about-codeowners/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,8 +3,7 @@
 # for review whenever someone opens a pull request.
 *       @AzureAD/AppleIdentityTeam
 # @AzureAD/AppleCIAMTeam owns any files in the */native_auth
-# directory at the root of the repository and any of its
-# subdirectories.
+# directories and any of its subdirectories.
 /MSAL/src/native_auth/ @AzureAD/AppleCIAMTeam
 /MSAL/test/unit/native_auth/ @AzureAD/AppleCIAMTeam
 /MSAL/test/integration/native_auth/ @AzureAD/AppleCIAMTeam

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # Unless a later match takes precedence, these users will be requested
 # for review whenever someone opens a pull request.
 *       @AzureAD/AppleIdentityTeam
-# @AzureAD/AppleCIAMTeam owns any files in the */native_auth
+# @AzureAD/MSAL-ObjC-CIAM owns any files in the */native_auth
 # directories and any of its subdirectories.
 /MSAL/src/native_auth/ @AzureAD/MSAL-ObjC-CIAM
 /MSAL/test/unit/native_auth/ @AzureAD/MSAL-ObjC-CIAM

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,12 @@
 # Unless a later match takes precedence, these users will be requested
 # for review whenever someone opens a pull request.
 *       @AzureAD/AppleIdentityTeam
+# @AzureAD/AppleCIAMTeam owns any files in the */native_auth
+# directory at the root of the repository and any of its
+# subdirectories.
+/MSAL/src/native_auth/ @AzureAD/AppleCIAMTeam
+/MSAL/test/unit/native_auth/ @AzureAD/AppleCIAMTeam
+/MSAL/test/integration/native_auth/ @AzureAD/AppleCIAMTeam
 # For more details about inheritance patterns, or to assign different
 # owners for individual file extensions, see:
 # https://help.github.com/articles/about-codeowners/


### PR DESCRIPTION
## Proposed changes

Updated CODEOWNERS file to give CIAM team ownership over Native Auth code.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

