### PR TITLE
Make delegates optional

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1029,6 +1029,35 @@
 		E20C217E2A7A61CC00E31598 /* ResetPasswordDelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20C217D2A7A61CC00E31598 /* ResetPasswordDelegateSpies.swift */; };
 		E20C21842A7A6CA400E31598 /* SignInCodeRequiredStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20C21832A7A6CA400E31598 /* SignInCodeRequiredStateTests.swift */; };
 		E20C218B2A7A805900E31598 /* SignInPasswordRequiredStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20C218A2A7A805800E31598 /* SignInPasswordRequiredStateTests.swift */; };
+		E22427C82B0526660006C55E /* SignUpDelegateDispatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427C72B0526660006C55E /* SignUpDelegateDispatchers.swift */; };
+		E22427C92B0526660006C55E /* SignUpDelegateDispatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427C72B0526660006C55E /* SignUpDelegateDispatchers.swift */; };
+		E22427D22B0577920006C55E /* SignInDelegateDispatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427D12B0577920006C55E /* SignInDelegateDispatchers.swift */; };
+		E22427D32B0577920006C55E /* SignInDelegateDispatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427D12B0577920006C55E /* SignInDelegateDispatchers.swift */; };
+		E22427D52B05886B0006C55E /* ResetPasswordDelegateDispatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427D42B05886B0006C55E /* ResetPasswordDelegateDispatchers.swift */; };
+		E22427D62B05886B0006C55E /* ResetPasswordDelegateDispatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427D42B05886B0006C55E /* ResetPasswordDelegateDispatchers.swift */; };
+		E22427D82B0588AD0006C55E /* DelegateDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427D72B0588AD0006C55E /* DelegateDispatcher.swift */; };
+		E22427D92B0588AD0006C55E /* DelegateDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427D72B0588AD0006C55E /* DelegateDispatcher.swift */; };
+		E22427DB2B0594670006C55E /* CredentialsDelegateDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427DA2B0594670006C55E /* CredentialsDelegateDispatcher.swift */; };
+		E22427DC2B0594670006C55E /* CredentialsDelegateDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427DA2B0594670006C55E /* CredentialsDelegateDispatcher.swift */; };
+		E22427DE2B05981A0006C55E /* SignInAfterSignUpDelegateDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427DD2B05981A0006C55E /* SignInAfterSignUpDelegateDispatcher.swift */; };
+		E22427DF2B05981A0006C55E /* SignInAfterSignUpDelegateDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427DD2B05981A0006C55E /* SignInAfterSignUpDelegateDispatcher.swift */; };
+		E22427E42B0650CD0006C55E /* SignUpPasswordStartDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427E32B0650CD0006C55E /* SignUpPasswordStartDelegateDispatcherTests.swift */; };
+		E22427E62B065D0D0006C55E /* SignUpStartDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427E52B065D0D0006C55E /* SignUpStartDelegateDispatcherTests.swift */; };
+		E22427E82B065DC00006C55E /* SignUpResendCodeDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427E72B065DC00006C55E /* SignUpResendCodeDelegateDispatcherTests.swift */; };
+		E22427EA2B065EAE0006C55E /* SignUpVerifyCodeDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427E92B065EAE0006C55E /* SignUpVerifyCodeDelegateDispatcherTests.swift */; };
+		E22427EC2B0662050006C55E /* SignUpPasswordRequiredDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427EB2B0662050006C55E /* SignUpPasswordRequiredDelegateDispatcherTests.swift */; };
+		E22427EE2B06637C0006C55E /* SignUpAttributesRequiredDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427ED2B06637C0006C55E /* SignUpAttributesRequiredDelegateDispatcherTests.swift */; };
+		E22427F22B0668910006C55E /* SignInPasswordStartDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427F12B0668910006C55E /* SignInPasswordStartDelegateDispatcherTests.swift */; };
+		E22427F42B066BBC0006C55E /* SignInStartDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427F32B066BBC0006C55E /* SignInStartDelegateDispatcherTests.swift */; };
+		E22427F62B066E850006C55E /* SignInPasswordRequiredDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427F52B066E850006C55E /* SignInPasswordRequiredDelegateDispatcherTests.swift */; };
+		E22427F82B066F750006C55E /* SignInResendCodeDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427F72B066F750006C55E /* SignInResendCodeDelegateDispatcherTests.swift */; };
+		E22427FA2B0670600006C55E /* SignInVerifyCodeDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427F92B0670600006C55E /* SignInVerifyCodeDelegateDispatcherTests.swift */; };
+		E22427FD2B0671A10006C55E /* ResetPasswordStartDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427FC2B0671A10006C55E /* ResetPasswordStartDelegateDispatcherTests.swift */; };
+		E22427FF2B06725C0006C55E /* ResetPasswordVerifyCodeDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427FE2B06725C0006C55E /* ResetPasswordVerifyCodeDelegateDispatcherTests.swift */; };
+		E22428012B0673290006C55E /* ResetPasswordResendCodeDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22428002B0673290006C55E /* ResetPasswordResendCodeDelegateDispatcherTests.swift */; };
+		E22428032B0673DF0006C55E /* ResetPasswordRequiredDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22428022B0673DF0006C55E /* ResetPasswordRequiredDelegateDispatcherTests.swift */; };
+		E22428052B0674A50006C55E /* SignInAfterSignUpDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22428042B0674A50006C55E /* SignInAfterSignUpDelegateDispatcherTests.swift */; };
+		E22428072B0676970006C55E /* DispatchAccessTokenRetrieveCompletedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22428062B0676970006C55E /* DispatchAccessTokenRetrieveCompletedTests.swift */; };
 		E22952682A1A4FCB00EDD58C /* MSALNativeAuthSignUpResponseValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22952672A1A4FCB00EDD58C /* MSALNativeAuthSignUpResponseValidatorTests.swift */; };
 		E22E20282A7936C50073A6FF /* MSALNativeAuthSignUpControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22E20272A7936C50073A6FF /* MSALNativeAuthSignUpControllerMock.swift */; };
 		E235610E29C23B23000E01CA /* MSALNativeAuthSignUpRequestProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E235610D29C23B23000E01CA /* MSALNativeAuthSignUpRequestProvider.swift */; };
