### PR TITLE
Remove correlation id from state actions

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1024,6 +1024,7 @@
 		DE92450E2A38601100C0389F /* MSALNativeAuthCredentialsControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE92450D2A38601100C0389F /* MSALNativeAuthCredentialsControlling.swift */; };
 		DE9245122A38736600C0389F /* CredentialsDelegates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9245112A38736600C0389F /* CredentialsDelegates.swift */; };
 		DE9245152A3875D700C0389F /* RetrieveAccessTokenError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9245142A3875D700C0389F /* RetrieveAccessTokenError.swift */; };
+		DE946FE52B0F713A00978493 /* MSALNativeAuthHTTPRequestMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE946FE42B0F713A00978493 /* MSALNativeAuthHTTPRequestMock.swift */; };
 		DE94C9E029F198D600C1EC1F /* MSALNativeAuthResetPasswordStartRequestParametersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE94C9DE29F1989600C1EC1F /* MSALNativeAuthResetPasswordStartRequestParametersTest.swift */; };
 		DE94C9E229F19AA200C1EC1F /* MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE94C9E129F19AA200C1EC1F /* MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift */; };
 		DE94C9E429F19C4C00C1EC1F /* MSALNativeAuthResetPasswordContinueRequestParametersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE94C9E329F19C4C00C1EC1F /* MSALNativeAuthResetPasswordContinueRequestParametersTest.swift */; };
@@ -2057,6 +2058,7 @@
 		DE92450D2A38601100C0389F /* MSALNativeAuthCredentialsControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCredentialsControlling.swift; sourceTree = "<group>"; };
 		DE9245112A38736600C0389F /* CredentialsDelegates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsDelegates.swift; sourceTree = "<group>"; };
 		DE9245142A3875D700C0389F /* RetrieveAccessTokenError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveAccessTokenError.swift; sourceTree = "<group>"; };
+		DE946FE42B0F713A00978493 /* MSALNativeAuthHTTPRequestMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthHTTPRequestMock.swift; sourceTree = "<group>"; };
 		DE94C9DE29F1989600C1EC1F /* MSALNativeAuthResetPasswordStartRequestParametersTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordStartRequestParametersTest.swift; sourceTree = "<group>"; };
 		DE94C9E129F19AA200C1EC1F /* MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift; sourceTree = "<group>"; };
 		DE94C9E329F19C4C00C1EC1F /* MSALNativeAuthResetPasswordContinueRequestParametersTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordContinueRequestParametersTest.swift; sourceTree = "<group>"; };
@@ -2435,6 +2437,7 @@
 				E20C217D2A7A61CC00E31598 /* ResetPasswordDelegateSpies.swift */,
 				E20C21742A7A61B600E31598 /* SignUpDelegateSpies.swift */,
 				E2F626B22A781CE300C4A303 /* SignInDelegatesSpies.swift */,
+				DE946FE42B0F713A00978493 /* MSALNativeAuthHTTPRequestMock.swift */,
 				9B61C91D2A27E5E200CE9E3A /* reset_password */,
 			);
 			path = mock;
@@ -6040,6 +6043,7 @@
 				DE94C9E629F19D9B00C1EC1F /* MSALNativeAuthResetPasswordSubmitRequestParametersTest.swift in Sources */,
 				289747AC2979487900838C80 /* MSALNativeAuthUrlRequestSerializerTests.swift in Sources */,
 				DE14D76129898CF900F37BEF /* MSALNativeAuthTestCase.swift in Sources */,
+				DE946FE52B0F713A00978493 /* MSALNativeAuthHTTPRequestMock.swift in Sources */,
 				B2725ED222C0469A009B454A /* MSALLegacySharedAccountsProviderTests.m in Sources */,
 				E2BC029A29D766B200041DBC /* MSALNativeAuthSignUpStartRequestParametersTest.swift in Sources */,
 				E2C1D2D429A3992100B26449 /* MSALNativeAuthBaseControllerTests.swift in Sources */,

--- a/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
+++ b/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
@@ -59,7 +59,7 @@ final class MSALNativeAuthResultFactory: MSALNativeAuthResultBuildable {
                 level: .error,
                 context: context,
                 format: "Claims for account could not be created - \(error)" )
-        }        
+        }
         guard let account = MSALAccount.init(msidAccount: tokenResult.account,
                                              createTenantProfile: false,
                                              accountClaims: jsonDictionary) else {

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -184,7 +184,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             stopTelemetryEvent(event, context: context)
 
             return .codeRequired(
-                newState: ResetPasswordCodeRequiredState(controller: self, flowToken: challengeToken),
+                newState: ResetPasswordCodeRequiredState(controller: self, flowToken: challengeToken, correlationId: context.correlationId()),
                 sentTo: sentTo,
                 channelTargetType: channelTargetType,
                 codeLength: codeLength
@@ -223,7 +223,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             stopTelemetryEvent(event, context: context)
             MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/challenge (resend code) request")
             return .codeRequired(
-                newState: ResetPasswordCodeRequiredState(controller: self, flowToken: challengeToken),
+                newState: ResetPasswordCodeRequiredState(controller: self, flowToken: challengeToken, correlationId: context.correlationId()),
                 sentTo: sentTo,
                 channelTargetType: channelTargetType,
                 codeLength: codeLength
@@ -276,7 +276,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         case .success(let passwordSubmitToken):
             stopTelemetryEvent(event, context: context)
             MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/continue request")
-            return .passwordRequired(newState: ResetPasswordRequiredState(controller: self, flowToken: passwordSubmitToken))
+            return .passwordRequired(newState: ResetPasswordRequiredState(controller: self,
+                                                                          flowToken: passwordSubmitToken,
+                                                                          correlationId: context.correlationId()))
         case .error(let apiError):
             let error = apiError.toVerifyCodePublicError()
             stopTelemetryEvent(event, context: context, error: error)
@@ -301,7 +303,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                            context: context,
                            format: "Invalid code error calling resetpassword/continue \(error.errorDescription ?? "No error description")")
 
-            let state = ResetPasswordCodeRequiredState(controller: self, flowToken: passwordResetToken)
+            let state = ResetPasswordCodeRequiredState(controller: self, flowToken: passwordResetToken, correlationId: context.correlationId())
             return .error(error: error, newState: state)
         }
     }
@@ -351,7 +353,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                            context: context,
                            format: "Password error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
 
-            return .error(error: error, newState: ResetPasswordRequiredState(controller: self, flowToken: passwordSubmitToken))
+            return .error(error: error, newState: ResetPasswordRequiredState(controller: self,
+                                                                             flowToken: passwordSubmitToken,
+                                                                             correlationId: context.correlationId()))
         case .error(let apiError):
             let error = apiError.toPasswordRequiredPublicError()
             self.stopTelemetryEvent(event, context: context, error: error)
@@ -469,7 +473,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                            context: context,
                            format: "Password error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
 
-            return .error(error: error, newState: ResetPasswordRequiredState(controller: self, flowToken: passwordResetToken))
+            return .error(error: error, newState: ResetPasswordRequiredState(controller: self,
+                                                                             flowToken: passwordResetToken,
+                                                                             correlationId: context.correlationId()))
         case .error(let apiError):
             let error = apiError.toPasswordRequiredPublicError()
             self.stopTelemetryEvent(event, context: context, error: error)

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -305,9 +305,12 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             let error = ResendCodeError()
             MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: received challenge error response: \(challengeError)")
             stopTelemetryEvent(event, context: context, error: error)
-            return .error(error: error, newState: SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken))
+            return .error(error: error, newState: SignInCodeRequiredState(scopes: scopes,
+                                                                          controller: self,
+                                                                          flowToken: credentialToken,
+                                                                          correlationId: context.correlationId()))
         case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
-            let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken)
+            let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken, correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context)
             return .codeRequired(newState: state, sentTo: sentTo, channelTargetType: channelType, codeLength: codeLength)
         }
@@ -327,7 +330,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             context: context,
             format: "SignIn completed with errorType: \(errorType)")
         stopTelemetryEvent(telemetryInfo, error: errorType)
-        let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken)
+        let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken, correlationId: context.correlationId())
         return .error(error: errorType.convertToVerifyCodeError(), newState: state)
     }
 
@@ -343,7 +346,11 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             context: telemetryInfo.context,
             format: "SignIn with username and password completed with errorType: \(errorType)")
         stopTelemetryEvent(telemetryInfo, error: errorType)
-        let state = SignInPasswordRequiredState(scopes: scopes, username: username, controller: self, flowToken: credentialToken)
+        let state = SignInPasswordRequiredState(scopes: scopes,
+                                                username: username,
+                                                controller: self,
+                                                flowToken: credentialToken,
+                                                correlationId: telemetryInfo.context.correlationId())
         return .error(error: errorType.convertToPasswordRequiredError(), newState: state)
     }
 
@@ -452,7 +459,8 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 scopes: scopes,
                 username: params.username,
                 controller: self,
-                flowToken: credentialToken
+                flowToken: credentialToken,
+                correlationId: params.context.correlationId()
             )
 
             return .init(.passwordRequired(newState: state), telemetryUpdate: { [weak self] result in
@@ -470,7 +478,10 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 }
             })
         case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
-            let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken)
+            let state = SignInCodeRequiredState(scopes: scopes,
+                                                controller: self,
+                                                flowToken: credentialToken,
+                                                correlationId: params.context.correlationId())
             stopTelemetryEvent(telemetryInfo)
             return .init(.codeRequired(newState: state, sentTo: sentTo, channelTargetType: channelType, codeLength: codeLength))
         case .error(let challengeError):
