### PR TITLE
Make errors extensible

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1113,6 +1113,17 @@
 		E2CD2E8D2A015C54009F8FFA /* MSALNativeAuthSignUpResponseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CD2E8C2A015C54009F8FFA /* MSALNativeAuthSignUpResponseValidator.swift */; };
 		E2CD2EB32A040012009F8FFA /* SignUpTestsValidatorHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CD2EB22A040012009F8FFA /* SignUpTestsValidatorHelpers.swift */; };
 		E2CD2EB52A0404DA009F8FFA /* MSALNativeAuthSignUpControllerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CD2EB42A0404DA009F8FFA /* MSALNativeAuthSignUpControllerSpy.swift */; };
+		E2CE910A2B0BA37D0009AEDD /* SignUpPasswordStartErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE91092B0BA37D0009AEDD /* SignUpPasswordStartErrorTests.swift */; };
+		E2CE910C2B0BA3BB0009AEDD /* SignUpStartErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE910B2B0BA3BB0009AEDD /* SignUpStartErrorTests.swift */; };
+		E2CE910E2B0BA3D30009AEDD /* PasswordRequiredErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE910D2B0BA3D30009AEDD /* PasswordRequiredErrorTests.swift */; };
+		E2CE91102B0BA3E80009AEDD /* AttributesRequiredErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE910F2B0BA3E80009AEDD /* AttributesRequiredErrorTests.swift */; };
+		E2CE91122B0BA3FC0009AEDD /* SignInPasswordStartErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE91112B0BA3FC0009AEDD /* SignInPasswordStartErrorTests.swift */; };
+		E2CE91142B0BA40F0009AEDD /* SignInStartErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE91132B0BA40F0009AEDD /* SignInStartErrorTests.swift */; };
+		E2CE91162B0BA4490009AEDD /* VerifyCodeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE91152B0BA4490009AEDD /* VerifyCodeErrorTests.swift */; };
+		E2CE91182B0BA4620009AEDD /* ResetPasswordStartErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE91172B0BA4620009AEDD /* ResetPasswordStartErrorTests.swift */; };
+		E2CE911A2B0BA4790009AEDD /* ResendCodeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE91192B0BA4790009AEDD /* ResendCodeErrorTests.swift */; };
+		E2CE911C2B0BA48D0009AEDD /* RetrieveAccessTokenErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE911B2B0BA48D0009AEDD /* RetrieveAccessTokenErrorTests.swift */; };
+		E2CE911E2B0BA4A60009AEDD /* SignInAfterSignUpErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CE911D2B0BA4A60009AEDD /* SignInAfterSignUpErrorTests.swift */; };
 		E2D3BC4F2A7BE1C4009C4D1F /* MSALNativeAuthUserAccountResult+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D3BC4E2A7BE1C4009C4D1F /* MSALNativeAuthUserAccountResult+Internal.swift */; };
 		E2DC31BC29AFA1E700051CE7 /* MSALNativeAuthPublicClientApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DC31BB29AFA1E700051CE7 /* MSALNativeAuthPublicClientApplication.swift */; };
 		E2DC31C829B0FDB100051CE7 /* MSALNativeAuthAuthorityProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DC31C729B0FDB100051CE7 /* MSALNativeAuthAuthorityProvider.swift */; };
@@ -2115,6 +2126,17 @@
 		E2CD2E8C2A015C54009F8FFA /* MSALNativeAuthSignUpResponseValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpResponseValidator.swift; sourceTree = "<group>"; };
 		E2CD2EB22A040012009F8FFA /* SignUpTestsValidatorHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpTestsValidatorHelpers.swift; sourceTree = "<group>"; };
 		E2CD2EB42A0404DA009F8FFA /* MSALNativeAuthSignUpControllerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpControllerSpy.swift; sourceTree = "<group>"; };
+		E2CE91092B0BA37D0009AEDD /* SignUpPasswordStartErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpPasswordStartErrorTests.swift; sourceTree = "<group>"; };
+		E2CE910B2B0BA3BB0009AEDD /* SignUpStartErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpStartErrorTests.swift; sourceTree = "<group>"; };
+		E2CE910D2B0BA3D30009AEDD /* PasswordRequiredErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordRequiredErrorTests.swift; sourceTree = "<group>"; };
+		E2CE910F2B0BA3E80009AEDD /* AttributesRequiredErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesRequiredErrorTests.swift; sourceTree = "<group>"; };
+		E2CE91112B0BA3FC0009AEDD /* SignInPasswordStartErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPasswordStartErrorTests.swift; sourceTree = "<group>"; };
+		E2CE91132B0BA40F0009AEDD /* SignInStartErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInStartErrorTests.swift; sourceTree = "<group>"; };
+		E2CE91152B0BA4490009AEDD /* VerifyCodeErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyCodeErrorTests.swift; sourceTree = "<group>"; };
+		E2CE91172B0BA4620009AEDD /* ResetPasswordStartErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordStartErrorTests.swift; sourceTree = "<group>"; };
+		E2CE91192B0BA4790009AEDD /* ResendCodeErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResendCodeErrorTests.swift; sourceTree = "<group>"; };
+		E2CE911B2B0BA48D0009AEDD /* RetrieveAccessTokenErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrieveAccessTokenErrorTests.swift; sourceTree = "<group>"; };
+		E2CE911D2B0BA4A60009AEDD /* SignInAfterSignUpErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAfterSignUpErrorTests.swift; sourceTree = "<group>"; };
 		E2D3BC4E2A7BE1C4009C4D1F /* MSALNativeAuthUserAccountResult+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MSALNativeAuthUserAccountResult+Internal.swift"; sourceTree = "<group>"; };
 		E2DC31BB29AFA1E700051CE7 /* MSALNativeAuthPublicClientApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthPublicClientApplication.swift; sourceTree = "<group>"; };
 		E2DC31C729B0FDB100051CE7 /* MSALNativeAuthAuthorityProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthAuthorityProvider.swift; sourceTree = "<group>"; };
@@ -2351,6 +2373,7 @@
 			isa = PBXGroup;
 			children = (
 				E22427E02B0650670006C55E /* delegate */,
+				E2CE91012B0BA34F0009AEDD /* error */,
 				E2CD2E3F29FBE957009F8FFA /* state_machine */,
 				287F64F22981A00400ED90BD /* MSALNativeAuthPublicClientApplicationTest.swift */,
 				DE87DE692A39E80B0032BF9E /* MSALNativeAuthUserAccountResultTests.swift */,
@@ -4134,6 +4157,24 @@
 			path = delegate_dispatcher;
 			sourceTree = "<group>";
 		};