@@ -2007,6 +2036,29 @@
 		E20C217D2A7A61CC00E31598 /* ResetPasswordDelegateSpies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordDelegateSpies.swift; sourceTree = "<group>"; };
 		E20C21832A7A6CA400E31598 /* SignInCodeRequiredStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInCodeRequiredStateTests.swift; sourceTree = "<group>"; };
 		E20C218A2A7A805800E31598 /* SignInPasswordRequiredStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPasswordRequiredStateTests.swift; sourceTree = "<group>"; };
+		E22427C72B0526660006C55E /* SignUpDelegateDispatchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpDelegateDispatchers.swift; sourceTree = "<group>"; };
+		E22427D12B0577920006C55E /* SignInDelegateDispatchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInDelegateDispatchers.swift; sourceTree = "<group>"; };
+		E22427D42B05886B0006C55E /* ResetPasswordDelegateDispatchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordDelegateDispatchers.swift; sourceTree = "<group>"; };
+		E22427D72B0588AD0006C55E /* DelegateDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegateDispatcher.swift; sourceTree = "<group>"; };
+		E22427DA2B0594670006C55E /* CredentialsDelegateDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsDelegateDispatcher.swift; sourceTree = "<group>"; };
+		E22427DD2B05981A0006C55E /* SignInAfterSignUpDelegateDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAfterSignUpDelegateDispatcher.swift; sourceTree = "<group>"; };
+		E22427E32B0650CD0006C55E /* SignUpPasswordStartDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpPasswordStartDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427E52B065D0D0006C55E /* SignUpStartDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpStartDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427E72B065DC00006C55E /* SignUpResendCodeDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpResendCodeDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427E92B065EAE0006C55E /* SignUpVerifyCodeDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpVerifyCodeDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427EB2B0662050006C55E /* SignUpPasswordRequiredDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpPasswordRequiredDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427ED2B06637C0006C55E /* SignUpAttributesRequiredDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpAttributesRequiredDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427F12B0668910006C55E /* SignInPasswordStartDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPasswordStartDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427F32B066BBC0006C55E /* SignInStartDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInStartDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427F52B066E850006C55E /* SignInPasswordRequiredDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPasswordRequiredDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427F72B066F750006C55E /* SignInResendCodeDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInResendCodeDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427F92B0670600006C55E /* SignInVerifyCodeDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInVerifyCodeDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427FC2B0671A10006C55E /* ResetPasswordStartDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordStartDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22427FE2B06725C0006C55E /* ResetPasswordVerifyCodeDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordVerifyCodeDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22428002B0673290006C55E /* ResetPasswordResendCodeDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordResendCodeDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22428022B0673DF0006C55E /* ResetPasswordRequiredDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordRequiredDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22428042B0674A50006C55E /* SignInAfterSignUpDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAfterSignUpDelegateDispatcherTests.swift; sourceTree = "<group>"; };
+		E22428062B0676970006C55E /* DispatchAccessTokenRetrieveCompletedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchAccessTokenRetrieveCompletedTests.swift; sourceTree = "<group>"; };
 		E22952672A1A4FCB00EDD58C /* MSALNativeAuthSignUpResponseValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpResponseValidatorTests.swift; sourceTree = "<group>"; };
 		E22E20272A7936C50073A6FF /* MSALNativeAuthSignUpControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpControllerMock.swift; sourceTree = "<group>"; };
 		E235610D29C23B23000E01CA /* MSALNativeAuthSignUpRequestProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpRequestProvider.swift; sourceTree = "<group>"; };
@@ -2298,6 +2350,7 @@
 		287F64F129819F6B00ED90BD /* public */ = {
 			isa = PBXGroup;
 			children = (
+				E22427E02B0650670006C55E /* delegate */,
 				E2CD2E3F29FBE957009F8FFA /* state_machine */,
 				287F64F22981A00400ED90BD /* MSALNativeAuthPublicClientApplicationTest.swift */,
 				DE87DE692A39E80B0032BF9E /* MSALNativeAuthUserAccountResultTests.swift */,
@@ -2443,6 +2496,7 @@
 		28DCD08829D70FA000C4601E /* state_machine */ = {
 			isa = PBXGroup;
 			children = (
+				E2CE91372B0D077C0009AEDD /* delegate_dispatcher */,
 				8DDF473E2A98FE1C00126A47 /* MSALNativeAuthRequiredAttributes.swift */,
 				28DCD09629D7171600C4601E /* error */,
 				28DCD09529D7170F00C4601E /* state */,
@@ -3753,6 +3807,54 @@
 			path = sign_in;
 			sourceTree = "<group>";
 		};
+		E22427E02B0650670006C55E /* delegate */ = {
+			isa = PBXGroup;
+			children = (
+				E22427F02B06686C0006C55E /* sign_in */,
+				E22427EF2B06685B0006C55E /* sign_up */,
+				E22427FB2B0670E90006C55E /* reset_password */,
+				E22428042B0674A50006C55E /* SignInAfterSignUpDelegateDispatcherTests.swift */,
+				E22428062B0676970006C55E /* DispatchAccessTokenRetrieveCompletedTests.swift */,
+			);
+			path = delegate;
+			sourceTree = "<group>";
+		};
+		E22427EF2B06685B0006C55E /* sign_up */ = {
+			isa = PBXGroup;
+			children = (
+				E22427ED2B06637C0006C55E /* SignUpAttributesRequiredDelegateDispatcherTests.swift */,
+				E22427EB2B0662050006C55E /* SignUpPasswordRequiredDelegateDispatcherTests.swift */,
+				E22427E32B0650CD0006C55E /* SignUpPasswordStartDelegateDispatcherTests.swift */,
+				E22427E72B065DC00006C55E /* SignUpResendCodeDelegateDispatcherTests.swift */,
+				E22427E52B065D0D0006C55E /* SignUpStartDelegateDispatcherTests.swift */,
+				E22427E92B065EAE0006C55E /* SignUpVerifyCodeDelegateDispatcherTests.swift */,
+			);
+			path = sign_up;
+			sourceTree = "<group>";
+		};
+		E22427F02B06686C0006C55E /* sign_in */ = {
+			isa = PBXGroup;
+			children = (
+				E22427F52B066E850006C55E /* SignInPasswordRequiredDelegateDispatcherTests.swift */,
+				E22427F12B0668910006C55E /* SignInPasswordStartDelegateDispatcherTests.swift */,
+				E22427F72B066F750006C55E /* SignInResendCodeDelegateDispatcherTests.swift */,
+				E22427F32B066BBC0006C55E /* SignInStartDelegateDispatcherTests.swift */,
+				E22427F92B0670600006C55E /* SignInVerifyCodeDelegateDispatcherTests.swift */,
+			);
+			path = sign_in;
+			sourceTree = "<group>";
+		};
+		E22427FB2B0670E90006C55E /* reset_password */ = {
+			isa = PBXGroup;
+			children = (
+				E22428022B0673DF0006C55E /* ResetPasswordRequiredDelegateDispatcherTests.swift */,
+				E22428002B0673290006C55E /* ResetPasswordResendCodeDelegateDispatcherTests.swift */,
+				E22427FC2B0671A10006C55E /* ResetPasswordStartDelegateDispatcherTests.swift */,
+				E22427FE2B06725C0006C55E /* ResetPasswordVerifyCodeDelegateDispatcherTests.swift */,
+			);
+			path = reset_password;
+			sourceTree = "<group>";
+		};
 		E235612F29C9CE81000E01CA /* sign_up */ = {
 			isa = PBXGroup;
 			children = (
@@ -4017,6 +4119,19 @@
 				E2CD2E5029FC087A009F8FFA /* SignUpAttributesRequiredStateTests.swift */,
 			);
 			path = sign_up;
+			sourceTree = "<group>";
+		};
+		E2CE91372B0D077C0009AEDD /* delegate_dispatcher */ = {
+			isa = PBXGroup;
+			children = (
+				E22427D72B0588AD0006C55E /* DelegateDispatcher.swift */,
+				E22427C72B0526660006C55E /* SignUpDelegateDispatchers.swift */,
+				E22427D12B0577920006C55E /* SignInDelegateDispatchers.swift */,
+				E22427D42B05886B0006C55E /* ResetPasswordDelegateDispatchers.swift */,
+				E22427DA2B0594670006C55E /* CredentialsDelegateDispatcher.swift */,
+				E22427DD2B05981A0006C55E /* SignInAfterSignUpDelegateDispatcher.swift */,
+			);
+			path = delegate_dispatcher;
 			sourceTree = "<group>";
 		};
 		E2EFAD072A69A2C300D6C3DE /* responses */ = {
@@ -5509,12 +5624,14 @@
 				DE9245122A38736600C0389F /* CredentialsDelegates.swift in Sources */,
 				B223B0C022ADFACB00FB8713 /* MSALLegacySharedAccount.m in Sources */,
 				E2EFACFE2A69915100D6C3DE /* SignInResults.swift in Sources */,
+				E22427D52B05886B0006C55E /* ResetPasswordDelegateDispatchers.swift in Sources */,
 				D61BD2AF1EBD09F90007E484 /* MSALLogger.m in Sources */,
 				DEE34F82D170B71C00BC302A /* MSALNativeAuthResetPasswordSubmitOauth2ErrorCode.swift in Sources */,
 				B253152C23DD66A300432133 /* MSALDeviceInfoProvider.m in Sources */,
 				E27332C02A153E6500E1B054 /* MSALNativeAuthErrorMessage.swift in Sources */,
 				DEDB29A929DDAEB3008DA85B /* MSALNativeAuthTokenOauth2ErrorCode.swift in Sources */,
 				E206FCEF2979BC4600AF4400 /* MSALNativeAuthSignInController.swift in Sources */,
+				E22427D82B0588AD0006C55E /* DelegateDispatcher.swift in Sources */,
 				DE92450C2A385ED800C0389F /* MSALNativeAuthCredentialsController.swift in Sources */,
 				B28BDA90217E9EAB003E5670 /* MSALOauth2ProviderFactory.m in Sources */,
 				B2AA5D6A23A353F200BD47D8 /* MSALSignoutParameters.m in Sources */,
@@ -5534,6 +5651,7 @@
 				DEE34F72D170B71C00BC302A /* MSALNativeAuthResetPasswordChallengeResponseError.swift in Sources */,
 				E2B8532F2A153651007A4776 /* MSALNativeAuthSignUpStartRequestProviderParameters.swift in Sources */,
 				B26756CC22921C5B000F01D7 /* MSALB2COauth2Provider.m in Sources */,
+				E22427D22B0577920006C55E /* SignInDelegateDispatchers.swift in Sources */,
 				28DCD0A029D7260B00C4601E /* MSALNativeAuthBaseState.swift in Sources */,
 				287F650C2982F4AD00ED90BD /* MSALNativeAuthResponseSerializer.swift in Sources */,
 				DEDB29A529DDA9DC008DA85B /* MSALNativeAuthSignInInitiateResponseError.swift in Sources */,
@@ -5609,8 +5727,11 @@
 				B2C17B0A1FC8DB2E0070A514 /* MSIDVersion.m in Sources */,
 				E2DC31C829B0FDB100051CE7 /* MSALNativeAuthAuthorityProvider.swift in Sources */,
 				28DCD0AE29D737E600C4601E /* VerifyCodeError.swift in Sources */,
+				E22427C82B0526660006C55E /* SignUpDelegateDispatchers.swift in Sources */,
 				289747B42979A3C800838C80 /* MSALNativeAuthParameters.swift in Sources */,
 				E2F626B02A78130700C4A303 /* SignInAfterSignUpState+Internal.swift in Sources */,
+				E22427DE2B05981A0006C55E /* SignInAfterSignUpDelegateDispatcher.swift in Sources */,
+				E22427DB2B0594670006C55E /* CredentialsDelegateDispatcher.swift in Sources */,
 				B26756C622921C42000F01D7 /* MSALAADOauth2Provider.m in Sources */,
 				DEE34F12D170B71C00BC302A /* MSALNativeAuthResetPasswordStartRequestParameters.swift in Sources */,
 				8D35C8E72A97BD0000BEC29A /* MSALNativeAuthErrorBasicAttributes.swift in Sources */,
@@ -5730,11 +5851,13 @@
 				23A169B52073325500B051F3 /* MSALPublicClientApplicationTests.m in Sources */,
 				D61F5BC01E5913BE00912CB8 /* SFSafariViewController+TestOverrides.m in Sources */,
 				B2725ED022C04689009B454A /* MSALLegacySharedAccountFactoryTests.m in Sources */,
+				E22427EE2B06637C0006C55E /* SignUpAttributesRequiredDelegateDispatcherTests.swift in Sources */,
 				E20C218B2A7A805900E31598 /* SignInPasswordRequiredStateTests.swift in Sources */,
 				E20C21752A7A61B600E31598 /* SignUpDelegateSpies.swift in Sources */,
 				E2F5BE9D298A6CEB00C67EC7 /* MSALNativeAuthResultFactoryTests.swift in Sources */,
 				DE14096B2A38DE0E008E6F1E /* CredentialsDelegateSpies.swift in Sources */,
 				DEDB29B129DEC770008DA85B /* MSALNativeAuthRequestErrorHandlerTests.swift in Sources */,
+				E22428032B0673DF0006C55E /* ResetPasswordRequiredDelegateDispatcherTests.swift in Sources */,
 				D69ADB3F1E516F9B00952049 /* MSALTestURLSessionDataTask.m in Sources */,
 				DEF1DD3C2AA9D07000D22194 /* MSALNativeAuthESTSApiErrorDescriptionsTests.swift in Sources */,
 				B256121B217EA44900999876 /* MSALOauth2FactoryProducerTests.m in Sources */,
@@ -5758,10 +5881,12 @@
 				E2F5BE8E29893A4100C67EC7 /* MSALNativeAuthEndpointTests.swift in Sources */,
 				287F64F0298186EA00ED90BD /* MSALNativeAuthInputValidatorTest.swift in Sources */,
 				8D61F9A12A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift in Sources */,
+				E22427E42B0650CD0006C55E /* SignUpPasswordStartDelegateDispatcherTests.swift in Sources */,
 				04D32CD01FD8AFF3000B123E /* MSALErrorConverterTests.m in Sources */,
 				E2F4DB2D2A1F5714009FBCD0 /* MSALNativeAuthSignUpContinueOauth2ErrorCodeTests.swift in Sources */,
 				287F6524298401AE00ED90BD /* MSALNativeAuthResponseSerializerTests.swift in Sources */,
 				E2CD2E4F29FC0451009F8FFA /* SignUpPasswordRequiredStateTests.swift in Sources */,
+				E22427F62B066E850006C55E /* SignInPasswordRequiredDelegateDispatcherTests.swift in Sources */,
 				E2EBD6212A1BB4640049467A /* MSALNativeAuthSignUpRequestProviderMock.swift in Sources */,
 				E2F4DB242A1F525A009FBCD0 /* MSALNativeAuthSignUpStartOauth2ErrorCodeTests.swift in Sources */,
 				A0274CDD24B54C8800BD198D /* MSALDevicePopManagerUtil.m in Sources */,
@@ -5775,6 +5900,7 @@
 				9BD2765F2A0E81CE00FBD033 /* ResetPasswordRequiredStateTests.swift in Sources */,
 				D69ADB371E516F9B00952049 /* MSALTestCase.m in Sources */,
 				DE94C9E829F19E6B00C1EC1F /* MSALNativeAuthResetPasswordPollCompletionRequestParametersTest.swift in Sources */,
+				E22427FD2B0671A10006C55E /* ResetPasswordStartDelegateDispatcherTests.swift in Sources */,
 				DE0D659529C1DCC9005798B1 /* MSALNativeAuthSignInInitiateRequestParametersTest.swift in Sources */,
 				E2CD2E5129FC087A009F8FFA /* SignUpAttributesRequiredStateTests.swift in Sources */,
 				28DE3FD02A0921E2003148A4 /* SignInTestsValidatorHelpers.swift in Sources */,
@@ -5809,13 +5935,20 @@
 				E25BC0832995429D00588549 /* MSALNativeAuthCacheMocks.swift in Sources */,
 				960751BB2183E82C00F2BF2F /* MSALAccountIdTests.m in Sources */,
 				E20C217E2A7A61CC00E31598 /* ResetPasswordDelegateSpies.swift in Sources */,
+				E22427F82B066F750006C55E /* SignInResendCodeDelegateDispatcherTests.swift in Sources */,
 				E248917A2A1CFA6B001ECBE2 /* MSALNativeAuthConfigStubs.swift in Sources */,
+				E22427E62B065D0D0006C55E /* SignUpStartDelegateDispatcherTests.swift in Sources */,
 				9B2BBA352A3297F80075F702 /* MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift in Sources */,
 				287F64D5297EC29400ED90BD /* MSALNativeAuthCurrentRequestTelemetryTests.swift in Sources */,
+				E22428072B0676970006C55E /* DispatchAccessTokenRetrieveCompletedTests.swift in Sources */,
 				A0274CBE24B432B100BD198D /* MSALAuthSchemeTests.m in Sources */,
+				E22427F22B0668910006C55E /* SignInPasswordStartDelegateDispatcherTests.swift in Sources */,
 				B286BA00238A08F6007833AD /* MSALB2CPolicyTests.m in Sources */,
+				E22428012B0673290006C55E /* ResetPasswordResendCodeDelegateDispatcherTests.swift in Sources */,
 				9B2BBA2F2A3293330075F702 /* MSALNativeAuthResetPasswordStartValidatedErrorTypeTests.swift in Sources */,
+				E22427EC2B0662050006C55E /* SignUpPasswordRequiredDelegateDispatcherTests.swift in Sources */,
 				DE5738BC2A8F79A800D9120D /* MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift in Sources */,
+				E22427FA2B0670600006C55E /* SignInVerifyCodeDelegateDispatcherTests.swift in Sources */,
 				E2EBD62A2A1BB7700049467A /* MSALNativeAuthSignUpResponseValidatorMock.swift in Sources */,
 				E25BC0852995430B00588549 /* MSALNativeAuthFactoriesMocks.swift in Sources */,
 				E2BC029C29D766CB00041DBC /* MSALNativeAuthSignUpContinueRequestParametersTest.swift in Sources */,
@@ -5831,14 +5964,17 @@
 				E23E956929D5BD6B001DC59C /* MSALNativeAuthSignUpRequestProviderTests.swift in Sources */,
 				DE5738BE2A8F7AC600D9120D /* MSALNativeAuthResetPasswordStartOauth2ErrorCodeTests.swift in Sources */,
 				609AF9332256BD0C00E2978D /* MSALAccountsProviderTests.m in Sources */,
+				E22428052B0674A50006C55E /* SignInAfterSignUpDelegateDispatcherTests.swift in Sources */,
 				DE54B59F2A4452DB00460B34 /* MSALNativeAuthTokenResponseValidatorTests.swift in Sources */,
 				DE5738BA2A8F780E00D9120D /* MSALNativeAuthResetPasswordSubmitOauth2ErrorCodeTests.swift in Sources */,
 				E20C21842A7A6CA400E31598 /* SignInCodeRequiredStateTests.swift in Sources */,
 				B2725EAC22BF2759009B454A /* MSALExternalAccountHandlerTests.m in Sources */,
+				E22427FF2B06725C0006C55E /* ResetPasswordVerifyCodeDelegateDispatcherTests.swift in Sources */,
 				232D6192224C53E500260C42 /* MSALClaimsRequestTests.m in Sources */,
 				9B2BBA312A3296010075F702 /* MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift in Sources */,
 				E25E6E5A2AA7727D0094461E /* MSALNativeAuthCredentialsControllerMock.swift in Sources */,
 				B286B9FD238A07A5007833AD /* MSALAcquireTokenTests.m in Sources */,
+				E22427F42B066BBC0006C55E /* SignInStartDelegateDispatcherTests.swift in Sources */,
 				DE5738B22A8E71D500D9120D /* MSALNativeAuthResetPasswordContinueResponseErrorTests.swift in Sources */,
 				9B6EECEF2A3146ED008ABA50 /* MSALNativeAuthResetPasswordResponseValidatorTests.swift in Sources */,
 				28FDC4AE2A38D81100E38BE1 /* MSALNativeAuthSignInControllerMock.swift in Sources */,
@@ -5847,9 +5983,11 @@
 				9B4EE9D52A1686A900F243C1 /* MSALNativeAuthResetPasswordControllerTests.swift in Sources */,
 				B29A56D52283D7430023F5E6 /* MSALAADAuthorityTests.m in Sources */,
 				287F64F32981A00400ED90BD /* MSALNativeAuthPublicClientApplicationTest.swift in Sources */,
+				E22427E82B065DC00006C55E /* SignUpResendCodeDelegateDispatcherTests.swift in Sources */,
 				E2CD2EB52A0404DA009F8FFA /* MSALNativeAuthSignUpControllerSpy.swift in Sources */,
 				9BD2765B2A0E7E7D00FBD033 /* ResetPasswordCodeSentStateTests.swift in Sources */,
 				E2F626B32A781CE300C4A303 /* SignInDelegatesSpies.swift in Sources */,
+				E22427EA2B065EAE0006C55E /* SignUpVerifyCodeDelegateDispatcherTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
@@ -115,6 +115,29 @@ class MSALNativeAuthBaseController {
         MSIDTelemetry.sharedInstance().flush(context.telemetryRequestId())
     }
 
+    /// Stops a telemetry event.
+    /// - Parameters:
+    ///   - event: The local event to be stopped.
+    ///   - context: The context object.
+    ///   - delegateDispatcherResult: The result sent by the ``DelegateDispatcher`` that contains whether the developer
+    ///                               has implemented the optional delegate or not.
+    ///   - controllerError: Optional error set by the Controller when handles the response from API.
+    ///                      (ex: SignUpController gets an .attributeValidationFailed. The controller will generate and error and send it here).
+    func stopTelemetryEvent(
+        _ event: MSIDTelemetryAPIEvent?,
+        context: MSIDRequestContext,
+        delegateDispatcherResult: Result<Void, MSALNativeAuthError>,
+        controllerError: MSALNativeAuthError? = nil
+    ) {
+        switch delegateDispatcherResult {
+        case .success:
+            stopTelemetryEvent(event, context: context, error: controllerError)
+        case .failure(let error):
+            MSALLogger.log(level: .error, context: context, format: "Error \(error.errorDescription ?? "No error description")")
+            stopTelemetryEvent(event, context: context, error: error)
+        }
+    }
+
     func complete<T>(
         _ telemetryEvent: MSIDTelemetryAPIEvent?,
         response: T? = nil,

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
@@ -25,6 +25,8 @@
 import Foundation
 
 protocol MSALNativeAuthCredentialsControlling {
+    typealias RefreshTokenCredentialControllerResponse = MSALNativeAuthControllerTelemetryWrapper<Result<String, RetrieveAccessTokenError>>
+
     func retrieveUserAccountResult(context: MSALNativeAuthRequestContext) -> MSALNativeAuthUserAccountResult?
-    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> Result<String, RetrieveAccessTokenError>
+    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> RefreshTokenCredentialControllerResponse
 }

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -56,19 +56,19 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
 
     // MARK: - Internal interface methods
 
-    func resetPassword(parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartResult {
+    func resetPassword(parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordStart, context: parameters.context)
         let response = await performStartRequest(parameters: parameters)
         return await handleStartResponse(response, event: event, context: parameters.context)
     }
 
-    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeResult {
+    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordResendCode, context: context)
         let response = await performChallengeRequest(passwordResetToken: passwordResetToken, context: context)
         return await handleResendCodeChallengeResponse(response, event: event, context: context)
     }
 
-    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordVerifyCodeResult {
+    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordSubmitCode, context: context)
 
         let params = MSALNativeAuthResetPasswordContinueRequestParameters(
@@ -86,7 +86,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         password: String,
         passwordSubmitToken: String,
         context: MSIDRequestContext
-    ) async -> ResetPasswordRequiredResult {
+    ) async -> ResetPasswordSubmitPasswordControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordSubmit, context: context)
 
         let params = MSALNativeAuthResetPasswordSubmitRequestParameters(
@@ -120,7 +120,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
 
     private func handleStartResponse(_ response: MSALNativeAuthResetPasswordStartValidatedResponse,
                                      event: MSIDTelemetryAPIEvent?,
-                                     context: MSIDRequestContext) async -> ResetPasswordStartResult {
+                                     context: MSIDRequestContext) async -> ResetPasswordStartControllerResponse {
 
         MSALLogger.log(level: .verbose, context: context, format: "Finished resetpassword/start request")
 
@@ -134,21 +134,21 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             MSALLogger.log(level: .error,
                            context: context,
                            format: "redirect error in resetpassword/start request \(error.errorDescription ?? "No error description")")
-            return .error(error)
+            return .init(.error(error))
         case .error(let apiError):
             let error = apiError.toResetPasswordStartPublicError()
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
                            format: "Error in resetpassword/start request \(error.errorDescription ?? "No error description")")
-            return .error(error)
+            return .init(.error(error))
         case .unexpectedError:
             let error = ResetPasswordStartError(type: .generalError)
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
                            format: "Unexpected error in resetpassword/start request \(error.errorDescription ?? "No error description")")
-            return .error(error)
+            return .init(.error(error))
         }
     }
 
@@ -177,39 +177,40 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         _ response: MSALNativeAuthResetPasswordChallengeValidatedResponse,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
-    ) async -> ResetPasswordStartResult {
+    ) async -> ResetPasswordStartControllerResponse {
         switch response {
         case .success(let sentTo, let channelTargetType, let codeLength, let challengeToken):
             MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/challenge request")
-            stopTelemetryEvent(event, context: context)
 
-            return .codeRequired(
+            return .init(.codeRequired(
                 newState: ResetPasswordCodeRequiredState(controller: self, flowToken: challengeToken, correlationId: context.correlationId()),
                 sentTo: sentTo,
                 channelTargetType: channelTargetType,
                 codeLength: codeLength
-            )
+            ), telemetryUpdate: { [weak self] result in
+                self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
+            })
         case .error(let apiError):
             let error = apiError.toResetPasswordStartPublicError()
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
                            format: "Error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
-            return .error(error)
+            return .init(.error(error))
         case .redirect:
             let error = ResetPasswordStartError(type: .browserRequired, message: MSALNativeAuthErrorMessage.browserRequired)
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
                            format: "Redirect error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
-            return .error(error)
+            return .init(.error(error))
         case .unexpectedError:
             let error = ResetPasswordStartError(type: .generalError)
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
                            format: "Unexpected error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
-            return .error(error)
+            return .init(.error(error))
         }
     }
 
@@ -217,24 +218,25 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         _ response: MSALNativeAuthResetPasswordChallengeValidatedResponse,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
-    ) async -> ResetPasswordResendCodeResult {
+    ) async -> ResetPasswordResendCodeControllerResponse {
         switch response {
         case .success(let sentTo, let channelTargetType, let codeLength, let challengeToken):
-            stopTelemetryEvent(event, context: context)
             MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/challenge (resend code) request")
-            return .codeRequired(
+            return .init(.codeRequired(
                 newState: ResetPasswordCodeRequiredState(controller: self, flowToken: challengeToken, correlationId: context.correlationId()),
                 sentTo: sentTo,
                 channelTargetType: channelTargetType,
                 codeLength: codeLength
-            )
+            ), telemetryUpdate: { [weak self] result in
+                self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
+            })
         case .error(let apiError):
             let error = apiError.toResendCodePublicError()
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
                            format: "Error in resetpassword/challenge request (resend code) \(error.errorDescription ?? "No error description")")
-            return .error(error: error, newState: nil)
+            return .init(.error(error: error, newState: nil))
         case .redirect,
                 .unexpectedError:
             let error = ResendCodeError()
@@ -242,7 +244,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             MSALLogger.log(level: .error,
                            context: context,
                            format: "Error in resetpassword/challenge request (resend code) \(error.errorDescription ?? "No error description")")
-            return .error(error: error, newState: nil)
+            return .init(.error(error: error, newState: nil))
         }
     }
 
@@ -271,21 +273,22 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         passwordResetToken: String,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
-    ) async -> ResetPasswordVerifyCodeResult {
+    ) async -> ResetPasswordSubmitCodeControllerResponse {
         switch response {
         case .success(let passwordSubmitToken):
-            stopTelemetryEvent(event, context: context)
             MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/continue request")
-            return .passwordRequired(newState: ResetPasswordRequiredState(controller: self,
-                                                                          flowToken: passwordSubmitToken,
-                                                                          correlationId: context.correlationId()))
+            let newState = ResetPasswordRequiredState(controller: self, flowToken: passwordSubmitToken, correlationId: context.correlationId())
+            return .init(.passwordRequired(newState: newState),
+                         telemetryUpdate: { [weak self] result in
+                self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
+            })
         case .error(let apiError):
             let error = apiError.toVerifyCodePublicError()
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
                            format: "Error in resetpassword/continue request \(error.errorDescription ?? "No error description")")
-            return .error(error: error, newState: nil)
+            return .init(.error(error: error, newState: nil))
         case .unexpectedError:
             let error = VerifyCodeError(type: .generalError)
             self.stopTelemetryEvent(event, context: context, error: error)
@@ -294,7 +297,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                            context: context,
                            format: "Error calling resetpassword/continue \(error.errorDescription ?? "No error description")")
 
-            return .error(error: error, newState: nil)
+            return .init(.error(error: error, newState: nil))
         case .invalidOOB:
             let error = VerifyCodeError(type: .invalidCode)
             self.stopTelemetryEvent(event, context: context, error: error)
@@ -304,7 +307,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                            format: "Invalid code error calling resetpassword/continue \(error.errorDescription ?? "No error description")")
 
             let state = ResetPasswordCodeRequiredState(controller: self, flowToken: passwordResetToken, correlationId: context.correlationId())
-            return .error(error: error, newState: state)
+            return .init(.error(error: error, newState: state))
         }
     }
 
@@ -333,7 +336,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         passwordSubmitToken: String,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
-    ) async -> ResetPasswordRequiredResult {
+    ) async -> ResetPasswordSubmitPasswordControllerResponse {
         MSALLogger.log(level: .info, context: context, format: "Finished resetpassword/submit request")
 
         switch response {
@@ -352,10 +355,8 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             MSALLogger.log(level: .error,
                            context: context,
                            format: "Password error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
-
-            return .error(error: error, newState: ResetPasswordRequiredState(controller: self,
-                                                                             flowToken: passwordSubmitToken,
-                                                                             correlationId: context.correlationId()))
+            let newState = ResetPasswordRequiredState(controller: self, flowToken: passwordSubmitToken, correlationId: context.correlationId())
+            return .init(.error(error: error, newState: newState))
         case .error(let apiError):
             let error = apiError.toPasswordRequiredPublicError()
             self.stopTelemetryEvent(event, context: context, error: error)
@@ -364,7 +365,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                            context: context,
                            format: "Error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
 
-            return .error(error: error, newState: nil)
+            return .init(.error(error: error, newState: nil))
         case .unexpectedError:
             let error = PasswordRequiredError(type: .generalError)
             self.stopTelemetryEvent(event, context: context, error: error)
@@ -373,7 +374,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                            context: context,
                            format: "Error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
 
-            return .error(error: error, newState: nil)
+            return .init(.error(error: error, newState: nil))
         }
     }
 
@@ -385,7 +386,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         retriesRemaining: Int,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
-    ) async -> ResetPasswordRequiredResult {
+    ) async -> ResetPasswordSubmitPasswordControllerResponse {
         MSALLogger.log(level: .verbose, context: context, format: "performing poll completion request...")
 
         let pollCompletionResponse = await performPollCompletionRequest(
@@ -438,7 +439,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         passwordResetToken: String,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
-    ) async -> ResetPasswordRequiredResult {
+    ) async -> ResetPasswordSubmitPasswordControllerResponse {
         MSALLogger.log(level: .info, context: context, format: "Finished resetpassword/poll_completion")
 
         switch response {
@@ -455,15 +456,15 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                     context: context
                 )
             case .succeeded:
-                stopTelemetryEvent(event, context: context)
-
-                return .completed
+                return .init(.completed, telemetryUpdate: { [weak self] result in
+                    self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
+                })
             case .failed:
                 let error = PasswordRequiredError(type: .generalError)
                 self.stopTelemetryEvent(event, context: context, error: error)
                 MSALLogger.log(level: .error, context: context, format: "password poll success returned status 'failed'")
 
-                return .error(error: error, newState: nil)
+                return .init(.error(error: error, newState: nil))
             }
         case .passwordError(let apiError):
             let error = apiError.toPasswordRequiredPublicError()
@@ -472,10 +473,8 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             MSALLogger.log(level: .error,
                            context: context,
                            format: "Password error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
-
-            return .error(error: error, newState: ResetPasswordRequiredState(controller: self,
-                                                                             flowToken: passwordResetToken,
-                                                                             correlationId: context.correlationId()))
+            let newState = ResetPasswordRequiredState(controller: self, flowToken: passwordResetToken, correlationId: context.correlationId())
+            return .init(.error(error: error, newState: newState))
         case .error(let apiError):
             let error = apiError.toPasswordRequiredPublicError()
             self.stopTelemetryEvent(event, context: context, error: error)
@@ -484,7 +483,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                            context: context,
                            format: "Error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
 
-            return .error(error: error, newState: nil)
+            return .init(.error(error: error, newState: nil))
         case .unexpectedError:
             let error = PasswordRequiredError(type: .generalError)
             self.stopTelemetryEvent(event, context: context, error: error)
@@ -493,7 +492,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                            context: context,
                            format: "Error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
 
-            return .error(error: error, newState: nil)
+            return .init(.error(error: error, newState: nil))
         }
     }
 
@@ -503,13 +502,13 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         retriesRemaining: Int,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
-    ) async -> ResetPasswordRequiredResult {
+    ) async -> ResetPasswordSubmitPasswordControllerResponse {
         guard retriesRemaining > 0 else {
             let error = PasswordRequiredError(type: .generalError)
             self.stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error, context: context, format: "password poll completion did not complete in time")
 
-            return .error(error: error, newState: nil)
+            return .init(.error(error: error, newState: nil))
         }
 
         MSALLogger.log(

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordControlling.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordControlling.swift
@@ -26,15 +26,20 @@
 
 protocol MSALNativeAuthResetPasswordControlling: AnyObject {
 
-    func resetPassword(parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartResult
+    typealias ResetPasswordStartControllerResponse = MSALNativeAuthControllerTelemetryWrapper<ResetPasswordStartResult>
+    typealias ResetPasswordResendCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<ResetPasswordResendCodeResult>
+    typealias ResetPasswordSubmitCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<ResetPasswordSubmitCodeResult>
+    typealias ResetPasswordSubmitPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<ResetPasswordSubmitPasswordResult>
 
-    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeResult
+    func resetPassword(parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartControllerResponse
 
-    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordVerifyCodeResult
+    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse
+
+    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse
 
     func submitPassword(
         password: String,
         passwordSubmitToken: String,
         context: MSIDRequestContext
-    ) async -> ResetPasswordRequiredResult
+    ) async -> ResetPasswordSubmitPasswordControllerResponse
 }

--- a/MSAL/src/native_auth/controllers/responses/CodeRequiredGenericResult.swift
+++ b/MSAL/src/native_auth/controllers/responses/CodeRequiredGenericResult.swift
@@ -24,16 +24,7 @@
 
 import Foundation
 
-/// Result type that contains information about the code sent, the next state of the reset password process and possible errors.
 enum CodeRequiredGenericResult<State: MSALNativeAuthBaseState, Error: MSALNativeAuthError> {
-    /// Returned if a user has received an email with code.
-    ///
-    /// - newState: An object representing the new state of the flow with follow on methods.
-    /// - sentTo: The email/phone number that the code was sent to.
-    /// - channelTargetType: The channel (email/phone) the code was sent through.
-    /// - codeLength: The length of the code required.
     case codeRequired(newState: State, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
-
-    /// An error object indicating why the operation failed.
     case error(error: Error, newState: State?)
 }

--- a/MSAL/src/native_auth/controllers/responses/ResetPasswordResults.swift
+++ b/MSAL/src/native_auth/controllers/responses/ResetPasswordResults.swift
@@ -24,38 +24,19 @@
 
 import Foundation
 
-/// Represents the result of starting the reset password process.
 enum ResetPasswordStartResult {
-    /// Returned if a user has received an email with code.
-    ///
-    /// - newState: An object representing the new state of the flow with follow on methods.
-    /// - sentTo: The email/phone number that the code was sent to.
-    /// - channelTargetType: The channel (email/phone) the code was sent through.
-    /// - codeLength: The length of the code required.
     case codeRequired(newState: ResetPasswordCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
-
-    /// An error object indicating why the operation failed.
     case error(ResetPasswordStartError)
 }
 
-/// Result type that contains information about the code sent, the next state of the reset password process and possible errors.
-/// See ``CodeRequiredGenericResult`` for more information.
 typealias ResetPasswordResendCodeResult = CodeRequiredGenericResult<ResetPasswordCodeRequiredState, ResendCodeError>
 
-/// Represents the result of verifying a reset password verification code.
-enum ResetPasswordVerifyCodeResult {
-    /// Returned when a password is required.
+enum ResetPasswordSubmitCodeResult {
     case passwordRequired(newState: ResetPasswordRequiredState)
-
-    /// An error object indicating why the operation failed.
     case error(error: VerifyCodeError, newState: ResetPasswordCodeRequiredState?)
 }
 
-/// Represents the result of verifying a reset password verification code.
-enum ResetPasswordRequiredResult {
-    /// Returned after the reset password operation completed successfully.
+enum ResetPasswordSubmitPasswordResult {
     case completed
-
-    /// An error object indicating why the operation failed.
     case error(error: PasswordRequiredError, newState: ResetPasswordRequiredState?)
 }

--- a/MSAL/src/native_auth/controllers/responses/SignInResults.swift
+++ b/MSAL/src/native_auth/controllers/responses/SignInResults.swift
@@ -24,59 +24,26 @@
 
 import Foundation
 
-/// Represents the result of sign in using password.
 enum SignInPasswordStartResult {
-    /// Returned after the sign in operation completed successfully. An object representing the signed in user account is returned.
     case completed(MSALNativeAuthUserAccountResult)
-
-    /// Returned if a user registered with email and code tries to sign in using password.
-    /// In this case MSAL will discard the password and will continue the sign in flow with code.
-    ///
-    /// - newState: An object representing the new state of the flow with follow on methods.
-    /// - sentTo: The email/phone number that the code was sent to.
-    /// - channelTargetType: The channel (email/phone) the code was sent through.
-    /// - codeLength: The length of the code required.
     case codeRequired(newState: SignInCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
-
-    /// An error object indicating why the operation failed.
     case error(SignInPasswordStartError)
 }
 
-/// Represents the result of sign in using code.
 enum SignInStartResult {
-    /// Returned if a user has received an email with code.
-    ///
-    /// - newState: An object representing the new state of the flow with follow on methods.
-    /// - sentTo: The email/phone number that the code was sent to.
-    /// - channelTargetType: The channel (email/phone) the code was sent through.
-    /// - codeLength: The length of the code required.
     case codeRequired(newState: SignInCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
-
-    /// Returned if a user registered with email and password tries to sign in using code.
     case passwordRequired(newState: SignInPasswordRequiredState)
-
-    /// An error object indicating why the operation failed.
     case error(SignInStartError)
 }
 
-/// Result type that contains information about the code sent, the next state of the reset password process and possible errors.
-/// See ``CodeRequiredGenericResult`` for more information.
 typealias SignInResendCodeResult = CodeRequiredGenericResult<SignInCodeRequiredState, ResendCodeError>
 
-/// Result type that contains information about the state of the sign in process.
 enum SignInPasswordRequiredResult {
-    /// Returned after the sign in operation completed successfully. An object representing the signed in user account is returned.
     case completed(MSALNativeAuthUserAccountResult)
-
-    /// An error object indicating why the operation failed. It may contain a ``SignInPasswordRequiredState`` to continue the flow.
     case error(error: PasswordRequiredError, newState: SignInPasswordRequiredState?)
 }
 
-/// Result type that contains information about the state of the sign in process.
 enum SignInVerifyCodeResult {
-    /// Returned after the sign in operation completed successfully. An object representing the signed in user account is returned.
     case completed(MSALNativeAuthUserAccountResult)
-
-    /// An error object indicating why the operation failed. It may contain a ``SignInPasswordRequiredState`` to continue the flow.
     case error(error: VerifyCodeError, newState: SignInCodeRequiredState?)
 }

--- a/MSAL/src/native_auth/controllers/responses/SignUpResults.swift
+++ b/MSAL/src/native_auth/controllers/responses/SignUpResults.swift
@@ -25,89 +25,36 @@
 import Foundation
 
 enum SignUpPasswordStartResult {
-    /// Returned if a user has received an email with code.
-    ///
-    /// - newState: An object representing the new state of the flow with follow on methods.
-    /// - sentTo: The email/phone number that the code was sent to.
-    /// - channelTargetType: The channel (email/phone) the code was sent through.
-    /// - codeLength: The length of the code required.
+
     case codeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
-
-    /// Returned when the attributes sent are invalid.
     case attributesInvalid([String])
-
-    /// An error object indicating why the operation failed.
     case error(SignUpPasswordStartError)
 }
 
 enum SignUpStartResult {
-    /// Returned if a user has received an email with code.
-    ///
-    /// - newState: An object representing the new state of the flow with follow on methods.
-    /// - sentTo: The email/phone number that the code was sent to.
-    /// - channelTargetType: The channel (email/phone) the code was sent through.
-    /// - codeLength: The length of the code required.
     case codeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
-
-    /// Returned when the attributes sent are invalid.
     case attributesInvalid([String])
-
-    /// An error object indicating why the operation failed.
     case error(SignUpStartError)
 }
 
-/// An object of this type is returned after a user submits the code sent to their email/phone.
-/// It contains the next state of the flow with follow on methods, depending on the server's response.
 enum SignUpVerifyCodeResult {
-    /// Returned after the sign up operation completed successfully.
     case completed(SignInAfterSignUpState)
-
-    /// Returned when a password is required.
     case passwordRequired(SignUpPasswordRequiredState)
-
-    /// Returned when attributes are required.
     case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
-
-    /// An error object indicating why the operation failed.
     case error(error: VerifyCodeError, newState: SignUpCodeRequiredState?)
 }
 
-enum SignUpResendCodeResult {
-    /// Returned if a user has received an email with code.
-    ///
-    /// - newState: An object representing the new state of the flow with follow on methods.
-    /// - sentTo: The email/phone number that the code was sent to.
-    /// - channelTargetType: The channel (email/phone) the code was sent through.
-    /// - codeLength: The length of the code required.
-    case codeRequired(newState: SignUpCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int)
+typealias SignUpResendCodeResult = CodeRequiredGenericResult<SignUpCodeRequiredState, ResendCodeError>
 
-    /// An error object indicating why the operation failed.
-    case error(ResendCodeError)
-}
-
-/// An object of this type is returned after a user submits their password.
-/// It contains the next state of the flow with follow on methods, depending on the server's response.
 enum SignUpPasswordRequiredResult {
-    /// Returned after the sign up operation completed successfully.
     case completed(SignInAfterSignUpState)
-
-    /// Returned when attributes are required.
     case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
-
-    /// An error object indicating why the operation failed.
     case error(error: PasswordRequiredError, newState: SignUpPasswordRequiredState?)
 }
 
 enum SignUpAttributesRequiredResult {
-    /// Returned after the sign up operation completed successfully.
     case completed(SignInAfterSignUpState)
-
-    /// Returned when attributes are required.
     case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], state: SignUpAttributesRequiredState)
-
-    /// Returned when the attributes sent are invalid.
     case attributesInvalid(attributes: [String], newState: SignUpAttributesRequiredState)
-
-    /// An error object indicating why the operation failed.
     case error(error: AttributesRequiredError)
 }

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -115,7 +115,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         slt: String?,
         scopes: [String]?,
         context: MSALNativeAuthRequestContext
-    ) async -> Result<MSALNativeAuthUserAccountResult, SignInAfterSignUpError> {
+    ) async -> SignInAfterSignUpControllerResponse {
         MSALLogger.log(level: .verbose, context: context, format: "SignIn after signUp started")
         let telemetryInfo = TelemetryInfo(
             event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInAfterSignUp, context: context),
@@ -125,7 +125,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             MSALLogger.log(level: .error, context: context, format: "SignIn not available because SLT is nil")
             let error = SignInAfterSignUpError(message: MSALNativeAuthErrorMessage.signInNotAvailable)
             stopTelemetryEvent(telemetryInfo, error: error)
-            return .failure(error)
+            return .init(.failure(error))
         }
         let scopes = joinScopes(scopes)
         guard let request = createTokenRequest(
@@ -137,7 +137,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         ) else {
             let error = SignInAfterSignUpError()
             stopTelemetryEvent(telemetryInfo, error: error)
-            return .failure(error)
+            return .init(.failure(error))
         }
         let config = factory.makeMSIDConfiguration(scopes: scopes)
         let response = await performAndValidateTokenRequest(request, config: config, context: context)
@@ -148,10 +148,12 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 scopes: scopes,
                 telemetryInfo: telemetryInfo,
                 onSuccess: { accountResult in
-                    continuation.resume(returning: .success(accountResult))
+                    continuation.resume(returning: .init(.success(accountResult), telemetryUpdate: { [weak self] result in
+                        self?.stopTelemetryEvent(telemetryInfo.event, context: context, delegateDispatcherResult: result)
+                    }))
                 },
                 onError: { error in
-                    continuation.resume(returning: .failure(SignInAfterSignUpError(message: error.errorDescription)))
+                    continuation.resume(returning: .init(.failure(SignInAfterSignUpError(message: error.errorDescription))))
                 }
             )
         }
@@ -163,7 +165,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         credentialToken: String,
         context: MSALNativeAuthRequestContext,
         scopes: [String]
-    ) async -> SignInVerifyCodeResult {
+    ) async -> SignInSubmitCodeControllerResponse {
         let telemetryInfo = TelemetryInfo(
             event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInSubmitCode, context: context),
             context: context
@@ -196,7 +198,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                     telemetryInfo: telemetryInfo,
                     config: config,
                     onSuccess: { accountResult in
-                        continuation.resume(returning: .completed(accountResult))
+                        continuation.resume(returning: .init(.completed(accountResult), telemetryUpdate: { [weak self] result in
+                            self?.stopTelemetryEvent(telemetryInfo.event, context: context, delegateDispatcherResult: result)
+                        }))
                     },
                     onError: { [weak self] error in
                         MSALLogger.log(level: .error, context: context, format: "SignIn submit code, token request failed with error \(error)")
@@ -229,7 +233,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         credentialToken: String,
         context: MSALNativeAuthRequestContext,
         scopes: [String]
-    ) async -> SignInPasswordRequiredResult {
+    ) async -> SignInSubmitPasswordControllerResponse {
         let telemetryInfo = TelemetryInfo(
             event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInSubmitPassword, context: context),
             context: context
@@ -261,7 +265,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                     telemetryInfo: telemetryInfo,
                     config: config,
                     onSuccess: { accountResult in
-                        continuation.resume(returning: .completed(accountResult))
+                        continuation.resume(returning: .init(.completed(accountResult), telemetryUpdate: { [weak self] result in
+                            self?.stopTelemetryEvent(telemetryInfo.event, context: context, delegateDispatcherResult: result)
+                        }))
                     },
                     onError: { [weak self] error in
                         MSALLogger.log(level: .error, context: context, format: "SignIn submit password, token request failed with error \(error)")
@@ -292,7 +298,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         credentialToken: String,
         context: MSALNativeAuthRequestContext,
         scopes: [String]
-    ) async -> SignInResendCodeResult {
+    ) async -> SignInResendCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignInResendCode, context: context)
         let result = await performAndValidateChallengeRequest(credentialToken: credentialToken, context: context)
         switch result {
@@ -300,19 +306,30 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             let error = ResendCodeError()
             MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: received unexpected password required API result")
             stopTelemetryEvent(event, context: context, error: error)
-            return .error(error: error, newState: nil)
+            return .init(.error(error: error, newState: nil))
         case .error(let challengeError):
             let error = ResendCodeError()
             MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: received challenge error response: \(challengeError)")
             stopTelemetryEvent(event, context: context, error: error)
-            return .error(error: error, newState: SignInCodeRequiredState(scopes: scopes,
-                                                                          controller: self,
-                                                                          flowToken: credentialToken,
-                                                                          correlationId: context.correlationId()))
+            return .init(.error(
+                error: error,
+                newState: SignInCodeRequiredState(
+                    scopes: scopes,
+                    controller: self,
+                    flowToken: credentialToken,
+                    correlationId: context.correlationId()))
+            )
         case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
             let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken, correlationId: context.correlationId())
-            stopTelemetryEvent(event, context: context)
-            return .codeRequired(newState: state, sentTo: sentTo, channelTargetType: channelType, codeLength: codeLength)
+            return .init(
+                .codeRequired(
+                    newState: state,
+                    sentTo: sentTo,
+                    channelTargetType: channelType,
+                    codeLength: codeLength),
+                telemetryUpdate: { [weak self] result in
+                    self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
+                })
         }
     }
 
@@ -324,14 +341,14 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         scopes: [String],
         credentialToken: String,
         context: MSALNativeAuthRequestContext
-    ) -> SignInVerifyCodeResult {
+    ) -> SignInSubmitCodeControllerResponse {
         MSALLogger.log(
             level: .error,
             context: context,
             format: "SignIn completed with errorType: \(errorType)")
         stopTelemetryEvent(telemetryInfo, error: errorType)
         let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken, correlationId: context.correlationId())
-        return .error(error: errorType.convertToVerifyCodeError(), newState: state)
+        return .init(.error(error: errorType.convertToVerifyCodeError(), newState: state))
     }
 
     private func processSubmitPasswordFailure(
@@ -340,18 +357,20 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         username: String,
         credentialToken: String,
         scopes: [String]
-    ) -> SignInPasswordRequiredResult {
+    ) -> SignInSubmitPasswordControllerResponse {
         MSALLogger.log(
             level: .error,
             context: telemetryInfo.context,
             format: "SignIn with username and password completed with errorType: \(errorType)")
         stopTelemetryEvent(telemetryInfo, error: errorType)
-        let state = SignInPasswordRequiredState(scopes: scopes,
-                                                username: username,
-                                                controller: self,
-                                                flowToken: credentialToken,
-                                                correlationId: telemetryInfo.context.correlationId())
-        return .error(error: errorType.convertToPasswordRequiredError(), newState: state)
+        let state = SignInPasswordRequiredState(
+            scopes: scopes,
+            username: username,
+            controller: self,
+            flowToken: credentialToken,
+            correlationId: telemetryInfo.context.correlationId()
+        )
+        return .init(.error(error: errorType.convertToPasswordRequiredError(), newState: state))
     }
 
     private func performAndValidateSignInInitiate(
@@ -464,26 +483,22 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             )
 
             return .init(.passwordRequired(newState: state), telemetryUpdate: { [weak self] result in
-                switch result {
-                case .success:
-                    MSALLogger.log(level: .verbose, context: telemetryInfo.context, format: "SignIn, password required")
-                    self?.stopTelemetryEvent(telemetryInfo)
-                case .failure(let error):
-                    MSALLogger.log(
-                        level: .error,
-                        context: telemetryInfo.context,
-                        format: "SignIn error: \(error.errorDescription ?? "No error description")"
-                    )
-                    self?.stopTelemetryEvent(telemetryInfo, error: error)
-                }
+                self?.stopTelemetryEvent(telemetryInfo.event, context: telemetryInfo.context, delegateDispatcherResult: result)
             })
         case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
             let state = SignInCodeRequiredState(scopes: scopes,
                                                 controller: self,
                                                 flowToken: credentialToken,
                                                 correlationId: params.context.correlationId())
-            stopTelemetryEvent(telemetryInfo)
-            return .init(.codeRequired(newState: state, sentTo: sentTo, channelTargetType: channelType, codeLength: codeLength))
+            return .init(
+                .codeRequired(
+                    newState: state,
+                    sentTo: sentTo,
+                    channelTargetType: channelType,
+                    codeLength: codeLength
+                ), telemetryUpdate: { [weak self] result in
+                    self?.stopTelemetryEvent(telemetryInfo.event, context: telemetryInfo.context, delegateDispatcherResult: result)
+                })
         case .error(let challengeError):
             let error = challengeError.convertToSignInStartError()
             MSALLogger.log(level: .error,
@@ -516,17 +531,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             )
 
             return .init(result, telemetryUpdate: { [weak self] result in
-                switch result {
-                case .success:
-                    self?.stopTelemetryEvent(telemetryInfo)
-                case .failure(let error):
-                    MSALLogger.log(
-                        level: .error,
-                        context: telemetryInfo.context,
-                        format: "SignIn error \(error.errorDescription ?? "No error description")"
-                    )
-                    self?.stopTelemetryEvent(telemetryInfo, error: error)
-                }
+                self?.stopTelemetryEvent(telemetryInfo.event, context: telemetryInfo.context, delegateDispatcherResult: result)
             })
         case .passwordRequired(let credentialToken):
             guard let request = createTokenRequest(
@@ -549,7 +554,10 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                     scopes: scopes,
                     telemetryInfo: telemetryInfo,
                     onSuccess: { accountResult in
-                        continuation.resume(returning: SignInPasswordControllerResponse(.completed(accountResult)))
+                    continuation.resume(returning: SignInPasswordControllerResponse(.completed(accountResult),
+                                                                                    telemetryUpdate: { [weak self] result in
+                        self?.stopTelemetryEvent(telemetryInfo.event, context: telemetryInfo.context, delegateDispatcherResult: result)
+                    }))
                     },
                     onError: { error in
                         continuation.resume(returning: SignInPasswordControllerResponse(.error(error)))

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
@@ -27,6 +27,11 @@ import Foundation
 protocol MSALNativeAuthSignInControlling {
     typealias SignInPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignInPasswordStartResult>
     typealias SignInCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignInStartResult>
+    typealias SignInAfterSignUpControllerResponse =
+        MSALNativeAuthControllerTelemetryWrapper<Result<MSALNativeAuthUserAccountResult, SignInAfterSignUpError>>
+    typealias SignInSubmitCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignInVerifyCodeResult>
+    typealias SignInSubmitPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignInPasswordRequiredResult>
+    typealias SignInResendCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignInResendCodeResult>
 
     func signIn(params: MSALNativeAuthSignInWithPasswordParameters) async -> SignInPasswordControllerResponse
 
@@ -37,9 +42,14 @@ protocol MSALNativeAuthSignInControlling {
         slt: String?,
         scopes: [String]?,
         context: MSALNativeAuthRequestContext
-    ) async -> Result<MSALNativeAuthUserAccountResult, SignInAfterSignUpError>
+    ) async -> SignInAfterSignUpControllerResponse
 
-    func submitCode(_ code: String, credentialToken: String, context: MSALNativeAuthRequestContext, scopes: [String]) async -> SignInVerifyCodeResult
+    func submitCode(
+        _ code: String,
+        credentialToken: String,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]
+    ) async -> SignInSubmitCodeControllerResponse
 
     func submitPassword(
         _ password: String,
@@ -47,7 +57,7 @@ protocol MSALNativeAuthSignInControlling {
         credentialToken: String,
         context: MSALNativeAuthRequestContext,
         scopes: [String]
-    ) async -> SignInPasswordRequiredResult
+    ) async -> SignInSubmitPasswordControllerResponse
 
-    func resendCode(credentialToken: String, context: MSALNativeAuthRequestContext, scopes: [String]) async -> SignInResendCodeResult
+    func resendCode(credentialToken: String, context: MSALNativeAuthRequestContext, scopes: [String]) async -> SignInResendCodeControllerResponse
 }

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
@@ -28,14 +28,16 @@ protocol MSALNativeAuthSignUpControlling: AnyObject {
 
     typealias SignUpStartPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpPasswordStartResult>
     typealias SignUpStartCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpStartResult>
+    typealias SignUpResendCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpResendCodeResult>
     typealias SignUpSubmitCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpVerifyCodeResult>
     typealias SignUpSubmitPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpPasswordRequiredResult>
+    typealias SignUpSubmitAttributesControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignUpAttributesRequiredResult>
 
     func signUpStartPassword(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartPasswordControllerResponse
 
     func signUpStartCode(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartCodeControllerResponse
 
-    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeResult
+    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeControllerResponse
 
     func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse
 
@@ -51,5 +53,5 @@ protocol MSALNativeAuthSignUpControlling: AnyObject {
         username: String,
         signUpToken: String,
         context: MSIDRequestContext
-    ) async -> SignUpAttributesRequiredResult
+    ) async -> SignUpSubmitAttributesControllerResponse
 }

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
@@ -25,7 +25,7 @@
 // swiftlint:disable line_length
 enum MSALNativeAuthErrorMessage {
     static let invalidScope = "Invalid scope"
-    static let delegateNotImplemented = "MSALNativeAuth has called an optional delegate method that has not been implemented"
+    static let delegateNotImplemented = "MSALNativeAuth has called the delegate method %@ that has not been implemented"
     static let unsupportedMFA = "MFA currently not supported. Use the browser instead"
     static let browserRequired = "Browser required. Use acquireTokenInteractively instead"
     static let userDoesNotHavePassword = "User does not have password associated with account"
@@ -34,8 +34,6 @@ enum MSALNativeAuthErrorMessage {
     static let attributeValidationFailedSignUpStart = "Check the invalid attributes and start the sign-up process again. Invalid attributes: %@"
     static let attributeValidationFailed = "Invalid attributes: %@"
     static let signInNotAvailable = "Sign In is not available at this point, please use the standalone sign in methods"
-    static let passwordRequiredNotImplemented = "Implementation of onSignInPasswordRequired required"
-    static let codeRequiredNotImplemented = "Implementation of onSignInCodeRequired required"
     static let codeRequiredForPasswordUserLog = "This user does not have a password associated with their account. SDK will call `delegate.onSignInCodeRequired()` and the entered password will be ignored"
 }
 

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -117,9 +117,12 @@ extension MSALNativeAuthPublicClientApplication {
         return await controller.signIn(params: params)
     }
 
-    func resetPasswordInternal(username: String, correlationId: UUID?) async -> ResetPasswordStartResult {
+    func resetPasswordInternal(
+        username: String,
+        correlationId: UUID?
+    ) async -> MSALNativeAuthResetPasswordControlling.ResetPasswordStartControllerResponse {
         guard inputValidator.isInputValid(username) else {
-            return .error(ResetPasswordStartError(type: .invalidUsername))
+            return .init(.error(ResetPasswordStartError(type: .invalidUsername)))
         }
 
         let controller = controllerFactory.makeResetPasswordController()

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -135,25 +135,20 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                 correlationId: correlationId
             )
 
+            let delegateDispatcher = SignUpPasswordStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
-                await delegate.onSignUpCodeRequired(
+                await delegateDispatcher.dispatchSignUpPasswordCodeRequired(
                     newState: newState,
                     sentTo: sentTo,
                     channelTargetType: channelTargetType,
                     codeLength: codeLength
                 )
             case .attributesInvalid(let attributes):
-                if let signUpAttributesMethod = delegate.onSignUpAttributesInvalid {
-                    controllerResponse.telemetryUpdate?(.success(()))
-                    await signUpAttributesMethod(attributes)
-                } else {
-                    let error = SignUpPasswordStartError(type: .generalError, message: MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
-                    controllerResponse.telemetryUpdate?(.failure(error))
-                    await delegate.onSignUpPasswordError(error: error)
-                }
+                await delegateDispatcher.dispatchSignUpAttributesInvalid(attributeNames: attributes)
             case .error(let error):
-                await delegate.onSignUpPasswordError(error: error)
+                await delegate.onSignUpPasswordStartError(error: error)
             }
         }
     }
@@ -172,26 +167,20 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
     ) {
         Task {
             let controllerResponse = await signUpInternal(username: username, attributes: attributes, correlationId: correlationId)
+            let delegateDispatcher = SignUpStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
-                await delegate.onSignUpCodeRequired(
+                await delegateDispatcher.dispatchSignUpCodeRequired(
                     newState: newState,
                     sentTo: sentTo,
                     channelTargetType: channelTargetType,
                     codeLength: codeLength
                 )
             case .attributesInvalid(let attributes):
-                if let signUpAttributesMethod = delegate.onSignUpAttributesInvalid {
-                    controllerResponse.telemetryUpdate?(.success(()))
-                    await signUpAttributesMethod(attributes)
-                } else {
-                    let error = SignUpStartError(type: .generalError, message: MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
-                    controllerResponse.telemetryUpdate?(.failure(error))
-                    await delegate.onSignUpError(error: error)
-                }
+                await delegateDispatcher.dispatchSignUpAttributesInvalid(attributeNames: attributes)
             case .error(let error):
-                await delegate.onSignUpError(error: error)
+                await delegate.onSignUpStartError(error: error)
             }
         }
     }
@@ -218,20 +207,20 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                 correlationId: correlationId
             )
 
+            let delegateDispatcher = SignInPasswordStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+
             switch controllerResponse.result {
             case .completed(let result):
-                await delegate.onSignInCompleted(result: result)
+                await delegateDispatcher.dispatchSignInCompleted(result: result)
             case .codeRequired(let newState, let sentTo, let channelType, let codeLength):
-                if let codeRequiredMethod = delegate.onSignInCodeRequired {
-                    controllerResponse.telemetryUpdate?(.success(()))
-                    await codeRequiredMethod(newState, sentTo, channelType, codeLength)
-                } else {
-                    let error = SignInPasswordStartError(type: .generalError, message: MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
-                    controllerResponse.telemetryUpdate?(.failure(error))
-                    await delegate.onSignInPasswordError(error: error)
-                }
+                await delegateDispatcher.dispatchSignInCodeRequired(
+                    newState: newState,
+                    sentTo: sentTo,
+                    channelTargetType: channelType,
+                    codeLength: codeLength
+                )
             case .error(let error):
-                await delegate.onSignInPasswordError(error: error)
+                await delegate.onSignInPasswordStartError(error: error)
             }
         }
     }
@@ -255,20 +244,20 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                 correlationId: correlationId
             )
 
+            let delegateDispatcher = SignInStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
-                await delegate.onSignInCodeRequired(newState: newState, sentTo: sentTo, channelTargetType: channelTargetType, codeLength: codeLength)
+                await delegateDispatcher.dispatchSignInCodeRequired(
+                    newState: newState,
+                    sentTo: sentTo,
+                    channelTargetType: channelTargetType,
+                    codeLength: codeLength
+                )
             case .passwordRequired(let newState):
-                if let passwordRequiredMethod = delegate.onSignInPasswordRequired {
-                    controllerResponse.telemetryUpdate?(.success(()))
-                    await passwordRequiredMethod(newState)
-                } else {
-                    let error = SignInStartError(type: .generalError, message: MSALNativeAuthErrorMessage.passwordRequiredNotImplemented)
-                    controllerResponse.telemetryUpdate?(.failure(error))
-                    await delegate.onSignInError(error: error)
-                }
+                await delegateDispatcher.dispatchSignInPasswordRequired(newState: newState)
             case .error(let error):
-                await delegate.onSignInError(error: error)
+                await delegate.onSignInStartError(error: error)
             }
         }
     }
@@ -284,18 +273,19 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: ResetPasswordStartDelegate
     ) {
         Task {
-            let result = await resetPasswordInternal(username: username, correlationId: correlationId)
+            let controllerResponse = await resetPasswordInternal(username: username, correlationId: correlationId)
+            let delegateDispatcher = ResetPasswordStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
-            switch result {
+            switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
-                await delegate.onResetPasswordCodeRequired(
+                await delegateDispatcher.dispatchResetPasswordCodeRequired(
                     newState: newState,
                     sentTo: sentTo,
                     channelTargetType: channelTargetType,
                     codeLength: codeLength
                 )
             case .error(let error):
-                await delegate.onResetPasswordError(error: error)
+                await delegate.onResetPasswordStartError(error: error)
             }
         }
     }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -26,7 +26,10 @@ import Foundation
 
 extension MSALNativeAuthUserAccountResult {
 
-    func getAccessTokenInternal(forceRefresh: Bool, correlationId: UUID?) async -> Result<String, RetrieveAccessTokenError> {
+    func getAccessTokenInternal(
+        forceRefresh: Bool,
+        correlationId: UUID?
+    ) async -> MSALNativeAuthCredentialsControlling.RefreshTokenCredentialControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         if let accessToken = self.authTokens.accessToken {
@@ -35,11 +38,11 @@ extension MSALNativeAuthUserAccountResult {
                 let credentialsController = controllerFactory.makeCredentialsController()
                 return await credentialsController.refreshToken(context: context, authTokens: authTokens)
             } else {
-                return .success(accessToken.accessToken)
+                return .init(.success(accessToken.accessToken))
             }
         } else {
             MSALLogger.log(level: .error, context: context, format: "Retrieve Access Token: Existing token not found")
-            return .failure(RetrieveAccessTokenError(type: .tokenNotFound))
+            return .init(.failure(RetrieveAccessTokenError(type: .tokenNotFound)))
         }
     }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -88,10 +88,11 @@ import Foundation
     @objc public func getAccessToken(forceRefresh: Bool = false, correlationId: UUID? = nil, delegate: CredentialsDelegate) {
         Task {
             let controllerResponse = await getAccessTokenInternal(forceRefresh: forceRefresh, correlationId: correlationId)
+            let delegateDispatcher = CredentialsDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
-            switch controllerResponse {
+            switch controllerResponse.result {
             case .success(let accessToken):
-                await delegate.onAccessTokenRetrieveCompleted(accessToken: accessToken)
+                await delegateDispatcher.dispatchAccessTokenRetrieveCompleted(accessToken: accessToken)
             case .failure(let error):
                 await delegate.onAccessTokenRetrieveError(error: error)
             }

--- a/MSAL/src/native_auth/public/state_machine/delegate/CredentialsDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/CredentialsDelegates.swift
@@ -26,11 +26,12 @@ import Foundation
 
 @objc
 public protocol CredentialsDelegate {
-    /// Notifies the delegate that the operation completed successfully.
-    /// - Parameter accessToken: The access token string.
-    @MainActor func onAccessTokenRetrieveCompleted(accessToken: String)
-
     /// Notifies the delegate that the operation resulted in an error.
     /// - Parameter error: An error object indicating why the operation failed.
     @MainActor func onAccessTokenRetrieveError(error: RetrieveAccessTokenError)
+
+    /// Notifies the delegate that the operation completed successfully.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onAccessTokenRetrieveError(error:)`` will be called.
+    /// - Parameter accessToken: The access token string.
+    @MainActor @objc optional func onAccessTokenRetrieveCompleted(accessToken: String)
 }

--- a/MSAL/src/native_auth/public/state_machine/delegate/ResetPasswordDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/ResetPasswordDelegates.swift
@@ -28,15 +28,16 @@ import Foundation
 public protocol ResetPasswordStartDelegate {
     /// Notifies the delegate that the operation resulted in an error.
     /// - Parameter error: An error object indicating why the operation failed.
-    @MainActor func onResetPasswordError(error: ResetPasswordStartError)
+    @MainActor func onResetPasswordStartError(error: ResetPasswordStartError)
 
     /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onResetPasswordStartError(error:)`` will be called.
     /// - Parameters:
     ///   - newState: An object representing the new state of the flow with follow on methods.
     ///   - sentTo: The email/phone number that the code was sent to.
     ///   - channelTargetType: The channel (email/phone) the code was sent through.
     ///   - codeLength: The length of the code required.
-    @MainActor func onResetPasswordCodeRequired(
+    @MainActor @objc optional func onResetPasswordCodeRequired(
         newState: ResetPasswordCodeRequiredState,
         sentTo: String,
         channelTargetType: MSALNativeAuthChannelType,
@@ -53,8 +54,9 @@ public protocol ResetPasswordVerifyCodeDelegate {
     @MainActor func onResetPasswordVerifyCodeError(error: VerifyCodeError, newState: ResetPasswordCodeRequiredState?)
 
     /// Notifies the delegate that a password is required from the user to continue.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onResetPasswordVerifyCodeError(error:newState:)`` will be called.
     /// - Parameter newState: An object representing the new state of the flow with follow on methods.
-    @MainActor func onPasswordRequired(newState: ResetPasswordRequiredState)
+    @MainActor @objc optional func onPasswordRequired(newState: ResetPasswordRequiredState)
 }
 
 @objc
@@ -66,12 +68,13 @@ public protocol ResetPasswordResendCodeDelegate {
     @MainActor func onResetPasswordResendCodeError(error: ResendCodeError, newState: ResetPasswordCodeRequiredState?)
 
     /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onResetPasswordResendCodeError(error:newState:)`` will be called.
     /// - Parameters:
     ///   - newState: An object representing the new state of the flow with follow on methods.
     ///   - sentTo: The email/phone number that the code was sent to.
     ///   - channelTargetType: The channel (email/phone) the code was sent through.
     ///   - codeLength: The length of the code required.
-    @MainActor func onResetPasswordResendCodeRequired(
+    @MainActor @objc optional func onResetPasswordResendCodeRequired(
         newState: ResetPasswordCodeRequiredState,
         sentTo: String,
         channelTargetType: MSALNativeAuthChannelType,
@@ -88,5 +91,6 @@ public protocol ResetPasswordRequiredDelegate {
     @MainActor func onResetPasswordRequiredError(error: PasswordRequiredError, newState: ResetPasswordRequiredState?)
 
     /// Notifies the delegate that the reset password operation completed successfully.
-    @MainActor func onResetPasswordCompleted()
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onResetPasswordRequiredError(error:newState:)`` will be called.
+    @MainActor @objc optional func onResetPasswordCompleted()
 }

--- a/MSAL/src/native_auth/public/state_machine/delegate/SignInAfterSignUpDelegate.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/SignInAfterSignUpDelegate.swift
@@ -31,6 +31,7 @@ public protocol SignInAfterSignUpDelegate {
     @MainActor func onSignInAfterSignUpError(error: SignInAfterSignUpError)
 
     /// Notifies the delegate that the sign in operation completed successfully.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignInAfterSignUpError(error:)`` will be called.
     /// - Parameter result: An object representing the signed in user account.
-    @MainActor func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
+    @MainActor @objc optional func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
 }

--- a/MSAL/src/native_auth/public/state_machine/delegate/SignInDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/SignInDelegates.swift
@@ -28,10 +28,10 @@ import Foundation
 public protocol SignInPasswordStartDelegate {
     /// Notifies the delegate that the operation resulted in an error.
     /// - Parameter error: An error object indicating why the operation failed.
-    @MainActor func onSignInPasswordError(error: SignInPasswordStartError)
+    @MainActor func onSignInPasswordStartError(error: SignInPasswordStartError)
 
     /// Notifies the delegate that a verification code is required from the user to continue.
-    /// - Note: If a flow requires a code but this optional method is not implemented, then ``onSignInPasswordError(error:)`` will be called.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignInPasswordStartError(error:)`` will be called.
     /// - Parameters:
     ///   - newState: An object representing the new state of the flow with follow on methods.
     ///   - sentTo: The email/phone number that the code was sent to.
@@ -44,28 +44,30 @@ public protocol SignInPasswordStartDelegate {
 
     /// Notifies the delegate that the sign in operation completed successfully.
     /// - Parameter result: An object representing the signed in user account.
-    @MainActor func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignInPasswordStartError(error:)`` will be called.
+    @MainActor @objc optional func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
 }
 
 @objc
 public protocol SignInStartDelegate {
     /// Notifies the delegate that the operation resulted in an error.
     /// - Parameter error: An error object indicating why the operation failed.
-    @MainActor func onSignInError(error: SignInStartError)
+    @MainActor func onSignInStartError(error: SignInStartError)
 
     /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignInStartError(error:)`` will be called.
     /// - Parameters:
     ///   - newState: An object representing the new state of the flow with follow on methods.
     ///   - sentTo: The email/phone number that the code was sent to.
     ///   - channelTargetType: The channel (email/phone) the code was sent through.
     ///   - codeLength: The length of the code required.
-    @MainActor func onSignInCodeRequired(newState: SignInCodeRequiredState,
-                                         sentTo: String,
-                                         channelTargetType: MSALNativeAuthChannelType,
-                                         codeLength: Int)
+    @MainActor @objc optional func onSignInCodeRequired(newState: SignInCodeRequiredState,
+                                                        sentTo: String,
+                                                        channelTargetType: MSALNativeAuthChannelType,
+                                                        codeLength: Int)
 
     /// Notifies the delegate that a password is required from the user to continue.
-    /// - Note: If a flow requires a password but this optional method is not implemented, then ``onSignInError(error:)`` will be called.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignInStartError(error:)`` will be called.
     /// - Parameter newState: An object representing the new state of the flow with follow on methods.
     @MainActor @objc optional func onSignInPasswordRequired(newState: SignInPasswordRequiredState)
 }
@@ -79,26 +81,30 @@ public protocol SignInPasswordRequiredDelegate {
     @MainActor func onSignInPasswordRequiredError(error: PasswordRequiredError, newState: SignInPasswordRequiredState?)
 
     /// Notifies the delegate that the sign in operation completed successfully.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignInPasswordRequiredError(error:newState:)`` will be called.
     /// - Parameter result: An object representing the signed in user account.
-    @MainActor func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
+    @MainActor @objc optional func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
 }
 
 @objc
 public protocol SignInResendCodeDelegate {
     /// Notifies the delegate that the operation resulted in an error.
-    /// - Parameter error: An error object indicating why the operation failed.
+    /// - Parameters:
+    ///   - error: An error object indicating why the operation failed.
+    ///   - newState: An object representing the new state of the flow with follow on methods.
     @MainActor func onSignInResendCodeError(error: ResendCodeError, newState: SignInCodeRequiredState?)
 
     /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignInResendCodeError(error:newState:)`` will be called.
     /// - Parameters:
     ///   - newState: An object representing the new state of the flow with follow on methods.
     ///   - sentTo: The email/phone number that the code was sent to.
     ///   - channelTargetType: The channel (email/phone) the code was sent through.
     ///   - codeLength: The length of the code required.
-    @MainActor func onSignInResendCodeCodeRequired(newState: SignInCodeRequiredState,
-                                                   sentTo: String,
-                                                   channelTargetType: MSALNativeAuthChannelType,
-                                                   codeLength: Int)
+    @MainActor @objc optional func onSignInResendCodeCodeRequired(newState: SignInCodeRequiredState,
+                                                                  sentTo: String,
+                                                                  channelTargetType: MSALNativeAuthChannelType,
+                                                                  codeLength: Int)
 }
 
 @objc
@@ -110,6 +116,7 @@ public protocol SignInVerifyCodeDelegate {
     @MainActor func onSignInVerifyCodeError(error: VerifyCodeError, newState: SignInCodeRequiredState?)
 
     /// Notifies the delegate that the sign in operation completed successfully.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignInVerifyCodeError(error:newState:)`` will be called.
     /// - Parameter result: An object representing the signed in user account.
-    @MainActor func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
+    @MainActor @objc optional func onSignInCompleted(result: MSALNativeAuthUserAccountResult)
 }

--- a/MSAL/src/native_auth/public/state_machine/delegate/SignUpDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/SignUpDelegates.swift
@@ -28,21 +28,22 @@ import Foundation
 public protocol SignUpPasswordStartDelegate {
     /// Notifies the delegate that the operation resulted in an error.
     /// - Parameter error: An error object indicating why the operation failed.
-    @MainActor func onSignUpPasswordError(error: SignUpPasswordStartError)
+    @MainActor func onSignUpPasswordStartError(error: SignUpPasswordStartError)
 
     /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpPasswordStartError(error:)`` will be called.
     /// - Parameters:
     ///   - newState: An object representing the new state of the flow with follow on methods.
     ///   - sentTo: The email/phone number that the code was sent to.
     ///   - channelTargetType: The channel (email/phone) the code was sent through.
     ///   - codeLength: The length of the code required.
-    @MainActor func onSignUpCodeRequired(newState: SignUpCodeRequiredState,
-                                         sentTo: String,
-                                         channelTargetType: MSALNativeAuthChannelType,
-                                         codeLength: Int)
+    @MainActor @objc optional func onSignUpCodeRequired(newState: SignUpCodeRequiredState,
+                                                        sentTo: String,
+                                                        channelTargetType: MSALNativeAuthChannelType,
+                                                        codeLength: Int)
 
     /// Notifies the delegate that invalid attributes were sent.
-    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpPasswordError(error)`` will be called.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpPasswordStartError(error:)`` will be called.
     /// - Parameter attributeNames: List of attribute names that failed validation.
     @MainActor @objc optional func onSignUpAttributesInvalid(attributeNames: [String])
 }
@@ -51,21 +52,22 @@ public protocol SignUpPasswordStartDelegate {
 public protocol SignUpStartDelegate {
     /// Notifies the delegate that the operation resulted in an error.
     /// - Parameter error: An error object indicating why the operation failed.
-    @MainActor func onSignUpError(error: SignUpStartError)
+    @MainActor func onSignUpStartError(error: SignUpStartError)
 
     /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpStartError(error:)`` will be called.
     /// - Parameters:
     ///   - newState: An object representing the new state of the flow with follow on methods.
     ///   - sentTo: The email/phone number that the code was sent to.
     ///   - channelTargetType: The channel (email/phone) the code was sent through.
     ///   - codeLength: The length of the code required.
-    @MainActor func onSignUpCodeRequired(newState: SignUpCodeRequiredState,
-                                         sentTo: String,
-                                         channelTargetType: MSALNativeAuthChannelType,
-                                         codeLength: Int)
+    @MainActor @objc optional func onSignUpCodeRequired(newState: SignUpCodeRequiredState,
+                                                        sentTo: String,
+                                                        channelTargetType: MSALNativeAuthChannelType,
+                                                        codeLength: Int)
 
     /// Notifies the delegate that invalid attributes were sent.
-    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpError(error)`` will be called.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpStartError(error:)`` will be called.
     /// - Parameter attributeNames: List of attribute names that failed validation.
     @MainActor @objc optional func onSignUpAttributesInvalid(attributeNames: [String])
 }
@@ -79,35 +81,39 @@ public protocol SignUpVerifyCodeDelegate {
     @MainActor func onSignUpVerifyCodeError(error: VerifyCodeError, newState: SignUpCodeRequiredState?)
 
     /// Notifies the delegate that attributes are required from the user to continue.
-    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpVerifyCodeError(error:newState:)`` will be called.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpVerifyCodeError(error:newState:)`` will be called.
     /// - Parameters:
     ///   - attributes: List of required attributes.
     ///   - newState: An object representing the new state of the flow with follow on methods.
     @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
 
     /// Notifies the delegate that a password is required from the user to continue.
-    /// - Note: If a flow requires a password but this optional method is not implemented, then ``onSignUpVerifyCodeError(error:newState:)`` will be called.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpVerifyCodeError(error:newState:)`` will be called.
     /// - Parameter newState: An object representing the new state of the flow with follow on methods.
     @MainActor @objc optional func onSignUpPasswordRequired(newState: SignUpPasswordRequiredState)
 
     /// Notifies the delegate that the sign up operation completed successfully.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpVerifyCodeError(error:newState:)`` will be called.
     /// - Parameter newState: An object representing the new state of the flow with follow on methods.
-    @MainActor func onSignUpCompleted(newState: SignInAfterSignUpState)
+    @MainActor @objc optional func onSignUpCompleted(newState: SignInAfterSignUpState)
 }
 
 @objc
 public protocol SignUpResendCodeDelegate {
     /// Notifies the delegate that the operation resulted in an error.
-    /// - Parameter error: An error object indicating why the operation failed.
-    @MainActor func onSignUpResendCodeError(error: ResendCodeError)
+    /// - Parameters:
+    ///   - error: An error object indicating why the operation failed.
+    ///   - newState: An object representing the new state of the flow with follow on methods.
+    @MainActor func onSignUpResendCodeError(error: ResendCodeError, newState: SignUpCodeRequiredState?)
 
     /// Notifies the delegate that a verification code is required from the user to continue.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpResendCodeError(error:newState:)`` will be called.
     /// - Parameters:
     ///   - newState: An object representing the new state of the flow with follow on methods.
     ///   - sentTo: The email/phone number that the code was sent to.
     ///   - channelTargetType: The channel (email/phone) the code was sent through.
     ///   - codeLength: The length of the code required.
-    @MainActor func onSignUpResendCodeCodeRequired(
+    @MainActor @objc optional func onSignUpResendCodeCodeRequired(
         newState: SignUpCodeRequiredState,
         sentTo: String,
         channelTargetType: MSALNativeAuthChannelType,
@@ -124,15 +130,16 @@ public protocol SignUpPasswordRequiredDelegate {
     @MainActor func onSignUpPasswordRequiredError(error: PasswordRequiredError, newState: SignUpPasswordRequiredState?)
 
     /// Notifies the delegate that attributes are required from the user to continue.
-    /// - Note: If a flow requires attributes but this optional method is not implemented, then ``onSignUpPasswordRequiredError(error:newState:)`` will be called.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpPasswordRequiredError(error:newState:)`` will be called.
     /// - Parameters:
     ///   - attributes: List of required attributes.
     ///   - newState: An object representing the new state of the flow with follow on methods.
     @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
 
     /// Notifies the delegate that the sign up operation completed successfully.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpPasswordRequiredError(error:newState:)`` will be called.
     /// - Parameter newState: An object representing the new state of the flow with follow on methods.
-    @MainActor func onSignUpCompleted(newState: SignInAfterSignUpState)
+    @MainActor @objc optional func onSignUpCompleted(newState: SignInAfterSignUpState)
 }
 
 @objc
@@ -142,18 +149,21 @@ public protocol SignUpAttributesRequiredDelegate {
     @MainActor func onSignUpAttributesRequiredError(error: AttributesRequiredError)
 
     /// Notifies the delegate that there are some required attributes to be sent.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpAttributesRequiredError(error:)`` will be called.
     /// - Parameters:
     ///     - attributes:  List of required attributes.
     ///     - newState: An object representing the new state of the flow with follow on methods.
-    @MainActor func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+    @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
 
     /// Notifies the delegate that invalid attributes were sent.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpAttributesRequiredError(error:)`` will be called.
     /// - Parameters:
     ///     - attributeNames: List of attribute names that failed validation.
     ///     - newState: An object representing the new state of the flow with follow on methods.
-    @MainActor func onSignUpAttributesInvalid(attributeNames: [String], newState: SignUpAttributesRequiredState)
+    @MainActor @objc optional func onSignUpAttributesInvalid(attributeNames: [String], newState: SignUpAttributesRequiredState)
 
     /// Notifies the delegate that the sign up operation completed successfully.
+    /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpAttributesRequiredError(error:)`` will be called.
     /// - Parameter newState: An object representing the new state of the flow with follow on methods.
-    @MainActor func onSignUpCompleted(newState: SignInAfterSignUpState)
+    @MainActor @objc optional func onSignUpCompleted(newState: SignInAfterSignUpState)
 }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+final class CredentialsDelegateDispatcher: DelegateDispatcher<CredentialsDelegate> {
+
+    func dispatchAccessTokenRetrieveCompleted(accessToken: String) async {
+        if let onAccessTokenRetrieveCompleted = delegate.onAccessTokenRetrieveCompleted {
+            telemetryUpdate?(.success(()))
+            await onAccessTokenRetrieveCompleted(accessToken)
+        } else {
+            let error = RetrieveAccessTokenError(type: .generalError, message: requiredErrorMessage(for: "onAccessTokenRetrieveCompleted"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onAccessTokenRetrieveError(error: error)
+        }
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/DelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/DelegateDispatcher.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+class DelegateDispatcher<T> {
+    let delegate: T
+    let telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?
+
+    init(delegate: T, telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?) {
+        self.delegate = delegate
+        self.telemetryUpdate = telemetryUpdate
+    }
+
+    func requiredErrorMessage(for method: String) -> String {
+        return String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, method)
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/ResetPasswordDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/ResetPasswordDelegateDispatchers.swift
@@ -1,0 +1,91 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+final class ResetPasswordStartDelegateDispatcher: DelegateDispatcher<ResetPasswordStartDelegate> {
+
+    func dispatchResetPasswordCodeRequired(
+        newState: ResetPasswordCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    ) async {
+        if let onResetPasswordCodeRequired = delegate.onResetPasswordCodeRequired {
+            telemetryUpdate?(.success(()))
+            await onResetPasswordCodeRequired(newState, sentTo, channelTargetType, codeLength)
+        } else {
+            let error = ResetPasswordStartError(type: .generalError, message: requiredErrorMessage(for: "onResetPasswordCodeRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onResetPasswordStartError(error: error)
+        }
+    }
+}
+
+final class ResetPasswordVerifyCodeDelegateDispatcher: DelegateDispatcher<ResetPasswordVerifyCodeDelegate> {
+
+    func dispatchPasswordRequired(newState: ResetPasswordRequiredState) async {
+        if let onPasswordRequired = delegate.onPasswordRequired {
+            telemetryUpdate?(.success(()))
+            await onPasswordRequired(newState)
+        } else {
+            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onPasswordRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onResetPasswordVerifyCodeError(error: error, newState: nil)
+        }
+    }
+}
+
+final class ResetPasswordResendCodeDelegateDispatcher: DelegateDispatcher<ResetPasswordResendCodeDelegate> {
+
+    func dispatchResetPasswordResendCodeRequired(
+        newState: ResetPasswordCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    ) async {
+        if let onResetPasswordResendCodeRequired = delegate.onResetPasswordResendCodeRequired {
+            telemetryUpdate?(.success(()))
+            await onResetPasswordResendCodeRequired(newState, sentTo, channelTargetType, codeLength)
+        } else {
+            let error = ResendCodeError(message: requiredErrorMessage(for: "onResetPasswordResendCodeRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onResetPasswordResendCodeError(error: error, newState: nil)
+        }
+    }
+}
+
+final class ResetPasswordRequiredDelegateDispatcher: DelegateDispatcher<ResetPasswordRequiredDelegate> {
+
+    func dispatchResetPasswordCompleted() async {
+        if let onResetPasswordCompleted = delegate.onResetPasswordCompleted {
+            telemetryUpdate?(.success(()))
+            await onResetPasswordCompleted()
+        } else {
+            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onResetPasswordCompleted"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onResetPasswordRequiredError(error: error, newState: nil)
+        }
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterSignUpDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterSignUpDelegateDispatcher.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+final class SignInAfterSignUpDelegateDispatcher: DelegateDispatcher<SignInAfterSignUpDelegate> {
+
+    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult) async {
+        if let onSignInCompleted = delegate.onSignInCompleted {
+            telemetryUpdate?(.success(()))
+            await onSignInCompleted(result)
+        } else {
+            let error = SignInAfterSignUpError(message: requiredErrorMessage(for: "onSignInCompleted"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignInAfterSignUpError(error: error)
+        }
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInDelegateDispatchers.swift
@@ -1,0 +1,132 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+final class SignInPasswordStartDelegateDispatcher: DelegateDispatcher<SignInPasswordStartDelegate> {
+
+    func dispatchSignInCodeRequired(
+        newState: SignInCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    ) async {
+        if let onSignInCodeRequired = delegate.onSignInCodeRequired {
+            telemetryUpdate?(.success(()))
+            await onSignInCodeRequired(newState, sentTo, channelTargetType, codeLength)
+        } else {
+            let error = SignInPasswordStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInCodeRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignInPasswordStartError(error: error)
+        }
+    }
+
+    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult) async {
+        if let onSignInCompleted = delegate.onSignInCompleted {
+            telemetryUpdate?(.success(()))
+            await onSignInCompleted(result)
+        } else {
+            let error = SignInPasswordStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignInPasswordStartError(error: error)
+        }
+    }
+}
+
+final class SignInStartDelegateDispatcher: DelegateDispatcher<SignInStartDelegate> {
+
+    func dispatchSignInCodeRequired(
+        newState: SignInCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    ) async {
+        if let onSignInCodeRequired = delegate.onSignInCodeRequired {
+            telemetryUpdate?(.success(()))
+            await onSignInCodeRequired(newState, sentTo, channelTargetType, codeLength)
+        } else {
+            let error = SignInStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInCodeRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignInStartError(error: error)
+        }
+    }
+
+    func dispatchSignInPasswordRequired(newState: SignInPasswordRequiredState) async {
+        if let onSignInPasswordRequired = delegate.onSignInPasswordRequired {
+            telemetryUpdate?(.success(()))
+            await onSignInPasswordRequired(newState)
+        } else {
+            let error = SignInStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInPasswordRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignInStartError(error: error)
+        }
+    }
+}
+
+final class SignInPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignInPasswordRequiredDelegate> {
+
+    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult) async {
+        if let onSignInCompleted = delegate.onSignInCompleted {
+            telemetryUpdate?(.success(()))
+            await onSignInCompleted(result)
+        } else {
+            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignInPasswordRequiredError(error: error, newState: nil)
+        }
+    }
+}
+
+final class SignInResendCodeDelegateDispatcher: DelegateDispatcher<SignInResendCodeDelegate> {
+
+    func dispatchSignInResendCodeCodeRequired(
+        newState: SignInCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    ) async {
+        if let onSignInResendCodeCodeRequired = delegate.onSignInResendCodeCodeRequired {
+            telemetryUpdate?(.success(()))
+            await onSignInResendCodeCodeRequired(newState, sentTo, channelTargetType, codeLength)
+        } else {
+            let error = ResendCodeError(message: requiredErrorMessage(for: "onSignInResendCodeCodeRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignInResendCodeError(error: error, newState: nil)
+        }
+    }
+}
+
+final class SignInVerifyCodeDelegateDispatcher: DelegateDispatcher<SignInVerifyCodeDelegate> {
+
+    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult) async {
+        if let onSignInCompleted = delegate.onSignInCompleted {
+            telemetryUpdate?(.success(()))
+            await onSignInCompleted(result)
+        } else {
+            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignInVerifyCodeError(error: error, newState: nil)
+        }
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignUpDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignUpDelegateDispatchers.swift
@@ -1,0 +1,201 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+final class SignUpPasswordStartDelegateDispatcher: DelegateDispatcher<SignUpPasswordStartDelegate> {
+
+    func dispatchSignUpPasswordCodeRequired(
+        newState: SignUpCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    ) async {
+        if let onSignUpCodeRequired = delegate.onSignUpCodeRequired {
+            telemetryUpdate?(.success(()))
+            await onSignUpCodeRequired(newState, sentTo, channelTargetType, codeLength)
+        } else {
+            let error = SignUpPasswordStartError(type: .generalError, message: requiredErrorMessage(for: "onSignUpCodeRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpPasswordStartError(error: error)
+        }
+    }
+
+    func dispatchSignUpAttributesInvalid(attributeNames: [String]) async {
+        if let onSignUpAttributesInvalid = delegate.onSignUpAttributesInvalid {
+            telemetryUpdate?(.success(()))
+            await onSignUpAttributesInvalid(attributeNames)
+        } else {
+            let error = SignUpPasswordStartError(type: .generalError, message: requiredErrorMessage(for: "onSignUpAttributesInvalid"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpPasswordStartError(error: error)
+        }
+    }
+}
+
+final class SignUpStartDelegateDispatcher: DelegateDispatcher<SignUpStartDelegate> {
+
+    func dispatchSignUpCodeRequired(
+        newState: SignUpCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    ) async {
+        if let onSignUpCodeRequired = delegate.onSignUpCodeRequired {
+            telemetryUpdate?(.success(()))
+            await onSignUpCodeRequired(newState, sentTo, channelTargetType, codeLength)
+        } else {
+            let error = SignUpStartError(type: .generalError, message: requiredErrorMessage(for: "onSignUpCodeRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpStartError(error: error)
+        }
+    }
+
+    func dispatchSignUpAttributesInvalid(attributeNames: [String]) async {
+        if let onSignUpAttributesInvalid = delegate.onSignUpAttributesInvalid {
+            telemetryUpdate?(.success(()))
+            await onSignUpAttributesInvalid(attributeNames)
+        } else {
+            let error = SignUpStartError(type: .generalError, message: requiredErrorMessage(for: "onSignUpAttributesInvalid"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpStartError(error: error)
+        }
+    }
+}
+
+final class SignUpVerifyCodeDelegateDispatcher: DelegateDispatcher<SignUpVerifyCodeDelegate> {
+
+    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) async {
+        if let onSignUpAttributesRequired = delegate.onSignUpAttributesRequired {
+            telemetryUpdate?(.success(()))
+            await onSignUpAttributesRequired(attributes, newState)
+        } else {
+            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignUpAttributesRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
+        }
+    }
+
+    func dispatchSignUpPasswordRequired(newState: SignUpPasswordRequiredState) async {
+        if let onSignUpPasswordRequired = delegate.onSignUpPasswordRequired {
+            telemetryUpdate?(.success(()))
+            await onSignUpPasswordRequired(newState)
+        } else {
+            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignUpPasswordRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
+        }
+    }
+
+    func dispatchSignUpCompleted(newState: SignInAfterSignUpState) async {
+        if let onSignUpCompleted = delegate.onSignUpCompleted {
+            telemetryUpdate?(.success(()))
+            await onSignUpCompleted(newState)
+        } else {
+            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignUpCompleted"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
+        }
+    }
+}
+
+final class SignUpResendCodeDelegateDispatcher: DelegateDispatcher<SignUpResendCodeDelegate> {
+
+    func dispatchSignUpResendCodeCodeRequired(
+        newState: SignUpCodeRequiredState,
+        sentTo: String,
+        channelTargetType: MSALNativeAuthChannelType,
+        codeLength: Int
+    ) async {
+        if let onSignUpResendCodeCodeRequired = delegate.onSignUpResendCodeCodeRequired {
+            telemetryUpdate?(.success(()))
+            await onSignUpResendCodeCodeRequired(newState, sentTo, channelTargetType, codeLength)
+        } else {
+            let error = ResendCodeError(message: requiredErrorMessage(for: "onSignUpResendCodeCodeRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpResendCodeError(error: error, newState: nil)
+        }
+    }
+}
+
+final class SignUpPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignUpPasswordRequiredDelegate> {
+
+    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) async {
+        if let onSignUpAttributesRequired = delegate.onSignUpAttributesRequired {
+            telemetryUpdate?(.success(()))
+            await onSignUpAttributesRequired(attributes, newState)
+        } else {
+            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onSignUpAttributesRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpPasswordRequiredError(error: error, newState: nil)
+        }
+    }
+
+    func dispatchSignUpCompleted(newState: SignInAfterSignUpState) async {
+        if let onSignUpCompleted = delegate.onSignUpCompleted {
+            telemetryUpdate?(.success(()))
+            await onSignUpCompleted(newState)
+        } else {
+            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onSignUpCompleted"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpPasswordRequiredError(error: error, newState: nil)
+        }
+    }
+}
+
+final class SignUpAttributesRequiredDelegateDispatcher: DelegateDispatcher<SignUpAttributesRequiredDelegate> {
+
+    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) async {
+        if let onSignUpAttributesRequired = delegate.onSignUpAttributesRequired {
+            telemetryUpdate?(.success(()))
+            await onSignUpAttributesRequired(attributes, newState)
+        } else {
+            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpAttributesRequired"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpAttributesRequiredError(error: error)
+        }
+    }
+
+    func dispatchSignUpAttributesInvalid(attributeNames: [String], newState: SignUpAttributesRequiredState) async {
+        if let onSignUpAttributesInvalid = delegate.onSignUpAttributesInvalid {
+            telemetryUpdate?(.success(()))
+            await onSignUpAttributesInvalid(attributeNames, newState)
+        } else {
+            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpAttributesInvalid"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpAttributesRequiredError(error: error)
+        }
+    }
+
+    func dispatchSignUpCompleted(newState: SignInAfterSignUpState) async {
+        if let onSignUpCompleted = delegate.onSignUpCompleted {
+            telemetryUpdate?(.success(()))
+            await onSignUpCompleted(newState)
+        } else {
+            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpCompleted"))
+            telemetryUpdate?(.failure(error))
+            await delegate.onSignUpAttributesRequiredError(error: error)
+        }
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
@@ -26,17 +26,17 @@ import Foundation
 
 extension ResetPasswordCodeRequiredState {
 
-    func resendCodeInternal() async -> ResetPasswordResendCodeResult {
+    func resendCodeInternal() async -> MSALNativeAuthResetPasswordControlling.ResetPasswordResendCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         return await controller.resendCode(passwordResetToken: flowToken, context: context)
     }
 
-    func submitCodeInternal(code: String) async -> ResetPasswordVerifyCodeResult {
+    func submitCodeInternal(code: String) async -> MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "ResetPassword flow, invalid code")
-            return .error(error: VerifyCodeError(type: .invalidCode), newState: self)
+            return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
         }
 
         return await controller.submitCode(code: code, passwordResetToken: flowToken, context: context)
@@ -45,12 +45,12 @@ extension ResetPasswordCodeRequiredState {
 
 extension ResetPasswordRequiredState {
 
-    func submitPasswordInternal(password: String) async -> ResetPasswordRequiredResult {
+    func submitPasswordInternal(password: String) async -> MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         guard inputValidator.isInputValid(password) else {
             MSALLogger.log(level: .error, context: context, format: "ResetPassword flow, invalid password")
-            return .error(error: PasswordRequiredError(type: .invalidPassword), newState: self)
+            return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
         }
 
         return await controller.submitPassword(password: password, passwordSubmitToken: flowToken, context: context)

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState+Internal.swift
@@ -26,7 +26,7 @@ import Foundation
 
 extension SignInAfterSignUpState {
 
-    func signInInternal(scopes: [String]?) async -> Result<MSALNativeAuthUserAccountResult, SignInAfterSignUpError> {
+    func signInInternal(scopes: [String]?) async -> MSALNativeAuthSignInControlling.SignInAfterSignUpControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         return await controller.signIn(username: username, slt: slt, scopes: scopes, context: context)
     }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -48,11 +48,12 @@ import Foundation
         delegate: SignInAfterSignUpDelegate
     ) {
         Task {
-            let controllerResult = await signInInternal(scopes: scopes)
+            let controllerResponse = await signInInternal(scopes: scopes)
+            let delegateDispatcher = SignInAfterSignUpDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
-            switch controllerResult {
+            switch controllerResponse.result {
             case .success(let accountResult):
-                await delegate.onSignInCompleted(result: accountResult)
+                await delegateDispatcher.dispatchSignInCompleted(result: accountResult)
             case .failure(let error):
                 await delegate.onSignInAfterSignUpError(error: error)
             }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
@@ -26,18 +26,18 @@ import Foundation
 
 extension SignInCodeRequiredState {
 
-    func submitCodeInternal(code: String) async -> SignInVerifyCodeResult {
+    func submitCodeInternal(code: String) async -> MSALNativeAuthSignInControlling.SignInSubmitCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, code submitted")
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn flow, invalid code")
-            return .error(error: VerifyCodeError(type: .invalidCode), newState: self)
+            return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
         }
 
         return await controller.submitCode(code, credentialToken: flowToken, context: context, scopes: scopes)
     }
 
-    func resendCodeInternal() async -> SignInResendCodeResult {
+    func resendCodeInternal() async -> MSALNativeAuthSignInControlling.SignInResendCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, resend code requested")
 
@@ -47,15 +47,13 @@ extension SignInCodeRequiredState {
 
 extension SignInPasswordRequiredState {
 
-    func submitPasswordInternal(
-        password: String
-    ) async -> SignInPasswordRequiredResult {
+    func submitPasswordInternal(password: String) async -> MSALNativeAuthSignInControlling.SignInSubmitPasswordControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALLogger.log(level: .info, context: context, format: "SignIn flow, password submitted")
 
         guard inputValidator.isInputValid(password) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn flow, invalid password")
-            return .error(error: PasswordRequiredError(type: .invalidPassword), newState: self)
+            return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
         }
 
         return await controller.submitPassword(password, username: username, credentialToken: flowToken, context: context, scopes: scopes)

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
@@ -58,11 +58,12 @@ import Foundation
     /// - Parameter delegate: Delegate that receives callbacks for the operation.
     public func resendCode(delegate: SignInResendCodeDelegate) {
         Task {
-            let result = await resendCodeInternal()
+            let controllerResponse = await resendCodeInternal()
+            let delegateDispatcher = SignInResendCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
-            switch result {
+            switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
-                await delegate.onSignInResendCodeCodeRequired(
+                await delegateDispatcher.dispatchSignInResendCodeCodeRequired(
                     newState: newState,
                     sentTo: sentTo,
                     channelTargetType: channelTargetType,
@@ -80,11 +81,12 @@ import Foundation
     ///   - delegate: Delegate that receives callbacks for the operation.
     public func submitCode(code: String, delegate: SignInVerifyCodeDelegate) {
         Task {
-            let result = await submitCodeInternal(code: code)
+            let controllerResponse = await submitCodeInternal(code: code)
+            let delegateDispatcher = SignInVerifyCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
-            switch result {
+            switch controllerResponse.result {
             case .completed(let accountResult):
-                await delegate.onSignInCompleted(result: accountResult)
+                await delegateDispatcher.dispatchSignInCompleted(result: accountResult)
             case .error(let error, let newState):
                 await delegate.onSignInVerifyCodeError(error: error, newState: newState)
             }
@@ -116,11 +118,12 @@ import Foundation
     ///   - delegate: Delegate that receives callbacks for the operation.
     public func submitPassword(password: String, delegate: SignInPasswordRequiredDelegate) {
         Task {
-            let result = await submitPasswordInternal(password: password)
+            let controllerResponse = await submitPasswordInternal(password: password)
+            let delegateDispatcher = SignInPasswordRequiredDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
-            switch result {
+            switch controllerResponse.result {
             case .completed(let accountResult):
-                await delegate.onSignInCompleted(result: accountResult)
+                await delegateDispatcher.dispatchSignInCompleted(result: accountResult)
             case .error(let error, let newState):
                 await delegate.onSignInPasswordRequiredError(error: error, newState: newState)
             }

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
@@ -26,7 +26,7 @@ import Foundation
 
 extension SignUpCodeRequiredState {
 
-    func resendCodeInternal() async -> SignUpResendCodeResult {
+    func resendCodeInternal() async -> MSALNativeAuthSignUpControlling.SignUpResendCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         return await controller.resendCode(username: username, context: context, signUpToken: flowToken)
     }
@@ -59,7 +59,7 @@ extension SignUpPasswordRequiredState {
 
 extension SignUpAttributesRequiredState {
 
-    func submitAttributesInternal(attributes: [String: Any]) async -> SignUpAttributesRequiredResult {
+    func submitAttributesInternal(attributes: [String: Any]) async -> MSALNativeAuthSignUpControlling.SignUpSubmitAttributesControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         return await controller.submitAttributes(attributes, username: username, signUpToken: flowToken, context: context)
     }

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/ResetPasswordDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/ResetPasswordDelegateSpies.swift
@@ -40,7 +40,7 @@ class ResetPasswordStartDelegateSpy: ResetPasswordStartDelegate {
         self.expectation = expectation
     }
 
-    func onResetPasswordError(error: MSAL.ResetPasswordStartError) {
+    func onResetPasswordStartError(error: MSAL.ResetPasswordStartError) {
         onResetPasswordErrorCalled = true
         self.error = error
 

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/SignInDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/SignInDelegateSpies.swift
@@ -37,7 +37,7 @@ class SignInPasswordStartDelegateSpy: SignInPasswordStartDelegate {
         self.expectation = expectation
     }
 
-    public func onSignInPasswordError(error: MSAL.SignInPasswordStartError) {
+    public func onSignInPasswordStartError(error: MSAL.SignInPasswordStartError) {
         onSignInPasswordErrorCalled = true
         self.error = error
 
@@ -71,7 +71,7 @@ class SignInStartDelegateSpy: SignInStartDelegate {
         self.expectation = expectation
     }
 
-    public func onSignInError(error: MSAL.SignInStartError) {
+    public func onSignInStartError(error: MSAL.SignInStartError) {
         onSignInErrorCalled = true
         self.error = error
 

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/SignUpDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/SignUpDelegateSpies.swift
@@ -26,7 +26,7 @@ import Foundation
 import XCTest
 import MSAL
 
-class SignUpPasswordStartDelegateSpy: SignUpPasswordStartDelegate {
+class SignUpPasswordStartDelegateSpy: SignUpPasswordStartDelegate {    
     private let expectation: XCTestExpectation
     private(set) var onSignUpPasswordErrorCalled = false
     private(set) var error: MSAL.SignUpPasswordStartError?
@@ -40,7 +40,7 @@ class SignUpPasswordStartDelegateSpy: SignUpPasswordStartDelegate {
         self.expectation = expectation
     }
 
-    func onSignUpPasswordError(error: SignUpPasswordStartError) {
+    func onSignUpPasswordStartError(error: MSAL.SignUpPasswordStartError) {
         onSignUpPasswordErrorCalled = true
         self.error = error
 
@@ -72,7 +72,7 @@ class SignUpStartDelegateSpy: SignUpStartDelegate {
         self.expectation = expectation
     }
 
-    func onSignUpError(error: SignUpStartError) {
+    func onSignUpStartError(error: SignUpStartError) {
         onSignUpErrorCalled = true
         self.error = error
 
@@ -148,7 +148,7 @@ class SignUpResendCodeDelegateSpy: SignUpResendCodeDelegate {
         self.expectation = expectation
     }
 
-    func onSignUpResendCodeError(error: ResendCodeError) {
+    func onSignUpResendCodeError(error: MSAL.ResendCodeError, newState: MSAL.SignUpCodeRequiredState?) {
         onSignUpResendCodeErrorCalled = true
         self.error = error
     }

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
@@ -196,6 +196,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let helper = prepareResetPasswordStartValidatorHelper(exp)
 
         let result = await sut.resetPassword(parameters: resetPasswordStartParams)
+        result.telemetryUpdate?(.success(()))
         helper.onResetPasswordCodeRequired(result)
 
         await fulfillment(of: [exp])
@@ -324,6 +325,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
 
         let result = await sut.resendCode(passwordResetToken: "passwordResetToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
         helper.onResetPasswordResendCodeRequired(result)
 
         await fulfillment(of: [exp])
@@ -437,6 +439,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
 
         let result = await sut.submitCode(code: "1234", passwordResetToken: "passwordResetToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
         helper.onPasswordRequired(result)
 
         await fulfillment(of: [exp])
@@ -548,6 +551,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
         let result = await sut.submitPassword(password: "password", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
         helper.onResetPasswordCompleted(result)
 
         await fulfillment(of: [exp])

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -394,6 +394,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
 
         let result = await sut.signIn(params: MSALNativeAuthSignInWithCodeParameters(username: expectedUsername, context: expectedContext, scopes: nil))
+        result.telemetryUpdate?(.success(()))
 
         helper.onSignInCodeRequired(result)
 
@@ -697,6 +698,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
 
         let result = await sut.resendCode(credentialToken: credentialToken, context: expectedContext, scopes: [])
+        result.telemetryUpdate?(.success(()))
 
         helper.onSignInResendCodeCodeRequired(result)
 

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
@@ -80,7 +80,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
 
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
@@ -104,7 +104,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper()
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
 
         XCTAssertTrue(requestProviderMock.challengeCalled)
 
@@ -170,7 +170,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
@@ -201,7 +201,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
         
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
         
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
@@ -232,7 +232,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
@@ -263,7 +263,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
         
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
@@ -285,7 +285,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
@@ -311,7 +311,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
@@ -336,6 +336,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
+        result.telemetryUpdate?(.success(()))
         helper.onSignUpCodeRequired(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -361,7 +362,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
@@ -386,7 +387,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
@@ -417,7 +418,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
@@ -443,7 +444,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
 
         let result = await sut.signUpStartPassword(parameters: signUpStartPasswordParams)
-        helper.onSignUpPasswordError(result)
+        helper.onSignUpPasswordStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordErrorCalled)
@@ -466,7 +467,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeErrorCalled)
@@ -490,7 +491,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper()
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
 
         XCTAssertTrue(requestProviderMock.challengeCalled)
 
@@ -554,7 +555,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeErrorCalled)
@@ -585,7 +586,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeErrorCalled)
@@ -616,7 +617,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeErrorCalled)
@@ -647,7 +648,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
         
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeErrorCalled)
@@ -669,7 +670,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeErrorCalled)
@@ -695,7 +696,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeErrorCalled)
@@ -720,6 +721,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
+        result.telemetryUpdate?(.success(()))
         helper.onSignUpCodeRequired(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -745,7 +747,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeErrorCalled)
@@ -770,7 +772,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeErrorCalled)
@@ -801,7 +803,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeErrorCalled)
@@ -827,7 +829,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
 
         let result = await sut.signUpStartCode(parameters: signUpStartCodeParams)
-        helper.onSignUpError(result)
+        helper.onSignUpStartError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeErrorCalled)
@@ -871,6 +873,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
         let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        result.telemetryUpdate?(.success(()))
         helper.onSignUpResendCodeCodeRequired(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -924,7 +927,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpResendCodeErrorCalled)
-        XCTAssertNil(helper.newState)
+        XCTAssertNotNil(helper.newState)
         XCTAssertNil(helper.sentTo)
         XCTAssertNil(helper.codeLength)
         XCTAssertNotNil(helper.error)
@@ -1709,6 +1712,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
         let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
         helper.onSignUpAttributesRequired(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1775,6 +1779,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
         let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        result.telemetryUpdate?(.success(()))
         helper.onSignUpAttributesValidationFailed(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1816,7 +1821,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
         let exp2 = expectation(description: "SignInAfterSignUp expectation")
         signInControllerMock.expectation = exp2
-        signInControllerMock.signInSLTResult = .failure(.init())
+        signInControllerMock.signInSLTResult = .init(.failure(.init()))
         helper.signInAfterSignUpState?.signIn(delegate: SignInAfterSignUpDelegateStub())
         await fulfillment(of: [exp2], timeout: 1)
 

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthCredentialsControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthCredentialsControllerMock.swift
@@ -28,10 +28,10 @@ import XCTest
 
 class MSALNativeAuthCredentialsControllerMock: MSALNativeAuthCredentialsControlling {
 
-    var refreshTokenResult: Result<String, RetrieveAccessTokenError>!
+    var refreshTokenResult: RefreshTokenCredentialControllerResponse!
     var accountResult: MSALNativeAuthUserAccountResult?
 
-    func refreshToken(context: MSAL.MSALNativeAuthRequestContext, authTokens: MSAL.MSALNativeAuthTokens) async -> Result<String, MSAL.RetrieveAccessTokenError> {
+    func refreshToken(context: MSAL.MSALNativeAuthRequestContext, authTokens: MSAL.MSALNativeAuthTokens) async -> RefreshTokenCredentialControllerResponse {
         return refreshTokenResult
     }
 

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthResetPasswordControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthResetPasswordControllerMock.swift
@@ -28,24 +28,24 @@ import XCTest
 
 class MSALNativeAuthResetPasswordControllerMock: MSALNativeAuthResetPasswordControlling {
 
-    var resetPasswordResult: ResetPasswordStartResult!
-    var resendCodeResult: ResetPasswordResendCodeResult!
-    var submitCodeResult: ResetPasswordVerifyCodeResult!
-    var submitPasswordResult: ResetPasswordRequiredResult!
+    var resetPasswordResponse: ResetPasswordStartControllerResponse!
+    var resendCodeResponse: ResetPasswordResendCodeControllerResponse!
+    var submitCodeResponse: ResetPasswordSubmitCodeControllerResponse!
+    var submitPasswordResponse: ResetPasswordSubmitPasswordControllerResponse!
 
-    func resetPassword(parameters: MSAL.MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartResult {
-        return resetPasswordResult
+    func resetPassword(parameters: MSAL.MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartControllerResponse {
+        return resetPasswordResponse
     }
 
-    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeResult {
-        return resendCodeResult
+    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
+        return resendCodeResponse
     }
 
-    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordVerifyCodeResult {
-        return submitCodeResult
+    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
+        return submitCodeResponse
     }
 
-    func submitPassword(password: String, passwordSubmitToken: String, context: MSIDRequestContext) async -> ResetPasswordRequiredResult {
-        return submitPasswordResult
+    func submitPassword(password: String, passwordSubmitToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
+        return submitPasswordResponse
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
@@ -33,10 +33,10 @@ class MSALNativeAuthSignInControllerMock: MSALNativeAuthSignInControlling {
 
     var signInPasswordStartResult: MSALNativeAuthSignInControlling.SignInPasswordControllerResponse!
     var signInStartResult: MSALNativeAuthSignInControlling.SignInCodeControllerResponse!
-    var signInSLTResult: Result<MSAL.MSALNativeAuthUserAccountResult, MSAL.SignInAfterSignUpError>!
-    var submitCodeResult: SignInVerifyCodeResult!
-    var submitPasswordResult: SignInPasswordRequiredResult!
-    var resendCodeResult: SignInResendCodeResult!
+    var signInSLTResult: SignInAfterSignUpControllerResponse!
+    var submitCodeResult: SignInSubmitCodeControllerResponse!
+    var submitPasswordResult: SignInSubmitPasswordControllerResponse!
+    var resendCodeResult: SignInResendCodeControllerResponse!
 
     func signIn(params: MSAL.MSALNativeAuthSignInWithPasswordParameters) async -> MSALNativeAuthSignInControlling.SignInPasswordControllerResponse {
         return signInPasswordStartResult
@@ -46,7 +46,7 @@ class MSALNativeAuthSignInControllerMock: MSALNativeAuthSignInControlling {
         return signInStartResult
     }
 
-    func signIn(username: String, slt: String?, scopes: [String]?, context: MSAL.MSALNativeAuthRequestContext) async -> Result<MSAL.MSALNativeAuthUserAccountResult, MSAL.SignInAfterSignUpError> {
+    func signIn(username: String, slt: String?, scopes: [String]?, context: MSAL.MSALNativeAuthRequestContext) async -> SignInAfterSignUpControllerResponse {
         self.username = username
         self.slt = slt
         expectation?.fulfill()
@@ -54,15 +54,15 @@ class MSALNativeAuthSignInControllerMock: MSALNativeAuthSignInControlling {
         return signInSLTResult
     }
 
-    func submitCode(_ code: String, credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInVerifyCodeResult {
+    func submitCode(_ code: String, credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInSubmitCodeControllerResponse {
         submitCodeResult
     }
 
-    func submitPassword(_ password: String, username: String, credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInPasswordRequiredResult {
+    func submitPassword(_ password: String, username: String, credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInSubmitPasswordControllerResponse {
         return submitPasswordResult
     }
 
-    func resendCode(credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInResendCodeResult {
+    func resendCode(credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInResendCodeControllerResponse {
         return resendCodeResult
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
@@ -30,10 +30,10 @@ class MSALNativeAuthSignUpControllerMock: MSALNativeAuthSignUpControlling {
 
     var startPasswordResult: MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse!
     var startResult: MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse!
-    var resendCodeResult: SignUpResendCodeResult!
+    var resendCodeResult: SignUpResendCodeControllerResponse!
     var submitCodeResult: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse!
     var submitPasswordResult: MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse!
-    var submitAttributesResult: SignUpAttributesRequiredResult!
+    var submitAttributesResult: SignUpSubmitAttributesControllerResponse!
 
     func signUpStartPassword(parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters) async -> MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse {
         return startPasswordResult
@@ -43,7 +43,7 @@ class MSALNativeAuthSignUpControllerMock: MSALNativeAuthSignUpControlling {
         return startResult
     }
 
-    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeResult {
+    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeControllerResponse {
         return resendCodeResult
     }
 
@@ -55,7 +55,7 @@ class MSALNativeAuthSignUpControllerMock: MSALNativeAuthSignUpControlling {
         return submitPasswordResult
     }
 
-    func submitAttributes(_ attributes: [String : Any], username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpAttributesRequiredResult {
+    func submitAttributes(_ attributes: [String : Any], username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpSubmitAttributesControllerResponse {
         return submitAttributesResult
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
@@ -62,11 +62,11 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         username: String,
         context: MSIDRequestContext,
         signUpToken: String
-    ) async -> SignUpResendCodeResult {
+    ) async -> SignUpResendCodeControllerResponse {
         self.context = context
         resendCodeCalled = true
         expectation.fulfill()
-        return .error(.init())
+        return .init(.error(error: .init(), newState: nil))
     }
 
     func submitCode(
@@ -98,10 +98,10 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         username: String,
         signUpToken: String,
         context: MSIDRequestContext
-    ) async -> SignUpAttributesRequiredResult {
+    ) async -> SignUpSubmitAttributesControllerResponse {
         self.context = context
         submitAttributesCalled = true
         expectation.fulfill()
-        return .error(error: .init())
+        return .init(.error(error: .init()))
     }
 }

--- a/MSAL/test/unit/native_auth/mock/ResetPasswordDelegateSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/ResetPasswordDelegateSpies.swift
@@ -39,7 +39,7 @@ class ResetPasswordStartDelegateSpy: ResetPasswordStartDelegate {
         self.expectation = expectation
     }
 
-    func onResetPasswordError(error: MSAL.ResetPasswordStartError) {
+    func onResetPasswordStartError(error: MSAL.ResetPasswordStartError) {
         onResetPasswordErrorCalled = true
         self.error = error
 
@@ -58,6 +58,22 @@ class ResetPasswordStartDelegateSpy: ResetPasswordStartDelegate {
         self.sentTo = sentTo
         self.channelTargetType = channelTargetType
         self.codeLength = codeLength
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class ResetPasswordStartDelegateOptionalMethodsNotImplemented: ResetPasswordStartDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var error: ResetPasswordStartError?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordStartError(error: MSAL.ResetPasswordStartError) {
+        self.error = error
 
         XCTAssertTrue(Thread.isMainThread)
         expectation?.fulfill()
@@ -101,6 +117,24 @@ class ResetPasswordResendCodeDelegateSpy: ResetPasswordResendCodeDelegate {
     }
 }
 
+class ResetPasswordResendCodeDelegateOptionalMethodsNotImplemented: ResetPasswordResendCodeDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var error: ResendCodeError?
+    private(set) var newState: ResetPasswordCodeRequiredState?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordResendCodeError(error: ResendCodeError, newState: ResetPasswordCodeRequiredState?) {
+        self.error = error
+        self.newState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
 class ResetPasswordVerifyCodeDelegateSpy: ResetPasswordVerifyCodeDelegate {
     let expectation: XCTestExpectation?
     private(set) var onResetPasswordVerifyCodeErrorCalled = false
@@ -131,6 +165,24 @@ class ResetPasswordVerifyCodeDelegateSpy: ResetPasswordVerifyCodeDelegate {
     }
 }
 
+class ResetPasswordVerifyCodeDelegateOptionalMethodsNotImplemented: ResetPasswordVerifyCodeDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var error: VerifyCodeError?
+    private(set) var newCodeRequiredState: ResetPasswordCodeRequiredState?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordVerifyCodeError(error: VerifyCodeError, newState: ResetPasswordCodeRequiredState?) {
+        self.error = error
+        newCodeRequiredState = newState
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
 class ResetPasswordRequiredDelegateSpy: ResetPasswordRequiredDelegate {
     let expectation: XCTestExpectation?
     private(set) var onResetPasswordRequiredErrorCalled = false
@@ -154,6 +206,24 @@ class ResetPasswordRequiredDelegateSpy: ResetPasswordRequiredDelegate {
 
     func onResetPasswordCompleted() {
         onResetPasswordCompletedCalled = true
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
+class ResetPasswordRequiredDelegateOptionalMethodsNotImplemented: ResetPasswordRequiredDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var error: PasswordRequiredError?
+    private(set) var newPasswordRequiredState: ResetPasswordRequiredState?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordRequiredError(error: PasswordRequiredError, newState: ResetPasswordRequiredState?) {
+        self.error = error
+        newPasswordRequiredState = newState
 
         XCTAssertTrue(Thread.isMainThread)
         expectation?.fulfill()

--- a/MSAL/test/unit/native_auth/mock/ResetPasswordTestValidatorHelpers.swift
+++ b/MSAL/test/unit/native_auth/mock/ResetPasswordTestValidatorHelpers.swift
@@ -27,17 +27,17 @@ import XCTest
 
 class ResetPasswordStartTestsValidatorHelper: ResetPasswordStartDelegateSpy {
 
-    func onResetPasswordError(_ input: ResetPasswordStartResult) {
-        guard case let .error(error) = input else {
+    func onResetPasswordError(_ input: MSALNativeAuthResetPasswordController.ResetPasswordStartControllerResponse) {
+        guard case let .error(error) = input.result else {
             expectation?.fulfill()
             return XCTFail("Should be an .error")
         }
 
-        Task { await self.onResetPasswordError(error: error) }
+        Task { await self.onResetPasswordStartError(error: error) }
     }
 
-    func onResetPasswordCodeRequired(_ input: ResetPasswordStartResult) {
-        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input else {
+    func onResetPasswordCodeRequired(_ input: MSALNativeAuthResetPasswordController.ResetPasswordStartControllerResponse) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input.result else {
             expectation?.fulfill()
             return XCTFail("Should be .codeRequired")
         }
@@ -50,8 +50,8 @@ class ResetPasswordStartTestsValidatorHelper: ResetPasswordStartDelegateSpy {
 
 class ResetPasswordResendCodeTestsValidatorHelper: ResetPasswordResendCodeDelegateSpy {
 
-    func onResetPasswordResendCodeError(_ input: ResetPasswordResendCodeResult) {
-        guard case let .error(error, newState) = input else {
+    func onResetPasswordResendCodeError(_ input: MSALNativeAuthResetPasswordController.ResetPasswordResendCodeControllerResponse) {
+        guard case let .error(error, newState) = input.result else {
             expectation?.fulfill()
             return XCTFail("should be .error")
         }
@@ -59,8 +59,8 @@ class ResetPasswordResendCodeTestsValidatorHelper: ResetPasswordResendCodeDelega
         Task { await self.onResetPasswordResendCodeError(error: error, newState: newState) }
     }
 
-    func onResetPasswordResendCodeRequired(_ input: ResetPasswordResendCodeResult) {
-        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input else {
+    func onResetPasswordResendCodeRequired(_ input: MSALNativeAuthResetPasswordController.ResetPasswordResendCodeControllerResponse) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input.result else {
             expectation?.fulfill()
             return XCTFail("Should be .codeRequired")
         }
@@ -73,8 +73,8 @@ class ResetPasswordResendCodeTestsValidatorHelper: ResetPasswordResendCodeDelega
 
 class ResetPasswordVerifyCodeTestsValidatorHelper: ResetPasswordVerifyCodeDelegateSpy {
 
-    func onResetPasswordVerifyCodeError(_ input: ResetPasswordVerifyCodeResult) {
-        guard case let .error(error, newState) = input else {
+    func onResetPasswordVerifyCodeError(_ input: MSALNativeAuthResetPasswordController.ResetPasswordSubmitCodeControllerResponse) {
+        guard case let .error(error, newState) = input.result else {
             expectation?.fulfill()
             return XCTFail("should be .error")
         }
@@ -82,8 +82,8 @@ class ResetPasswordVerifyCodeTestsValidatorHelper: ResetPasswordVerifyCodeDelega
         Task { await self.onResetPasswordVerifyCodeError(error: error, newState: newState) }
     }
 
-    func onPasswordRequired(_ input: ResetPasswordVerifyCodeResult) {
-        guard case let .passwordRequired(newState) = input else {
+    func onPasswordRequired(_ input: MSALNativeAuthResetPasswordController.ResetPasswordSubmitCodeControllerResponse) {
+        guard case let .passwordRequired(newState) = input.result else {
             expectation?.fulfill()
             return XCTFail("should be .success")
         }
@@ -94,8 +94,8 @@ class ResetPasswordVerifyCodeTestsValidatorHelper: ResetPasswordVerifyCodeDelega
 
 class ResetPasswordRequiredTestsValidatorHelper: ResetPasswordRequiredDelegateSpy {
 
-    func onResetPasswordRequiredError(_ input: ResetPasswordRequiredResult) {
-        guard case let .error(error, newState) = input else {
+    func onResetPasswordRequiredError(_ input: MSALNativeAuthResetPasswordController.ResetPasswordSubmitPasswordControllerResponse) {
+        guard case let .error(error, newState) = input.result else {
             expectation?.fulfill()
             return XCTFail("should be .error")
         }
@@ -103,8 +103,8 @@ class ResetPasswordRequiredTestsValidatorHelper: ResetPasswordRequiredDelegateSp
         Task { await self.onResetPasswordRequiredError(error: error, newState: newState) }
     }
 
-    func onResetPasswordCompleted(_ input: ResetPasswordRequiredResult) {
-        guard case .completed = input else {
+    func onResetPasswordCompleted(_ input: MSALNativeAuthResetPasswordController.ResetPasswordSubmitPasswordControllerResponse) {
+        guard case .completed = input.result else {
             expectation?.fulfill()
             return XCTFail("should be .success")
         }

--- a/MSAL/test/unit/native_auth/mock/SignInDelegatesSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/SignInDelegatesSpies.swift
@@ -40,7 +40,7 @@ open class SignInPasswordStartDelegateSpy: SignInPasswordStartDelegate {
         self.expectedUserAccountResult = expectedUserAccountResult
     }
 
-    public func onSignInPasswordError(error: MSAL.SignInPasswordStartError) {
+    public func onSignInPasswordStartError(error: MSAL.SignInPasswordStartError) {
         if let expectedError = expectedError {
             XCTAssertTrue(Thread.isMainThread)
             XCTAssertEqual(error.type, expectedError.type)
@@ -115,9 +115,27 @@ class SignInPasswordRequiredDelegateSpy: SignInPasswordRequiredDelegate {
     }
 }
 
+final class SignInPasswordRequiredDelegateOptionalMethodsNotImplemented: SignInPasswordRequiredDelegate {
+
+    private(set) var newPasswordRequiredState: SignInPasswordRequiredState?
+    let expectation: XCTestExpectation
+    var delegateError: PasswordRequiredError?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignInPasswordRequiredError(error: MSAL.PasswordRequiredError, newState: MSAL.SignInPasswordRequiredState?) {
+        XCTAssertTrue(Thread.isMainThread)
+        delegateError = error
+        newPasswordRequiredState = newState
+        expectation.fulfill()
+    }
+}
+
 open class SignInPasswordStartDelegateFailureSpy: SignInPasswordStartDelegate {
 
-    public func onSignInPasswordError(error: MSAL.SignInPasswordStartError) {
+    public func onSignInPasswordStartError(error: MSAL.SignInPasswordStartError) {
         XCTFail("This method should not be called")
     }
 
@@ -151,7 +169,7 @@ open class SignInCodeStartDelegateSpy: SignInStartDelegate {
         self.expectedError = expectedError
     }
 
-    public func onSignInError(error: SignInStartError) {
+    public func onSignInStartError(error: SignInStartError) {
         XCTAssertEqual(error.type, expectedError?.type)
         XCTAssertEqual(error.localizedDescription, expectedError?.localizedDescription)
         XCTAssertTrue(Thread.isMainThread)
@@ -204,6 +222,23 @@ class SignInResendCodeDelegateSpy: SignInResendCodeDelegate {
     }
 }
 
+class SignInResendCodeDelegateOptionalMethodsNotImplemented: SignInResendCodeDelegate {
+
+    private(set) var newSignInCodeRequiredState: SignInCodeRequiredState?
+    private(set) var newSignInResendCodeError: ResendCodeError?
+    let expectation: XCTestExpectation
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignInResendCodeError(error: ResendCodeError, newState: SignInCodeRequiredState?) {
+        newSignInCodeRequiredState = newState
+        newSignInResendCodeError = error
+        expectation.fulfill()
+    }
+}
+
 class SignInCodeStartDelegateWithPasswordRequiredSpy: SignInCodeStartDelegateSpy {
     var passwordRequiredState: SignInPasswordRequiredState?
 
@@ -250,6 +285,24 @@ open class SignInVerifyCodeDelegateSpy: SignInVerifyCodeDelegate {
     }
 }
 
+final class SignInVerifyCodeDelegateOptionalMethodsNotImplemented: SignInVerifyCodeDelegate {
+
+    private let expectation: XCTestExpectation
+    var expectedError: VerifyCodeError?
+    var expectedUserAccountResult: MSALNativeAuthUserAccountResult?
+    var expectedNewState: SignInCodeRequiredState?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    public func onSignInVerifyCodeError(error: VerifyCodeError, newState: SignInCodeRequiredState?) {
+        expectedError = error
+        XCTAssertTrue(Thread.isMainThread)
+        expectation.fulfill()
+    }
+}
+
 open class SignInAfterSignUpDelegateSpy: SignInAfterSignUpDelegate {
 
     private let expectation: XCTestExpectation
@@ -283,6 +336,23 @@ open class SignInAfterSignUpDelegateSpy: SignInAfterSignUpDelegate {
     }
 }
 
+final class SignInAfterSignUpDelegateOptionalMethodsNotImplemented: SignInAfterSignUpDelegate {
+
+    private let expectation: XCTestExpectation
+    var expectedError: SignInAfterSignUpError?
+
+    init(expectation: XCTestExpectation, expectedError: SignInAfterSignUpError? = nil) {
+        self.expectation = expectation
+        self.expectedError = expectedError
+    }
+
+    public func onSignInAfterSignUpError(error: MSAL.SignInAfterSignUpError) {
+        XCTAssertEqual(error.errorDescription, expectedError?.errorDescription)
+        XCTAssertTrue(Thread.isMainThread)
+        expectation.fulfill()
+    }
+}
+
 final class SignInPasswordStartDelegateOptionalMethodNotImplemented: SignInPasswordStartDelegate {
     private let expectation: XCTestExpectation
     var expectedError: SignInPasswordStartError?
@@ -294,7 +364,7 @@ final class SignInPasswordStartDelegateOptionalMethodNotImplemented: SignInPassw
         self.expectedUserAccountResult = expectedUserAccountResult
     }
 
-    func onSignInPasswordError(error: MSAL.SignInPasswordStartError) {
+    func onSignInPasswordStartError(error: MSAL.SignInPasswordStartError) {
         if let expectedError = expectedError {
             XCTAssertTrue(Thread.isMainThread)
             XCTAssertEqual(error.type, expectedError.type)
@@ -305,15 +375,22 @@ final class SignInPasswordStartDelegateOptionalMethodNotImplemented: SignInPassw
         XCTFail("This method should not be called")
         expectation.fulfill()
     }
+}
 
-    func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {
-        if let expectedUserAccountResult = expectedUserAccountResult {
-            XCTAssertTrue(Thread.isMainThread)
-            XCTAssertEqual(expectedUserAccountResult.idToken, result.idToken)
-            XCTAssertEqual(expectedUserAccountResult.scopes, result.scopes)
-        } else {
-            XCTFail("This method should not be called")
-        }
+final class SignInCodeStartDelegateOptionalMethodNotImplemented: SignInStartDelegate {
+
+    let expectation: XCTestExpectation
+    var expectedError: SignInStartError?
+
+    init(expectation: XCTestExpectation, expectedError: SignInStartError) {
+        self.expectation = expectation
+        self.expectedError = expectedError
+    }
+
+    public func onSignInStartError(error: SignInStartError) {
+        XCTAssertEqual(error.type, expectedError?.type)
+        XCTAssertEqual(error.localizedDescription, expectedError?.localizedDescription)
+        XCTAssertTrue(Thread.isMainThread)
         expectation.fulfill()
     }
 }

--- a/MSAL/test/unit/native_auth/mock/SignInTestsValidatorHelpers.swift
+++ b/MSAL/test/unit/native_auth/mock/SignInTestsValidatorHelpers.swift
@@ -34,7 +34,7 @@ class SignInPasswordStartTestsValidatorHelper: SignInPasswordStartDelegateSpy {
         }
 
         self.expectedError = error
-        Task { await self.onSignInPasswordError(error: error) }
+        Task { await self.onSignInPasswordStartError(error: error) }
     }
 
     func onSignInCodeRequired(_ input: MSALNativeAuthSignInController.SignInPasswordControllerResponse) {
@@ -86,7 +86,7 @@ class SignInCodeStartTestsValidatorHelper: SignInCodeStartDelegateSpy {
             return XCTFail("input should be .error")
         }
 
-        Task { await self.onSignInError(error: error) }
+        Task { await self.onSignInStartError(error: error) }
     }
     
     func onSignInCodeRequired(_ input: MSALNativeAuthSignInControlling.SignInCodeControllerResponse) {
@@ -101,8 +101,8 @@ class SignInCodeStartTestsValidatorHelper: SignInCodeStartDelegateSpy {
 
 class SignInResendCodeTestsValidatorHelper: SignInResendCodeDelegateSpy {
     
-    func onSignInResendCodeError(_ input: SignInResendCodeResult) {
-        guard case let .error(error, newState) = input else {
+    func onSignInResendCodeError(_ input: MSALNativeAuthSignInController.SignInResendCodeControllerResponse) {
+        guard case let .error(error, newState) = input.result else {
             expectation.fulfill()
             return XCTFail("input should be .error")
         }
@@ -110,8 +110,8 @@ class SignInResendCodeTestsValidatorHelper: SignInResendCodeDelegateSpy {
         Task { await self.onSignInResendCodeError(error: error, newState: newState) }
     }
 
-    func onSignInResendCodeCodeRequired(_ input: SignInResendCodeResult) {
-        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input else {
+    func onSignInResendCodeCodeRequired(_ input: MSALNativeAuthSignInController.SignInResendCodeControllerResponse) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input.result else {
             expectation.fulfill()
             return XCTFail("input should be .codeRequired")
         }

--- a/MSAL/test/unit/native_auth/mock/SignUpDelegateSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/SignUpDelegateSpies.swift
@@ -41,7 +41,7 @@ class SignUpPasswordStartDelegateSpy: SignUpPasswordStartDelegate {
         self.expectation = expectation
     }
 
-    func onSignUpPasswordError(error: MSAL.SignUpPasswordStartError) {
+    func onSignUpPasswordStartError(error: MSAL.SignUpPasswordStartError) {
         onSignUpPasswordErrorCalled = true
         self.error = error
 
@@ -85,7 +85,7 @@ class SignUpCodeStartDelegateSpy: SignUpStartDelegate {
         self.expectation = expectation
     }
 
-    func onSignUpError(error: MSAL.SignUpStartError) {
+    func onSignUpStartError(error: MSAL.SignUpStartError) {
         onSignUpCodeErrorCalled = true
         self.error = error
 
@@ -127,8 +127,9 @@ class SignUpResendCodeDelegateSpy: SignUpResendCodeDelegate {
         self.expectation = expectation
     }
 
-    func onSignUpResendCodeError(error: ResendCodeError) {
+    func onSignUpResendCodeError(error: MSAL.ResendCodeError, newState: MSAL.SignUpCodeRequiredState?) {
         onSignUpResendCodeErrorCalled = true
+        self.newState = newState
         self.error = error
 
         XCTAssertTrue(Thread.isMainThread)
@@ -147,6 +148,22 @@ class SignUpResendCodeDelegateSpy: SignUpResendCodeDelegate {
     }
 }
 
+class SignUpResendCodeDelegateMethodsNotImplemented: SignUpResendCodeDelegate {
+    let expectation: XCTestExpectation?
+    private(set) var error: ResendCodeError?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpResendCodeError(error: MSAL.ResendCodeError, newState: MSAL.SignUpCodeRequiredState?) {
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
 class SignUpVerifyCodeDelegateSpy: SignUpVerifyCodeDelegate {
     let expectation: XCTestExpectation?
     private(set) var onSignUpVerifyCodeErrorCalled = false
@@ -158,6 +175,7 @@ class SignUpVerifyCodeDelegateSpy: SignUpVerifyCodeDelegate {
     private(set) var newAttributesRequiredState: SignUpAttributesRequiredState?
     private(set) var newPasswordRequiredState: SignUpPasswordRequiredState?
     private(set) var newSignInAfterSignUpState: SignInAfterSignUpState?
+    private(set) var newAttributesRequired: [MSALNativeAuthRequiredAttributes]?
 
     init(expectation: XCTestExpectation? = nil) {
         self.expectation = expectation
@@ -174,6 +192,7 @@ class SignUpVerifyCodeDelegateSpy: SignUpVerifyCodeDelegate {
 
     func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
         onSignUpAttributesRequiredCalled = true
+        newAttributesRequired = attributes
         newAttributesRequiredState = newState
 
         XCTAssertTrue(Thread.isMainThread)
@@ -206,6 +225,7 @@ class SignUpPasswordRequiredDelegateSpy: SignUpPasswordRequiredDelegate {
     private(set) var newPasswordRequiredState: SignUpPasswordRequiredState?
     private(set) var newAttributesRequiredState: SignUpAttributesRequiredState?
     private(set) var signInAfterSignUpState: SignInAfterSignUpState?
+    private(set) var newAttributesRequired: [MSALNativeAuthRequiredAttributes]?
 
     init(expectation: XCTestExpectation? = nil) {
         self.expectation = expectation
@@ -223,6 +243,7 @@ class SignUpPasswordRequiredDelegateSpy: SignUpPasswordRequiredDelegate {
     func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
         onSignUpAttributesRequiredCalled = true
         newAttributesRequiredState = newState
+        newAttributesRequired = attributes
 
         XCTAssertTrue(Thread.isMainThread)
         expectation?.fulfill()
@@ -285,6 +306,22 @@ class SignUpAttributesRequiredDelegateSpy: SignUpAttributesRequiredDelegate {
     }
 }
 
+class SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented: SignUpAttributesRequiredDelegate {
+    private let expectation: XCTestExpectation?
+    private(set) var error: AttributesRequiredError?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func onSignUpAttributesRequiredError(error: MSAL.AttributesRequiredError) {
+        self.error = error
+
+        XCTAssertTrue(Thread.isMainThread)
+        expectation?.fulfill()
+    }
+}
+
 class SignUpVerifyCodeDelegateOptionalMethodsNotImplemented: SignUpVerifyCodeDelegate {
     private let expectation: XCTestExpectation
     private(set) var error: VerifyCodeError?
@@ -298,10 +335,6 @@ class SignUpVerifyCodeDelegateOptionalMethodsNotImplemented: SignUpVerifyCodeDel
         XCTAssertTrue(Thread.isMainThread)
         expectation.fulfill()
     }
-
-    func onSignUpCompleted(newState: SignInAfterSignUpState) {
-        XCTAssertTrue(Thread.isMainThread)
-    }
 }
 
 class SignUpPasswordStartDelegateOptionalMethodsNotImplemented: SignUpPasswordStartDelegate {
@@ -313,16 +346,11 @@ class SignUpPasswordStartDelegateOptionalMethodsNotImplemented: SignUpPasswordSt
         self.expectation = expectation
     }
 
-    func onSignUpPasswordError(error: MSAL.SignUpPasswordStartError) {
+    func onSignUpPasswordStartError(error: MSAL.SignUpPasswordStartError) {
         onSignUpPasswordErrorCalled = true
         self.error = error
 
         XCTAssertTrue(Thread.isMainThread)
-        self.expectation?.fulfill()
-    }
-    
-    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
-        XCTFail("This method should not be called")
         self.expectation?.fulfill()
     }
 }
@@ -336,16 +364,11 @@ class SignUpStartDelegateOptionalMethodsNotImplemented: SignUpStartDelegate {
         self.expectation = expectation
     }
 
-    func onSignUpError(error: MSAL.SignUpStartError) {
+    func onSignUpStartError(error: MSAL.SignUpStartError) {
         onSignUpStartErrorCalled = true
         self.error = error
 
         XCTAssertTrue(Thread.isMainThread)
-        self.expectation?.fulfill()
-    }
-    
-    func onSignUpCodeRequired(newState: MSAL.SignUpCodeRequiredState, sentTo: String, channelTargetType: MSAL.MSALNativeAuthChannelType, codeLength: Int) {
-        XCTFail("This method should not be called")
         self.expectation?.fulfill()
     }
 }
@@ -362,9 +385,5 @@ class SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented: SignUpPasswor
         self.error = error
         XCTAssertTrue(Thread.isMainThread)
         expectation.fulfill()
-    }
-
-    func onSignUpCompleted(newState: SignInAfterSignUpState) {
-        XCTAssertTrue(Thread.isMainThread)
     }
 }

--- a/MSAL/test/unit/native_auth/mock/SignUpTestsValidatorHelpers.swift
+++ b/MSAL/test/unit/native_auth/mock/SignUpTestsValidatorHelpers.swift
@@ -27,14 +27,14 @@ import XCTest
 
 class SignUpPasswordStartTestsValidatorHelper: SignUpPasswordStartDelegateSpy {
 
-    func onSignUpPasswordError(_ input: MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse) {
+    func onSignUpPasswordStartError(_ input: MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse) {
         guard case let .error(error) = input.result else {
             expectation?.fulfill()
             return XCTFail("Should be an .error")
         }
 
         Task {
-            await self.onSignUpPasswordError(error: error)
+            await self.onSignUpPasswordStartError(error: error)
         }
     }
 
@@ -63,14 +63,14 @@ class SignUpPasswordStartTestsValidatorHelper: SignUpPasswordStartDelegateSpy {
 
 class SignUpCodeStartTestsValidatorHelper: SignUpCodeStartDelegateSpy {
 
-    func onSignUpError(_ input: MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse) {
+    func onSignUpStartError(_ input: MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse) {
         guard case let .error(error) = input.result else {
             expectation?.fulfill()
             return XCTFail("Should be an .error")
         }
 
         Task {
-            await self.onSignUpError(error: error)
+            await self.onSignUpStartError(error: error)
         }
     }
 
@@ -99,19 +99,19 @@ class SignUpCodeStartTestsValidatorHelper: SignUpCodeStartDelegateSpy {
 
 class SignUpResendCodeTestsValidatorHelper: SignUpResendCodeDelegateSpy {
 
-    func onSignUpResendCodeError(_ input: SignUpResendCodeResult) {
-        guard case let .error(error) = input else {
+    func onSignUpResendCodeError(_ input: MSALNativeAuthSignUpController.SignUpResendCodeControllerResponse) {
+        guard case let .error(error, newState) = input.result else {
             expectation?.fulfill()
             return XCTFail("Should be an .error")
         }
 
         Task {
-            await self.onSignUpResendCodeError(error: error)
+            await self.onSignUpResendCodeError(error: error, newState: newState)
         }
     }
 
-    func onSignUpResendCodeCodeRequired(_ input: SignUpResendCodeResult) {
-        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input else {
+    func onSignUpResendCodeCodeRequired(_ input: MSALNativeAuthSignUpController.SignUpResendCodeControllerResponse) {
+        guard case let .codeRequired(newState, sentTo, channelTargetType, codeLength) = input.result else {
             expectation?.fulfill()
             return XCTFail("Should be .codeRequired")
         }
@@ -221,8 +221,8 @@ class SignUpAttributesRequiredTestsValidatorHelper {
         self.expectation = expectation
     }
 
-    func onSignUpAttributesRequired(_ input: SignUpAttributesRequiredResult) {
-        guard case let .attributesRequired(attributes, state) = input else {
+    func onSignUpAttributesRequired(_ input: MSALNativeAuthSignUpController.SignUpSubmitAttributesControllerResponse) {
+        guard case let .attributesRequired(attributes, state) = input.result else {
             expectation?.fulfill()
             return XCTFail("Should be .attributesInvalid")
         }
@@ -234,8 +234,8 @@ class SignUpAttributesRequiredTestsValidatorHelper {
         expectation?.fulfill()
     }
 
-    func onSignUpAttributesRequiredError(_ input: SignUpAttributesRequiredResult) {
-        guard case let .error(error) = input else {
+    func onSignUpAttributesRequiredError(_ input: MSALNativeAuthSignUpController.SignUpSubmitAttributesControllerResponse) {
+        guard case let .error(error) = input.result else {
             expectation?.fulfill()
             return XCTFail("Should be an .error")
         }
@@ -246,8 +246,8 @@ class SignUpAttributesRequiredTestsValidatorHelper {
         expectation?.fulfill()
     }
 
-    func onSignUpAttributesValidationFailed(_ input: SignUpAttributesRequiredResult) {
-        guard case let .attributesInvalid(attributes, state) = input else {
+    func onSignUpAttributesValidationFailed(_ input: MSALNativeAuthSignUpController.SignUpSubmitAttributesControllerResponse) {
+        guard case let .attributesInvalid(attributes, state) = input.result else {
             expectation?.fulfill()
             return XCTFail("Should be an .error")
         }
@@ -259,8 +259,8 @@ class SignUpAttributesRequiredTestsValidatorHelper {
         expectation?.fulfill()
     }
 
-    func onSignUpCompleted(_ input: SignUpAttributesRequiredResult) {
-        guard case .completed = input else {
+    func onSignUpCompleted(_ input: MSALNativeAuthSignUpController.SignUpSubmitAttributesControllerResponse) {
+        guard case .completed = input.result else {
             expectation?.fulfill()
             return XCTFail("Should be an .error")
         }

--- a/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
@@ -39,38 +39,38 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         self.expectation = expectation
     }
 
-    func resetPassword(parameters: MSAL.MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartResult {
+    func resetPassword(parameters: MSAL.MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartControllerResponse {
         self.context = parameters.context
         resetPasswordCalled = true
         expectation.fulfill()
 
-        return .error(.init(type: .generalError))
+        return .init(.error(.init(type: .generalError)))
     }
 
-    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeResult {
+    func resendCode(passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
         self.flowToken = passwordResetToken
         self.context = context
         resendCodeCalled = true
         expectation.fulfill()
 
-        return .error(error: .init(), newState: nil)
+        return .init(.error(error: .init(), newState: nil))
     }
 
-    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordVerifyCodeResult {
+    func submitCode(code: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
         self.flowToken = passwordResetToken
         self.context = context
         submitCodeCalled = true
         expectation.fulfill()
 
-        return .error(error: .init(type: .generalError), newState: nil)
+        return .init(.error(error: .init(type: .generalError), newState: nil))
     }
 
-    func submitPassword(password: String, passwordSubmitToken: String, context: MSIDRequestContext) async -> ResetPasswordRequiredResult {
+    func submitPassword(password: String, passwordSubmitToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
         self.flowToken = passwordSubmitToken
         self.context = context
         submitPasswordCalled = true
         expectation.fulfill()
 
-        return .error(error: .init(type: .generalError), newState: nil)
+        return .init(.error(error: .init(type: .generalError), newState: nil))
     }
 }

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -88,8 +88,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     }
 
     func testSignUpPassword_delegate_whenValidDataIsPassed_shouldReturnCodeRequired() {
-        let exp = expectation(description: "sign-up public interface")
-        let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
+        let exp1 = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "sign-up public interface telemetry")
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: exp1)
 
         let expectedResult: SignUpPasswordStartResult = .codeRequired(
             newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId),
@@ -97,11 +98,13 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controllerFactoryMock.signUpController.startPasswordResult = .init(expectedResult)
+        controllerFactoryMock.signUpController.startPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
         sut.signUpUsingPassword(username: "correct", password: "correct", delegate: delegate)
 
-        wait(for: [exp])
+        wait(for: [exp1, exp2])
 
         XCTAssertEqual(delegate.newState?.flowToken, "flowToken")
         XCTAssertEqual(delegate.sentTo, "sentTo")
@@ -109,35 +112,70 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         XCTAssertEqual(delegate.codeLength, 1)
     }
 
+    func testSignUpPassword_delegate_butDelegateMethodIsNotImplemented_shouldReturnError() {
+        let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "sign-up public interface telemetry")
+        let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: exp)
+        
+        let expectedResult: SignUpPasswordStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controllerFactoryMock.signUpController.startPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        sut.signUpUsingPassword(username: "correct", password: "correct", delegate: delegate)
+        
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired")
+        )
+    }
+
     func testSignUpPassword_delegate_whenSendAttributes_shouldReturnAttributesInvalid() {
         let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
         let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
         let expectedInvalidAttributes = ["attribute"]
 
         let expectedResult: SignUpPasswordStartResult = .attributesInvalid(expectedInvalidAttributes)
-        controllerFactoryMock.signUpController.startPasswordResult = .init(expectedResult)
+        controllerFactoryMock.signUpController.startPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
         sut.signUpUsingPassword(username: "correct", password: "correct", delegate: delegate)
 
-        wait(for: [exp])
+        wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.attributeNames, expectedInvalidAttributes)
     }
 
     func testSignUpPassword_delegate_whenSendAttributes_butDelegateMethodIsNotImplemented_itShouldReturnAttributesInvalid() {
         let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
         let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: exp)
         let expectedInvalidAttributes = ["attribute"]
 
         let expectedResult: SignUpPasswordStartResult = .attributesInvalid(expectedInvalidAttributes)
-        controllerFactoryMock.signUpController.startPasswordResult = .init(expectedResult)
+        controllerFactoryMock.signUpController.startPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
         sut.signUpUsingPassword(username: "correct", password: "correct", delegate: delegate)
 
-        wait(for: [exp])
+        wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.error?.type, .generalError)
-        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
+        XCTAssertEqual(
+            delegate.error?.errorDescription, 
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid")
+        )
     }
 
     // Sign Up with code
@@ -152,6 +190,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
     func testSignUp_delegate_whenValidDataIsPassed_shouldReturnCodeRequired() {
         let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
         let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
 
         let expectedResult: SignUpStartResult = .codeRequired(
@@ -160,11 +199,13 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controllerFactoryMock.signUpController.startResult = .init(expectedResult)
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
         sut.signUp(username: "correct", delegate: delegate)
 
-        wait(for: [exp])
+        wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.newState?.flowToken, "flowToken")
         XCTAssertEqual(delegate.sentTo, "sentTo")
@@ -172,35 +213,70 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         XCTAssertEqual(delegate.codeLength, 1)
     }
 
+    func testSignUp_delegate_butDelegateMethodIsNotImplemented_shouldReturnError() {
+        let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        let expectedResult: SignUpStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        sut.signUp(username: "correct", delegate: delegate)
+
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired")
+        )
+    }
+
     func testSignUp_delegate_whenSendAttributes_shouldReturnAttributesInvalid() {
         let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
         let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
         let expectedInvalidAttributes = ["attribute"]
 
         let expectedResult: SignUpStartResult = .attributesInvalid(expectedInvalidAttributes)
-        controllerFactoryMock.signUpController.startResult = .init(expectedResult)
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
         sut.signUp(username: "correct", delegate: delegate)
 
-        wait(for: [exp])
+        wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.attributeNames, expectedInvalidAttributes)
     }
 
     func testSignUp_delegate_whenSendAttributes_butDelegateMethodIsNotImplemented_itShouldReturnAttributesInvalid() {
         let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
         let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: exp)
         let expectedInvalidAttributes = ["attribute"]
 
         let expectedResult: SignUpStartResult = .attributesInvalid(expectedInvalidAttributes)
-        controllerFactoryMock.signUpController.startResult = .init(expectedResult)
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
         sut.signUp(username: "correct", delegate: delegate)
 
-        wait(for: [exp])
+        wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.error?.type, .generalError)
-        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid")
+        )
     }
 
     // Sign in with password
@@ -220,13 +296,34 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     }
 
     func testSignInPassword_delegate_whenValidUserAndPasswordAreUsed_shouldReturnSuccess() {
-        let expectation = expectation(description: "sign-in public interface")
-        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedUserAccountResult: MSALNativeAuthUserAccountResultStub.result)
+        let exp1 = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = SignInPasswordStartDelegateSpy(expectation: exp1, expectedUserAccountResult: MSALNativeAuthUserAccountResultStub.result)
 
-        controllerFactoryMock.signInController.signInPasswordStartResult = .init(.init(.completed(MSALNativeAuthUserAccountResultStub.result)))
+        controllerFactoryMock.signInController.signInPasswordStartResult = .init(.init(.completed(MSALNativeAuthUserAccountResultStub.result), telemetryUpdate: { _ in
+            exp2.fulfill()
+        }))
         sut.signInUsingPassword(username: "correct", password: "correct", delegate: delegate)
 
-        wait(for: [expectation], timeout: 1)
+        wait(for: [exp1, exp2], timeout: 1)
+    }
+
+    func testSignInPassword_delegate_whenSuccessIsReturnedButUserHasNotImplementedOptionalDelegate_shouldReturnError() {
+        let exp = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let expectedError = SignInPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
+
+        let expectedResult: SignInPasswordStartResult = .completed(MSALNativeAuthUserAccountResultStub.result)
+
+        controllerFactoryMock.signInController.signInPasswordStartResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        sut.signInUsingPassword(username: "correct", password: "correct", delegate: delegate)
+
+        wait(for: [exp, exp2], timeout: 1)
     }
 
     func testSignInPassword_delegate_whenCodeIsRequiredAndUserHasImplementedOptionalDelegate_shouldReturnCodeRequired() {
@@ -258,7 +355,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let exp = expectation(description: "sign-in public interface")
         let exp2 = expectation(description: "expectation Telemetry")
 
-        let expectedError = SignInPasswordStartError(type: .generalError, message: MSALNativeAuthErrorMessage.codeRequiredNotImplemented)
+        let expectedError = SignInPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInPasswordStartResult = .codeRequired(
@@ -287,8 +384,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     }
 
     func testSignIn_delegate_whenValidUserIsUsed_shouldReturnCodeRequired() {
-        let expectation = expectation(description: "sign-in public interface")
-        let delegate = SignInCodeStartDelegateSpy(expectation: expectation)
+        let exp1 = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = SignInCodeStartDelegateSpy(expectation: exp1)
         delegate.expectedSentTo = "sentTo"
         delegate.expectedCodeLength = 1
         delegate.expectedChannelTargetType = .email
@@ -300,10 +398,35 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             codeLength: 1
         )
 
-        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult)
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
         sut.signIn(username: "correct", delegate: delegate)
 
-        wait(for: [expectation], timeout: 1)
+        wait(for: [exp1, exp2], timeout: 1)
+    }
+
+    func testSignIn_delegate_whenValidUserIsUsedButUserHasNotImplementedOptionalDelegate_shouldReturnError() {
+        let exp = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
+        let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
+
+        let expectedResult: SignInStartResult = .codeRequired(
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        sut.signIn(username: "correct", delegate: delegate)
+
+        wait(for: [exp, exp2], timeout: 1)
     }
 
     func testSignIn_delegate_whenPasswordIsRequiredAndUserHasImplementedOptionalDelegate_shouldReturnPasswordRequired() {
@@ -330,7 +453,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let exp = expectation(description: "sign-in public interface")
         let exp2 = expectation(description: "expectation Telemetry")
 
-        let expectedError = SignInStartError(type: .generalError, message: MSALNativeAuthErrorMessage.passwordRequiredNotImplemented)
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInPasswordRequired"))
         let delegate = SignInCodeStartDelegateSpy(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .passwordRequired(
@@ -357,8 +480,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     }
 
     func testResetPassword_delegate_whenValidUserIsUsed_shouldReturnCodeRequired() {
-        let expectation = expectation(description: "sign-in public interface")
-        let delegate = ResetPasswordStartDelegateSpy(expectation: expectation)
+        let exp1 = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = ResetPasswordStartDelegateSpy(expectation: exp1)
 
         let expectedResult: ResetPasswordStartResult = .codeRequired(
             newState: .init(controller: controllerFactoryMock.resetPasswordController, flowToken: "flowToken", correlationId: correlationId),
@@ -367,15 +491,43 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             codeLength: 1
         )
 
-        controllerFactoryMock.resetPasswordController.resetPasswordResult = .init(expectedResult)
+        controllerFactoryMock.resetPasswordController.resetPasswordResponse = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
         sut.resetPassword(username: "correct", delegate: delegate)
 
-        wait(for: [expectation], timeout: 1)
+        wait(for: [exp1, exp2], timeout: 1)
 
         XCTAssertEqual(delegate.newState?.flowToken, "flowToken")
         XCTAssertEqual(delegate.sentTo, "sentTo")
         XCTAssertEqual(delegate.channelTargetType, .email)
         XCTAssertEqual(delegate.codeLength, 1)
+    }
+
+    func testResetPassword_delegate_butDelegateMethodIsNotImplemented_shouldReturnError() {
+        let exp = expectation(description: "reset-password public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = ResetPasswordStartDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        let expectedResult: ResetPasswordStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.resetPasswordController, flowToken: "flowToken", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controllerFactoryMock.resetPasswordController.resetPasswordResponse = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        sut.resetPassword(username: "correct", delegate: delegate)
+
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCodeRequired")
+        )
     }
     
     // MARK: - CorrelationId

--- a/MSAL/test/unit/native_auth/public/delegate/DispatchAccessTokenRetrieveCompletedTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/DispatchAccessTokenRetrieveCompletedTests.swift
@@ -1,0 +1,83 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class DispatchAccessTokenRetrieveCompletedTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: CredentialsDelegateDispatcher!
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchAccessTokenRetrieveCompleted_whenDelegateMethodsAreImplemented() async {
+        let expectedToken = "token"
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedAccessToken: expectedToken)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        await sut.dispatchAccessTokenRetrieveCompleted(accessToken: expectedToken)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.expectedAccessToken, expectedToken)
+    }
+
+    func test_dispatchAccessTokenRetrieveCompleted_whenDelegateOptionalMethodsNotImplemented() async {
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onAccessTokenRetrieveCompleted"))
+        let delegate = CredentialsDelegateOptionalMethodsNotImplemented(expectation: delegateExp, expectedError: expectedError)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? RetrieveAccessTokenError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedResult = MSALNativeAuthUserAccountResultStub.result
+
+        await sut.dispatchAccessTokenRetrieveCompleted(accessToken: "token")
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.expectedError)
+
+        func checkError(_ error: RetrieveAccessTokenError?) {
+            XCTAssertEqual(error?.type, .generalError)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/SignInAfterSignUpDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/SignInAfterSignUpDelegateDispatcherTests.swift
@@ -1,0 +1,82 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignInAfterSignUpDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignInAfterSignUpDelegateDispatcher!
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignInCompleted_whenDelegateMethodsAreImplemented() async {
+        let expectedResult = MSALNativeAuthUserAccountResultStub.result
+        let delegate = SignInAfterSignUpDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        await sut.dispatchSignInCompleted(result: expectedResult)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.expectedUserAccountResult, expectedResult)
+    }
+
+    func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
+        let expectedError = SignInAfterSignUpError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let delegate = SignInAfterSignUpDelegateOptionalMethodsNotImplemented(expectation: delegateExp, expectedError: expectedError)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? SignInAfterSignUpError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedResult = MSALNativeAuthUserAccountResultStub.result
+
+        await sut.dispatchSignInCompleted(result: expectedResult)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.expectedError)
+
+        func checkError(_ error: SignInAfterSignUpError?) {
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordRequiredDelegateDispatcherTests.swift
@@ -1,0 +1,80 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: ResetPasswordRequiredDelegateDispatcher!
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchPasswordRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = ResetPasswordRequiredDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        await sut.dispatchResetPasswordCompleted()
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertTrue(delegate.onResetPasswordCompletedCalled)
+    }
+
+    func test_dispatchPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = ResetPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCompleted"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        await sut.dispatchResetPasswordCompleted()
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: PasswordRequiredError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordResendCodeDelegateDispatcherTests.swift
@@ -1,0 +1,104 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: ResetPasswordResendCodeDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchResetPasswordResendCodeRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = ResetPasswordResendCodeDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchResetPasswordResendCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newState, expectedState)
+        XCTAssertEqual(delegate.sentTo, expectedSentTo)
+        XCTAssertEqual(delegate.channelTargetType, expectedChannelTargetType)
+        XCTAssertEqual(delegate.codeLength, expectedCodeLength)
+    }
+
+    func test_dispatchResetPasswordResendCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = ResetPasswordResendCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordResendCodeRequired"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchResetPasswordResendCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: ResendCodeError?) {
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordStartDelegateDispatcherTests.swift
@@ -1,0 +1,105 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: ResetPasswordStartDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchResetPasswordCodeRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = ResetPasswordStartDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchResetPasswordCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newState, expectedState)
+        XCTAssertEqual(delegate.sentTo, expectedSentTo)
+        XCTAssertEqual(delegate.channelTargetType, expectedChannelTargetType)
+        XCTAssertEqual(delegate.codeLength, expectedCodeLength)
+    }
+
+    func test_dispatchResetPasswordCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = ResetPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = ResetPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCodeRequired"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? ResetPasswordStartError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchResetPasswordCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: ResetPasswordStartError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordVerifyCodeDelegateDispatcherTests.swift
@@ -1,0 +1,86 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: ResetPasswordVerifyCodeDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchPasswordRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = ResetPasswordVerifyCodeDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = ResetPasswordRequiredState(controller: controllerFactoryMock.resetPasswordController, flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchPasswordRequired(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newPasswordRequiredState, expectedState)
+    }
+
+    func test_dispatchPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = ResetPasswordVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onPasswordRequired"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = ResetPasswordRequiredState(controller: controllerFactoryMock.resetPasswordController, flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchPasswordRequired(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: VerifyCodeError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordRequiredDelegateDispatcherTests.swift
@@ -1,0 +1,84 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignInPasswordRequiredDelegateDispatcherTests: XCTestCase {
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignInPasswordRequiredDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignInCompleted_whenDelegateMethodsAreImplemented() async {
+        let expectedResult = MSALNativeAuthUserAccountResultStub.result
+        let delegate = SignInPasswordRequiredDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        await sut.dispatchSignInCompleted(result: expectedResult)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.expectedUserAccountResult, expectedResult)
+    }
+
+    func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let delegate = SignInPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedResult = MSALNativeAuthUserAccountResultStub.result
+
+        await sut.dispatchSignInCompleted(result: expectedResult)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.delegateError)
+
+        func checkError(_ error: PasswordRequiredError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordStartDelegateDispatcherTests.swift
@@ -1,0 +1,151 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignInPasswordStartDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignInCodeRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignInPasswordStartDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchSignInCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newSignInCodeRequiredState, expectedState)
+        XCTAssertEqual(delegate.expectedSentTo, expectedSentTo)
+        XCTAssertEqual(delegate.expectedChannelTargetType, expectedChannelTargetType)
+        XCTAssertEqual(delegate.expectedCodeLength, expectedCodeLength)
+    }
+
+    func test_dispatchSignInCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let expectedError = SignInPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
+        let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
+
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? SignInPasswordStartError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchSignInCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.expectedError)
+
+        func checkError(_ error: SignInPasswordStartError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+
+    func test_dispatchSignInCompleted_whenDelegateMethodsAreImplemented() async {
+        let expectedResult = MSALNativeAuthUserAccountResultStub.result
+        let delegate = SignInPasswordStartDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        await sut.dispatchSignInCompleted(result: expectedResult)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.expectedUserAccountResult, expectedResult)
+    }
+
+    func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
+        let expectedError = SignInPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
+
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? SignInPasswordStartError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedResult = MSALNativeAuthUserAccountResultStub.result
+
+        await sut.dispatchSignInCompleted(result: expectedResult)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.expectedError)
+
+        func checkError(_ error: SignInPasswordStartError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInResendCodeDelegateDispatcherTests.swift
@@ -1,0 +1,101 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignInResendCodeDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignInResendCodeCodeRequired_whenDelegateMethodsAreImplemented() async {
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        let delegate = SignInResendCodeDelegateSpy(expectation: delegateExp, expectedSentTo: expectedSentTo, expectedChannelTargetType: expectedChannelTargetType, expectedCodeLength: expectedCodeLength)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        await sut.dispatchSignInResendCodeCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newSignInCodeRequiredState, expectedState)
+    }
+
+    func test_dispatchSignInResendCodeCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignInResendCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInResendCodeCodeRequired"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchSignInResendCodeCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.newSignInResendCodeError)
+
+        func checkError(_ error: ResendCodeError?) {
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInStartDelegateDispatcherTests.swift
@@ -1,0 +1,151 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignInStartDelegateDispatcherTests: XCTestCase {
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignInStartDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignInCodeRequired_whenDelegateMethodsAreImplemented() async {
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        let delegate = SignInCodeStartDelegateSpy(expectation: delegateExp, expectedSentTo: expectedSentTo, expectedChannelTargetType: expectedChannelTargetType, expectedCodeLength: expectedCodeLength)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        await sut.dispatchSignInCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newSignInCodeRequiredState, expectedState)
+        XCTAssertEqual(delegate.expectedSentTo, expectedSentTo)
+        XCTAssertEqual(delegate.expectedChannelTargetType, expectedChannelTargetType)
+        XCTAssertEqual(delegate.expectedCodeLength, expectedCodeLength)
+    }
+
+    func test_dispatchSignInCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
+        let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
+
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? SignInStartError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchSignInCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.expectedError)
+
+        func checkError(_ error: SignInStartError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+
+    func test_dispatchSignInPasswordRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignInCodeStartDelegateWithPasswordRequiredSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInPasswordRequiredState(scopes: [], username: "username", controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignInPasswordRequired(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.passwordRequiredState, expectedState)
+    }
+
+    func test_dispatchSignInPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInPasswordRequired"))
+        let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
+
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? SignInStartError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInPasswordRequiredState(scopes: [], username: "username", controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignInPasswordRequired(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.expectedError)
+
+        func checkError(_ error: SignInStartError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInVerifyCodeDelegateDispatcherTests.swift
@@ -1,0 +1,85 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignInVerifyCodeDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignInVerifyCodeDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignInCompleted_whenDelegateMethodsAreImplemented() async {
+        let expectedResult = MSALNativeAuthUserAccountResultStub.result
+        let delegate = SignInVerifyCodeDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        await sut.dispatchSignInCompleted(result: expectedResult)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.expectedUserAccountResult, expectedResult)
+    }
+
+    func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let delegate = SignInVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedResult = MSALNativeAuthUserAccountResultStub.result
+
+        await sut.dispatchSignInCompleted(result: expectedResult)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.expectedError)
+
+        func checkError(_ error: VerifyCodeError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
@@ -1,0 +1,189 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignUpAttributesRequiredDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+            .init(name: "attribute1", type: "", required: true),
+            .init(name: "attribute2", type: "", required: true),
+        ]
+
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.attributes, expectedAttributes)
+        XCTAssertEqual(delegate.newState, expectedState)
+    }
+
+    func test_dispatchSignUpAttributesRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+            .init(name: "attribute1", type: "", required: true),
+            .init(name: "attribute2", type: "", required: true),
+        ]
+
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: AttributesRequiredError?) {
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+
+    func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributeNames = ["attribute1", "attribute2"]
+
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.invalidAttributes, expectedAttributeNames)
+        XCTAssertEqual(delegate.newState, expectedState)
+    }
+
+    func test_dispatchSignUpAttributesInvalid_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributeNames = ["attribute1", "attribute2"]
+
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: AttributesRequiredError?) {
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+
+    func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpCompleted(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newSignInAfterSignUpState, expectedState)
+    }
+
+    func test_dispatchSignUpCompleted_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpCompleted(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: AttributesRequiredError?) {
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
@@ -1,0 +1,142 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignUpPasswordRequiredDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpPasswordRequiredDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+            .init(name: "attribute1", type: "", required: true),
+            .init(name: "attribute2", type: "", required: true),
+        ]
+
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newAttributesRequired, expectedAttributes)
+        XCTAssertEqual(delegate.newAttributesRequiredState, expectedState)
+    }
+
+    func test_dispatchSignUpVerifyCode_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+            .init(name: "attribute1", type: "", required: true),
+            .init(name: "attribute2", type: "", required: true),
+        ]
+
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: PasswordRequiredError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+
+    func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpPasswordRequiredDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpCompleted(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.signInAfterSignUpState, expectedState)
+    }
+
+    func test_dispatchSignUpCompleted_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpCompleted(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: PasswordRequiredError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordStartDelegateDispatcherTests.swift
@@ -1,0 +1,150 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignUpPasswordStartDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignUpPasswordCodeRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchSignUpPasswordCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newState, expectedState)
+        XCTAssertEqual(delegate.sentTo, expectedSentTo)
+        XCTAssertEqual(delegate.channelTargetType, expectedChannelTargetType)
+        XCTAssertEqual(delegate.codeLength, expectedCodeLength)
+    }
+
+    func test_dispatchSignUpPasswordCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = SignUpPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? SignUpPasswordStartError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchSignUpPasswordCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: SignUpPasswordStartError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+
+    func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributeNames = ["attribute1", "attribute2"]
+
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.attributeNames, expectedAttributeNames)
+    }
+
+    func test_dispatchSignUpAttributesInvalid_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = SignUpPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? SignUpPasswordStartError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributeNames = ["attribute1", "attribute2"]
+
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: SignUpPasswordStartError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpResendCodeDelegateDispatcherTests.swift
@@ -1,0 +1,104 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignUpResendCodeDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignUpResendCode_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpResendCodeDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchSignUpResendCodeCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newState, expectedState)
+        XCTAssertEqual(delegate.sentTo, expectedSentTo)
+        XCTAssertEqual(delegate.channelTargetType, expectedChannelTargetType)
+        XCTAssertEqual(delegate.codeLength, expectedCodeLength)
+    }
+
+    func test_dispatchSignUpResendCode_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpResendCodeDelegateMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpResendCodeCodeRequired"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchSignUpResendCodeCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: ResendCodeError?) {
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpStartDelegateDispatcherTests.swift
@@ -1,0 +1,150 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignUpStartDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignUpStartDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignUpCodeRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpCodeStartDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchSignUpCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newState, expectedState)
+        XCTAssertEqual(delegate.sentTo, expectedSentTo)
+        XCTAssertEqual(delegate.channelTargetType, expectedChannelTargetType)
+        XCTAssertEqual(delegate.codeLength, expectedCodeLength)
+    }
+
+    func test_dispatchSignUpCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedSentTo = "user@contoso.com"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+
+        await sut.dispatchSignUpCodeRequired(
+            newState: expectedState,
+            sentTo: expectedSentTo,
+            channelTargetType: expectedChannelTargetType,
+            codeLength: expectedCodeLength
+        )
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: SignUpStartError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+
+    func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpCodeStartDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributeNames = ["attribute1", "attribute2"]
+
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.attributeNames, expectedAttributeNames)
+    }
+
+    func test_dispatchSignUpAttributesInvalid_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributeNames = ["attribute1", "attribute2"]
+
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: SignUpStartError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
@@ -1,0 +1,187 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@testable import MSAL
+import XCTest
+
+final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
+
+    private var telemetryExp: XCTestExpectation!
+    private var delegateExp: XCTestExpectation!
+    private var sut: SignUpVerifyCodeDelegateDispatcher!
+    private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
+
+    override func setUp() {
+        super.setUp()
+        telemetryExp = expectation(description: "delegateDispatcher telemetry exp")
+        delegateExp = expectation(description: "delegateDispatcher delegate exp")
+    }
+
+    func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+            .init(name: "attribute1", type: "", required: true),
+            .init(name: "attribute2", type: "", required: true),
+        ]
+
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newAttributesRequired, expectedAttributes)
+        XCTAssertEqual(delegate.newAttributesRequiredState, expectedState)
+    }
+
+    func test_dispatchSignUpVerifyCode_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+            .init(name: "attribute1", type: "", required: true),
+            .init(name: "attribute2", type: "", required: true),
+        ]
+
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: VerifyCodeError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+
+    func test_dispatchSignUpPasswordRequired_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignUpPasswordRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpPasswordRequired(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newPasswordRequiredState, expectedState)
+    }
+
+    func test_dispatchSignUpPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpPasswordRequired"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignUpPasswordRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpPasswordRequired(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: VerifyCodeError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+
+    func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
+        let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case .success = result else {
+                return XCTFail("wrong result")
+            }
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpCompleted(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+
+        XCTAssertEqual(delegate.newSignInAfterSignUpState, expectedState)
+    }
+
+    func test_dispatchSignUpCompleted_whenDelegateOptionalMethodsNotImplemented() async {
+        let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
+            guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
+                return XCTFail("wrong result")
+            }
+
+            checkError(customError)
+            self.telemetryExp.fulfill()
+        })
+
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+
+        await sut.dispatchSignUpCompleted(newState: expectedState)
+
+        await fulfillment(of: [telemetryExp, delegateExp])
+        checkError(delegate.error)
+
+        func checkError(_ error: VerifyCodeError?) {
+            XCTAssertEqual(error?.type, expectedError.type)
+            XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+        }
+    }
+}

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
@@ -31,25 +31,80 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
 
     private var correlationId: UUID = UUID()
     private var exp: XCTestExpectation!
-    private var controller: MSALNativeAuthResetPasswordControllerSpy!
+    private var controllerSpy: MSALNativeAuthResetPasswordControllerSpy!
+    private var controllerMock: MSALNativeAuthResetPasswordControllerMock!
     private var sut: ResetPasswordRequiredState!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-
-        exp = expectation(description: "ResetPasswordRequiredState expectation")
-        controller = MSALNativeAuthResetPasswordControllerSpy(expectation: exp)
-        sut = ResetPasswordRequiredState(controller: controller, flowToken: "<token>", correlationId: correlationId)
-    }
-
     func test_submitPassword_usesControllerSuccessfully() {
-        XCTAssertNil(controller.context)
-        XCTAssertFalse(controller.submitPasswordCalled)
+        exp = expectation(description: "ResetPasswordRequiredState expectation")
+        controllerSpy = MSALNativeAuthResetPasswordControllerSpy(expectation: exp)
+        XCTAssertNil(controllerSpy.context)
+        XCTAssertFalse(controllerSpy.submitPasswordCalled)
 
+        let sut = ResetPasswordRequiredState(controller: controllerSpy, flowToken: "<token>", correlationId: correlationId)
         sut.submitPassword(password: "1234", delegate: ResetPasswordRequiredDelegateSpy())
 
         wait(for: [exp], timeout: 1)
-        XCTAssertEqual(controller.context?.correlationId(), correlationId)
-        XCTAssertTrue(controller.submitPasswordCalled)
+        XCTAssertEqual(controllerSpy.context?.correlationId(), correlationId)
+        XCTAssertTrue(controllerSpy.submitPasswordCalled)
+    }
+
+    func test_submitPassword_delegate_whenError_shouldReturnCorrectError() {
+        controllerMock = MSALNativeAuthResetPasswordControllerMock()
+        let sut = ResetPasswordRequiredState(controller: controllerMock, flowToken: "<token>", correlationId: correlationId)
+
+        let expectedError = PasswordRequiredError(type: .invalidPassword, message: nil)
+        let expectedState = ResetPasswordRequiredState(controller: controllerMock, flowToken: "flowToken", correlationId: correlationId)
+
+        let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.error(error: expectedError, newState: expectedState))
+        controllerMock.submitPasswordResponse = expectedResult
+
+        let exp = expectation(description: "reset password states")
+        let delegate = ResetPasswordRequiredDelegateSpy(expectation: exp)
+
+        sut.submitPassword(password: "incorrect", delegate: delegate)
+        wait(for: [exp])
+
+        XCTAssertEqual(delegate.error?.type, expectedError.type)
+        XCTAssertEqual(delegate.newPasswordRequiredState, expectedState)
+    }
+
+    func test_submitPassword_delegate_whenSuccess_shouldReturnCompleted() {
+        let exp = expectation(description: "reset password states")
+        let exp2 = expectation(description: "telemetry expectation")
+        controllerMock = MSALNativeAuthResetPasswordControllerMock()
+        let sut = ResetPasswordRequiredState(controller: controllerMock, flowToken: "<token>", correlationId: correlationId)
+
+        let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.completed, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+        controllerMock.submitPasswordResponse = expectedResult
+
+        let delegate = ResetPasswordRequiredDelegateSpy(expectation: exp)
+
+        sut.submitPassword(password: "incorrect", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertTrue(delegate.onResetPasswordCompletedCalled)
+    }
+
+    func test_submitPassword_delegate_whenSuccess_butOptionalMethodsNotImplemented_shouldReturnCorrectError() {
+        let exp = expectation(description: "reset password states")
+        let exp2 = expectation(description: "telemetry expectation")
+        controllerMock = MSALNativeAuthResetPasswordControllerMock()
+        let sut = ResetPasswordRequiredState(controller: controllerMock, flowToken: "<token>", correlationId: correlationId)
+
+        let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.completed, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+        controllerMock.submitPasswordResponse = expectedResult
+
+        let delegate = ResetPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitPassword(password: "incorrect", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCompleted"))
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
@@ -43,6 +43,8 @@ final class SignInCodeRequiredStateTests: XCTestCase {
     // ResendCode
 
     func test_resendCode_delegate_withError_shouldReturnSignInResendCodeError() {
+        let exp = expectation(description: "sign-in states")
+
         let expectedError = ResendCodeError(message: "test error")
         let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
 
@@ -52,7 +54,6 @@ final class SignInCodeRequiredStateTests: XCTestCase {
         )
         controller.resendCodeResult = .init(expectedResult)
 
-        let exp = expectation(description: "sign-in states")
         let delegate = SignInResendCodeDelegateSpy(expectation: exp)
 
         sut.resendCode(delegate: delegate)
@@ -63,6 +64,8 @@ final class SignInCodeRequiredStateTests: XCTestCase {
     }
 
     func test_resendCode_delegate_success_shouldReturnSignInResendCodeCodeRequired() {
+        let exp = expectation(description: "sign-in states")
+        let exp2 = expectation(description: "expectation Telemetry")
         let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
 
         let expectedResult: SignInResendCodeResult = .codeRequired(
@@ -71,19 +74,43 @@ final class SignInCodeRequiredStateTests: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controller.resendCodeResult = .init(expectedResult)
+        controller.resendCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
-        let exp = expectation(description: "sign-in states")
         let delegate = SignInResendCodeDelegateSpy(expectation: exp, expectedSentTo: "sentTo", expectedChannelTargetType: .email, expectedCodeLength: 1)
 
         sut.resendCode(delegate: delegate)
-        wait(for: [exp])
+        wait(for: [exp, exp2])
         XCTAssertEqual(delegate.newSignInCodeRequiredState?.flowToken, expectedState.flowToken)
+    }
+
+    func test_resendCode_delegate_success_butMethodNotImplemented_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-in states")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2", correlationId: UUID())
+
+        let expectedResult: SignInResendCodeResult = .codeRequired(
+            newState: expectedState,
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controller.resendCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignInResendCodeDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.resendCode(delegate: delegate)
+        wait(for: [exp, exp2])
+        XCTAssertEqual(delegate.newSignInResendCodeError?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInResendCodeCodeRequired"))
     }
 
     // SubmitCode
 
     func test_submitCode_delegate_withError_shouldReturnSignInVerifyCodeError() {
+        let exp = expectation(description: "sign-in states")
         let expectedError = VerifyCodeError(type: .invalidCode)
         let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
 
@@ -93,7 +120,6 @@ final class SignInCodeRequiredStateTests: XCTestCase {
         )
         controller.submitCodeResult = .init(expectedResult)
 
-        let exp = expectation(description: "sign-in states")
         let delegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedError: expectedError)
         delegate.expectedNewState = expectedState
 
@@ -102,15 +128,36 @@ final class SignInCodeRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_success_shouldReturnAccountResult() {
+        let exp = expectation(description: "sign-in states")
+        let exp2 = expectation(description: "expectation Telemetry")
         let expectedAccountResult = MSALNativeAuthUserAccountResultStub.result
 
         let expectedResult: SignInVerifyCodeResult = .completed(expectedAccountResult)
-        controller.submitCodeResult = .init(expectedResult)
+        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
-        let exp = expectation(description: "sign-in states")
         let delegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedUserAccountResult: expectedAccountResult)
 
         sut.submitCode(code: "1234", delegate: delegate)
-        wait(for: [exp])
+        wait(for: [exp, exp2])
+    }
+
+    func test_submitCode_delegate_success_whenMethodsNotImplemented_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-in states")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let expectedAccountResult = MSALNativeAuthUserAccountResultStub.result
+
+        let expectedResult: SignInVerifyCodeResult = .completed(expectedAccountResult)
+        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignInVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+        XCTAssertEqual(delegate.expectedError?.type, .generalError)
+        XCTAssertEqual(delegate.expectedError?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
@@ -60,15 +60,37 @@ final class SignInPasswordRequiredStateTests: XCTestCase {
     }
 
     func test_submitPassword_delegate_success_shouldReturnSuccess() {
+        let exp = expectation(description: "sign-in states")
+        let exp2 = expectation(description: "expectation Telemetry")
         let expectedAccountResult = MSALNativeAuthUserAccountResultStub.result
 
         let expectedResult: SignInPasswordRequiredResult = .completed(expectedAccountResult)
-        controller.submitPasswordResult = .init(expectedResult)
+        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
-        let exp = expectation(description: "sign-in states")
         let delegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedUserAccountResult: expectedAccountResult)
 
-        sut.submitPassword(password: "invalid password", delegate: delegate)
-        wait(for: [exp])
+        sut.submitPassword(password: "password", delegate: delegate)
+        wait(for: [exp, exp2])
+    }
+
+    func test_submitPassword_delegate_success_whenMethodsNotImplemented_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-in states")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let expectedAccountResult = MSALNativeAuthUserAccountResultStub.result
+
+        let expectedResult: SignInPasswordRequiredResult = .completed(expectedAccountResult)
+        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignInPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitPassword(password: "password", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertNil(delegate.newPasswordRequiredState)
+        XCTAssertEqual(delegate.delegateError?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
@@ -58,53 +58,120 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     }
 
     func test_submitPassword_delegate_whenSuccess_shouldReturnCompleted() {
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "telemetry expectation")
         let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: correlationId)
 
         let expectedResult: SignUpAttributesRequiredResult = .completed(expectedState)
-        controller.submitAttributesResult = .init(expectedResult)
+        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
-        let exp = expectation(description: "sign-up states")
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
 
         sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
-        wait(for: [exp])
+        wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.newSignInAfterSignUpState, expectedState)
     }
 
+    func test_submitPassword_delegate_whenSuccess_butMethodNotImplemented_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "telemetry expectation")
+        let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: UUID())
+
+        let expectedResult: SignUpAttributesRequiredResult = .completed(expectedState)
+        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+    }
+
     func test_submitPassword_delegate_whenAttributesRequired_shouldReturnAttributesRequired() {
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "telemetry expectation")
         let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt", correlationId: correlationId)
         let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
             .init(name: "anAttribute", type: "aType", required: true)
         ]
 
         let expectedResult: SignUpAttributesRequiredResult = .attributesRequired(attributes: expectedAttributes, state: expectedState)
-        controller.submitAttributesResult = .init(expectedResult)
+        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
-        let exp = expectation(description: "sign-up states")
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
 
         sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
-        wait(for: [exp])
+        wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.attributes, expectedAttributes)
         XCTAssertEqual(delegate.newState, expectedState)
     }
 
-    func test_submitPassword_delegate_whenAttributesAreInvalud_shouldReturnAttributesInvalid() {
+    func test_submitPassword_delegate_whenAttributesRequired_butMethodNotImplemented_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "telemetry expectation")
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt", correlationId: correlationId)
+        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+            .init(name: "anAttribute", type: "aType", required: true)
+        ]
+
+        let expectedResult: SignUpAttributesRequiredResult = .attributesRequired(attributes: expectedAttributes, state: expectedState)
+        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+    }
+
+    func test_submitPassword_delegate_whenAttributesAreInvalid_shouldReturnAttributesInvalid() {
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "telemetry expectation")
         let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt", correlationId: correlationId)
         let expectedAttributes = ["anAttribute"]
 
         let expectedResult: SignUpAttributesRequiredResult = .attributesInvalid(attributes: expectedAttributes, newState: expectedState)
-        controller.submitAttributesResult = .init(expectedResult)
+        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
-        let exp = expectation(description: "sign-up states")
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
 
         sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
-        wait(for: [exp])
+        wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.invalidAttributes, expectedAttributes)
         XCTAssertEqual(delegate.newState, expectedState)
+    }
+
+    func test_submitPassword_delegate_whenAttributesAreInvalid_butMethodNotImplemented_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "telemetry expectation")
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt", correlationId: correlationId)
+        let expectedAttributes = ["anAttribute"]
+
+        let expectedResult: SignUpAttributesRequiredResult = .attributesInvalid(attributes: expectedAttributes, newState: expectedState)
+        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitAttributes(attributes: ["key":"value"], delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"))
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
@@ -46,7 +46,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
         let expectedError = ResendCodeError(message: "test error")
 
-        let expectedResult: SignUpResendCodeResult = .error(expectedError)
+        let expectedResult: SignUpResendCodeResult = .error(error: expectedError, newState: nil)
         controller.resendCodeResult = .init(expectedResult)
 
         let exp = expectation(description: "sign-up states")
@@ -59,6 +59,8 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     }
 
     func test_resendCode_delegate_success_shouldReturnCodeRequired() {
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "telemetry expectation")
         let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpResendCodeResult = .codeRequired(
@@ -67,18 +69,42 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controller.resendCodeResult = .init(expectedResult)
+        controller.resendCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
-        let exp = expectation(description: "sign-in states")
         let delegate = SignUpResendCodeDelegateSpy(expectation: exp)
 
         sut.resendCode(delegate: delegate)
-        wait(for: [exp])
+        wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.newState?.flowToken, expectedState.flowToken)
         XCTAssertEqual(delegate.sentTo, "sentTo")
         XCTAssertEqual(delegate.channelTargetType, .email)
         XCTAssertEqual(delegate.codeLength, 1)
+    }
+
+    func test_resendCode_delegate_success_butMethodNotImplemented() {
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "telemetry expectation")
+        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+
+        let expectedResult: SignUpResendCodeResult = .codeRequired(
+            newState: expectedState,
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controller.resendCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpResendCodeDelegateMethodsNotImplemented(expectation: exp)
+
+        sut.resendCode(delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpResendCodeCodeRequired"))
     }
 
     // SubmitCode
@@ -123,8 +149,6 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_whenPasswordRequired_ButUserHasNotImplementedOptionalDelegate_shouldReturnCorrectError() {
-        let expectedError = VerifyCodeError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
-
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
 
@@ -138,8 +162,11 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         sut.submitCode(code: "1234", delegate: delegate)
         wait(for: [exp, exp2])
 
-        XCTAssertEqual(delegate.error?.type, expectedError.type)
-        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.delegateNotImplemented)
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpPasswordRequired")
+        )
     }
 
     func test_submitCode_delegate_whenAttributesRequired_AndUserHasImplementedOptionalDelegate_shouldReturnAttributesRequired() {
@@ -162,8 +189,6 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_whenAttributesRequired_ButUserHasNotImplementedOptionalDelegate_shouldReturnCorrectError() {
-        let expectedError = VerifyCodeError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
-
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
 
@@ -177,22 +202,49 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         sut.submitCode(code: "1234", delegate: delegate)
         wait(for: [exp, exp2])
 
-        XCTAssertEqual(delegate.error?.type, expectedError.type)
-        XCTAssertEqual(delegate.error?.errorDescription, MSALNativeAuthErrorMessage.delegateNotImplemented)
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired")
+        )
     }
 
     func test_submitCode_delegate_whenSuccess_shouldReturnAccountResult() {
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "telemetry expectation")
         let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: correlationId)
 
         let expectedResult: SignUpVerifyCodeResult = .completed(expectedSignInAfterSignUpState)
-        controller.submitCodeResult = .init(expectedResult)
+        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
 
-        let exp = expectation(description: "sign-up states")
         let delegate = SignUpVerifyCodeDelegateSpy(expectation: exp)
 
         sut.submitCode(code: "1234", delegate: delegate)
-        wait(for: [exp])
+        wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.newSignInAfterSignUpState, expectedSignInAfterSignUpState)
+    }
+
+    func test_submitCode_delegate_whenSuccess_ButUserHasNotImplementedOptionalDelegate_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-up states")
+        let exp2 = expectation(description: "telemetry expectation")
+        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: correlationId)
+        let result: SignUpVerifyCodeResult = .completed(expectedSignInAfterSignUpState)
+        controller.submitCodeResult = .init(result, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        sut.submitCode(code: "1234", delegate: delegate)
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted")
+        )
     }
 }


### PR DESCRIPTION
## Proposed changes

This PR makes all delegates optional. The only delegates that are mandatory now are those that return errors.

With extensibility in mind, a new set of classes called "DelegateDispatchers" (name can be changed) has been introduced. The role of these dispatchers is to handle the different versions of delegates that the developer implements as we introduce new possible changes in the public interface, and to return in the delegate that has been implemented. 

If the developer hasn't implemented a delegate necessary to continue the flow, an error is returned.

Example:

```
if let onSignUpCompleted = delegate.onSignUpCompletedNew {
  await onSignUpCompleted(newState, date)
} else if let onSignUpCompleted = delegate.onSignUpCompletedOld {
  await onSignUpCompleted(newState)
} else {
  await delegate.onSignUpError(error: error)
}
```

I also considered the approach of moving the entire response handling to a different class, but I think in this case we would have a class that needs to handle the response + decide which delegate it should use to return to the developer. As our public methods grow, it can become difficult to manage all that code in one single place.

This PR also adds a `newState` parameter to the `SignUpResendCodeDelegate` method:
`@MainActor func onSignUpResendCodeError(error: ResendCodeError, newState: SignUpCodeRequiredState?)`

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)