@@ -495,7 +506,10 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
             MSALLogger.log(level: .warning, context: telemetryInfo.context, format: MSALNativeAuthErrorMessage.codeRequiredForPasswordUserLog)
             let result: SignInPasswordStartResult = .codeRequired(
-                newState: SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken),
+                newState: SignInCodeRequiredState(scopes: scopes,
+                                                  controller: self,
+                                                  flowToken: credentialToken,
+                                                  correlationId: params.context.correlationId()),
                 sentTo: sentTo,
                 channelTargetType: channelType,
                 codeLength: codeLength

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -323,7 +323,10 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             stopTelemetryEvent(event, context: context)
             return SignUpStartPasswordControllerResponse(
                 .codeRequired(
-                    newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                    newState: SignUpCodeRequiredState(controller: self,
+                                                      username: username,
+                                                      flowToken: signUpToken,
+                                                      correlationId: context.correlationId()),
                     sentTo: sentTo,
                     channelTargetType: challengeType,
                     codeLength: codeLength
@@ -366,7 +369,10 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             stopTelemetryEvent(event, context: context)
             return SignUpStartCodeControllerResponse(
                 .codeRequired(
-                    newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                    newState: SignUpCodeRequiredState(controller: self,
+                                                      username: username,
+                                                      flowToken: signUpToken,
+                                                      correlationId: context.correlationId()),
                     sentTo: sentTo,
                     channelTargetType: challengeType,
                     codeLength: codeLength
@@ -408,7 +414,10 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge resendCode request")
             stopTelemetryEvent(event, context: context)
             return .codeRequired(
-                newState: SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken),
+                newState: SignUpCodeRequiredState(controller: self,
+                                                  username: username,
+                                                  flowToken: signUpToken,
+                                                  correlationId: context.correlationId()),
                 sentTo: sentTo,
                 channelTargetType: challengeType,
                 codeLength: codeLength
@@ -443,7 +452,10 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         case .passwordRequired(let signUpToken):
             MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge request after credential_required")
 
-            let state = SignUpPasswordRequiredState(controller: self, username: username, flowToken: signUpToken)
+            let state = SignUpPasswordRequiredState(controller: self,
+                                                    username: username,
+                                                    flowToken: signUpToken,
+                                                    correlationId: context.correlationId())
 
             return .init(.passwordRequired(state), telemetryUpdate: { [weak self] result in
                 switch result {
@@ -509,7 +521,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
 
             let error = VerifyCodeError(type: .invalidCode)
             stopTelemetryEvent(event, context: context, error: error)
-            let state = SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken)
+            let state = SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken, correlationId: context.correlationId())
             return .init(.error(error: error, newState: state))
         case .credentialRequired(let signUpToken):
             MSALLogger.log(level: .verbose, context: context, format: "credential_required received in signup/continue request")
@@ -519,7 +531,11 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         case .attributesRequired(let signUpToken, let attributes):
             MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
 
-            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            let state = SignUpAttributesRequiredState(controller: self,
+                                                      username: username,
+                                                      flowToken: signUpToken,
+                                                      correlationId: context.correlationId())
+
             return .init(.attributesRequired(attributes: attributes, newState: state), telemetryUpdate: { [weak self] result in
                 switch result {
                 case .success:
@@ -567,12 +583,19 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 format: "invalid_user_input error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")"
             )
 
-            let state = SignUpPasswordRequiredState(controller: self, username: username, flowToken: signUpToken)
+            let state = SignUpPasswordRequiredState(controller: self,
+                                                    username: username,
+                                                    flowToken: signUpToken,
+                                                    correlationId: context.correlationId())
+
             return .init(.error(error: error, newState: state))
         case .attributesRequired(let signUpToken, let attributes):
             MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
 
-            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            let state = SignUpAttributesRequiredState(controller: self,
+                                                      username: username,
+                                                      flowToken: signUpToken,
+                                                      correlationId: context.correlationId())
 
             return .init(.attributesRequired(attributes: attributes, newState: state), telemetryUpdate: { [weak self] result in
                 switch result {
@@ -620,7 +643,11 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                            context: context,
                            format: "attributes_required received in signup/continue submitAttributes request: \(attributes)")
 
-            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            let state = SignUpAttributesRequiredState(controller: self,
+                                                      username: username,
+                                                      flowToken: signUpToken,
+                                                      correlationId: context.correlationId())
+
             return .attributesRequired(attributes: attributes, state: state)
         case .attributeValidationFailed(let signUpToken, let invalidAttributes):
             let message = "attribute_validation_failed from signup/continue submitAttributes request. Make sure these attributes are correct: \(invalidAttributes)" // swiftlint:disable:this line_length
@@ -630,7 +657,11 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             let error = AttributesRequiredError(message: errorMessage)
             stopTelemetryEvent(event, context: context, error: error)
 
-            let state = SignUpAttributesRequiredState(controller: self, username: username, flowToken: signUpToken)
+            let state = SignUpAttributesRequiredState(controller: self,
+                                                      username: username,
+                                                      flowToken: signUpToken,
+                                                      correlationId: context.correlationId())
+
             return .attributesInvalid(attributes: invalidAttributes, newState: state)
         case .error(let apiError):
             let error = apiError.toAttributesRequiredPublicError()
@@ -659,6 +690,6 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
     ) -> SignInAfterSignUpState {
         MSALLogger.log(level: .info, context: context, format: "SignUp completed successfully")
         stopTelemetryEvent(event, context: context)
-        return SignInAfterSignUpState(controller: signInController, username: username, slt: slt)
+        return SignInAfterSignUpState(controller: signInController, username: username, slt: slt, correlationId: context.correlationId())
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/MSALNativeAuthBaseState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/MSALNativeAuthBaseState.swift
@@ -27,8 +27,10 @@ import Foundation
 @objc
 public class MSALNativeAuthBaseState: NSObject {
     let flowToken: String
+    let correlationId: UUID
 
-    init(flowToken: String) {
+    init(flowToken: String, correlationId: UUID) {
         self.flowToken = flowToken
+        self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
@@ -26,12 +26,12 @@ import Foundation
 
 extension ResetPasswordCodeRequiredState {
 
-    func resendCodeInternal(correlationId: UUID?) async -> ResetPasswordResendCodeResult {
+    func resendCodeInternal() async -> ResetPasswordResendCodeResult {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         return await controller.resendCode(passwordResetToken: flowToken, context: context)
     }
 
-    func submitCodeInternal(code: String, correlationId: UUID?) async -> ResetPasswordVerifyCodeResult {
+    func submitCodeInternal(code: String) async -> ResetPasswordVerifyCodeResult {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         guard inputValidator.isInputValid(code) else {
@@ -45,7 +45,7 @@ extension ResetPasswordCodeRequiredState {
 
 extension ResetPasswordRequiredState {
 
-    func submitPasswordInternal(password: String, correlationId: UUID?) async -> ResetPasswordRequiredResult {
+    func submitPasswordInternal(password: String) async -> ResetPasswordRequiredResult {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         guard inputValidator.isInputValid(password) else {

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates.swift
@@ -32,23 +32,22 @@ public class ResetPasswordBaseState: MSALNativeAuthBaseState {
     init(
         controller: MSALNativeAuthResetPasswordControlling,
         flowToken: String,
-        inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator()
+        inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
+        correlationId: UUID
     ) {
         self.controller = controller
         self.inputValidator = inputValidator
-        super.init(flowToken: flowToken)
+        super.init(flowToken: flowToken, correlationId: correlationId)
     }
 }
 
 /// An object of this type is created when a user is required to supply a verification code to continue a reset password flow.
 @objcMembers public class ResetPasswordCodeRequiredState: ResetPasswordBaseState {
     /// Requests the server to resend the verification code to the user.
-    /// - Parameters:
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
-    ///   - delegate: Delegate that receives callbacks for the operation.
-    public func resendCode(correlationId: UUID? = nil, delegate: ResetPasswordResendCodeDelegate) {
+    /// - Parameter delegate: Delegate that receives callbacks for the operation.
+    public func resendCode(delegate: ResetPasswordResendCodeDelegate) {
         Task {
-            let result = await resendCodeInternal(correlationId: correlationId)
+            let result = await resendCodeInternal()
 
             switch result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -67,11 +66,10 @@ public class ResetPasswordBaseState: MSALNativeAuthBaseState {
     /// Submits the code to the server for verification.
     /// - Parameters:
     ///   - code: Verification code that the user supplied.
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     ///   - delegate: Delegate that receives callbacks for the operation.
-    public func submitCode(code: String, correlationId: UUID? = nil, delegate: ResetPasswordVerifyCodeDelegate) {
+    public func submitCode(code: String, delegate: ResetPasswordVerifyCodeDelegate) {
         Task {
-            let result = await submitCodeInternal(code: code, correlationId: correlationId)
+            let result = await submitCodeInternal(code: code)
 
             switch result {
             case .passwordRequired(let newState):
@@ -88,11 +86,10 @@ public class ResetPasswordBaseState: MSALNativeAuthBaseState {
     /// Submits the password to the server for verification.
     /// - Parameters:
     ///   - password: Password that the user supplied.
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     ///   - delegate: Delegate that receives callbacks for the operation.
-    public func submitPassword(password: String, correlationId: UUID? = nil, delegate: ResetPasswordRequiredDelegate) {
+    public func submitPassword(password: String, delegate: ResetPasswordRequiredDelegate) {
         Task {
-            let result = await submitPasswordInternal(password: password, correlationId: correlationId)
+            let result = await submitPasswordInternal(password: password)
 
             switch result {
             case .completed:

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState+Internal.swift
@@ -26,7 +26,7 @@ import Foundation
 
 extension SignInAfterSignUpState {
 
-    func signInInternal(scopes: [String]?, correlationId: UUID?) async -> Result<MSALNativeAuthUserAccountResult, SignInAfterSignUpError> {
+    func signInInternal(scopes: [String]?) async -> Result<MSALNativeAuthUserAccountResult, SignInAfterSignUpError> {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         return await controller.signIn(username: username, slt: slt, scopes: scopes, context: context)
     }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -30,25 +30,25 @@ import Foundation
     let controller: MSALNativeAuthSignInControlling
     let username: String
     let slt: String?
+    let correlationId: UUID
 
-    init(controller: MSALNativeAuthSignInControlling, username: String, slt: String?) {
+    init(controller: MSALNativeAuthSignInControlling, username: String, slt: String?, correlationId: UUID) {
         self.username = username
         self.slt = slt
         self.controller = controller
+        self.correlationId = correlationId
     }
 
     /// Sign in the user that signed up.
     /// - Parameters:
     ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(
         scopes: [String]? = nil,
-        correlationId: UUID? = nil,
         delegate: SignInAfterSignUpDelegate
     ) {
         Task {
-            let controllerResult = await signInInternal(scopes: scopes, correlationId: correlationId)
+            let controllerResult = await signInInternal(scopes: scopes)
 
             switch controllerResult {
             case .success(let accountResult):

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
@@ -26,7 +26,7 @@ import Foundation
 
 extension SignInCodeRequiredState {
 
-    func submitCodeInternal(code: String, correlationId: UUID?) async -> SignInVerifyCodeResult {
+    func submitCodeInternal(code: String) async -> SignInVerifyCodeResult {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, code submitted")
         guard inputValidator.isInputValid(code) else {
@@ -37,7 +37,7 @@ extension SignInCodeRequiredState {
         return await controller.submitCode(code, credentialToken: flowToken, context: context, scopes: scopes)
     }
 
-    func resendCodeInternal(correlationId: UUID?) async -> SignInResendCodeResult {
+    func resendCodeInternal() async -> SignInResendCodeResult {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, resend code requested")
 
@@ -48,8 +48,7 @@ extension SignInCodeRequiredState {
 extension SignInPasswordRequiredState {
 
     func submitPasswordInternal(
-        password: String,
-        correlationId: UUID?
+        password: String
     ) async -> SignInPasswordRequiredResult {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALLogger.log(level: .info, context: context, format: "SignIn flow, password submitted")

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
@@ -31,10 +31,11 @@ import Foundation
     init(
         controller: MSALNativeAuthSignInControlling,
         inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
-        flowToken: String) {
+        flowToken: String,
+        correlationId: UUID) {
         self.controller = controller
         self.inputValidator = inputValidator
-        super.init(flowToken: flowToken)
+        super.init(flowToken: flowToken, correlationId: correlationId)
     }
 }
 
@@ -47,18 +48,17 @@ import Foundation
         scopes: [String],
         controller: MSALNativeAuthSignInControlling,
         inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
-        flowToken: String) {
+        flowToken: String,
+        correlationId: UUID) {
         self.scopes = scopes
-        super.init(controller: controller, inputValidator: inputValidator, flowToken: flowToken)
+        super.init(controller: controller, inputValidator: inputValidator, flowToken: flowToken, correlationId: correlationId)
     }
 
     /// Requests the server to resend the verification code to the user.
-    /// - Parameters:
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
-    ///   - delegate: Delegate that receives callbacks for the operation.
-    public func resendCode(correlationId: UUID? = nil, delegate: SignInResendCodeDelegate) {
+    /// - Parameter delegate: Delegate that receives callbacks for the operation.
+    public func resendCode(delegate: SignInResendCodeDelegate) {
         Task {
-            let result = await resendCodeInternal(correlationId: correlationId)
+            let result = await resendCodeInternal()
 
             switch result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -77,11 +77,10 @@ import Foundation
     /// Submits the code to the server for verification.
     /// - Parameters:
     ///   - code: Verification code that the user supplies.
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     ///   - delegate: Delegate that receives callbacks for the operation.
-    public func submitCode(code: String, correlationId: UUID? = nil, delegate: SignInVerifyCodeDelegate) {
+    public func submitCode(code: String, delegate: SignInVerifyCodeDelegate) {
         Task {
-            let result = await submitCodeInternal(code: code, correlationId: correlationId)
+            let result = await submitCodeInternal(code: code)
 
             switch result {
             case .completed(let accountResult):
@@ -104,20 +103,20 @@ import Foundation
         username: String,
         controller: MSALNativeAuthSignInControlling,
         inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
-        flowToken: String) {
+        flowToken: String,
+        correlationId: UUID) {
         self.scopes = scopes
         self.username = username
-        super.init(controller: controller, inputValidator: inputValidator, flowToken: flowToken)
+        super.init(controller: controller, inputValidator: inputValidator, flowToken: flowToken, correlationId: correlationId)
     }
 
     /// Submits the password to the server for verification.
     /// - Parameters:
     ///   - password: Password that the user supplied.
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     ///   - delegate: Delegate that receives callbacks for the operation.
-    public func submitPassword(password: String, correlationId: UUID? = nil, delegate: SignInPasswordRequiredDelegate) {
+    public func submitPassword(password: String, delegate: SignInPasswordRequiredDelegate) {
         Task {
-            let result = await submitPasswordInternal(password: password, correlationId: correlationId)
+            let result = await submitPasswordInternal(password: password)
 
             switch result {
             case .completed(let accountResult):

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
@@ -26,12 +26,12 @@ import Foundation
 
 extension SignUpCodeRequiredState {
 
-    func resendCodeInternal(correlationId: UUID?) async -> SignUpResendCodeResult {
+    func resendCodeInternal() async -> SignUpResendCodeResult {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         return await controller.resendCode(username: username, context: context, signUpToken: flowToken)
     }
 
-    func submitCodeInternal(code: String, correlationId: UUID?) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
+    func submitCodeInternal(code: String) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         guard inputValidator.isInputValid(code) else {
@@ -45,10 +45,7 @@ extension SignUpCodeRequiredState {
 
 extension SignUpPasswordRequiredState {
 
-    func submitPasswordInternal(
-        password: String,
-        correlationId: UUID?
-    ) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
+    func submitPasswordInternal(password: String) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         guard inputValidator.isInputValid(password) else {
@@ -62,7 +59,7 @@ extension SignUpPasswordRequiredState {
 
 extension SignUpAttributesRequiredState {
 
-    func submitAttributesInternal(attributes: [String: Any], correlationId: UUID?) async -> SignUpAttributesRequiredResult {
+    func submitAttributesInternal(attributes: [String: Any]) async -> SignUpAttributesRequiredResult {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         return await controller.submitAttributes(attributes, username: username, signUpToken: flowToken, context: context)
     }

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
@@ -34,24 +34,23 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
         controller: MSALNativeAuthSignUpControlling,
         username: String,
         flowToken: String,
-        inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator()
+        inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
+        correlationId: UUID
     ) {
         self.controller = controller
         self.username = username
         self.inputValidator = inputValidator
-        super.init(flowToken: flowToken)
+        super.init(flowToken: flowToken, correlationId: correlationId)
     }
 }
 
 /// An object of this type is created when a user is required to supply a verification code to continue a sign up flow.
 @objcMembers public class SignUpCodeRequiredState: SignUpBaseState {
     /// Requests the server to resend the verification code to the user.
-    /// - Parameters:
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
-    ///   - delegate: Delegate that receives callbacks for the operation.
-    public func resendCode(correlationId: UUID? = nil, delegate: SignUpResendCodeDelegate) {
+    /// - Parameter delegate: Delegate that receives callbacks for the operation.
+    public func resendCode(delegate: SignUpResendCodeDelegate) {
         Task {
-            let result = await resendCodeInternal(correlationId: correlationId)
+            let result = await resendCodeInternal()
 
             switch result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -70,11 +69,10 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     /// Submits the code to the server for verification.
     /// - Parameters:
     ///   - code: Verification code that the user supplies.
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     ///   - delegate: Delegate that receives callbacks for the operation.
-    public func submitCode(code: String, correlationId: UUID? = nil, delegate: SignUpVerifyCodeDelegate) {
+    public func submitCode(code: String, delegate: SignUpVerifyCodeDelegate) {
         Task {
-            let controllerResponse = await submitCodeInternal(code: code, correlationId: correlationId)
+            let controllerResponse = await submitCodeInternal(code: code)
 
             switch controllerResponse.result {
             case .completed(let state):
@@ -110,11 +108,10 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     /// Submits the password to the server for verification.
     /// - Parameters:
     ///   - password: Password that the user supplied.
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     ///   - delegate: Delegate that receives callbacks for the operation.
-    public func submitPassword(password: String, correlationId: UUID? = nil, delegate: SignUpPasswordRequiredDelegate) {
+    public func submitPassword(password: String, delegate: SignUpPasswordRequiredDelegate) {
         Task {
-            let controllerResponse = await submitPasswordInternal(password: password, correlationId: correlationId)
+            let controllerResponse = await submitPasswordInternal(password: password)
 
             switch controllerResponse.result {
             case .completed(let state):
@@ -141,14 +138,12 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     /// - Parameters:
     ///   - attributes: Dictionary of attributes that the user supplied.
     ///   - delegate: Delegate that receives callbacks for the operation.
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     public func submitAttributes(
         attributes: [String: Any],
-        delegate: SignUpAttributesRequiredDelegate,
-        correlationId: UUID? = nil
+        delegate: SignUpAttributesRequiredDelegate
     ) {
         Task {
-            let result = await submitAttributesInternal(attributes: attributes, correlationId: correlationId)
+            let result = await submitAttributesInternal(attributes: attributes)
 
             switch result {
             case .completed(let state):

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
@@ -97,7 +97,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.invalidOOBValue, endpoint: .signInToken)
         }
 
-        signInDelegateSpy.newStateCodeRequired?.submitCode(code: "badc0d3", correlationId: correlationId, delegate: signInVerifyCodeDelegateSpy)
+        signInDelegateSpy.newStateCodeRequired?.submitCode(code: "badc0d3", delegate: signInVerifyCodeDelegateSpy)
 
         await fulfillment(of: [verifyCodeExpectation], timeout: 2)
 
@@ -140,7 +140,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             XCTAssertNotEqual(otp, "<otp not set>")
         }
 
-        signInDelegateSpy.newStateCodeRequired?.submitCode(code: otp, correlationId: correlationId, delegate: signInVerifyCodeDelegateSpy)
+        signInDelegateSpy.newStateCodeRequired?.submitCode(code: otp, delegate: signInVerifyCodeDelegateSpy)
 
         await fulfillment(of: [verifyCodeExpectation], timeout: 2)
 
@@ -199,7 +199,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.invalidPassword, endpoint: .signInToken)
         }
 
-        signInDelegateSpy.newStatePasswordRequired?.submitPassword(password: "An Invalid Password", correlationId: correlationId, delegate: signInPasswordRequiredDelegateSpy)
+        signInDelegateSpy.newStatePasswordRequired?.submitPassword(password: "An Invalid Password", delegate: signInPasswordRequiredDelegateSpy)
 
         await fulfillment(of: [passwordRequiredExpectation], timeout: 2)
 
@@ -237,7 +237,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.tokenSuccess, endpoint: .signInToken)
         }
 
-        signInDelegateSpy.newStatePasswordRequired?.submitPassword(password: password, correlationId: correlationId, delegate: signInPasswordRequiredDelegateSpy)
+        signInDelegateSpy.newStatePasswordRequired?.submitPassword(password: password, delegate: signInPasswordRequiredDelegateSpy)
 
         await fulfillment(of: [passwordRequiredExpectation], timeout: 2)
 

--- a/MSAL/test/integration/native_auth/end_to_end/sign_out/MSALNativeAuthSignOutEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_out/MSALNativeAuthSignOutEndToEndTests.swift
@@ -59,7 +59,7 @@ final class MSALNativeAuthSignOutEndToEndTests: MSALNativeAuthEndToEndBaseTestCa
             XCTAssertNotEqual(otp, "<otp not set>")
         }
 
-        signInDelegateSpy.newStateCodeRequired?.submitCode(code: otp, correlationId: correlationId, delegate: signInVerifyCodeDelegateSpy)
+        signInDelegateSpy.newStateCodeRequired?.submitCode(code: otp, delegate: signInVerifyCodeDelegateSpy)
 
         await fulfillment(of: [verifyCodeExpectation], timeout: defaultTimeout)
 
@@ -110,7 +110,7 @@ final class MSALNativeAuthSignOutEndToEndTests: MSALNativeAuthEndToEndBaseTestCa
             XCTAssertNotEqual(otp, "<otp not set>")
         }
 
-        signInDelegateSpy.newStateCodeRequired?.submitCode(code: otp, correlationId: correlationId, delegate: signInVerifyCodeDelegateSpy)
+        signInDelegateSpy.newStateCodeRequired?.submitCode(code: otp, delegate: signInVerifyCodeDelegateSpy)
 
         await fulfillment(of: [verifyCodeExpectation], timeout: defaultTimeout)
 

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift
@@ -64,7 +64,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
             try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
         }
 
-        signUpStartDelegate.newState?.submitCode(code: "1234", correlationId: correlationId, delegate: signUpVerifyCodeDelegate)
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate)
 
         await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
         XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
@@ -78,7 +78,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
             try await mockResponse(.tokenSuccess, endpoint: .signInToken)
         }
 
-        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(delegate: signInAfterSignUpDelegate)
 
         await fulfillment(of: [signInExp], timeout: defaultTimeout)
         checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
@@ -114,7 +114,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
             try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
         }
 
-        signUpStartDelegate.newState?.submitCode(code: "1234", correlationId: correlationId, delegate: signUpVerifyCodeDelegate)
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate)
 
         await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
         XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
@@ -128,7 +128,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
             try await mockResponse(.tokenSuccess, endpoint: .signInToken)
         }
 
-        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(delegate: signInAfterSignUpDelegate)
 
         await fulfillment(of: [signInExp], timeout: defaultTimeout)
         checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
@@ -164,7 +164,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
             try await mockResponse(.challengeTypePassword, endpoint: .signUpChallenge)
         }
 
-        signUpStartDelegate.newState?.submitCode(code: "1234", correlationId: correlationId, delegate: signUpVerifyCodeDelegate)
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate)
 
         await fulfillment(of: [credentialRequiredExp], timeout: defaultTimeout)
         XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpPasswordRequiredCalled)
@@ -180,7 +180,6 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
         signUpVerifyCodeDelegate.passwordRequiredState?.submitPassword(
             password: "1234",
-            correlationId: correlationId,
             delegate: signUpPasswordDelegate
         )
 
@@ -196,7 +195,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
             try await mockResponse(.tokenSuccess, endpoint: .signInToken)
         }
 
-        signUpPasswordDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+        signUpPasswordDelegate.signInAfterSignUpState?.signIn(delegate: signInAfterSignUpDelegate)
 
         await fulfillment(of: [signInExp], timeout: defaultTimeout)
         checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
@@ -232,7 +231,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
             try await mockResponse(.challengeTypePassword, endpoint: .signUpChallenge)
         }
 
-        signUpStartDelegate.newState?.submitCode(code: "1234", correlationId: correlationId, delegate: signUpVerifyCodeDelegate)
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate)
 
         await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
         XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpPasswordRequiredCalled)
@@ -248,7 +247,6 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
         signUpVerifyCodeDelegate.passwordRequiredState?.submitPassword(
             password: "1234",
-            correlationId: correlationId,
             delegate: signUpPasswordDelegate
         )
 
@@ -266,8 +264,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
         signUpPasswordDelegate.attributesRequiredState?.submitAttributes(
             attributes: attributes,
-            delegate: signUpAttributesRequiredDelegate,
-            correlationId: correlationId
+            delegate: signUpAttributesRequiredDelegate
         )
 
         await fulfillment(of: [attributesRequiredExp], timeout: defaultTimeout)
@@ -282,7 +279,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
             try await mockResponse(.tokenSuccess, endpoint: .signInToken)
         }
 
-        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(delegate: signInAfterSignUpDelegate)
 
         await fulfillment(of: [signInExp], timeout: defaultTimeout)
         checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
@@ -318,7 +315,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
             try await mockResponse(.challengeTypePassword, endpoint: .signUpChallenge)
         }
 
-        signUpStartDelegate.newState?.submitCode(code: "1234", correlationId: correlationId, delegate: signUpVerifyCodeDelegate)
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate)
 
         await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
         XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpPasswordRequiredCalled)
@@ -334,7 +331,6 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
         signUpVerifyCodeDelegate.passwordRequiredState?.submitPassword(
             password: "1234",
-            correlationId: correlationId,
             delegate: signUpPasswordDelegate
         )
 
@@ -352,8 +348,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
         signUpPasswordDelegate.attributesRequiredState?.submitAttributes(
             attributes: attributes,
-            delegate: signUpAttributesRequiredDelegate,
-            correlationId: correlationId
+            delegate: signUpAttributesRequiredDelegate
         )
 
         await fulfillment(of: [attributesRequiredExp2], timeout: defaultTimeout)
@@ -370,8 +365,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
         signUpAttributesRequiredDelegate.attributesRequiredState?.submitAttributes(
             attributes: attributes,
-            delegate: signUpAttributesRequiredDelegate,
-            correlationId: correlationId
+            delegate: signUpAttributesRequiredDelegate
         )
 
         await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
@@ -386,7 +380,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
             try await mockResponse(.tokenSuccess, endpoint: .signInToken)
         }
 
-        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(delegate: signInAfterSignUpDelegate)
 
         await fulfillment(of: [signInExp], timeout: defaultTimeout)
         checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
@@ -421,7 +415,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
             try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
         }
 
-        signUpStartDelegate.newState?.submitCode(code: "1234", correlationId: correlationId, delegate: signUpVerifyCodeDelegate)
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate)
 
         await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
         XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameEndToEndTests.swift
@@ -59,7 +59,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
         }
 
-        signUpStartDelegate.newState?.submitCode(code: "1234", correlationId: correlationId, delegate: signUpVerifyCodeDelegate)
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate)
 
         await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
         XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
@@ -73,7 +73,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.tokenSuccess, endpoint: .signInToken)
         }
 
-        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(delegate: signInAfterSignUpDelegate)
 
         await fulfillment(of: [signInExp], timeout: defaultTimeout)
         checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
@@ -103,7 +103,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
         }
 
-        signUpStartDelegate.newState?.submitCode(code: "1234", correlationId: correlationId, delegate: signUpVerifyCodeDelegate)
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate)
 
         await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
         XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)
@@ -117,7 +117,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.tokenSuccess, endpoint: .signInToken)
         }
 
-        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+        signUpVerifyCodeDelegate.signInAfterSignUpState?.signIn(delegate: signInAfterSignUpDelegate)
 
         await fulfillment(of: [signInExp], timeout: defaultTimeout)
         checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
@@ -147,7 +147,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
         }
 
-        signUpStartDelegate.newState?.submitCode(code: "1234", correlationId: correlationId, delegate: signUpVerifyCodeDelegate)
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate)
 
         await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
         XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpAttributesRequiredCalled)
@@ -163,8 +163,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
         signUpVerifyCodeDelegate.attributesRequiredNewState?.submitAttributes(
             attributes: attributes,
-            delegate: signUpAttributesRequiredDelegate,
-            correlationId: correlationId
+            delegate: signUpAttributesRequiredDelegate
         )
 
         await fulfillment(of: [attributesExp], timeout: defaultTimeout)
@@ -179,7 +178,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.tokenSuccess, endpoint: .signInToken)
         }
 
-        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(delegate: signInAfterSignUpDelegate)
 
         await fulfillment(of: [signInExp], timeout: defaultTimeout)
         checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
@@ -209,7 +208,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.attributesRequired, endpoint: .signUpContinue)
         }
 
-        signUpStartDelegate.newState?.submitCode(code: "1234", correlationId: correlationId, delegate: signUpVerifyCodeDelegate)
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate)
 
         await fulfillment(of: [submitCodeExp], timeout: defaultTimeout)
         XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpAttributesRequiredCalled)
@@ -225,8 +224,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
         signUpVerifyCodeDelegate.attributesRequiredNewState?.submitAttributes(
             attributes: attributes,
-            delegate: signUpAttributesRequiredDelegate,
-            correlationId: correlationId
+            delegate: signUpAttributesRequiredDelegate
         )
 
         await fulfillment(of: [submitAttributesExp1], timeout: defaultTimeout)
@@ -243,8 +241,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
         signUpAttributesRequiredDelegate.attributesRequiredState?.submitAttributes(
             attributes: attributes,
-            delegate: signUpAttributesRequiredDelegate,
-            correlationId: correlationId
+            delegate: signUpAttributesRequiredDelegate
         )
 
         await fulfillment(of: [submitAttributesExp2], timeout: defaultTimeout)
@@ -259,7 +256,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.tokenSuccess, endpoint: .signInToken)
         }
 
-        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(correlationId: correlationId, delegate: signInAfterSignUpDelegate)
+        signUpAttributesRequiredDelegate.signInAfterSignUpState?.signIn(delegate: signInAfterSignUpDelegate)
 
         await fulfillment(of: [signInExp], timeout: defaultTimeout)
         checkSignInAfterSignUpDelegate(signInAfterSignUpDelegate)
@@ -289,7 +286,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
             try await mockResponse(.signUpContinueSuccess, endpoint: .signUpContinue)
         }
 
-        signUpStartDelegate.newState?.submitCode(code: "1234", correlationId: correlationId, delegate: signUpVerifyCodeDelegate)
+        signUpStartDelegate.newState?.submitCode(code: "1234", delegate: signUpVerifyCodeDelegate)
 
         await fulfillment(of: [signUpCompleteExp], timeout: defaultTimeout)
         XCTAssertTrue(signUpVerifyCodeDelegate.onSignUpCompletedCalled)

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthBaseControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthBaseControllerTests.swift
@@ -241,8 +241,7 @@ final class MSALNativeAuthBaseControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_performRequest_withSuccess() async {
-        let request = MSIDHttpRequest()
-        HttpModuleMockConfigurator.configure(request: request, responseJson: ["response"])
+        let request = MSALNativeAuthHTTPRequestMock.prepareMockRequest(responseJson: ["response"])
 
         let result: Result<[String], Error> = await sut.performRequest(request, context: contextMock)
 
@@ -255,8 +254,7 @@ final class MSALNativeAuthBaseControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_performRequest_withUnexpectedError() async {
-        let request = MSIDHttpRequest()
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [nil] as [Any?])
+        let request = MSALNativeAuthHTTPRequestMock.prepareMockRequest(responseJson: [nil])
 
         let result: Result<[String], Error> = await sut.performRequest(request, context: contextMock)
 

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
@@ -115,7 +115,7 @@ final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
         let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
 
         requestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: nil, signInSLT: nil, grantType: MSALNativeAuthGrantType.refreshToken, scope: "" , password: nil, oobCode: nil, includeChallengeType: true, refreshToken: "refreshToken")
-        requestProviderMock.throwingTokenError = ErrorMock.error
+        requestProviderMock.throwingRefreshTokenError = ErrorMock.error
 
         let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .generalError))
 
@@ -135,12 +135,9 @@ final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
                                                                 authTokens: authTokens,
                                                                 configuration: MSALNativeAuthConfigStubs.configuration, cacheAccessor: MSALNativeAuthCacheAccessorMock())
 
-        let request = MSIDHttpRequest()
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
-        requestProviderMock.result = request
+        requestProviderMock.mockRequestRefreshTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
 
         let expectedAccessToken = "accessToken"
         let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedAccessToken: expectedAccessToken)
@@ -174,15 +171,12 @@ final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
     }
 
     private func checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError, validatorError: MSALNativeAuthTokenValidatedErrorType) async {
-        let request = MSIDHttpRequest()
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         let expectation = expectation(description: "CredentialsController")
 
-        requestProviderMock.result = request
+        requestProviderMock.mockRequestRefreshTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
 
         let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedError: publicError)
         responseValidatorMock.tokenValidatedResponse = .error(validatorError)

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
@@ -79,10 +79,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordStart_returnsSuccess_it_callsChallenge() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
         validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateResetPasswordChallengeFunc(.unexpectedError)
         _ = prepareResetPasswordStartValidatorHelper()
@@ -93,7 +93,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordStartPassword_returns_redirect_it_returnsBrowserRequiredError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
         validatorMock.mockValidateResetPasswordStartFunc(.redirect)
 
@@ -115,7 +115,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordStart_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
         validatorMock.mockValidateResetPasswordStartFunc(.error(.userNotFound(message: nil)))
 
@@ -137,7 +137,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenValidatorInResetPasswordStart_returns_unexpectedError_it_returnsGeneralError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
         validatorMock.mockValidateResetPasswordStartFunc(.unexpectedError)
 
@@ -161,7 +161,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     // MARK: - ResetPasswordStart (/challenge request) tests
 
     func test_whenResetPasswordStart_challenge_cantCreateRequest_it_returns_unexpectedError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
         validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
         requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
@@ -185,10 +185,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordStart_challenge_succeeds_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
         validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "resetPasswordToken"))
 
@@ -210,10 +210,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordStart_challenge_returns_redirect_it_returnsRedirectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
         validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateResetPasswordChallengeFunc(.redirect)
 
@@ -235,10 +235,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordStart_challenge_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
         validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         let error : MSALNativeAuthResetPasswordChallengeValidatedResponse = .error(
             MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken,
@@ -268,10 +268,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenValidatorInResetPasswordStart_challenge_returns_unexpectedError_it_returnsGeneralError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
         validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateResetPasswordChallengeFunc(.unexpectedError)
 
@@ -315,7 +315,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordResendCode_succeeds_it_returnsResetPasswordResendCodeRequired() async {
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
 
         validatorMock.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "flowToken response"))
@@ -338,7 +338,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordResendCode_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         let error : MSALNativeAuthResetPasswordChallengeValidatedResponse = .error(
             MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest,
@@ -366,7 +366,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordResendCode_returns_redirect_it_returnsCorrectError() async {
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateResetPasswordChallengeFunc(.redirect)
 
@@ -387,7 +387,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordResendCode_returns_unexpectedError_it_returnsCorrectError() async {
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateResetPasswordChallengeFunc(.unexpectedError)
 
@@ -429,7 +429,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordSubmitCode_succeeds_it_returnsPasswordRequired() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateResetPasswordContinueFunc(.success(passwordSubmitToken: ""))
 
@@ -449,7 +449,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordSubmitCode_returns_invalidOOB_it_returnsInvalidCode() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateResetPasswordContinueFunc(.invalidOOB)
 
@@ -469,7 +469,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordSubmitCode_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         let error : MSALNativeAuthResetPasswordContinueValidatedResponse = .error(
             MSALNativeAuthResetPasswordContinueResponseError(error: .invalidRequest,
@@ -497,7 +497,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordSubmitCode_returns_unexpectedError_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateResetPasswordContinueFunc(.unexpectedError)
 
@@ -537,10 +537,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSubmitPassword_succeeds_it_returnsCompleted() async {
-        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
-        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded))
 
@@ -559,7 +559,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordSubmitPassword_returns_passwordError_it_returnsCorrectError() async {
-        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
         let error : MSALNativeAuthResetPasswordSubmitValidatedResponse = .passwordError(error:
             MSALNativeAuthResetPasswordSubmitResponseError(error: .passwordTooWeak,
@@ -586,7 +586,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordSubmitPassword_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
         let error : MSALNativeAuthResetPasswordSubmitValidatedResponse = .error(
             MSALNativeAuthResetPasswordSubmitResponseError(error: .invalidRequest,
@@ -612,7 +612,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenResetPasswordSubmitPassword_returns_unexpectedError_it_returnsCorrectError() async {
-        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
         validatorMock.mockValidateResetPasswordSubmitFunc(.unexpectedError)
 
@@ -633,10 +633,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     // MARK: - SubmitPassword - poll completion tests
 
     func test_whenSubmitPassword_pollCompletion_returns_failed_it_returnsResetPasswordRequiredError() async {
-        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
-        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.unexpectedError)
 
@@ -654,10 +654,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSubmitPassword_pollCompletion_returns_unexpectedError_it_returnsCorrectError() async {
-        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
-        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.unexpectedError)
 
@@ -675,10 +675,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSubmitPassword_pollCompletion_returns_passwordError_it_returnsCorrectError() async {
-        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
-        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         let error : MSALNativeAuthResetPasswordPollCompletionValidatedResponse =
             .passwordError(error:
@@ -707,10 +707,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSubmitPassword_pollCompletion_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
-        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         let error : MSALNativeAuthResetPasswordPollCompletionValidatedResponse = .error(
             MSALNativeAuthResetPasswordPollCompletionResponseError(error: .expiredToken,
@@ -736,10 +736,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSubmitPassword_pollCompletion_returns_notStarted_it_returnsCorrectErrorAfterRetries() async {
-        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 1))
-        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
 
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .notStarted))
@@ -760,10 +760,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSubmitPassword_pollCompletion_returns_failed_it_returnsError() async {
-        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
-        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .failed))
 
@@ -783,10 +783,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSubmitPassword_pollCompletion_returns_inProgress_it_returnsErrorAfterRetries() async {
-        requestProviderMock.mockSubmitRequestFunc(prepareMockRequest())
+        requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
-        requestProviderMock.mockPollCompletionRequestFunc(prepareMockRequest())
+        requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .inProgress))
 
@@ -908,16 +908,9 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
             passwordResetToken: token)
     }
 
-    private func prepareMockRequest() -> MSIDHttpRequest {
-        let request = MSIDHttpRequest()
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
-        return request
-    }
-
     private func prepareMockRequestsForPollCompletionRetries(_ count: Int) {
         for _ in 1...count {
-            _ = prepareMockRequest()
+            _ = MSALNativeAuthHTTPRequestMock.prepareMockRequest()
         }
     }
 }

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -94,26 +94,21 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     func test_whenUserSpecifiesScope_defaultScopesShouldBeIncluded() async throws {
         let expectation = expectation(description: "SignInController")
 
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let expectedScopes = "scope1 scope2 openid profile offline_access"
         let credentialToken = "credentialToken"
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
-
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedCredentialToken = credentialToken
         signInRequestProviderMock.expectedContext = expectedContext
 
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
 
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInPasswordStartError(type: .generalError))
@@ -128,20 +123,16 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
     func test_whenUserSpecifiesScopes_NoDuplicatedScopeShouldBeSent() async throws {
         let expectation = expectation(description: "SignInController")
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let expectedScopes = "scope1 openid profile offline_access"
         let credentialToken = "credentialToken"
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
-
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedCredentialToken = credentialToken
         signInRequestProviderMock.expectedContext = expectedContext
@@ -159,7 +150,6 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_successfulResponseAndValidation_shouldCompleteSignIn() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
@@ -167,19 +157,16 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedCredentialToken = credentialToken
         signInRequestProviderMock.expectedContext = expectedContext
 
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedUsername = expectedUsername
         tokenRequestProviderMock.expectedContext = expectedContext
 
@@ -200,7 +187,6 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_successfulResponseAndUnsuccessfulValidation_shouldReturnError() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
@@ -208,19 +194,16 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedCredentialToken = credentialToken
         signInRequestProviderMock.expectedContext = expectedContext
 
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedUsername = expectedUsername
         tokenRequestProviderMock.expectedContext = expectedContext
 
@@ -240,7 +223,6 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_errorResponse_shouldReturnError() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
@@ -248,18 +230,15 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .error(.invalidToken(message: nil))
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedContext = expectedContext
 
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedUsername = expectedUsername
         tokenRequestProviderMock.expectedContext = expectedContext
 
@@ -292,25 +271,21 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenCredentialsAreRequired_browserRequiredErrorIsReturned() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let credentialToken = "credentialToken"
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedCredentialToken = credentialToken
         signInRequestProviderMock.expectedContext = expectedContext
 
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedCredentialToken = credentialToken
 
         let expectation = expectation(description: "SignInController")
@@ -328,7 +303,6 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignInUsingPassword_apiReturnsChallengeTypeOOB_codeRequiredShouldBeCalled() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedSentTo = "sentTo"
@@ -339,13 +313,11 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedCredentialToken = credentialToken
         signInRequestProviderMock.expectedContext = expectedContext
@@ -365,7 +337,6 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignInUsingPassword_apiReturnsChallengeTypeOOB__butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedSentTo = "sentTo"
@@ -376,13 +347,11 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedCredentialToken = credentialToken
         signInRequestProviderMock.expectedContext = expectedContext
@@ -404,7 +373,6 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     // MARK: sign in with username and code
     
     func test_whenSignInWithCodeStartWithValidInfo_codeRequiredShouldBeCalled() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let sentTo = "sentTo"
         let channelTargetType = MSALNativeAuthChannelType.email
@@ -412,12 +380,10 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let credentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         let expectation = expectation(description: "SignInController")
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedCredentialToken = credentialToken
         signInRequestProviderMock.expectedContext = expectedContext
@@ -436,15 +402,12 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_afterSignInWithCodeSubmitCode_signInShouldCompleteSuccessfully() {
-        let request = MSIDHttpRequest()
         let credentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         let expectation = expectation(description: "SignInController")
 
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: defaultScopes, password: nil, oobCode: "code", includeChallengeType: false, refreshToken: nil)
 
@@ -453,8 +416,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         cacheAccessorMock.mockUserAccounts = [MSALNativeAuthUserAccountResultStub.account]
         cacheAccessorMock.expectedMSIDTokenResult = tokenResult
 
-        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), flowToken: credentialToken)
-        state.submitCode(code: "code", correlationId: defaultUUID, delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedUserAccountResult: userAccountResult))
+        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), flowToken: credentialToken, correlationId: defaultUUID)
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedUserAccountResult: userAccountResult))
 
         wait(for: [expectation], timeout: 1)
         XCTAssertTrue(cacheAccessorMock.clearCacheWasCalled)
@@ -463,23 +426,20 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_afterSignInWithCodeSubmitCode_whenTokenCacheIsNotValid_it_shouldReturnCorrectError() {
-        let request = MSIDHttpRequest()
         let credentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         let expectation = expectation(description: "SignInController")
 
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: defaultScopes, password: nil, oobCode: "code", includeChallengeType: false, refreshToken: nil)
 
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
         cacheAccessorMock.expectedMSIDTokenResult = nil
 
-        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), flowToken: credentialToken)
-        state.submitCode(code: "code", correlationId: defaultUUID, delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)))
+        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), flowToken: credentialToken, correlationId: defaultUUID)
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)))
 
         wait(for: [expectation], timeout: 1)
 
@@ -516,15 +476,12 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithCodeChallengeRequestCreationFail_errorShouldBeReturned() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         let expectation = expectation(description: "SignInController")
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError()
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: "credentialToken")
         
@@ -550,17 +507,14 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithCodePasswordIsRequired_newStateIsPropagatedToUser() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedCredentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
 
         let expectation = expectation(description: "SignInController")
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: expectedCredentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: expectedCredentialToken)
         
@@ -577,17 +531,14 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignInWithCodePasswordIsRequired_newStateIsPropagatedToUser_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedCredentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         let expectation = expectation(description: "SignInController")
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: expectedCredentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: expectedCredentialToken)
 
@@ -604,17 +555,14 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithCodeSubmitPassword_signInIsCompletedSuccessfully() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedCredentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        
         let exp = expectation(description: "SignInController")
         
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
 
@@ -624,8 +572,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         cacheAccessorMock.mockUserAccounts = [MSALNativeAuthUserAccountResultStub.account]
         cacheAccessorMock.expectedMSIDTokenResult = tokenResult
 
-        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
-        state.submitPassword(password: expectedPassword, correlationId: defaultUUID, delegate: mockDelegate)
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken, correlationId: defaultUUID)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate)
 
         await fulfillment(of: [exp], timeout: 1)
 
@@ -635,17 +583,14 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignInWithCodeSubmitPassword_whenTokenCacheIsNotValid_it_shouldReturnCorrectError() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedCredentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-
         let exp = expectation(description: "SignInController")
 
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
 
@@ -654,22 +599,19 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
         cacheAccessorMock.expectedMSIDTokenResult = nil
 
-        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
-        state.submitPassword(password: expectedPassword, correlationId: defaultUUID, delegate: mockDelegate)
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken, correlationId: defaultUUID)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate)
 
         await fulfillment(of: [exp], timeout: 1)
         checkTelemetryEventResult(id: .telemetryApiIdSignInSubmitPassword, isSuccessful: false)
     }
     
     func test_whenSignInWithCodeSubmitPasswordTokenRequestCreationFail_errorShouldBeReturned() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedCredentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        
         let exp = expectation(description: "SignInController")
         
         tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
@@ -677,8 +619,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         
         let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
 
-        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
-        state.submitPassword(password: expectedPassword, correlationId: defaultUUID, delegate: mockDelegate)
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken, correlationId: defaultUUID)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertNotNil(mockDelegate.newPasswordRequiredState)
@@ -711,8 +653,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
 
-        let state = SignInCodeRequiredState(scopes: [], controller: sut, flowToken: credentialToken)
-        state.submitCode(code: "code", correlationId: defaultUUID, delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)))
+        let state = SignInCodeRequiredState(scopes: [], controller: sut, flowToken: credentialToken, correlationId: defaultUUID)
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)))
 
         wait(for: [expectation], timeout: 1)
         XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