+		E2CE91012B0BA34F0009AEDD /* error */ = {
+			isa = PBXGroup;
+			children = (
+				E2CE91092B0BA37D0009AEDD /* SignUpPasswordStartErrorTests.swift */,
+				E2CE910B2B0BA3BB0009AEDD /* SignUpStartErrorTests.swift */,
+				E2CE910D2B0BA3D30009AEDD /* PasswordRequiredErrorTests.swift */,
+				E2CE910F2B0BA3E80009AEDD /* AttributesRequiredErrorTests.swift */,
+				E2CE91112B0BA3FC0009AEDD /* SignInPasswordStartErrorTests.swift */,
+				E2CE91132B0BA40F0009AEDD /* SignInStartErrorTests.swift */,
+				E2CE91152B0BA4490009AEDD /* VerifyCodeErrorTests.swift */,
+				E2CE91172B0BA4620009AEDD /* ResetPasswordStartErrorTests.swift */,
+				E2CE91192B0BA4790009AEDD /* ResendCodeErrorTests.swift */,
+				E2CE911B2B0BA48D0009AEDD /* RetrieveAccessTokenErrorTests.swift */,
+				E2CE911D2B0BA4A60009AEDD /* SignInAfterSignUpErrorTests.swift */,
+			);
+			path = error;
+			sourceTree = "<group>";
+		};
 		E2EFAD072A69A2C300D6C3DE /* responses */ = {
 			isa = PBXGroup;
 			children = (
@@ -5878,6 +5919,7 @@
 				DE5738B62A8E790100D9120D /* MSALNativeAuthTokenValidatedErrorTypeTests.swift in Sources */,
 				9BB5180B2A2A2B5B00D6276A /* MSALNativeAuthResetPasswordControllerSpy.swift in Sources */,
 				DE94C9E229F19AA200C1EC1F /* MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift in Sources */,
+				E2CE91102B0BA3E80009AEDD /* AttributesRequiredErrorTests.swift in Sources */,
 				E2F5BE8E29893A4100C67EC7 /* MSALNativeAuthEndpointTests.swift in Sources */,
 				287F64F0298186EA00ED90BD /* MSALNativeAuthInputValidatorTest.swift in Sources */,
 				8D61F9A12A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift in Sources */,
@@ -5887,6 +5929,7 @@
 				287F6524298401AE00ED90BD /* MSALNativeAuthResponseSerializerTests.swift in Sources */,
 				E2CD2E4F29FC0451009F8FFA /* SignUpPasswordRequiredStateTests.swift in Sources */,
 				E22427F62B066E850006C55E /* SignInPasswordRequiredDelegateDispatcherTests.swift in Sources */,
+				E2CE910C2B0BA3BB0009AEDD /* SignUpStartErrorTests.swift in Sources */,
 				E2EBD6212A1BB4640049467A /* MSALNativeAuthSignUpRequestProviderMock.swift in Sources */,
 				E2F4DB242A1F525A009FBCD0 /* MSALNativeAuthSignUpStartOauth2ErrorCodeTests.swift in Sources */,
 				A0274CDD24B54C8800BD198D /* MSALDevicePopManagerUtil.m in Sources */,
@@ -5894,6 +5937,7 @@
 				9B2BBA372A3298080075F702 /* MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCodeTests.swift in Sources */,
 				B2725E7F22BD88BE009B454A /* NSStringAccountIdentifiersTest.m in Sources */,
 				287F64D4297EC29400ED90BD /* MSALNativeAuthTelemetryProviderTests.swift in Sources */,
+				E2CE910A2B0BA37D0009AEDD /* SignUpPasswordStartErrorTests.swift in Sources */,
 				E22952682A1A4FCB00EDD58C /* MSALNativeAuthSignUpResponseValidatorTests.swift in Sources */,
 				E286E2DD2A1BAEA800666DD0 /* MSALNativeAuthSignUpControllerTests.swift in Sources */,
 				B2725EC522BF4865009B454A /* MSALMockExternalAccountHandler.m in Sources */,
@@ -5915,12 +5959,15 @@
 				B253153B23DD717900432133 /* MSALDeviceInfoProviderTests.m in Sources */,
 				9B61C91C2A27E57C00CE9E3A /* MSALNativeAuthResetPasswordResponseValidatorMock.swift in Sources */,
 				DE40A4D32A8F80C100928CEE /* MSALNativeAuthSignUpContinueResponseErrorTests.swift in Sources */,
+				E2CE91162B0BA4490009AEDD /* VerifyCodeErrorTests.swift in Sources */,
 				DE94C9E029F198D600C1EC1F /* MSALNativeAuthResetPasswordStartRequestParametersTest.swift in Sources */,
 				DE14096D2A38DF41008E6F1E /* MSALNativeAuthCredentialsControllerTests.swift in Sources */,
 				DE5738B42A8E74DC00D9120D /* MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift in Sources */,
 				DE87DE6A2A39E80B0032BF9E /* MSALNativeAuthUserAccountResultTests.swift in Sources */,
+				E2CE91182B0BA4620009AEDD /* ResetPasswordStartErrorTests.swift in Sources */,
 				E2BDD98B2A28FBDD00E3ED6B /* MSALNativeAuthErrorRequiredAttributesTests.swift in Sources */,
 				E2CD2E4A29FBEA36009F8FFA /* SignUpCodeSentStateTests.swift in Sources */,
+				E2CE911A2B0BA4790009AEDD /* ResendCodeErrorTests.swift in Sources */,
 				23A68A9320F59E6B0071E435 /* NSString+MSALTestUtil.m in Sources */,
 				E25E6E512AA7725F0094461E /* MSALNativeAuthResetPasswordControllerMock.swift in Sources */,
 				9B61C9132A27E51900CE9E3A /* MSALNativeAuthResetPasswordRequestProviderMock.swift in Sources */,
@@ -5936,6 +5983,7 @@
 				960751BB2183E82C00F2BF2F /* MSALAccountIdTests.m in Sources */,
 				E20C217E2A7A61CC00E31598 /* ResetPasswordDelegateSpies.swift in Sources */,
 				E22427F82B066F750006C55E /* SignInResendCodeDelegateDispatcherTests.swift in Sources */,
+				E2CE911C2B0BA48D0009AEDD /* RetrieveAccessTokenErrorTests.swift in Sources */,
 				E248917A2A1CFA6B001ECBE2 /* MSALNativeAuthConfigStubs.swift in Sources */,
 				E22427E62B065D0D0006C55E /* SignUpStartDelegateDispatcherTests.swift in Sources */,
 				9B2BBA352A3297F80075F702 /* MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift in Sources */,
@@ -5951,6 +5999,7 @@
 				E22427FA2B0670600006C55E /* SignInVerifyCodeDelegateDispatcherTests.swift in Sources */,
 				E2EBD62A2A1BB7700049467A /* MSALNativeAuthSignUpResponseValidatorMock.swift in Sources */,
 				E25BC0852995430B00588549 /* MSALNativeAuthFactoriesMocks.swift in Sources */,
+				E2CE91122B0BA3FC0009AEDD /* SignInPasswordStartErrorTests.swift in Sources */,
 				E2BC029C29D766CB00041DBC /* MSALNativeAuthSignUpContinueRequestParametersTest.swift in Sources */,
 				E2960A112A1F4D2F000F441B /* MSALNativeAuthSignUpChallengeResponseErrorTests.swift in Sources */,
 				DE94C9E629F19D9B00C1EC1F /* MSALNativeAuthResetPasswordSubmitRequestParametersTest.swift in Sources */,
@@ -5962,6 +6011,7 @@
 				E2C1D2D429A3992100B26449 /* MSALNativeAuthBaseControllerTests.swift in Sources */,
 				DE40A4CA2A8F801200928CEE /* MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests.swift in Sources */,
 				E23E956929D5BD6B001DC59C /* MSALNativeAuthSignUpRequestProviderTests.swift in Sources */,
+				E2CE91142B0BA40F0009AEDD /* SignInStartErrorTests.swift in Sources */,
 				DE5738BE2A8F7AC600D9120D /* MSALNativeAuthResetPasswordStartOauth2ErrorCodeTests.swift in Sources */,
 				609AF9332256BD0C00E2978D /* MSALAccountsProviderTests.m in Sources */,
 				E22428052B0674A50006C55E /* SignInAfterSignUpDelegateDispatcherTests.swift in Sources */,
@@ -5977,6 +6027,8 @@
 				E22427F42B066BBC0006C55E /* SignInStartDelegateDispatcherTests.swift in Sources */,
 				DE5738B22A8E71D500D9120D /* MSALNativeAuthResetPasswordContinueResponseErrorTests.swift in Sources */,
 				9B6EECEF2A3146ED008ABA50 /* MSALNativeAuthResetPasswordResponseValidatorTests.swift in Sources */,
+				E2CE911E2B0BA4A60009AEDD /* SignInAfterSignUpErrorTests.swift in Sources */,
+				E2CE910E2B0BA3D30009AEDD /* PasswordRequiredErrorTests.swift in Sources */,
 				28FDC4AE2A38D81100E38BE1 /* MSALNativeAuthSignInControllerMock.swift in Sources */,
 				B281B33B226BC225009619AB /* MSALPublicClientApplicationConfigTests.m in Sources */,
 				E2F5BE9A29896ADB00C67EC7 /* MSALNativeAuthSignInControllerTests.swift in Sources */,

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
@@ -35,6 +35,14 @@ enum MSALNativeAuthErrorMessage {
     static let attributeValidationFailed = "Invalid attributes: %@"
     static let signInNotAvailable = "Sign In is not available at this point, please use the standalone sign in methods"
     static let codeRequiredForPasswordUserLog = "This user does not have a password associated with their account. SDK will call `delegate.onSignInCodeRequired()` and the entered password will be ignored"
+    static let userAlreadyExists = "User already exists"
+    static let invalidPassword = "Invalid password"
+    static let invalidCredentials = "Invalid credentials"
+    static let invalidUsername = "Invalid username"
+    static let generalError = "General error"
+    static let invalidCode = "Invalid code"
+    static let refreshTokenExpired = "Refresh token is expired"
+    static let tokenNotFound = "Token not found"
 }
 
 // swiftlint:enable line_length

--- a/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
@@ -63,7 +63,7 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
         case .userNotFound(let message):
             return SignInPasswordStartError(type: .userNotFound, message: message)
         case .invalidPassword(let message):
-            return SignInPasswordStartError(type: .invalidPassword, message: message)
+            return SignInPasswordStartError(type: .invalidCredentials, message: message)
         case .strongAuthRequired(let message):
             return SignInPasswordStartError(type: .browserRequired, message: message)
         case .expiredRefreshToken(let message):

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -85,7 +85,7 @@ extension MSALNativeAuthPublicClientApplication {
         }
 
         guard inputValidator.isInputValid(password) else {
-            return .init(.error(SignInPasswordStartError(type: .invalidPassword)))
+            return .init(.error(SignInPasswordStartError(type: .invalidCredentials)))
         }
 
         let controller = controllerFactory.makeSignInController()

--- a/MSAL/src/native_auth/public/state_machine/error/MSALNativeAuthError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/MSALNativeAuthError.swift
@@ -24,15 +24,14 @@
 
 import Foundation
 
-@objc
+@objcMembers
 public class MSALNativeAuthError: NSObject, LocalizedError {
+    /// Describes why an error occurred and provides more information about the error.
+    public var errorDescription: String? { message }
+
     private let message: String?
 
     init(message: String? = nil) {
         self.message = message
-    }
-
-    public var errorDescription: String? {
-        message
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/PasswordRequiredError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/PasswordRequiredError.swift
@@ -24,12 +24,17 @@
 
 import Foundation
 
-@objc
+@objcMembers
 public class PasswordRequiredError: MSALNativeAuthError {
-    /// An error type indicating the type of error that occurred
-    @objc public let type: PasswordRequiredErrorType
+    enum ErrorType: CaseIterable {
+        case browserRequired
+        case invalidPassword
+        case generalError
+    }
 
-    init(type: PasswordRequiredErrorType, message: String? = nil) {
+    let type: ErrorType
+
+    init(type: ErrorType, message: String? = nil) {
         self.type = type
         super.init(message: message)
     }
@@ -38,7 +43,7 @@ public class PasswordRequiredError: MSALNativeAuthError {
         switch signInPasswordError.type {
         case .browserRequired:
             self.type = .browserRequired
-        case .invalidPassword:
+        case .invalidCredentials:
             self.type = .invalidPassword
         default:
             self.type = .generalError
@@ -46,6 +51,7 @@ public class PasswordRequiredError: MSALNativeAuthError {
         super.init(message: signInPasswordError.errorDescription)
     }
 
+    /// Describes why an error occurred and provides more information about the error.
     public override var errorDescription: String? {
         if let description = super.errorDescription {
             return description
@@ -53,18 +59,21 @@ public class PasswordRequiredError: MSALNativeAuthError {
 
         switch type {
         case .browserRequired:
-            return "Browser required"
+            return MSALNativeAuthErrorMessage.browserRequired
         case .invalidPassword:
-            return "Invalid password"
+            return MSALNativeAuthErrorMessage.invalidPassword
         case .generalError:
-            return "General error"
+            return MSALNativeAuthErrorMessage.generalError
         }
     }
-}
 
-@objc
-public enum PasswordRequiredErrorType: Int {
-    case browserRequired
-    case generalError
-    case invalidPassword
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
+    }
+
+    /// Returns `true` when the password is not valid.
+    public var isInvalidPassword: Bool {
+        return type == .invalidPassword
+    }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/ResendCodeError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/ResendCodeError.swift
@@ -26,11 +26,12 @@ import Foundation
 
 @objc
 public class ResendCodeError: MSALNativeAuthError {
+    /// Describes why an error occurred and provides more information about the error.
     public override var errorDescription: String? {
         if let description = super.errorDescription {
             return description
         }
 
-        return "General error"
+        return MSALNativeAuthErrorMessage.generalError
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/ResetPasswordStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/ResetPasswordStartError.swift
@@ -24,16 +24,24 @@
 
 import Foundation
 
-@objc
+@objcMembers
 public class ResetPasswordStartError: MSALNativeAuthError {
-    /// An error type indicating the type of error that occurred
-    @objc public let type: ResetPasswordStartErrorType
+    enum ErrorType: CaseIterable {
+        case browserRequired
+        case userDoesNotHavePassword
+        case userNotFound
+        case invalidUsername
+        case generalError
+    }
 
-    init(type: ResetPasswordStartErrorType, message: String? = nil) {
+    let type: ErrorType
+
+    init(type: ErrorType, message: String? = nil) {
         self.type = type
         super.init(message: message)
     }
 
+    /// Describes why an error occurred and provides more information about the error.
     public override var errorDescription: String? {
         if let description = super.errorDescription {
             return description
@@ -41,24 +49,35 @@ public class ResetPasswordStartError: MSALNativeAuthError {
 
         switch type {
         case .browserRequired:
-            return "Browser required"
-        case .generalError:
-            return "General error"
+            return MSALNativeAuthErrorMessage.browserRequired
         case .userDoesNotHavePassword:
-            return "User does not have a password"
+            return MSALNativeAuthErrorMessage.userDoesNotHavePassword
         case .userNotFound:
-            return "User not found"
+            return MSALNativeAuthErrorMessage.userNotFound
         case .invalidUsername:
-            return "Invalid username"
+            return MSALNativeAuthErrorMessage.invalidUsername
+        case .generalError:
+            return MSALNativeAuthErrorMessage.generalError
         }
     }
-}
 
-@objc
-public enum ResetPasswordStartErrorType: Int {
-    case browserRequired
-    case generalError
-    case userDoesNotHavePassword
-    case userNotFound
-    case invalidUsername
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
+    }
+
+    /// Returns `true` if the user does not have a password.
+    public var isUserDoesNotHavePassword: Bool {
+        return type == .userDoesNotHavePassword
+    }
+
+    /// Returns `true` if the user that is trying to reset their password cannot be found.
+    public var isUserNotFound: Bool {
+        return type == .userNotFound
+    }
+
+    /// Returns `true` when the username is not valid.
+    public var isInvalidUsername: Bool {
+        return type == .invalidUsername
+    }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/RetrieveAccessTokenError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/RetrieveAccessTokenError.swift
@@ -24,38 +24,52 @@
 
 import Foundation
 
-@objc
+@objcMembers
 public class RetrieveAccessTokenError: MSALNativeAuthError {
-    /// An error type indicating the type of error that occurred
-    @objc public let type: RetrieveAccessTokenErrorType
+    enum ErrorType: CaseIterable {
+        case browserRequired
+        case refreshTokenExpired
+        case tokenNotFound
+        case generalError
+    }
 
-    init(type: RetrieveAccessTokenErrorType, message: String? = nil) {
+    let type: ErrorType
+
+    init(type: ErrorType, message: String? = nil) {
         self.type = type
         super.init(message: message)
     }
 
+    /// Describes why an error occurred and provides more information about the error.
     public override var errorDescription: String? {
         if let description = super.errorDescription {
             return description
         }
 
         switch type {
-        case .generalError:
-            return "General error"
-        case .refreshTokenExpired:
-            return "Refresh token expired"
-        case .tokenNotFound:
-            return "Token not found"
         case .browserRequired:
-            return "Browser required"
+            return MSALNativeAuthErrorMessage.browserRequired
+        case .refreshTokenExpired:
+            return MSALNativeAuthErrorMessage.refreshTokenExpired
+        case .tokenNotFound:
+            return MSALNativeAuthErrorMessage.tokenNotFound
+        case .generalError:
+            return MSALNativeAuthErrorMessage.generalError
         }
     }
-}
 
-@objc
-public enum RetrieveAccessTokenErrorType: Int {
-    case generalError
-    case refreshTokenExpired
-    case tokenNotFound
-    case browserRequired
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
+    }
+
+    /// Returns `true` if the refresh token has expired.
+    public var isRefreshTokenExpired: Bool {
+        return type == .refreshTokenExpired
+    }
+
+    /// Returns `true` if the existing token cannot be found.
+    public var isTokenNotFound: Bool {
+        return type == .tokenNotFound
+    }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/SignInAfterSignUpError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignInAfterSignUpError.swift
@@ -26,11 +26,12 @@ import Foundation
 
 @objc
 public class SignInAfterSignUpError: MSALNativeAuthError {
+    /// Describes why an error occurred and provides more information about the error.
     public override var errorDescription: String? {
         if let description = super.errorDescription {
             return description
         }
 
-        return "General error"
+        return MSALNativeAuthErrorMessage.generalError
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/SignInPasswordStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignInPasswordStartError.swift
@@ -24,16 +24,24 @@
 
 import Foundation
 
-@objc
+@objcMembers
 public class SignInPasswordStartError: MSALNativeAuthError {
-    /// An error type indicating the type of error that occurred
-    @objc public let type: SignInPasswordStartErrorType
+    enum ErrorType: CaseIterable {
+        case browserRequired
+        case userNotFound
+        case invalidCredentials
+        case invalidUsername
+        case generalError
+    }
 
-    init(type: SignInPasswordStartErrorType, message: String? = nil) {
+    let type: ErrorType
+
+    init(type: ErrorType, message: String? = nil) {
         self.type = type
         super.init(message: message)
     }
 
+    /// Describes why an error occurred and provides more information about the error.
     public override var errorDescription: String? {
         if let description = super.errorDescription {
             return description
@@ -41,24 +49,35 @@ public class SignInPasswordStartError: MSALNativeAuthError {
 
         switch type {
         case .browserRequired:
-            return "Browser required"
+            return MSALNativeAuthErrorMessage.browserRequired
         case .userNotFound:
-            return "User not found"
-        case .invalidPassword:
-            return "Invalid password"
+            return MSALNativeAuthErrorMessage.userNotFound
+        case .invalidCredentials:
+            return MSALNativeAuthErrorMessage.invalidCredentials
         case .invalidUsername:
-            return "Invalid username"
+            return MSALNativeAuthErrorMessage.invalidUsername
         case .generalError:
-            return "General error"
+            return MSALNativeAuthErrorMessage.generalError
         }
     }
-}
 
-@objc
-public enum SignInPasswordStartErrorType: Int {
-    case browserRequired
-    case userNotFound
-    case invalidPassword
-    case invalidUsername
-    case generalError
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
+    }
+
+    /// Returns `true` if the user that is trying to sign in cannot be found.
+    public var isUserNotFound: Bool {
+        return type == .userNotFound
+    }
+
+    /// Returns `true` when the credentials are not valid.
+    public var isInvalidCredentials: Bool {
+        return type == .invalidCredentials
+    }
+
+    /// Returns `true` when the username is not valid.
+    public var isInvalidUsername: Bool {
+        return type == .invalidUsername
+    }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/SignInStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignInStartError.swift
@@ -24,16 +24,23 @@
 
 import Foundation
 
-@objc
+@objcMembers
 public class SignInStartError: MSALNativeAuthError {
-    /// An error type indicating the type of error that occurred
-    @objc public let type: SignInStartErrorType
+    enum ErrorType: CaseIterable {
+        case browserRequired
+        case userNotFound
+        case invalidUsername
+        case generalError
+    }
 
-    init(type: SignInStartErrorType, message: String? = nil) {
+    let type: ErrorType
+
+    init(type: ErrorType, message: String? = nil) {
         self.type = type
         super.init(message: message)
     }
 
+    /// Describes why an error occurred and provides more information about the error.
     public override var errorDescription: String? {
         if let description = super.errorDescription {
             return description
@@ -41,21 +48,28 @@ public class SignInStartError: MSALNativeAuthError {
 
         switch type {
         case .browserRequired:
-            return "Browser required"
+            return MSALNativeAuthErrorMessage.browserRequired
         case .userNotFound:
-            return "User not found"
+            return MSALNativeAuthErrorMessage.userNotFound
         case .invalidUsername:
-            return "Invalid username"
+            return MSALNativeAuthErrorMessage.invalidUsername
         case .generalError:
-            return "General error"
+            return MSALNativeAuthErrorMessage.generalError
         }
     }
-}
 
-@objc
-public enum SignInStartErrorType: Int {
-    case browserRequired
-    case userNotFound
-    case invalidUsername
-    case generalError
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
+    }
+
+    /// Returns `true` if the user that is trying to sign in cannot be found.
+    public var isUserNotFound: Bool {
+        return type == .userNotFound
+    }
+
+    /// Returns `true` when the username is not valid.
+    public var isInvalidUsername: Bool {
+        return type == .invalidUsername
+    }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/SignUpPasswordStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignUpPasswordStartError.swift
@@ -24,16 +24,24 @@
 
 import Foundation
 
-@objc
+@objcMembers
 public class SignUpPasswordStartError: MSALNativeAuthError {
-    /// An error type indicating the type of error that occurred
-    @objc public let type: SignUpPasswordStartErrorType
+    enum ErrorType: CaseIterable {
+        case browserRequired
+        case userAlreadyExists
+        case invalidPassword
+        case invalidUsername
+        case generalError
+    }
 
-    init(type: SignUpPasswordStartErrorType, message: String? = nil) {
+    let type: ErrorType
+
+    init(type: ErrorType, message: String? = nil) {
         self.type = type
         super.init(message: message)
     }
 
+    /// Describes why an error occurred and provides more information about the error.
     public override var errorDescription: String? {
         if let description = super.errorDescription {
             return description
@@ -41,25 +49,35 @@ public class SignUpPasswordStartError: MSALNativeAuthError {
 
         switch type {
         case .browserRequired:
-            return "Browser required"
+            return MSALNativeAuthErrorMessage.browserRequired
         case .userAlreadyExists:
-            return "User already exists"
+            return MSALNativeAuthErrorMessage.userAlreadyExists
         case .invalidPassword:
-            return "Invalid password"
+            return MSALNativeAuthErrorMessage.invalidPassword
         case .invalidUsername:
-            return "Invalid username"
+            return MSALNativeAuthErrorMessage.invalidUsername
         case .generalError:
-            return "General error"
+            return MSALNativeAuthErrorMessage.generalError
         }
     }
 
-}
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
+    }
 
-@objc
-public enum SignUpPasswordStartErrorType: Int {
-    case browserRequired
-    case userAlreadyExists
-    case invalidPassword
-    case invalidUsername
-    case generalError
+    /// Returns `true` when the user is trying to register an existing username.
+    public var isUserAlreadyExists: Bool {
+        return type == .userAlreadyExists
+    }
+
+    /// Returns `true` when the password is not valid.
+    public var isInvalidPassword: Bool {
+        return type == .invalidPassword
+    }
+
+    /// Returns `true` when the username is not valid.
+    public var isInvalidUsername: Bool {
+        return type == .invalidUsername
+    }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/SignUpStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignUpStartError.swift
@@ -24,16 +24,23 @@
 
 import Foundation
 
-@objc
+@objcMembers
 public class SignUpStartError: MSALNativeAuthError {
-    /// An error type indicating the type of error that occurred
-    @objc public let type: SignUpStartErrorType
+    enum ErrorType: CaseIterable {
+        case browserRequired
+        case userAlreadyExists
+        case invalidUsername
+        case generalError
+    }
 
-    init(type: SignUpStartErrorType, message: String? = nil) {
+    let type: ErrorType
+
+    init(type: ErrorType, message: String? = nil) {
         self.type = type
         super.init(message: message)
     }
 
+    /// Describes why an error occurred and provides more information about the error.
     public override var errorDescription: String? {
         if let description = super.errorDescription {
             return description
@@ -41,21 +48,28 @@ public class SignUpStartError: MSALNativeAuthError {
 
         switch type {
         case .browserRequired:
-            return "Browser required"
+            return MSALNativeAuthErrorMessage.browserRequired
         case .userAlreadyExists:
-            return "User already exists"
+            return MSALNativeAuthErrorMessage.userAlreadyExists
         case .invalidUsername:
-            return "Invalid username"
+            return MSALNativeAuthErrorMessage.invalidUsername
         case .generalError:
-            return "General error"
+            return MSALNativeAuthErrorMessage.generalError
         }
     }
-}
 
-@objc
-public enum SignUpStartErrorType: Int {
-    case browserRequired
-    case userAlreadyExists
-    case invalidUsername
-    case generalError
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
+    }
+
+    /// Returns `true` when the user is trying to register an existing username.
+    public var isUserAlreadyExists: Bool {
+        return type == .userAlreadyExists
+    }
+
+    /// Returns `true` when the username is not valid.
+    public var isInvalidUsername: Bool {
+        return type == .invalidUsername
+    }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/VerifyCodeError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/VerifyCodeError.swift
@@ -24,16 +24,22 @@
 
 import Foundation
 
-@objc
+@objcMembers
 public class VerifyCodeError: MSALNativeAuthError {
-    /// An error type indicating the type of error that occurred
-    @objc public let type: VerifyCodeErrorType
+    enum ErrorType: CaseIterable {
+        case browserRequired
+        case invalidCode
+        case generalError
+    }
 
-    init(type: VerifyCodeErrorType, message: String? = nil) {
+    let type: ErrorType
+
+    init(type: ErrorType, message: String? = nil) {
         self.type = type
         super.init(message: message)
     }
 
+    /// Describes why an error occurred and provides more information about the error.
     public override var errorDescription: String? {
         if let description = super.errorDescription {
             return description
@@ -41,18 +47,21 @@ public class VerifyCodeError: MSALNativeAuthError {
 
         switch type {
         case .browserRequired:
-            return "Browser required"
-        case .generalError:
-            return "General error"
+            return MSALNativeAuthErrorMessage.browserRequired
         case .invalidCode:
-            return "Invalid code"
+            return MSALNativeAuthErrorMessage.invalidCode
+        case .generalError:
+            return MSALNativeAuthErrorMessage.generalError
         }
     }
-}
 
-@objc
-public enum VerifyCodeErrorType: Int {
-    case browserRequired
-    case generalError
-    case invalidCode
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
+    }
+
+    /// Returns `true` when the code introduced is not valid.
+    public var isInvalidCode: Bool {
+        return type == .invalidCode
+    }
 }

--- a/MSAL/test/integration/native_auth/common/MSALNativeAuthIntegrationBaseTests.swift
+++ b/MSAL/test/integration/native_auth/common/MSALNativeAuthIntegrationBaseTests.swift
@@ -32,7 +32,7 @@ class MSALNativeAuthIntegrationBaseTests: XCTestCase {
     let mockAPIHandler = MockAPIHandler()
     let correlationId = UUID()
     let config: MSALNativeAuthConfiguration = try! MSALNativeAuthConfiguration(clientId: UUID().uuidString,
-                                                                               authority: MSALCIAMAuthority(url: URL(string: (ProcessInfo.processInfo.environment["mockAPIURL"] ?? "<mock api url not set>") + "/test")!),
+                                                                               authority: MSALCIAMAuthority(url: URL(string: (ProcessInfo.processInfo.environment["authorityURL"] ?? "<mock api url not set>") + "/test")!),
                                                                                challengeTypes: [.password, .oob, .redirect])
     var sut: MSIDHttpRequest!
     

--- a/MSAL/test/integration/native_auth/common/MockAPIHandler.swift
+++ b/MSAL/test/integration/native_auth/common/MockAPIHandler.swift
@@ -26,7 +26,7 @@ import XCTest
 
 class MockAPIHandler {
     
-    private let baseURL = (ProcessInfo.processInfo.environment["mockAPIURL"] ?? "<mock api url not set>") + "/config/"
+    private let baseURL = (ProcessInfo.processInfo.environment["authorityURL"] ?? "<mock api url not set>") + "/config/"
 
     func clearQueues(correlationId: UUID) throws {
         guard let url = URL(string: baseURL + "all") else {

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
@@ -45,7 +45,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         await fulfillment(of: [signInExpectation], timeout: 2)
 
         XCTAssertTrue(signInDelegateSpy.onSignInPasswordErrorCalled)
-        XCTAssertEqual(signInDelegateSpy.error?.type, .userNotFound)
+        XCTAssertTrue(signInDelegateSpy.error!.isUserNotFound)
     }
 
     func test_signInWithKnownUsernameInvalidPasswordResultsInError() async throws {
@@ -67,7 +67,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         await fulfillment(of: [signInExpectation], timeout: 2)
 
         XCTAssertTrue(signInDelegateSpy.onSignInPasswordErrorCalled)
-        XCTAssertEqual(signInDelegateSpy.error?.type, .invalidPassword)
+        XCTAssertTrue(signInDelegateSpy.error!.isInvalidCredentials)
     }
 
     // Hero Scenario 2.2.1. Sign in – Email and Password on SINGLE screen (Email & Password)

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
@@ -43,7 +43,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
         await fulfillment(of: [signInExpectation], timeout: 2)
 
         XCTAssertTrue(signInDelegateSpy.onSignInErrorCalled)
-        XCTAssertEqual(signInDelegateSpy.error?.type, .userNotFound)
+        XCTAssertTrue(signInDelegateSpy.error!.isUserNotFound)
     }
 
     func test_signInWithKnownUsernameResultsInOTPSent() async throws {
@@ -103,7 +103,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
         XCTAssertTrue(signInVerifyCodeDelegateSpy.onSignInVerifyCodeErrorCalled)
         XCTAssertNotNil(signInVerifyCodeDelegateSpy.error)
-        XCTAssertEqual(signInVerifyCodeDelegateSpy.error?.type, .invalidCode)
+        XCTAssertTrue(signInVerifyCodeDelegateSpy.error!.isInvalidCode)
     }
 
     // Hero Scenario 1.2.1. Sign in (Email & Email OTP)
@@ -204,7 +204,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
         await fulfillment(of: [passwordRequiredExpectation], timeout: 2)
 
         XCTAssertTrue(signInPasswordRequiredDelegateSpy.onSignInPasswordRequiredErrorCalled)
-        XCTAssertEqual(signInPasswordRequiredDelegateSpy.error?.type, .invalidPassword)
+        XCTAssertTrue(signInPasswordRequiredDelegateSpy.error!.isInvalidPassword)
     }
 
     // Hero Scenario 2.2.2. Sign in – Email and Password on MULTIPLE screens (Email & Password)

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -267,7 +267,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError, message: "Unsupported challenge type"), validatorError: .unsupportedChallengeType(message: "Unsupported challenge type"))
         await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .generalError, message: "Invalid scope"), validatorError: .invalidScope(message: "Invalid scope"))
         await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .invalidPassword), validatorError: .invalidPassword(message: nil))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInPasswordStartError(type: .invalidCredentials), validatorError: .invalidPassword(message: nil))
     }
     
     func test_whenCredentialsAreRequired_browserRequiredErrorIsReturned() async {
@@ -336,7 +336,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: true)
     }
 
-    func test_whenSignInUsingPassword_apiReturnsChallengeTypeOOB__butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
+    func test_whenSignInUsingPassword_apiReturnsChallengeTypeOOB_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedSentTo = "sentTo"
@@ -455,7 +455,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedContext = expectedContext
-        signInRequestProviderMock.throwingInitError = MSALNativeAuthError()
+        signInRequestProviderMock.throwingInitError = MSALNativeAuthError(message: nil)
 
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
 
@@ -483,7 +483,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError()
+        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError(message: nil)
         signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: "credentialToken")
         
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
@@ -615,7 +615,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let exp = expectation(description: "SignInController")
         
-        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil)
         signInRequestProviderMock.expectedContext = expectedContext
         
         let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
@@ -652,7 +652,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectation = expectation(description: "SignInController")
 
         signInRequestProviderMock.expectedContext = expectedContext
-        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil)
 
         let state = SignInCodeRequiredState(scopes: [], controller: sut, flowToken: credentialToken, correlationId: defaultUUID)
         state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)))
@@ -711,7 +711,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         
         let expectation = expectation(description: "SignInController")
 
-        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError()
+        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError(message: nil)
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
 
@@ -802,7 +802,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let exp = expectation(description: "SignInController")
         
-        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError()
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil)
         signInRequestProviderMock.expectedContext = expectedContext
         
         let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: exp, expectedError: SignInAfterSignUpError())
@@ -852,7 +852,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     
     // MARK: private methods
 
-    private func checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: VerifyCodeErrorType, validatorError: MSALNativeAuthTokenValidatedErrorType) {
+    private func checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: VerifyCodeError.ErrorType, validatorError: MSALNativeAuthTokenValidatedErrorType) {
         let expectedCredentialToken = "credentialToken"
         let expectedOOBCode = "code"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
@@ -70,7 +70,7 @@ final class MSALNativeAuthResetPasswordPollCompletionResponseErrorTests: XCTestC
     
     // MARK: private methods
     
-    private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredErrorType) {
+    private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthResetPasswordPollCompletionResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
         let error = sut.toPasswordRequiredPublicError()
         XCTAssertEqual(error.type, expectedErrorType)

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
@@ -66,7 +66,7 @@ final class MSALNativeAuthResetPasswordSubmitResponseErrorTests: XCTestCase {
     
     // MARK: private methods
     
-    private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredErrorType) {
+    private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthResetPasswordSubmitResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
         let error = sut.toPasswordRequiredPublicError()
         XCTAssertEqual(error.type, expectedErrorType)

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
@@ -104,14 +104,14 @@ final class MSALNativeAuthSignUpChallengeResponseErrorTests: XCTestCase {
         
     // MARK: private methods
     
-    private func testSignUpChallengeErrorToSignUpPasswordStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: SignUpPasswordStartErrorType) {
+    private func testSignUpChallengeErrorToSignUpPasswordStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: SignUpPasswordStartError.ErrorType) {
         sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
         let error = sut.toSignUpPasswordStartPublicError()
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }
     
-    private func testSignUpChallengeErrorToSignUpStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartErrorType) {
+    private func testSignUpChallengeErrorToSignUpStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartError.ErrorType) {
         sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
         let error = sut.toSignUpStartPublicError()
         XCTAssertEqual(error.type, expectedErrorType)
@@ -124,7 +124,7 @@ final class MSALNativeAuthSignUpChallengeResponseErrorTests: XCTestCase {
         XCTAssertEqual(error.errorDescription, description)
     }
     
-    private func testSignUpChallengeErrorToPasswordRequired(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredErrorType) {
+    private func testSignUpChallengeErrorToPasswordRequired(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
         let error = sut.toPasswordRequiredPublicError()
         XCTAssertEqual(error.type, expectedErrorType)

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
@@ -218,14 +218,14 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
     
     // MARK: private methods
     
-    private func testSignUpContinueErrorToVerifyCode(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?, expectedErrorType: VerifyCodeErrorType) {
+    private func testSignUpContinueErrorToVerifyCode(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?, expectedErrorType: VerifyCodeError.ErrorType) {
         sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
         let error = sut.toVerifyCodePublicError()
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }
     
-    private func testSignUpContinueErrorToPasswordRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredErrorType) {
+    private func testSignUpContinueErrorToPasswordRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
         let error = sut.toPasswordRequiredPublicError()
         XCTAssertEqual(error.type, expectedErrorType)

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
@@ -140,14 +140,14 @@ final class MSALNativeAuthSignUpStartResponseErrorTests: XCTestCase {
 
     // MARK: private methods
     
-    private func testSignUpStartErrorToSignUpStartPassword(code: MSALNativeAuthSignUpStartOauth2ErrorCode, description: String?, expectedErrorType: SignUpPasswordStartErrorType) {
+    private func testSignUpStartErrorToSignUpStartPassword(code: MSALNativeAuthSignUpStartOauth2ErrorCode, description: String?, expectedErrorType: SignUpPasswordStartError.ErrorType) {
         sut = MSALNativeAuthSignUpStartResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
         let error = sut.toSignUpStartPasswordPublicError()
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }
     
-    private func testSignUpStartErrorToSignUpStart(code: MSALNativeAuthSignUpStartOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartErrorType) {
+    private func testSignUpStartErrorToSignUpStart(code: MSALNativeAuthSignUpStartOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartError.ErrorType) {
         sut = MSALNativeAuthSignUpStartResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
         let error = sut.toSignUpStartPublicError()
         XCTAssertEqual(error.type, expectedErrorType)

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
@@ -36,7 +36,7 @@ final class MSALNativeAuthSignInInitiateValidatedErrorTypeTests: XCTestCase {
     func test_convertToSignInStartError_redirect() {
         let error = sut.redirect.convertToSignInStartError()
         XCTAssertEqual(error.type, .browserRequired)
-        XCTAssertEqual(error.errorDescription, "Browser required")
+        XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.browserRequired)
     }
     
     func test_convertToSignInStartError_invalidClient() {
@@ -74,7 +74,7 @@ final class MSALNativeAuthSignInInitiateValidatedErrorTypeTests: XCTestCase {
     func test_convertToSignInPasswordStartError_redirect() {
         let error = sut.redirect.convertToSignInPasswordStartError()
         XCTAssertEqual(error.type, .browserRequired)
-        XCTAssertEqual(error.errorDescription, "Browser required")
+        XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.browserRequired)
     }
     
     func test_convertToSignInPasswordStartError_invalidClient() {
@@ -92,7 +92,7 @@ final class MSALNativeAuthSignInInitiateValidatedErrorTypeTests: XCTestCase {
     func test_convertToSignInPasswordStartError_invalidServerResponse() {
         let error = sut.invalidServerResponse.convertToSignInPasswordStartError()
         XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, "General error")
+        XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.generalError)
     }
     
     func test_convertToSignInPasswordStartError_userNotFound() {

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
@@ -77,7 +77,7 @@ final class MSALNativeAuthTokenValidatedErrorTypeTests: XCTestCase {
     
     func test_convertToSignInPasswordStartError_invalidPassword() {
         let error = sut.invalidPassword(message: testDescription).convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .invalidPassword)
+        XCTAssertEqual(error.type, .invalidCredentials)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
     

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -290,7 +290,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     
     func testSignInPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
-        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidPassword))
+        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidCredentials))
         sut.signInUsingPassword(username: "correct", password: "", delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }

--- a/MSAL/test/unit/native_auth/public/error/AttributesRequiredErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/AttributesRequiredErrorTests.swift
@@ -16,22 +16,27 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+import XCTest
+@testable import MSAL
 
-@objc
-public class AttributesRequiredError: MSALNativeAuthError {
-    /// Describes why an error occurred and provides more information about the error.
-    public override var errorDescription: String? {
-        if let description = super.errorDescription {
-            return description
-        }
+final class AttributesRequiredErrorTests: XCTestCase {
 
-        return MSALNativeAuthErrorMessage.generalError
+    private var sut: AttributesRequiredError!
+
+    func test_customErrorDescription() {
+        let expectedMessage = "Custom error message"
+        sut = .init(message: expectedMessage)
+        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    }
+
+    func test_defaultErrorDescription() {
+        sut = .init()
+        XCTAssertEqual(sut.errorDescription, MSALNativeAuthErrorMessage.generalError)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/PasswordRequiredErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/PasswordRequiredErrorTests.swift
@@ -1,0 +1,73 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class PasswordRequiredErrorTests: XCTestCase {
+
+    private var sut: PasswordRequiredError!
+
+    func test_totalCases() {
+        XCTAssertEqual(PasswordRequiredError.ErrorType.allCases.count, 3)
+    }
+
+    func test_customErrorDescription() {
+        let expectedMessage = "Custom error message"
+        sut = .init(type: .generalError, message: expectedMessage)
+        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    }
+
+    func test_defaultErrorDescription() {
+        let sut: [PasswordRequiredError] = [
+            .init(type: .browserRequired),
+            .init(type: .invalidPassword),
+            .init(type: .generalError)
+        ]
+
+        let expectedErrorDescriptions = [
+            MSALNativeAuthErrorMessage.browserRequired,
+            MSALNativeAuthErrorMessage.invalidPassword,
+            MSALNativeAuthErrorMessage.generalError
+        ]
+
+        let errorDescriptions = sut.map { $0.errorDescription }
+        
+        zip(errorDescriptions, expectedErrorDescriptions).forEach {
+            XCTAssertEqual($0, $1)
+        }
+    }
+
+    func test_isBrowserRequired() {
+        sut = .init(type: .browserRequired)
+        XCTAssertTrue(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isInvalidPassword)
+    }
+
+    func test_isInvalidPassword() {
+        sut = .init(type: .invalidPassword)
+        XCTAssertTrue(sut.isInvalidPassword)
+        XCTAssertFalse(sut.isBrowserRequired)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/error/ResendCodeErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/ResendCodeErrorTests.swift
@@ -16,22 +16,27 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+import XCTest
+@testable import MSAL
 
-@objc
-public class AttributesRequiredError: MSALNativeAuthError {
-    /// Describes why an error occurred and provides more information about the error.
-    public override var errorDescription: String? {
-        if let description = super.errorDescription {
-            return description
-        }
+final class ResendCodeErrorTests: XCTestCase {
 
-        return MSALNativeAuthErrorMessage.generalError
+    private var sut: ResendCodeError!
+
+    func test_customErrorDescription() {
+        let expectedMessage = "Custom error message"
+        sut = .init(message: expectedMessage)
+        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    }
+
+    func test_defaultErrorDescription() {
+        sut = .init()
+        XCTAssertEqual(sut.errorDescription, MSALNativeAuthErrorMessage.generalError)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/ResetPasswordStartErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/ResetPasswordStartErrorTests.swift
@@ -1,0 +1,97 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class ResetPasswordStartErrorTests: XCTestCase {
+
+    private var sut: ResetPasswordStartError!
+
+    func test_totalCases() {
+        XCTAssertEqual(ResetPasswordStartError.ErrorType.allCases.count, 5)
+    }
+
+    func test_customErrorDescription() {
+        let expectedMessage = "Custom error message"
+        sut = .init(type: .generalError, message: expectedMessage)
+        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    }
+
+    func test_defaultErrorDescription() {
+        let sut: [ResetPasswordStartError] = [
+            .init(type: .browserRequired),
+            .init(type: .userDoesNotHavePassword),
+            .init(type: .userNotFound),
+            .init(type: .invalidUsername),
+            .init(type: .generalError)
+        ]
+
+        let expectedIdentifiers = [
+            MSALNativeAuthErrorMessage.browserRequired,
+            MSALNativeAuthErrorMessage.userDoesNotHavePassword,
+            MSALNativeAuthErrorMessage.userNotFound,
+            MSALNativeAuthErrorMessage.invalidUsername,
+            MSALNativeAuthErrorMessage.generalError
+        ]
+
+        let errorDescriptions = sut.map { $0.errorDescription }
+
+        zip(errorDescriptions, expectedIdentifiers).forEach {
+            XCTAssertEqual($0, $1)
+        }
+    }
+
+    func test_isBrowserRequired() {
+        sut = .init(type: .browserRequired)
+        XCTAssertTrue(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserDoesNotHavePassword)
+        XCTAssertFalse(sut.isUserNotFound)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isUserDoesNotHaveAPassword() {
+        sut = .init(type: .userDoesNotHavePassword)
+        XCTAssertTrue(sut.isUserDoesNotHavePassword)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserNotFound)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isUserNotFound() {
+        sut = .init(type: .userNotFound)
+        XCTAssertTrue(sut.isUserNotFound)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserDoesNotHavePassword)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isInvalidUsername() {
+        sut = .init(type: .invalidUsername)
+        XCTAssertTrue(sut.isInvalidUsername)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserDoesNotHavePassword)
+        XCTAssertFalse(sut.isUserNotFound)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/error/RetrieveAccessTokenErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/RetrieveAccessTokenErrorTests.swift
@@ -1,0 +1,84 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class RetrieveAccessTokenErrorTests: XCTestCase {
+
+    private var sut: RetrieveAccessTokenError!
+
+    func test_totalCases() {
+        XCTAssertEqual(RetrieveAccessTokenError.ErrorType.allCases.count, 4)
+    }
+
+    func test_customErrorDescription() {
+        let expectedMessage = "Custom error message"
+        sut = .init(type: .generalError, message: expectedMessage)
+        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    }
+
+    func test_defaultErrorDescription() {
+        let sut: [RetrieveAccessTokenError] = [
+            .init(type: .browserRequired),
+            .init(type: .refreshTokenExpired),
+            .init(type: .tokenNotFound),
+            .init(type: .generalError)
+        ]
+
+        let expectedIdentifiers = [
+            MSALNativeAuthErrorMessage.browserRequired,
+            MSALNativeAuthErrorMessage.refreshTokenExpired,
+            MSALNativeAuthErrorMessage.tokenNotFound,
+            MSALNativeAuthErrorMessage.generalError
+        ]
+
+        let errorDescriptions = sut.map { $0.errorDescription }
+
+        zip(errorDescriptions, expectedIdentifiers).forEach {
+            XCTAssertEqual($0, $1)
+        }
+    }
+
+    func test_isBrowserRequired() {
+        sut = .init(type: .browserRequired)
+        XCTAssertTrue(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isRefreshTokenExpired)
+        XCTAssertFalse(sut.isTokenNotFound)
+    }
+
+    func test_isRefreshTokenExpired() {
+        sut = .init(type: .refreshTokenExpired)
+        XCTAssertTrue(sut.isRefreshTokenExpired)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isTokenNotFound)
+    }
+
+    func test_isTokenNotFound() {
+        sut = .init(type: .tokenNotFound)
+        XCTAssertTrue(sut.isTokenNotFound)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isRefreshTokenExpired)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/error/SignInAfterSignUpErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignInAfterSignUpErrorTests.swift
@@ -16,22 +16,27 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+import XCTest
+@testable import MSAL
 
-@objc
-public class AttributesRequiredError: MSALNativeAuthError {
-    /// Describes why an error occurred and provides more information about the error.
-    public override var errorDescription: String? {
-        if let description = super.errorDescription {
-            return description
-        }
+final class SignInAfterSignUpErrorTests: XCTestCase {
 
-        return MSALNativeAuthErrorMessage.generalError
+    private var sut: SignInAfterSignUpError!
+
+    func test_customErrorDescription() {
+        let expectedMessage = "Custom error message"
+        sut = .init(message: expectedMessage)
+        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    }
+
+    func test_defaultErrorDescription() {
+        sut = .init()
+        XCTAssertEqual(sut.errorDescription, MSALNativeAuthErrorMessage.generalError)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/SignInPasswordStartErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignInPasswordStartErrorTests.swift
@@ -1,0 +1,97 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class SignInPasswordStartErrorTests: XCTestCase {
+
+    private var sut: SignInPasswordStartError!
+
+    func test_totalCases() {
+        XCTAssertEqual(SignInPasswordStartError.ErrorType.allCases.count, 5)
+    }
+
+    func test_customErrorDescription() {
+        let expectedMessage = "Custom error message"
+        sut = .init(type: .generalError, message: expectedMessage)
+        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    }
+
+    func test_defaultErrorDescription() {
+        let sut: [SignInPasswordStartError] = [
+            .init(type: .browserRequired),
+            .init(type: .userNotFound),
+            .init(type: .invalidCredentials),
+            .init(type: .invalidUsername),
+            .init(type: .generalError)
+        ]
+
+        let expectedDescriptions = [
+            MSALNativeAuthErrorMessage.browserRequired,
+            MSALNativeAuthErrorMessage.userNotFound,
+            MSALNativeAuthErrorMessage.invalidCredentials,
+            MSALNativeAuthErrorMessage.invalidUsername,
+            MSALNativeAuthErrorMessage.generalError
+        ]
+
+        let errorDescriptions = sut.map { $0.errorDescription }
+
+        zip(errorDescriptions, expectedDescriptions).forEach {
+            XCTAssertEqual($0, $1)
+        }
+    }
+
+    func test_isBrowserRequired() {
+        sut = .init(type: .browserRequired)
+        XCTAssertTrue(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserNotFound)
+        XCTAssertFalse(sut.isInvalidCredentials)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isUserNotFound() {
+        sut = .init(type: .userNotFound)
+        XCTAssertTrue(sut.isUserNotFound)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isInvalidCredentials)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isInvalidPassword() {
+        sut = .init(type: .invalidCredentials)
+        XCTAssertTrue(sut.isInvalidCredentials)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserNotFound)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isInvalidUsername() {
+        sut = .init(type: .invalidUsername)
+        XCTAssertTrue(sut.isInvalidUsername)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserNotFound)
+        XCTAssertFalse(sut.isInvalidCredentials)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/error/SignInStartErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignInStartErrorTests.swift
@@ -1,0 +1,84 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class SignInStartErrorTests: XCTestCase {
+    private var sut: SignInStartError!
+
+    func test_totalCases() {
+        XCTAssertEqual(SignInStartError.ErrorType.allCases.count, 4)
+    }
+
+    func test_customErrorDescription() {
+        let expectedMessage = "Custom error message"
+        sut = .init(type: .generalError, message: expectedMessage)
+        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    }
+
+    func test_defaultErrorDescription() {
+        let sut: [SignInStartError] = [
+            .init(type: .browserRequired),
+            .init(type: .userNotFound),
+            .init(type: .invalidUsername),
+            .init(type: .generalError)
+        ]
+
+        let expectedDescriptions = [
+            MSALNativeAuthErrorMessage.browserRequired,
+            MSALNativeAuthErrorMessage.userNotFound,
+            MSALNativeAuthErrorMessage.invalidUsername,
+            MSALNativeAuthErrorMessage.generalError
+        ]
+
+        let errorDescriptions = sut.map { $0.errorDescription }
+
+        zip(errorDescriptions, expectedDescriptions).forEach {
+            XCTAssertEqual($0, $1)
+        }
+    }
+
+
+    func test_isBrowserRequired() {
+        sut = .init(type: .browserRequired)
+        XCTAssertTrue(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserNotFound)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isUserNotFound() {
+        sut = .init(type: .userNotFound)
+        XCTAssertTrue(sut.isUserNotFound)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isInvalidUsername() {
+        sut = .init(type: .invalidUsername)
+        XCTAssertTrue(sut.isInvalidUsername)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserNotFound)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/error/SignUpPasswordStartErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignUpPasswordStartErrorTests.swift
@@ -1,0 +1,97 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class SignUpPasswordStartErrorTests: XCTestCase {
+
+    private var sut: SignUpPasswordStartError!
+
+    func test_totalCases() {
+        XCTAssertEqual(SignUpPasswordStartError.ErrorType.allCases.count, 5)
+    }
+
+    func test_customErrorDescription() {
+        let expectedMessage = "Custom error message"
+        sut = .init(type: .generalError, message: expectedMessage)
+        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    }
+
+    func test_defaultErrorDescription() {
+        let sut: [SignUpPasswordStartError] = [
+            .init(type: .browserRequired),
+            .init(type: .userAlreadyExists),
+            .init(type: .invalidPassword),
+            .init(type: .invalidUsername),
+            .init(type: .generalError)
+        ]
+
+        let expectedDescriptions = [
+            MSALNativeAuthErrorMessage.browserRequired,
+            MSALNativeAuthErrorMessage.userAlreadyExists,
+            MSALNativeAuthErrorMessage.invalidPassword,
+            MSALNativeAuthErrorMessage.invalidUsername,
+            MSALNativeAuthErrorMessage.generalError
+        ]
+
+        let errorDescriptions = sut.map { $0.errorDescription }
+
+        zip(errorDescriptions, expectedDescriptions).forEach {
+            XCTAssertEqual($0, $1)
+        }
+    }
+
+    func test_isBrowserRequired() {
+        sut = .init(type: .browserRequired)
+        XCTAssertTrue(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserAlreadyExists)
+        XCTAssertFalse(sut.isInvalidPassword)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isUserAlreadyExists() {
+        sut = .init(type: .userAlreadyExists)
+        XCTAssertTrue(sut.isUserAlreadyExists)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isInvalidPassword)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isInvalidPassword() {
+        sut = .init(type: .invalidPassword)
+        XCTAssertTrue(sut.isInvalidPassword)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserAlreadyExists)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isInvalidUsername() {
+        sut = .init(type: .invalidUsername)
+        XCTAssertTrue(sut.isInvalidUsername)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserAlreadyExists)
+        XCTAssertFalse(sut.isInvalidPassword)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/error/SignUpStartErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignUpStartErrorTests.swift
@@ -1,0 +1,84 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class SignUpStartErrorTests: XCTestCase {
+
+    private var sut: SignUpStartError!
+
+    func test_totalCases() {
+        XCTAssertEqual(SignUpStartError.ErrorType.allCases.count, 4)
+    }
+
+    func test_customErrorDescription() {
+        let expectedMessage = "Custom error message"
+        sut = .init(type: .generalError, message: expectedMessage)
+        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    }
+
+    func test_defaultErrorDescription() {
+        let sut: [SignUpPasswordStartError] = [
+            .init(type: .browserRequired),
+            .init(type: .userAlreadyExists),
+            .init(type: .invalidUsername),
+            .init(type: .generalError)
+        ]
+
+        let expectedDescriptions = [
+            MSALNativeAuthErrorMessage.browserRequired,
+            MSALNativeAuthErrorMessage.userAlreadyExists,
+            MSALNativeAuthErrorMessage.invalidUsername,
+            MSALNativeAuthErrorMessage.generalError
+        ]
+
+        let errorDescriptions = sut.map { $0.errorDescription }
+
+        zip(errorDescriptions, expectedDescriptions).forEach {
+            XCTAssertEqual($0, $1)
+        }
+    }
+
+    func test_isBrowserRequired() {
+        sut = .init(type: .browserRequired)
+        XCTAssertTrue(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserAlreadyExists)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isUserAlreadyExists() {
+        sut = .init(type: .userAlreadyExists)
+        XCTAssertTrue(sut.isUserAlreadyExists)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isInvalidUsername)
+    }
+
+    func test_isInvalidUsername() {
+        sut = .init(type: .invalidUsername)
+        XCTAssertTrue(sut.isInvalidUsername)
+        XCTAssertFalse(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isUserAlreadyExists)
+    }
+}

--- a/MSAL/test/unit/native_auth/public/error/VerifyCodeErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/VerifyCodeErrorTests.swift
@@ -1,0 +1,73 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class VerifyCodeErrorTests: XCTestCase {
+
+    private var sut: VerifyCodeError!
+
+    func test_totalCases() {
+        XCTAssertEqual(VerifyCodeError.ErrorType.allCases.count, 3)
+    }
+
+    func test_customErrorDescription() {
+        let expectedMessage = "Custom error message"
+        sut = .init(type: .generalError, message: expectedMessage)
+        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    }
+
+    func test_defaultErrorDescription() {
+        let sut: [VerifyCodeError] = [
+            .init(type: .browserRequired),
+            .init(type: .invalidCode),
+            .init(type: .generalError)
+        ]
+
+        let expectedDescriptions = [
+            MSALNativeAuthErrorMessage.browserRequired,
+            MSALNativeAuthErrorMessage.invalidCode,
+            MSALNativeAuthErrorMessage.generalError
+        ]
+
+        let errorDescriptions = sut.map { $0.errorDescription }
+
+        zip(errorDescriptions, expectedDescriptions).forEach {
+            XCTAssertEqual($0, $1)
+        }
+    }
+
+    func test_isBrowserRequired() {
+        sut = .init(type: .browserRequired)
+        XCTAssertTrue(sut.isBrowserRequired)
+        XCTAssertFalse(sut.isInvalidCode)
+    }
+
+    func test_isInvalidCode() {
+        sut = .init(type: .invalidCode)
+        XCTAssertTrue(sut.isInvalidCode)
+        XCTAssertFalse(sut.isBrowserRequired)
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR makes errors extensible by transforming them from `enum` (that are frozen in Swift) into classes.

Now the developer can do for every error:

- Check for utility variables (they are different for every error, but all of them start with "error.isXXX" (ex: `error.isBrowserRequired`)
- Check for `error.errorDescription`, which returns a `String?`. This is part of the `LocalizedError` protocol that all of our errors conform to.

### Swift developers can:

```swift
func onSignUpError(error: MSAL.SignUpStartError) {

  print(error.errorDescription)

  if error.isBrowserRequired {
    ...
  } else if error.isInvalidUsername {
    ...
  } else {
    ...
  }
}
```
### Objective-C developers can:

```objective-c
- (void)onSignInPasswordErrorWithError:(SignInPasswordStartError * _Nonnull)error {

  NSLog(@"%@", error.errorDescription);

  if (error.isBrowserRequired) {
      ...
  } else if (error.isUserNotFound) {
      ...
  }
}
```
## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [x] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)