@@ -736,19 +678,16 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
         
     func test_signInWithCodeResendCode_shouldSendNewCode() async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let sentTo = "sentTo"
         let channelTargetType = MSALNativeAuthChannelType.email
         let codeLength = 4
         let credentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
 
         let expectation = expectation(description: "SignInController")
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedCredentialToken = credentialToken
         signInRequestProviderMock.expectedContext = expectedContext
@@ -784,15 +723,12 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_signInWithCodeResendCodePasswordRequired_shouldReturnAnError() async {
-        let request = MSIDHttpRequest()
         let credentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
 
         let expectation = expectation(description: "SignInController")
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedContext = expectedContext
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
@@ -809,15 +745,12 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_signInWithCodeResendCodeChallengeReturnError_shouldReturnAnError() async {
-        let request = MSIDHttpRequest()
         let credentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
 
         let expectation = expectation(description: "SignInController")
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedContext = expectedContext
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
@@ -837,15 +770,12 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     // MARK: signIn using SLT
     
     func test_whenSignInWithSLT_signInIsCompletedSuccessfully() {
-        let request = MSIDHttpRequest()
         let slt = "signInSLT"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        
         let expectation = expectation(description: "SignInController")
         
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: "", credentialToken: nil, signInSLT: slt, grantType: .slt, scope: defaultScopes, password: nil, oobCode: nil, includeChallengeType: false, refreshToken: nil)
 
@@ -856,8 +786,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         cacheAccessorMock.expectedMSIDTokenResult = tokenResult
         
-        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt)
-        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt, correlationId: defaultUUID)
+        state.signIn(delegate: mockDelegate)
 
         wait(for: [expectation], timeout: 1)
         XCTAssertTrue(cacheAccessorMock.validateAndSaveTokensWasCalled)
@@ -865,12 +795,9 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithSLTTokenRequestCreationFail_errorShouldBeReturned() {
-        let request = MSIDHttpRequest()
         let slt = "signInSLT"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        
         let exp = expectation(description: "SignInController")
         
         tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
@@ -878,8 +805,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         
         let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: exp, expectedError: SignInAfterSignUpError())
 
-        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt)
-        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt, correlationId: defaultUUID)
+        state.signIn(delegate: mockDelegate)
         
         wait(for: [exp], timeout: 1)
         XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
@@ -887,23 +814,20 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithSLTTokenReturnError_shouldReturnAnError() {
-        let request = MSIDHttpRequest()
         let slt = "signInSLT"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
 
         let expectation = expectation(description: "SignInController")
 
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
 
         let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Invalid Client ID"))
 
         tokenResponseValidatorMock.tokenValidatedResponse = .error(.invalidClient(message: "Invalid Client ID"))
 
-        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt)
-        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt, correlationId: defaultUUID)
+        state.signIn(delegate: mockDelegate)
 
         wait(for: [expectation], timeout: 1)
         XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
@@ -915,8 +839,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Sign In is not available at this point, please use the standalone sign in methods"))
 
-        let state = SignInAfterSignUpState(controller: sut, username: "username", slt: nil)
-        state.signIn(correlationId: defaultUUID, delegate: mockDelegate)
+        let state = SignInAfterSignUpState(controller: sut, username: "username", slt: nil, correlationId: defaultUUID)
+        state.signIn(delegate: mockDelegate)
 
         wait(for: [expectation], timeout: 1)
         XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
@@ -927,23 +851,20 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     // MARK: private methods
 
     private func checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: VerifyCodeErrorType, validatorError: MSALNativeAuthTokenValidatedErrorType) {
-        let request = MSIDHttpRequest()
         let expectedCredentialToken = "credentialToken"
         let expectedOOBCode = "code"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        
         let exp = expectation(description: "SignInController")
         
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: "", password: nil, oobCode: expectedOOBCode, includeChallengeType: true, refreshToken: nil)
         let mockDelegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedError: VerifyCodeError(type: delegateError))
         tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
         
-        let state = SignInCodeRequiredState(scopes: [], controller: sut, flowToken: expectedCredentialToken)
-        state.submitCode(code: expectedOOBCode, correlationId: defaultUUID, delegate: mockDelegate)
+        let state = SignInCodeRequiredState(scopes: [], controller: sut, flowToken: expectedCredentialToken, correlationId: defaultUUID)
+        state.submitCode(code: expectedOOBCode, delegate: mockDelegate)
 
         wait(for: [exp], timeout: 1)
         XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
@@ -952,24 +873,21 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     private func checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError, validatorError: MSALNativeAuthTokenValidatedErrorType) async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedCredentialToken = "credentialToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        
         let exp = expectation(description: "SignInController")
         
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
         let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: publicError)
         tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
 
-        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken)
-        state.submitPassword(password: expectedPassword, correlationId: defaultUUID, delegate: mockDelegate)
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken, correlationId: defaultUUID)
+        state.submitPassword(password: expectedPassword, delegate: mockDelegate)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
@@ -978,16 +896,13 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     private func checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError, validatorError: MSALNativeAuthSignInChallengeValidatedErrorType) async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
 
         let expectation = expectation(description: "SignInController")
 
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
+        signInRequestProviderMock.mockChallengeRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: "credentialToken")
         signInResponseValidatorMock.challengeValidatedResponse = .error(validatorError)
         
@@ -1003,17 +918,14 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     private func checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError, validatorError: MSALNativeAuthSignInInitiateValidatedErrorType) async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
 
         let expectation = expectation(description: "SignInController")
 
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedContext = expectedContext
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInResponseValidatorMock.initiateValidatedResponse = .error(validatorError)
 
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
@@ -1028,27 +940,23 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     private func checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError, validatorError: MSALNativeAuthTokenValidatedErrorType) async {
-        let request = MSIDHttpRequest()
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let credentialToken = "credentialToken"
-        
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
 
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
         
-        signInRequestProviderMock.result = request
+        signInRequestProviderMock.mockInitiateRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
+        signInRequestProviderMock.mockChallengeRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedCredentialToken = credentialToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         let expectation = expectation(description: "SignInController")
 
-        tokenRequestProviderMock.result = request
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
         tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
@@ -94,10 +94,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartPassword_returnsVerificationRequired_it_returnsChallenge() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
 
@@ -113,7 +113,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
     func test_whenSignUpStartPassword_returnsAttributeValidationFailed_it_returnsChallenge() async {
         let invalidAttributes = ["name"]
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
 
@@ -138,7 +138,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
     func test_whenSignUpStartPassword_telemetryUpdateFails_it_updatesTelemetryCorrectly() async {
         let invalidAttributes = ["name"]
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
 
@@ -162,7 +162,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartPassword_returns_redirect_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         validatorMock.mockValidateSignUpStartFunc(.redirect)
 
@@ -184,7 +184,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartPassword_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         let error : MSALNativeAuthSignUpStartValidatedResponse = .error(
             MSALNativeAuthSignUpStartResponseError(error: .passwordTooLong,
@@ -215,7 +215,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartPassword_returns_invalidUsername_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         let invalidUsername : MSALNativeAuthSignUpStartValidatedResponse = .invalidUsername(
             MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
@@ -246,7 +246,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignUpStartPassword_returns_invalidClientId_it_returnsGeneralError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         let invalidClientId : MSALNativeAuthSignUpStartValidatedResponse = .invalidClientId(
             MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
@@ -277,7 +277,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenValidatorInSignUpStartPassword_returns_unexpectedError_it_returnsGeneralError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         validatorMock.mockValidateSignUpStartFunc(.unexpectedError)
 
@@ -301,7 +301,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     // MARK: - SignUpPasswordStart (/challenge request) tests
 
     func test_whenSignUpStartPassword_challenge_cantCreateRequest_it_returns_unexpectedError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
@@ -325,10 +325,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartPassword_challenge_succeeds_it_continuesTheFlow() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
 
@@ -350,10 +350,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartPassword_challenge_returns_passwordRequired_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired(""))
 
@@ -375,10 +375,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartPassword_challenge_returns_redirect_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.redirect)
 
@@ -400,10 +400,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartPassword_challenge_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
             MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
@@ -432,10 +432,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenValidatorInSignUpStartPassword_challenge_returns_unexpectedError_it_returnsGeneralError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
 
@@ -480,10 +480,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartCode_returnsVerificationRequired_it_returnsChallenge() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
 
@@ -499,7 +499,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
     func test_whenSignUpStartCode_returnsAttributeValidationFailed_it_returnsCorrectError() async {
         let invalidAttributes = ["name"]
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
 
@@ -523,7 +523,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
     func test_whenSignUpStartCode_telemetryUpdateFails_it_updatesTelemetryCorrectly() async {
         let invalidAttributes = ["name"]
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         validatorMock.mockValidateSignUpStartFunc(.attributeValidationFailed(invalidAttributes: invalidAttributes))
 
@@ -546,7 +546,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartCode_returns_redirect_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         validatorMock.mockValidateSignUpStartFunc(.redirect)
 
@@ -568,7 +568,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartCode_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         let error : MSALNativeAuthSignUpStartValidatedResponse = .error(
             MSALNativeAuthSignUpStartResponseError(error: .userAlreadyExists,
@@ -599,7 +599,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartCode_returns_invalidUsername_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         let invalidUsername : MSALNativeAuthSignUpStartValidatedResponse = .invalidUsername(
             MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
@@ -630,7 +630,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignUpStartCode_returns_invalidClientId_it_returnsGeneralError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         let invalidClientId : MSALNativeAuthSignUpStartValidatedResponse = .invalidClientId(
             MSALNativeAuthSignUpStartResponseError(error: .invalidRequest,
@@ -661,7 +661,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenValidatorInSignUpStartCode_returns_unexpectedError_it_returnsGeneralError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         validatorMock.mockValidateSignUpStartFunc(.unexpectedError)
 
@@ -685,7 +685,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     // MARK: - SignUpCodeStart (/challenge request) tests
 
     func test_whenSignUpStartCode_challenge_cantCreateRequest_it_returns_unexpectedError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
@@ -709,10 +709,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartCode_challenge_succeeds_it_continuesTheFlow() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken 1", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 1")
         validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
 
@@ -734,10 +734,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartCode_challenge_succeedsPassword_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired(""))
 
@@ -759,10 +759,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartCode_challenge_returns_redirect_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.redirect)
 
@@ -784,10 +784,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpStartCode_challenge_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
             MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
@@ -816,10 +816,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenValidatorInSignUpStartCode_challenge_it_returns_unexpectedError_returnsGeneralError() async {
-        requestProviderMock.mockStartRequestFunc(prepareMockRequest())
+        requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
         validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
 
@@ -863,7 +863,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpResendCode_succeeds_it_continuesTheFlow() async {
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken"))
 
@@ -885,7 +885,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpResendCode_succeedsPassword_it_returnsCorrectError() async {
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
         validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 1"))
 
@@ -906,7 +906,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpResendCode_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
             MSALNativeAuthSignUpChallengeResponseError(error: .invalidRequest,
@@ -933,7 +933,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpResendCode_returns_redirect_it_returnsCorrectError() async {
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.redirect)
 
@@ -954,7 +954,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpResendCode_returns_unexpectedError_it_returnsCorrectError() async {
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
 
@@ -997,7 +997,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSubmitCode_succeeds_it_continuesTheFlow() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         validatorMock.mockValidateSignUpContinueFunc(.success(""))
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
 
@@ -1018,7 +1018,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_invalidUserInput_it_returnsInvalidCode() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         let error : MSALNativeAuthSignUpContinueValidatedResponse = .invalidUserInput(
             MSALNativeAuthSignUpContinueResponseError(error: .invalidOOBValue,
                                                       errorDescription: nil,
@@ -1049,7 +1049,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_attributesRequired_it_returnsAttributesRequired() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken", requiredAttributes: []))
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
 
@@ -1072,7 +1072,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_attributesRequired_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken", requiredAttributes: []))
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
 
@@ -1095,7 +1095,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_attributeValidationFailed_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["name"]))
 
@@ -1116,7 +1116,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         let error : MSALNativeAuthSignUpContinueValidatedResponse = .error(
             MSALNativeAuthSignUpContinueResponseError(error: .invalidRequest,
@@ -1147,7 +1147,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_unexpectedError_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateSignUpContinueFunc(.unexpectedError)
 
@@ -1170,10 +1170,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     // MARK: - SubmitCode + credential_required error tests
 
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
 
@@ -1192,7 +1192,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andCantCreateRequest() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
         requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
@@ -1215,10 +1215,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andSucceeds() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
         validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 3"))
 
@@ -1244,10 +1244,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
         validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 3"))
 
@@ -1273,10 +1273,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andSucceedOOB_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
         validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("", .email, 4, "signUpToken 3"))
 
@@ -1296,10 +1296,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andRedirects() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
         validatorMock.mockValidateSignUpChallengeFunc(.redirect)
 
@@ -1322,10 +1322,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andReturnsError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
         let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
             MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
@@ -1354,10 +1354,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andReturnsUnexpectedError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
-        requestProviderMock.mockChallengeRequestFunc(prepareMockRequest())
+        requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
 
@@ -1401,7 +1401,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSubmitPassword_succeeds_it_continuesTheFlow() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
         validatorMock.mockValidateSignUpContinueFunc(.success("signInSLT"))
 
@@ -1421,7 +1421,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitPassword_returns_invalidUserInput_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
         let error : MSALNativeAuthSignUpContinueValidatedResponse = .invalidUserInput(
             MSALNativeAuthSignUpContinueResponseError(error: .passwordTooWeak,
@@ -1452,7 +1452,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitPassword_returns_attributesRequired_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
         validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
 
@@ -1474,7 +1474,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitPassword_returns_attributesRequired_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
         validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
 
@@ -1496,7 +1496,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitPassword_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
         let error : MSALNativeAuthSignUpContinueValidatedResponse = .error(
             MSALNativeAuthSignUpContinueResponseError(error: .invalidRequest,
@@ -1526,7 +1526,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitPassword_returns_credentialRequired_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
         validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
 
@@ -1546,7 +1546,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitPassword_returns_unexpectedError_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
         validatorMock.mockValidateSignUpContinueFunc(.unexpectedError)
 
@@ -1566,7 +1566,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitPassword_returns_attributeValidationFailed_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
         validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["key"]))
 
@@ -1610,7 +1610,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSubmitAttributes_succeeds_it_continuesTheFlow() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
             grantType: .attributes,
             oobCode: nil,
@@ -1633,7 +1633,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitAttributes_returns_invalidUserInput_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
             grantType: .attributes,
             oobCode: nil,
@@ -1665,7 +1665,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitAttributes_returns_error_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
             grantType: .attributes,
             oobCode: nil,
@@ -1697,7 +1697,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitAttributes_returns_attributesRequired_it_returnsAttributesRequiredError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
             grantType: .attributes,
             oobCode: nil,
@@ -1719,7 +1719,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitAttributes_returns_credentialRequired_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
             grantType: .attributes,
             oobCode: nil,
@@ -1741,7 +1741,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitAttributes_returns_unexpectedError_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
             grantType: .attributes,
             oobCode: nil,
@@ -1763,7 +1763,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenSignUpSubmitAttributes_returns_attributeValidationFailed_it_returnsCorrectError() async {
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(
             grantType: .attributes,
             oobCode: nil,
@@ -1796,7 +1796,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
             func onSignInCompleted(result: MSAL.MSALNativeAuthUserAccountResult) {}
         }
 
-        requestProviderMock.mockContinueRequestFunc(prepareMockRequest())
+        requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
         validatorMock.mockValidateSignUpContinueFunc(.success(slt))
 
@@ -1917,13 +1917,6 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         XCTAssertNil(helper.error)
 
         return helper
-    }
-
-    private func prepareMockRequest() -> MSIDHttpRequest {
-        let request = MSIDHttpRequest()
-        HttpModuleMockConfigurator.configure(request: request, responseJson: [""])
-        
-        return request
     }
 
     private func expectedChallengeParams(token: String = "signUpToken") -> (token: String, context: MSIDRequestContext) {

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
@@ -91,3 +91,37 @@ class MSALNativeAuthControllerFactoryMock: MSALNativeAuthControllerBuildable {
         return credentialsController
     }
 }
+
+class MSALNativeAuthControllerProtocolFactoryMock: MSALNativeAuthControllerBuildable {
+    
+    var signUpController: MSALNativeAuthSignUpControlling!
+    var signInController: MSALNativeAuthSignInControlling!
+    var resetPasswordController: MSALNativeAuthResetPasswordControlling!
+    var credentialsController: MSALNativeAuthCredentialsControlling!
+    
+    init (signUpController: MSALNativeAuthSignUpControlling = MSALNativeAuthSignUpControllerMock(),
+          signInController: MSALNativeAuthSignInControlling = MSALNativeAuthSignInControllerMock(),
+          resetPasswordController: MSALNativeAuthResetPasswordControlling = MSALNativeAuthResetPasswordControllerMock(),
+          credentialsController: MSALNativeAuthCredentialsControlling = MSALNativeAuthCredentialsControllerMock()) {
+        self.signUpController = signUpController
+        self.signInController = signInController
+        self.resetPasswordController = resetPasswordController
+        self.credentialsController = credentialsController
+    }
+    
+    func makeSignUpController() -> MSAL.MSALNativeAuthSignUpControlling {
+        return signUpController
+    }
+    
+    func makeSignInController() -> MSAL.MSALNativeAuthSignInControlling {
+        return signInController
+    }
+    
+    func makeResetPasswordController() -> MSAL.MSALNativeAuthResetPasswordControlling {
+        return resetPasswordController
+    }
+    
+    func makeCredentialsController() -> MSAL.MSALNativeAuthCredentialsControlling {
+        return credentialsController
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthHTTPRequestMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthHTTPRequestMock.swift
@@ -20,36 +20,19 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
-import Foundation
 
 import XCTest
 @testable import MSAL
+@_implementationOnly import MSAL_Private
 
-final class ResetPasswordRequiredStateTests: XCTestCase {
-
-    private var correlationId: UUID = UUID()
-    private var exp: XCTestExpectation!
-    private var controller: MSALNativeAuthResetPasswordControllerSpy!
-    private var sut: ResetPasswordRequiredState!
-
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-
-        exp = expectation(description: "ResetPasswordRequiredState expectation")
-        controller = MSALNativeAuthResetPasswordControllerSpy(expectation: exp)
-        sut = ResetPasswordRequiredState(controller: controller, flowToken: "<token>", correlationId: correlationId)
-    }
-
-    func test_submitPassword_usesControllerSuccessfully() {
-        XCTAssertNil(controller.context)
-        XCTAssertFalse(controller.submitPasswordCalled)
-
-        sut.submitPassword(password: "1234", delegate: ResetPasswordRequiredDelegateSpy())
-
-        wait(for: [exp], timeout: 1)
-        XCTAssertEqual(controller.context?.correlationId(), correlationId)
-        XCTAssertTrue(controller.submitPasswordCalled)
+class MSALNativeAuthHTTPRequestMock {
+    static func prepareMockRequest(request: MSIDHttpRequest = MSIDHttpRequest(), 
+                                   response: HTTPURLResponse? = nil,
+                                   responseJson: [Any?] = [""]) -> MSIDHttpRequest {
+        HttpModuleMockConfigurator.configure(request: request, response: response, responseJson: responseJson)
+        return request
     }
 }
+

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestErrorHandlerTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestErrorHandlerTests.swift
@@ -32,12 +32,10 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
 
     private var sut: MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInInitiateResponseError>!
     private let error = NSError(domain:"Test Error Domain", code:400, userInfo:nil)
-    private var httpRequest: MSIDHttpRequest!
     private let context = MSALNativeAuthRequestContextMock(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
 
     override func setUpWithError() throws {
         sut = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInInitiateResponseError>()
-        httpRequest = MSIDHttpRequest()
         try super.setUpWithError()
     }
 
@@ -73,7 +71,7 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
             httpVersion: nil,
             headerFields: nil
         )
-        HttpModuleMockConfigurator.configure(request: httpRequest, response: httpResponse, responseJson: [])
+        let httpRequest = MSALNativeAuthHTTPRequestMock.prepareMockRequest(response: httpResponse, responseJson: [])
         httpRequest.retryCounter = 5
 
         sut.handleError(
@@ -85,7 +83,7 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
             externalSSOContext: nil,
             context: context
         ) { result, error in
-            XCTAssertEqual(self.httpRequest.retryCounter, 4)
+            XCTAssertEqual(httpRequest.retryCounter, 4)
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)
@@ -101,7 +99,7 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
             headerFields: nil
         )
 
-        HttpModuleMockConfigurator.configure(request: httpRequest, response: httpResponse, responseJson: [])
+        let httpRequest = MSALNativeAuthHTTPRequestMock.prepareMockRequest(response: httpResponse, responseJson: [])
         httpRequest.retryCounter = 0
 
         sut.handleError(
@@ -138,8 +136,7 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
             httpVersion: nil,
             headerFields: [kMSIDWwwAuthenticateHeader: "PKeyAuth Context=TestContext,Version=1.0"]
         )
-
-        HttpModuleMockConfigurator.configure(request: httpRequest, response: httpResponse, responseJson: [])
+        let httpRequest = MSALNativeAuthHTTPRequestMock.prepareMockRequest(response: httpResponse, responseJson: [])
 
         let secondHttpResponse = HTTPURLResponse(
             url: HttpModuleMockConfigurator.baseUrl,
@@ -183,6 +180,8 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
             headerFields: nil
         )
 
+        let httpRequest = MSALNativeAuthHTTPRequestMock.prepareMockRequest()
+        
         var dictionary = [String: Any]()
         dictionary["error"] = "invalid_request"
         dictionary["error_description"] = "Request parameter validation failed"
@@ -225,6 +224,8 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
             headerFields: nil
         )
 
+        let httpRequest = MSALNativeAuthHTTPRequestMock.prepareMockRequest()
+        
         var dictionary = [String: Any]()
         dictionary["error"] = "verification_required"
         dictionary["error_description"] = "AADSTS55102: Verification required."
@@ -266,6 +267,8 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
             httpVersion: nil,
             headerFields: nil
         )
+        
+        let httpRequest = MSALNativeAuthHTTPRequestMock.prepareMockRequest()
 
         let dictionary = [String: Any]()
         let data = try JSONSerialization.data(withJSONObject: dictionary)
@@ -300,6 +303,8 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
             headerFields: nil
         )
 
+        let httpRequest = MSALNativeAuthHTTPRequestMock.prepareMockRequest()
+        
         var dictionary = [String: Any]()
         dictionary["error_key_incorrect"] = "invalid_request"
         let data = try JSONSerialization.data(withJSONObject: dictionary)
@@ -333,6 +338,8 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
             httpVersion: nil,
             headerFields: nil
         )
+        
+        let httpRequest = MSALNativeAuthHTTPRequestMock.prepareMockRequest()
 
         sut.handleError(
             error,

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
@@ -67,7 +67,7 @@ final class MSALNativeAuthRequestableTests: XCTestCase {
         }
         
         let authority = try MSALCIAMAuthority(url: authorityUrl)
-        var config = try MSALNativeAuthConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
+        let config = try MSALNativeAuthConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
                                                       authority: authority,
                                                       challengeTypes: [.redirect])
         

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -26,13 +26,22 @@ import Foundation
 
 import XCTest
 @testable import MSAL
+@_implementationOnly import MSAL_Private
 @_implementationOnly import MSAL_Unit_Test_Private
 
 final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
     private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
     private var sut: MSALNativeAuthPublicClientApplication!
+    private var correlationId: UUID = UUID()
 
+    private let clientId = "clientId"
+    private let authorityURL = URL(string: "https://microsoft.com")
+    
+    private var authority: MSALCIAMAuthority!
+    private var configuration : MSALNativeAuthConfiguration!
+    private var contextMock: MSALNativeAuthRequestContext!
+    
     override func setUp() {
         super.setUp()
 
@@ -41,6 +50,10 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             inputValidator: MSALNativeAuthInputValidator(),
             internalChallengeTypes: []
         )
+        
+        authority = try! MSALCIAMAuthority(url: authorityURL!)
+        configuration = try! MSALNativeAuthConfiguration(clientId: clientId, authority: authority!, challengeTypes: [.oob, .password])
+        contextMock = .init(correlationId: .init(uuidString: correlationId.uuidString)!)
     }
 
     func testInit_whenPassingB2CAuthority_itShouldThrowError() throws {
@@ -79,7 +92,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
 
         let expectedResult: SignUpPasswordStartResult = .codeRequired(
-            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken"),
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -142,7 +155,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
 
         let expectedResult: SignUpStartResult = .codeRequired(
-            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken"),
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -226,7 +239,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         delegate.expectedChannelTargetType = .email
 
         let expectedResult: SignInPasswordStartResult = .codeRequired(
-            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: ""),
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -249,7 +262,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInPasswordStartResult = .codeRequired(
-            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: ""),
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -281,7 +294,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         delegate.expectedChannelTargetType = .email
 
         let expectedResult: SignInStartResult = .codeRequired(
-            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: ""),
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -299,7 +312,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         let delegate = SignInCodeStartDelegateWithPasswordRequiredSpy(expectation: exp1)
 
-        let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, flowToken: "flowToken")
+        let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
         let expectedResult: SignInStartResult = .passwordRequired(newState: expectedState)
 
         controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
@@ -321,7 +334,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignInCodeStartDelegateSpy(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .passwordRequired(
-            newState: SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, flowToken: "")
+            newState: SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, flowToken: "", correlationId: correlationId)
         )
 
         controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
@@ -348,7 +361,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = ResetPasswordStartDelegateSpy(expectation: expectation)
 
         let expectedResult: ResetPasswordStartResult = .codeRequired(
-            newState: .init(controller: controllerFactoryMock.resetPasswordController, flowToken: "flowToken"),
+            newState: .init(controller: controllerFactoryMock.resetPasswordController, flowToken: "flowToken", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -363,5 +376,527 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         XCTAssertEqual(delegate.sentTo, "sentTo")
         XCTAssertEqual(delegate.channelTargetType, .email)
         XCTAssertEqual(delegate.codeLength, 1)
+    }
+    
+    // MARK: - CorrelationId
+        
+    // SignUp Password
+    // Testing SingUpStart -> SingUpChallenge -> SingUpContinue -> SignInToken with Password
+    
+    func testSignUpPassword_correlationId_whenSetOnStart_itCascadesToAll() {
+        let expectationPasswordStart = expectation(description: "Sign Up Password Start")
+        let delegatePasswordStart = SignUpPasswordStartDelegateSpy(expectation: expectationPasswordStart)
+        let expectationVerifyCode = expectation(description: "Sign Up Verify Code")
+        let delegateVerifyCode = SignUpVerifyCodeDelegateSpy(expectation: expectationVerifyCode)
+        let expectationSignInAfterSingUp = expectation(description: "Sign In After Sign Up")
+        let delegateSignInAfterSignUp = SignInAfterSignUpDelegateSpy(expectation: expectationSignInAfterSingUp)
+        
+        let signUpRequestProviderMock = MSALNativeAuthSignUpRequestProviderMock()
+        signUpRequestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedStartRequestParameters = expectedSignUpStartPasswordParams
+        signUpRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedChallengeRequestParameters = expectedSignUpChallengeParams()
+        signUpRequestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedContinueRequestParameters = expectedSignUpContinueParams(token: "signUpToken 2")
+        
+        let signUpResponseValidatorMock = MSALNativeAuthSignUpResponseValidatorMock()
+        signUpResponseValidatorMock.mockValidateSignUpStartFunc((.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""])))
+        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
+        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success("signInSLT"))
+        
+        let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
+        
+        let expectedUsername = "username"
+        let expectedScopes = "scope1 scope2 openid profile offline_access"
+        
+        let tokenResponse = MSIDCIAMTokenResponse()
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+        
+        let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: expectedUsername, credentialToken: nil, signInSLT: "signInSLT", grantType: MSALNativeAuthGrantType.slt, scope: expectedScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedContext = contextMock
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        
+        let tokenResponseValidatorMock = MSALNativeAuthTokenResponseValidatorMock()
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        
+        let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
+        let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
+                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
+                                                                                                 refreshToken: nil,
+                                                                                                 rawIdToken: nil),
+                                                                configuration: MSALNativeAuthConfigStubs.configuration,
+                                                                cacheAccessor: MSALNativeAuthCacheAccessorMock())
+        authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
+        
+        let tokenResult = MSIDTokenResult()
+        tokenResult.rawIdToken = "idToken"
+        let cacheAccessorMock = MSALNativeAuthCacheAccessorMock()
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+        
+        delegateSignInAfterSignUp.expectedUserAccountResult = userAccountResult
+        let signInAfterSignUpController = MSALNativeAuthSignInController(clientId: clientId,
+                                                                         signInRequestProvider: signInRequestProviderMock,
+                                                                         tokenRequestProvider: tokenRequestProviderMock, 
+                                                                         cacheAccessor: cacheAccessorMock,
+                                                                         factory: authResultFactoryMock,
+                                                                         signInResponseValidator: MSALNativeAuthSignInResponseValidatorMock(),
+                                                                         tokenResponseValidator: tokenResponseValidatorMock)
+        let signUpController = MSALNativeAuthSignUpController(config: configuration,
+                                                              requestProvider: signUpRequestProviderMock,
+                                                              responseValidator: signUpResponseValidatorMock,
+                                                              signInController: signInAfterSignUpController)
+        
+        let controllerFactory = MSALNativeAuthControllerProtocolFactoryMock(signUpController: signUpController)
+        
+        sut = MSALNativeAuthPublicClientApplication(
+            controllerFactory: controllerFactory,
+            inputValidator: MSALNativeAuthInputValidator(),
+            internalChallengeTypes: []
+        )
+        
+        // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
+        // MSALNativeAuthSignUpRequestProviderMock class - checkStartParameters and checkChallengeParameters functions
+        sut.signUpUsingPassword(username: "username", password: "password", attributes: ["key": "value"], correlationId: correlationId, delegate: delegatePasswordStart)
+        
+        wait(for: [expectationPasswordStart])
+        
+        // Correlation Id is validated internally against expectedContinueRequestParameters in the
+        // MSALNativeAuthSignUpRequestProviderMock class - checkContinueParameters function
+        delegatePasswordStart.newState?.submitCode(code: "1234", delegate: delegateVerifyCode)
+        
+        wait(for: [expectationVerifyCode])
+        
+        // Correlation Id is validated internally against expectedTokenParams in the
+        // MSALNativeAuthTokenRequestProviderMock class - checkContext function
+        delegateVerifyCode.newSignInAfterSignUpState?.signIn(scopes: ["scope1", "scope2"], delegate: delegateSignInAfterSignUp)
+        
+        wait(for: [expectationSignInAfterSingUp])
+        
+        // User account result is validated internally against expectedUserAccountResult in the
+        // SignInAfterSignUpDelegateSpy class - onSignInCompleted function
+        XCTAssertTrue(delegateSignInAfterSignUp.onSignInCompletedCalled)
+    }
+    
+    // SignUp Code
+    // Testing SingUpStart -> SingUpChallenge -> SingUpContinue -> SignInToken with Code
+    
+    func testSignUpCode_correlationId_whenSetOnStart_itCascadesToAll() {
+        let expectationCodeStart = expectation(description: "Sign Up Code Start")
+        let delegateCodeStart = SignUpCodeStartDelegateSpy(expectation: expectationCodeStart)
+        let expectationVerifyCode = expectation(description: "Sign Up Verify Code")
+        let delegateVerifyCode = SignUpVerifyCodeDelegateSpy(expectation: expectationVerifyCode)
+        let expectationSignInAfterSingUp = expectation(description: "Sign In After Sign Up")
+        let delegateSignInAfterSignUp = SignInAfterSignUpDelegateSpy(expectation: expectationSignInAfterSingUp)
+        
+        let signUpRequestProviderMock = MSALNativeAuthSignUpRequestProviderMock()
+        signUpRequestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedStartRequestParameters = expectedSignUpStartCodeParams
+        signUpRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedChallengeRequestParameters = expectedSignUpChallengeParams()
+        signUpRequestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedContinueRequestParameters = expectedSignUpContinueParams(token: "signUpToken 2")
+        
+        let signUpResponseValidatorMock = MSALNativeAuthSignUpResponseValidatorMock()
+        signUpResponseValidatorMock.mockValidateSignUpStartFunc((.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""])))
+        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
+        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success("signInSLT"))
+        
+        let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
+        
+        let expectedUsername = "username"
+        let expectedScopes = "scope1 scope2 openid profile offline_access"
+        
+        let tokenResponse = MSIDCIAMTokenResponse()
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+        
+        let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: expectedUsername, credentialToken: nil, signInSLT: "signInSLT", grantType: MSALNativeAuthGrantType.slt, scope: expectedScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedContext = contextMock
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        
+        let tokenResponseValidatorMock = MSALNativeAuthTokenResponseValidatorMock()
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        
+        let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
+        let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
+                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
+                                                                                                 refreshToken: nil,
+                                                                                                 rawIdToken: nil),
+                                                                configuration: MSALNativeAuthConfigStubs.configuration,
+                                                                cacheAccessor: MSALNativeAuthCacheAccessorMock())
+        authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
+        
+        let tokenResult = MSIDTokenResult()
+        tokenResult.rawIdToken = "idToken"
+        let cacheAccessorMock = MSALNativeAuthCacheAccessorMock()
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+        
+        delegateSignInAfterSignUp.expectedUserAccountResult = userAccountResult
+        let signInAfterSignUpController = MSALNativeAuthSignInController(clientId: clientId,
+                                                                         signInRequestProvider: signInRequestProviderMock,
+                                                                         tokenRequestProvider: tokenRequestProviderMock,
+                                                                         cacheAccessor: cacheAccessorMock,
+                                                                         factory: authResultFactoryMock,
+                                                                         signInResponseValidator: MSALNativeAuthSignInResponseValidatorMock(),
+                                                                         tokenResponseValidator: tokenResponseValidatorMock)
+        let signUpController = MSALNativeAuthSignUpController(config: configuration,
+                                                              requestProvider: signUpRequestProviderMock,
+                                                              responseValidator: signUpResponseValidatorMock,
+                                                              signInController: signInAfterSignUpController)
+        
+        let controllerFactory = MSALNativeAuthControllerProtocolFactoryMock(signUpController: signUpController)
+        
+        sut = MSALNativeAuthPublicClientApplication(
+            controllerFactory: controllerFactory,
+            inputValidator: MSALNativeAuthInputValidator(),
+            internalChallengeTypes: []
+        )
+        
+        // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
+        // MSALNativeAuthSignUpRequestProviderMock class - checkStartParameters and checkChallengeParameters functions
+        sut.signUp(username: "username", attributes: ["key": "value"], correlationId: correlationId, delegate: delegateCodeStart)
+        
+        wait(for: [expectationCodeStart])
+        
+        // Correlation Id is validated internally against expectedContinueRequestParameters in the
+        // MSALNativeAuthSignUpRequestProviderMock class - checkContinueParameters function
+        delegateCodeStart.newState?.submitCode(code: "1234", delegate: delegateVerifyCode)
+        
+        wait(for: [expectationVerifyCode])
+        
+        // Correlation Id is validated internally against expectedTokenParams in the
+        // MSALNativeAuthTokenRequestProviderMock class - checkContext function
+        delegateVerifyCode.newSignInAfterSignUpState?.signIn(scopes: ["scope1", "scope2"], delegate: delegateSignInAfterSignUp)
+        wait(for: [expectationSignInAfterSingUp])
+        
+        // User account result is validated internally against expectedUserAccountResult in the
+        // SignInAfterSignUpDelegateSpy class - onSignInCompleted function
+        XCTAssertTrue(delegateSignInAfterSignUp.onSignInCompletedCalled)
+    }
+    
+    // SignIn Password
+    // Testing SignInInitiate -> SignInChallenge -> SignInToken with Password
+    
+    func testSignInPassword_correlationId_whenSetOnStart_itCascadesToAll() {
+        let expectationPasswordStart = expectation(description: "Sign In Password Start")
+        let delegatePasswordStart = SignInPasswordStartDelegateSpy(expectation: expectationPasswordStart)
+        let expectationVerifyCode = expectation(description: "Sign In Verify Code")
+        let delegateVerifyCode = SignInVerifyCodeDelegateSpy(expectation: expectationVerifyCode)
+        
+        let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.expectedUsername = "username"
+        
+        signInRequestProviderMock.expectedContext = contextMock
+        let credentialToken = "<credentialToken>"
+        let expectedSentTo = "sentTo"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+        let signInResponseValidatorMock = MSALNativeAuthSignInResponseValidatorMock()
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+        
+        let expectedScopes = "scope1 scope2 openid profile offline_access"
+        
+        let tokenResponse = MSIDCIAMTokenResponse()
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+        
+        let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: expectedScopes, password: nil, oobCode: "1234", includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedContext = contextMock
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        
+        let tokenResponseValidatorMock = MSALNativeAuthTokenResponseValidatorMock()
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        
+        let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
+        let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
+                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
+                                                                                                 refreshToken: nil,
+                                                                                                 rawIdToken: nil),
+                                                                configuration: MSALNativeAuthConfigStubs.configuration,
+                                                                cacheAccessor: MSALNativeAuthCacheAccessorMock())
+        authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
+        
+        let tokenResult = MSIDTokenResult()
+        tokenResult.rawIdToken = "idToken"
+        let cacheAccessorMock = MSALNativeAuthCacheAccessorMock()
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+        
+        delegateVerifyCode.expectedUserAccountResult = userAccountResult
+        let signInController = MSALNativeAuthSignInController(clientId: clientId,
+                                                                         signInRequestProvider: signInRequestProviderMock,
+                                                                         tokenRequestProvider: tokenRequestProviderMock,
+                                                                         cacheAccessor: cacheAccessorMock,
+                                                                         factory: authResultFactoryMock,
+                                                                         signInResponseValidator: signInResponseValidatorMock,
+                                                                         tokenResponseValidator: tokenResponseValidatorMock)
+        let controllerFactory = MSALNativeAuthControllerProtocolFactoryMock(signInController: signInController)
+        
+        sut = MSALNativeAuthPublicClientApplication(
+            controllerFactory: controllerFactory,
+            inputValidator: MSALNativeAuthInputValidator(),
+            internalChallengeTypes: []
+        )
+        
+        // Correlation Id is validated internally against contextMock on both initiate and challenge in the
+        // MSALNativeAuthSignInRequestProviderMock class - checkContext function
+        sut.signInUsingPassword(username: "username", password: "password", scopes: ["scope1", "scope2"], correlationId: correlationId, delegate: delegatePasswordStart)
+        
+        wait(for: [expectationPasswordStart])
+        
+        // Correlation Id is validated internally against expectedTokenParams
+        // MSALNativeAuthTokenRequestProviderMock class - checkContext function
+        delegatePasswordStart.newSignInCodeRequiredState?.submitCode(code: "1234", delegate: delegateVerifyCode)
+        wait(for: [expectationVerifyCode])
+        
+        // User account result is validated internally against expectedUserAccountResult in the
+        // SignInVerifyCodeDelegateSpy class - onSignInCompleted function
+        XCTAssertTrue(delegateVerifyCode.onSignInCompletedCalled)
+    }
+    
+    // SignIn Code
+    // Testing SignInInitiate -> SignInChallenge -> SignInToken with Code
+    
+    func testSignInCode_correlationId_whenSetOnStart_itCascadesToAll() {
+        let expectationCodeStart = expectation(description: "Sign In Code Start")
+        let delegateCodeStart = SignInCodeStartDelegateSpy(expectation: expectationCodeStart)
+        let expectationVerifyCode = expectation(description: "Sign In Verify Code")
+        let delegateVerifyCode = SignInVerifyCodeDelegateSpy(expectation: expectationVerifyCode)
+        
+        let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.expectedUsername = "username"
+        signInRequestProviderMock.expectedContext = contextMock
+        
+        let credentialToken = "<credentialToken>"
+        let expectedSentTo = "sentTo"
+        let expectedChannelTargetType = MSALNativeAuthChannelType.email
+        let expectedCodeLength = 4
+        delegateCodeStart.expectedSentTo = expectedSentTo
+        delegateCodeStart.expectedChannelTargetType = expectedChannelTargetType
+        delegateCodeStart.expectedCodeLength = expectedCodeLength
+        
+        let signInResponseValidatorMock = MSALNativeAuthSignInResponseValidatorMock()
+        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+        
+        let expectedScopes = "scope1 scope2 openid profile offline_access"
+        
+        let tokenResponse = MSIDCIAMTokenResponse()
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+        
+        let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: expectedScopes, password: nil, oobCode: "1234", includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedContext = contextMock
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        
+        let tokenResponseValidatorMock = MSALNativeAuthTokenResponseValidatorMock()
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+        
+        let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
+        let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
+                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
+                                                                                                 refreshToken: nil,
+                                                                                                 rawIdToken: nil),
+                                                                configuration: MSALNativeAuthConfigStubs.configuration,
+                                                                cacheAccessor: MSALNativeAuthCacheAccessorMock())
+        authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
+        
+        let tokenResult = MSIDTokenResult()
+        tokenResult.rawIdToken = "idToken"
+        let cacheAccessorMock = MSALNativeAuthCacheAccessorMock()
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+        
+        delegateVerifyCode.expectedUserAccountResult = userAccountResult
+        let signInController = MSALNativeAuthSignInController(clientId: clientId,
+                                                                         signInRequestProvider: signInRequestProviderMock,
+                                                                         tokenRequestProvider: tokenRequestProviderMock,
+                                                                         cacheAccessor: cacheAccessorMock,
+                                                                         factory: authResultFactoryMock,
+                                                                         signInResponseValidator: signInResponseValidatorMock,
+                                                                         tokenResponseValidator: tokenResponseValidatorMock)
+        let controllerFactory = MSALNativeAuthControllerProtocolFactoryMock(signInController: signInController)
+        
+        sut = MSALNativeAuthPublicClientApplication(
+            controllerFactory: controllerFactory,
+            inputValidator: MSALNativeAuthInputValidator(),
+            internalChallengeTypes: []
+        )
+        
+        // Correlation Id is validated internally against contextMock on both initiate and challenge in the
+        // MSALNativeAuthSignInRequestProviderMock class - checkContext function
+        sut.signIn(username: "username", scopes: ["scope1", "scope2"], correlationId: correlationId, delegate: delegateCodeStart)
+        wait(for: [expectationCodeStart])
+        
+        // Correlation Id is validated internally against expectedTokenParams
+        // MSALNativeAuthTokenRequestProviderMock class - checkContext function
+        delegateCodeStart.newSignInCodeRequiredState?.submitCode(code: "1234", delegate: delegateVerifyCode)
+        wait(for: [expectationVerifyCode])
+        
+        // User account result is validated internally against expectedUserAccountResult in the
+        // SignInVerifyCodeDelegateSpy class - onSignInCompleted function
+        XCTAssertTrue(delegateVerifyCode.onSignInCompletedCalled)
+    }
+    
+    // PasswordReset
+    // Testing PasswordResetStart -> PasswordResetChallenge -> PasswordResetContinue -> PasswordResetComplete -> PasswordResetSubmit -> PollCompletion
+    
+    func testResetPassword_correlationId_whenSetOnStart_itCascadesToAll() {
+        let expectationPasswordResetStart = expectation(description: "Password Reset Start")
+        let delegatePasswordResetStart = ResetPasswordStartDelegateSpy(expectation: expectationPasswordResetStart)
+        let expectationPasswordResetVerifyCode = expectation(description: "Password Reset Verify Code")
+        let delegatePasswordResetVerifyCode = ResetPasswordVerifyCodeDelegateSpy(expectation: expectationPasswordResetVerifyCode)
+        let expectationPasswordResetRequired = expectation(description: "Password Reset Required")
+        let delegatePasswordResetRequired = ResetPasswordRequiredDelegateSpy(expectation: expectationPasswordResetRequired)
+        
+        let resetPasswordRequestProviderMock = MSALNativeAuthResetPasswordRequestProviderMock ()
+        resetPasswordRequestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        resetPasswordRequestProviderMock.expectedStartRequestParameters = expectedResetPasswordStartParams
+        resetPasswordRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        resetPasswordRequestProviderMock.expectedChallengeRequestParameters = expectedResetPasswordChallengeParams(token: "passwordResetToken")
+        resetPasswordRequestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        resetPasswordRequestProviderMock.expectedContinueRequestParameters = expectedResetPasswordContinueParams(token: "passwordResetToken 2")
+        resetPasswordRequestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        resetPasswordRequestProviderMock.expectedSubmitRequestParameters = expectedResetPasswordSubmitParams(token: "passwordSubmitToken")
+        resetPasswordRequestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        resetPasswordRequestProviderMock.expectedPollCompletionParameters = expectedResetPasswordPollCompletionParameters(token: "passwordResetToken 3")
+        
+        let resetPasswordResponseValidator = MSALNativeAuthResetPasswordResponseValidatorMock()
+        resetPasswordResponseValidator.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        resetPasswordResponseValidator.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "passwordResetToken 2"))
+        resetPasswordResponseValidator.mockValidateResetPasswordContinueFunc(.success(passwordSubmitToken: "passwordSubmitToken"))
+        resetPasswordResponseValidator.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken 3", pollInterval: 0))
+        resetPasswordResponseValidator.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded))
+        
+        let resetPasswordController = MSALNativeAuthResetPasswordController(config: configuration,
+                                                                            requestProvider: resetPasswordRequestProviderMock,
+                                                                            responseValidator: resetPasswordResponseValidator)
+        
+        let controllerFactory = MSALNativeAuthControllerProtocolFactoryMock(resetPasswordController: resetPasswordController)
+        
+        sut = MSALNativeAuthPublicClientApplication(
+            controllerFactory: controllerFactory,
+            inputValidator: MSALNativeAuthInputValidator(),
+            internalChallengeTypes: []
+        )
+        
+        // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
+        // MSALNativeAuthResetPasswordRequestProviderMock class - checkParameters(params: MSALNativeAuthResetPasswordStartRequestProviderParameters)
+        // and checkParameters(token: String, context: MSIDRequestContext) functions
+        sut.resetPassword(username: "username", correlationId: correlationId, delegate: delegatePasswordResetStart)
+        
+        wait(for: [expectationPasswordResetStart])
+        
+        // Correlation Id is validated internally against expectedContinueRequestParameters in the
+        // MSALNativeAuthResetPasswordRequestProviderMock class - checkParameters(_ params: MSALNativeAuthResetPasswordContinueRequestParameters) function
+        delegatePasswordResetStart.newState?.submitCode(code: "1234", delegate: delegatePasswordResetVerifyCode)
+        
+        wait(for: [expectationPasswordResetVerifyCode])
+        
+        // Correlation Id is validated internally against expectedSubmitRequestParameters and expectedPollCompletionParameters
+        // MSALNativeAuthResetPasswordRequestProviderMock class - checkParameters(_ params: MSALNativeAuthResetPasswordSubmitRequestParameters) function
+        // and checkParameters(_ params: MSALNativeAuthResetPasswordPollCompletionRequestParameters) function
+        delegatePasswordResetVerifyCode.newPasswordRequiredState?.submitPassword(password: "password", delegate: delegatePasswordResetRequired)
+        
+        wait(for: [expectationPasswordResetRequired])
+        
+        XCTAssertTrue(delegatePasswordResetRequired.onResetPasswordCompletedCalled)
+    }
+    
+    private var expectedSignUpStartPasswordParams: MSALNativeAuthSignUpStartRequestProviderParameters {
+        .init(
+            username: "username",
+            password: "password",
+            attributes: ["key": "value"],
+            context: contextMock
+        )
+    }
+    
+    private var expectedSignUpStartCodeParams: MSALNativeAuthSignUpStartRequestProviderParameters {
+        .init(
+            username: "username",
+            password: nil,
+            attributes: ["key": "value"],
+            context: contextMock
+        )
+    }
+    
+    private func expectedSignUpChallengeParams(token: String = "signUpToken") -> (token: String, context: MSIDRequestContext) {
+        return (token: token, context: contextMock)
+    }
+    
+    private func expectedSignUpContinueParams(
+        grantType: MSALNativeAuthGrantType = .oobCode,
+        token: String = "signUpToken",
+        password: String? = nil,
+        oobCode: String? = "1234",
+        attributes: [String: Any]? = nil
+    ) -> MSALNativeAuthSignUpContinueRequestProviderParams {
+        .init(
+            grantType: grantType,
+            signUpToken: token,
+            password: password,
+            oobCode: oobCode,
+            attributes: attributes,
+            context: contextMock
+        )
+    }
+    
+    private var expectedResetPasswordStartParams: MSALNativeAuthResetPasswordStartRequestProviderParameters {
+        .init(
+            username: "username",
+            context: contextMock
+        )
+    }
+    
+    private func expectedResetPasswordChallengeParams(token: String = "passwordResetToken") -> (token: String, context: MSIDRequestContext) {
+        return (token: token, context: contextMock)
+    }
+    
+    private func expectedResetPasswordContinueParams(
+        grantType: MSALNativeAuthGrantType = .oobCode,
+        token: String = "passwordResetToken",
+        oobCode: String? = "1234"
+    ) -> MSALNativeAuthResetPasswordContinueRequestParameters {
+        .init(
+            context: contextMock,
+            passwordResetToken: token,
+            grantType: grantType,
+            oobCode: oobCode
+        )
+    }
+    
+    private func expectedResetPasswordSubmitParams(
+        token: String = "passwordSubmitToken",
+        password: String = "password"
+    ) -> MSALNativeAuthResetPasswordSubmitRequestParameters {
+        .init(
+            context: contextMock,
+            passwordSubmitToken: token,
+            newPassword: password)
+    }
+
+    private func expectedResetPasswordPollCompletionParameters(
+        token: String = "passwordResetToken"
+    ) -> MSALNativeAuthResetPasswordPollCompletionRequestParameters {
+        .init(
+            context: contextMock,
+            passwordResetToken: token)
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
@@ -30,12 +30,13 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
 
     private var controller: MSALNativeAuthResetPasswordControllerMock!
     private var sut: ResetPasswordCodeRequiredState!
+    private var correlationId: UUID = UUID()
 
     override func setUpWithError() throws {
         try super.setUpWithError()
 
         controller = .init()
-        sut = ResetPasswordCodeRequiredState(controller: controller, flowToken: "<token>")
+        sut = ResetPasswordCodeRequiredState(controller: controller, flowToken: "<token>", correlationId: correlationId)
     }
 
     // MARK: - Delegates
@@ -44,7 +45,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
 
     func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
         let expectedError = ResendCodeError(message: "test error")
-        let expectedState = ResetPasswordCodeRequiredState(controller: controller, flowToken: "flowToken")
+        let expectedState = ResetPasswordCodeRequiredState(controller: controller, flowToken: "flowToken", correlationId: correlationId)
 
         let expectedResult: ResetPasswordResendCodeResult = .error(error: expectedError, newState: expectedState)
         controller.resendCodeResult = .init(expectedResult)
@@ -60,7 +61,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
     }
 
     func test_resendCode_delegate_success_shouldReturnCodeRequired() {
-        let expectedState = ResetPasswordCodeRequiredState(controller: controller, flowToken: "flowToken 2")
+        let expectedState = ResetPasswordCodeRequiredState(controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
 
         let expectedResult: ResetPasswordResendCodeResult = .codeRequired(
             newState: expectedState,
@@ -86,7 +87,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
 
     func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
         let expectedError = VerifyCodeError(type: .invalidCode)
-        let expectedState = ResetPasswordCodeRequiredState(controller: controller, flowToken: "flowToken")
+        let expectedState = ResetPasswordCodeRequiredState(controller: controller, flowToken: "flowToken", correlationId: correlationId)
 
         let expectedResult: ResetPasswordVerifyCodeResult = .error(error: expectedError, newState: expectedState)
         controller.submitCodeResult = .init(expectedResult)
@@ -102,7 +103,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_success_shouldReturnPasswordRequired() {
-        let expectedState = ResetPasswordRequiredState(controller: controller, flowToken: "flowToken 2")
+        let expectedState = ResetPasswordRequiredState(controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
 
         let expectedResult: ResetPasswordVerifyCodeResult = .passwordRequired(newState: expectedState)
         controller.submitCodeResult = .init(expectedResult)

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
@@ -29,12 +29,13 @@ final class SignInCodeRequiredStateTests: XCTestCase {
 
     private var sut: SignInCodeRequiredState!
     private var controller: MSALNativeAuthSignInControllerMock!
+    private var correlationId: UUID = UUID()
 
     override func setUp() {
         super.setUp()
 
         controller = .init()
-        sut = .init(scopes: [], controller: controller, flowToken: "flowToken")
+        sut = .init(scopes: [], controller: controller, flowToken: "flowToken", correlationId: correlationId)
     }
 
     // MARK: - Delegates
@@ -43,7 +44,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
 
     func test_resendCode_delegate_withError_shouldReturnSignInResendCodeError() {
         let expectedError = ResendCodeError(message: "test error")
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2")
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
 
         let expectedResult: SignInResendCodeResult = .error(
             error: expectedError,
@@ -62,7 +63,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
     }
 
     func test_resendCode_delegate_success_shouldReturnSignInResendCodeCodeRequired() {
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2")
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
 
         let expectedResult: SignInResendCodeResult = .codeRequired(
             newState: expectedState,
@@ -84,7 +85,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
 
     func test_submitCode_delegate_withError_shouldReturnSignInVerifyCodeError() {
         let expectedError = VerifyCodeError(type: .invalidCode)
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2")
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
 
         let expectedResult: SignInVerifyCodeResult = .error(
             error: expectedError,

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
@@ -29,19 +29,20 @@ final class SignInPasswordRequiredStateTests: XCTestCase {
 
     private var sut: SignInPasswordRequiredState!
     private var controller: MSALNativeAuthSignInControllerMock!
+    private var correlationId: UUID = UUID()
 
     override func setUp() {
         super.setUp()
 
         controller = .init()
-        sut = .init(scopes: [], username: "username", controller: controller, flowToken: "flowToken")
+        sut = .init(scopes: [], username: "username", controller: controller, flowToken: "flowToken", correlationId: correlationId)
     }
 
     // MARK: - Delegates
 
     func test_submitPassword_delegate_withError_shouldReturnError() {
         let expectedError = PasswordRequiredError(type: .invalidPassword)
-        let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controller, flowToken: "flowToken 2")
+        let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
 
         let expectedResult: SignInPasswordRequiredResult = .error(
             error: expectedError,

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
@@ -31,12 +31,13 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
 
     private var controller: MSALNativeAuthSignUpControllerMock!
     private var sut: SignUpAttributesRequiredState!
+    private var correlationId: UUID = UUID()
 
     override func setUpWithError() throws {
         try super.setUpWithError()
 
         controller = .init()
-        sut = SignUpAttributesRequiredState(controller: controller, username: "<username>", flowToken: "<token>")
+        sut = SignUpAttributesRequiredState(controller: controller, username: "<username>", flowToken: "<token>", correlationId: correlationId)
     }
 
     // MARK: - Delegate
@@ -57,7 +58,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     }
 
     func test_submitPassword_delegate_whenSuccess_shouldReturnCompleted() {
-        let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt")
+        let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: correlationId)
 
         let expectedResult: SignUpAttributesRequiredResult = .completed(expectedState)
         controller.submitAttributesResult = .init(expectedResult)
@@ -72,7 +73,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     }
 
     func test_submitPassword_delegate_whenAttributesRequired_shouldReturnAttributesRequired() {
-        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt")
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt", correlationId: correlationId)
         let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
             .init(name: "anAttribute", type: "aType", required: true)
         ]
@@ -91,7 +92,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     }
 
     func test_submitPassword_delegate_whenAttributesAreInvalud_shouldReturnAttributesInvalid() {
-        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt")
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt", correlationId: correlationId)
         let expectedAttributes = ["anAttribute"]
 
         let expectedResult: SignUpAttributesRequiredResult = .attributesInvalid(attributes: expectedAttributes, newState: expectedState)

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
@@ -30,12 +30,13 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
 
     private var controller: MSALNativeAuthSignUpControllerMock!
     private var sut: SignUpCodeRequiredState!
+    private var correlationId: UUID = UUID()
 
     override func setUpWithError() throws {
         try super.setUpWithError()
 
         controller = .init()
-        sut = SignUpCodeRequiredState(controller: controller, username: "<username>", flowToken: "<token>")
+        sut = SignUpCodeRequiredState(controller: controller, username: "<username>", flowToken: "<token>", correlationId: correlationId)
     }
 
     // MARK: - Delegates
@@ -58,7 +59,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     }
 
     func test_resendCode_delegate_success_shouldReturnCodeRequired() {
-        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpResendCodeResult = .codeRequired(
             newState: expectedState,
@@ -84,7 +85,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
 
     func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
         let expectedError = VerifyCodeError(type: .invalidCode)
-        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpVerifyCodeResult = .error(
             error: expectedError,
@@ -103,7 +104,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_whenPasswordRequired_AndUserHasImplementedOptionalDelegate_shouldReturnPasswordRequired() {
-        let expectedPasswordRequiredState = SignUpPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+        let expectedPasswordRequiredState = SignUpPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
@@ -127,7 +128,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
 
-        let expectedResult: SignUpVerifyCodeResult = .passwordRequired(.init(controller: controller, username: "", flowToken: ""))
+        let expectedResult: SignUpVerifyCodeResult = .passwordRequired(.init(controller: controller, username: "", flowToken: "", correlationId: correlationId))
         controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
             exp2.fulfill()
         })
@@ -142,7 +143,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_whenAttributesRequired_AndUserHasImplementedOptionalDelegate_shouldReturnAttributesRequired() {
-        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
@@ -166,7 +167,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
 
-        let expectedResult: SignUpVerifyCodeResult = .attributesRequired(attributes: [], newState: .init(controller: controller, username: "", flowToken: "")) //.attributesRequired(.init(controller: controller, flowToken: ""))
+        let expectedResult: SignUpVerifyCodeResult = .attributesRequired(attributes: [], newState: .init(controller: controller, username: "", flowToken: "", correlationId: correlationId))
         controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
             exp2.fulfill()
         })
@@ -181,7 +182,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_whenSuccess_shouldReturnAccountResult() {
-        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt")
+        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: correlationId)
 
         let expectedResult: SignUpVerifyCodeResult = .completed(expectedSignInAfterSignUpState)
         controller.submitCodeResult = .init(expectedResult)

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
@@ -31,19 +31,20 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
 
     private var controller: MSALNativeAuthSignUpControllerMock!
     private var sut: SignUpPasswordRequiredState!
+    private var correlationId: UUID = UUID()
 
     override func setUpWithError() throws {
         try super.setUpWithError()
 
         controller = .init()
-        sut = SignUpPasswordRequiredState(controller: controller, username: "<username>", flowToken: "<token>")
+        sut = SignUpPasswordRequiredState(controller: controller, username: "<username>", flowToken: "<token>", correlationId: correlationId)
     }
 
     // MARK: - Delegate
 
     func test_submitPassword_delegate_whenError_shouldReturnPasswordRequiredError() {
         let expectedError = PasswordRequiredError(type: .invalidPassword)
-        let expectedState = SignUpPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+        let expectedState = SignUpPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpPasswordRequiredResult = .error(error: expectedError, newState: expectedState)
         controller.submitPasswordResult = .init(expectedResult)
@@ -59,7 +60,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_whenAttributesRequired_AndUserHasImplementedOptionalDelegate_shouldReturnAttributesRequired() {
-        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
@@ -79,7 +80,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
 
     func test_submitCode_delegate_whenAttributesRequired_ButUserHasNotImplementedOptionalDelegate_shouldReturnPasswordRequiredError() {
         let expectedError = PasswordRequiredError(type: .generalError, message: MSALNativeAuthErrorMessage.delegateNotImplemented)
-        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2")
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
@@ -99,7 +100,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_whenSuccess_shouldReturnSignUpCompleted() {
-        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt")
+        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
 


### PR DESCRIPTION
## Proposed changes

Correlation id was hidden from state machine action methods. External developer should be able to set correlation Id only from the publicClientApplication class.
Correlation id is being passed in the state context, to be consistent along the flow.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
Refactored `SignInDelegateSpies.swift` to match more the `SignUp` and `ResetPassword` Spy implementation.
Added `MSALNativeAuthControllerFactoryRequestProviderMock` which allows us to do end to end testing without network connection by injecting MockRequestProviders and Validators into the Controllers
Added `MSALNativeAuthHTTPRequestMock` to unify the creation of the mock HTTP Request


