### PR TITLE
Don't send empty attribute list in SignUp/start

### DIFF
--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -494,7 +494,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         MSALLogger.log(level: .info, context: context, format: "Finished resetpassword/poll_completion")
 
         switch response {
-        case .success(let status, let slt):
+        case .success(let status, let continuationToken):
             switch status {
             case .inProgress,
                  .notStarted:
@@ -511,7 +511,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 let signInAfterResetPasswordState = SignInAfterResetPasswordState(
                     controller: signInController,
                     username: username,
-                    slt: slt,
+                    slt: continuationToken,
                     correlationId: context.correlationId()
                 )
                 return .init(.completed(signInAfterResetPasswordState), telemetryUpdate: { [weak self] result in
@@ -558,6 +558,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             return .init(.error(error: error, newState: nil))
         }
     }
+    // swiftlint:enable function_body_length
 
     private func retryPollCompletion(
         passwordResetToken: String,

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -405,7 +405,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 newState: SignUpCodeRequiredState(
                     controller: self,
                     username: username,
-                    flowToken: signUpToken, 
+                    flowToken: signUpToken,
                     correlationId: context.correlationId()
                 ),
                 sentTo: sentTo,

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordPollCompletionResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordPollCompletionResponse.swift
@@ -28,6 +28,6 @@ struct MSALNativeAuthResetPasswordPollCompletionResponse: Decodable {
 
     // MARK: - Variables
     let status: MSALNativeAuthResetPasswordPollCompletionStatus
-    let signInSLT: String?
+    let continuationToken: String?
     let expiresIn: Int?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
@@ -34,9 +34,4 @@ struct MSALNativeAuthResetPasswordStartResponse: Decodable {
         case passwordResetToken
         case challengeType
     }
-
-    init(passwordResetToken: String?, challengeType: MSALNativeAuthInternalChallengeType?) {
-        self.passwordResetToken = passwordResetToken
-        self.challengeType = challengeType
-    }
 }

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
@@ -244,9 +244,8 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
     private func handlePollCompletionSuccess(
         _ response: MSALNativeAuthResetPasswordPollCompletionResponse
     ) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
-        // Even if the `signInSLT` is nil, the ResetPassword flow is considered successfully completed
-        // TODO: Update to continuation_token
-        return .success(status: response.status, slt: response.signInSLT)
+        // Even if the `continuationToken` is nil, the ResetPassword flow is considered successfully completed
+        return .success(status: response.status, continuationToken: response.continuationToken)
     }
 
     private func handlePollCompletionError(

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordValidatedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordValidatedResponses.swift
@@ -73,7 +73,7 @@ enum MSALNativeAuthResetPasswordSubmitValidatedResponse: Equatable {
 
 enum MSALNativeAuthResetPasswordPollCompletionValidatedResponse: Equatable {
     // TODO: Update to continuation_token
-    case success(status: MSALNativeAuthResetPasswordPollCompletionStatus, slt: String?)
+    case success(status: MSALNativeAuthResetPasswordPollCompletionStatus, continuationToken: String?)
     case passwordError(error: MSALNativeAuthResetPasswordPollCompletionResponseError)
     case error(MSALNativeAuthResetPasswordPollCompletionResponseError)
     case unexpectedError

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
@@ -42,14 +42,11 @@ final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProv
     }
 
     func start(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) throws -> MSIDHttpRequest {
-        guard let attributes = try formatAttributes(parameters.attributes) else {
-            throw MSALNativeAuthInternalError.invalidAttributes
-        }
-
+        let formattedAttributes = try formatAttributes(parameters.attributes)
         let params = MSALNativeAuthSignUpStartRequestParameters(
             username: parameters.username,
             password: parameters.password,
-            attributes: attributes,
+            attributes: formattedAttributes,
             context: parameters.context
         )
 
@@ -74,14 +71,14 @@ final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProv
     }
 
     func `continue`(parameters: MSALNativeAuthSignUpContinueRequestProviderParams) throws -> MSIDHttpRequest {
-        let attributesFormatted = try parameters.attributes.map { try formatAttributes($0) } ?? nil
+        let formattedAttributes = try formatAttributes(parameters.attributes)
 
         let params = MSALNativeAuthSignUpContinueRequestParameters(
             grantType: parameters.grantType,
             signUpToken: parameters.signUpToken,
             password: parameters.password,
             oobCode: parameters.oobCode,
-            attributes: attributesFormatted,
+            attributes: formattedAttributes,
             context: parameters.context
         )
 
@@ -92,7 +89,10 @@ final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProv
         return request
     }
 
-    private func formatAttributes(_ attributes: [String: Any]) throws -> String? {
+    private func formatAttributes(_ attributes: [String: Any]?) throws -> String? {
+        guard let attributes = attributes else {
+            return nil
+        }
         guard JSONSerialization.isValidJSONObject(attributes) else {
             throw MSALNativeAuthInternalError.invalidAttributes
         }

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
@@ -93,6 +93,9 @@ final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProv
     }
 
     private func formatAttributes(_ attributes: [String: Any]) throws -> String? {
+        guard JSONSerialization.isValidJSONObject(attributes) else {
+            throw MSALNativeAuthInternalError.invalidAttributes
+        }
         let data = try JSONSerialization.data(withJSONObject: attributes)
         return String(data: data, encoding: .utf8)
     }

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpStartRequestProviderParameters.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpStartRequestProviderParameters.swift
@@ -25,6 +25,6 @@
 struct MSALNativeAuthSignUpStartRequestProviderParameters {
     let username: String
     let password: String?
-    let attributes: [String: Any]
+    let attributes: [String: Any]?
     let context: MSALNativeAuthRequestContext
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -45,7 +45,7 @@ extension MSALNativeAuthPublicClientApplication {
         let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
             username: username,
             password: password,
-            attributes: attributes ?? [:],
+            attributes: attributes,
             context: context
         )
 
@@ -67,7 +67,7 @@ extension MSALNativeAuthPublicClientApplication {
         let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
             username: username,
             password: nil,
-            attributes: attributes ?? [:],
+            attributes: attributes,
             context: context
         )
 

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -26,7 +26,7 @@ import Foundation
 
 /// An object of this type is created when a user has reset their password successfully.
 @objcMembers public class SignInAfterResetPasswordState: SignInAfterPreviousFlowBaseState {
-    /// Sign in the user that signed up.
+    /// Sign in the user that just reset the password.
     /// - Parameters:
     ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.

--- a/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordPollCompletionIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordPollCompletionIntegrationTests.swift
@@ -57,7 +57,7 @@ final class MSALNativeAuthResetPasswordPollCompletionIntegrationTests: MSALNativ
         let response: MSALNativeAuthResetPasswordPollCompletionResponse? = try await performTestSucceed()
 
         XCTAssertNotNil(response?.status)
-        XCTAssertNil(response?.signInSLT)
+        XCTAssertNil(response?.continuationToken)
         XCTAssertNil(response?.expiresIn)
     }
 
@@ -71,7 +71,7 @@ final class MSALNativeAuthResetPasswordPollCompletionIntegrationTests: MSALNativ
         let response: MSALNativeAuthResetPasswordPollCompletionResponse? = try await performTestSucceed()
 
         XCTAssertNotNil(response?.status)
-        XCTAssertNil(response?.signInSLT)
+        XCTAssertNil(response?.continuationToken)
         XCTAssertNil(response?.expiresIn)
     }
 
@@ -85,7 +85,7 @@ final class MSALNativeAuthResetPasswordPollCompletionIntegrationTests: MSALNativ
         let response: MSALNativeAuthResetPasswordPollCompletionResponse? = try await performTestSucceed()
 
         XCTAssertNotNil(response?.status)
-        XCTAssertNil(response?.signInSLT)
+        XCTAssertNil(response?.continuationToken)
         XCTAssertNil(response?.expiresIn)
     }
 
@@ -99,7 +99,7 @@ final class MSALNativeAuthResetPasswordPollCompletionIntegrationTests: MSALNativ
         let response: MSALNativeAuthResetPasswordPollCompletionResponse? = try await performTestSucceed()
 
         XCTAssertNotNil(response?.status)
-        XCTAssertNil(response?.signInSLT)
+        XCTAssertNil(response?.continuationToken)
         XCTAssertNil(response?.expiresIn)
     }
 

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
@@ -546,7 +546,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
-        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, slt: nil))
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, continuationToken: nil))
 
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
@@ -747,7 +747,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
 
-        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .notStarted, slt: "<slt>"))
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .notStarted, continuationToken: "<continuationToken>"))
 
         prepareMockRequestsForPollCompletionRetries(5)
 
@@ -770,7 +770,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
-        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .failed, slt: ""))
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .failed, continuationToken: ""))
 
         prepareMockRequestsForPollCompletionRetries(5)
 
@@ -793,7 +793,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
-        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .inProgress, slt: "<slt>"))
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .inProgress, continuationToken: "<continuationToken>"))
 
         prepareMockRequestsForPollCompletionRetries(5)
 
@@ -810,11 +810,11 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         checkTelemetryEventResult(id: .telemetryApiIdResetPasswordSubmit, isSuccessful: false)
     }
 
-    // MARK: - Sign-in with SLT (Short-Lived Token)
+    // MARK: - Sign-in with continuationToken
 
-    func test_whenResetPasswordSucceeds_and_userCallsSignInWithSLT_ResetPasswordControllerPassesCorrectParams() async {
+    func test_whenResetPasswordSucceeds_and_userCallsSignInWithContinuationToken_ResetPasswordControllerPassesCorrectParams() async {
         let username = "username"
-        let slt = "signInSLT"
+        let continuationToken = "continuationToken"
 
         class SignInAfterResetPasswordDelegateStub: SignInAfterResetPasswordDelegate {
             func onSignInAfterResetPasswordError(error: MSAL.SignInAfterResetPasswordError) {}
@@ -834,7 +834,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
-        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, slt: slt))
+        validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, continuationToken: continuationToken))
 
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
@@ -857,7 +857,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         await fulfillment(of: [exp2], timeout: 1)
 
         XCTAssertEqual(signInControllerMock.username, username)
-        XCTAssertEqual(signInControllerMock.slt, slt)
+        XCTAssertEqual(signInControllerMock.slt, continuationToken)
     }
 
     // MARK: - Common Methods

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
@@ -34,12 +34,15 @@ class MSALNativeAuthSignUpControllerMock: MSALNativeAuthSignUpControlling {
     var submitCodeResult: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse!
     var submitPasswordResult: MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse!
     var submitAttributesResult: SignUpSubmitAttributesControllerResponse!
+    var signUpStartRequestParameters: MSALNativeAuthSignUpStartRequestProviderParameters?
 
     func signUpStartPassword(parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters) async -> MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse {
+        signUpStartRequestParameters = parameters
         return startPasswordResult
     }
 
     func signUpStartCode(parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters) async -> MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse {
+        signUpStartRequestParameters = parameters
         return startResult
     }
 

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
@@ -62,7 +62,8 @@ class MSALNativeAuthSignUpRequestProviderMock: MSALNativeAuthSignUpRequestProvid
         XCTAssertEqual(params.username, expectedStartRequestParameters.username)
         XCTAssertEqual(params.password, expectedStartRequestParameters.password)
         XCTAssertEqual(params.context.correlationId(), expectedStartRequestParameters.context.correlationId())
-        XCTAssertEqual(params.attributes["key"] as? String, expectedStartRequestParameters.attributes["key"] as? String)
+        XCTAssertNotNil(params.attributes)
+        XCTAssertEqual(params.attributes?["key"] as? String, expectedStartRequestParameters.attributes?["key"] as? String)
     }
 
     func mockChallengeRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
@@ -58,6 +58,23 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
         checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
     }
     
+    func test_signUpStartRequestWithNoAttributes_is_created_successfully() throws {
+        let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            password: "1234",
+            attributes: nil,
+            context: MSALNativeAuthRequestContext(correlationId: context.correlationId())
+        )
+
+        let request = try sut.start(parameters: parameters)
+
+        checkBodyParams(request.parameters, for: .signUpStart, expectAttributes: false)
+        checkUrlRequest(request.urlRequest!, for: .signUpStart)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpStart).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+    
     func test_signUpStartRequestWithInvalidAttributes_throwAnError() throws {
         let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
             username: DEFAULT_TEST_ID_TOKEN_USERNAME,
@@ -85,13 +102,32 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
             signUpToken: "sign-up-token",
             password: "1234",
             oobCode: nil,
-            attributes: nil,
+            attributes: ["city": "dublin"],
             context: context
         )
 
         let request = try sut.continue(parameters: parameters)
 
         checkBodyParams(request.parameters, for: .signUpContinue)
+        checkUrlRequest(request.urlRequest!, for: .signUpContinue)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpContinue).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+    
+    func test_signUpContinueRequestWithNoAttributes_is_created_successfully() throws {
+        let parameters = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: "sign-up-token",
+            password: "1234",
+            oobCode: nil,
+            attributes: nil,
+            context: context
+        )
+
+        let request = try sut.continue(parameters: parameters)
+
+        checkBodyParams(request.parameters, for: .signUpContinue, expectAttributes: false)
         checkUrlRequest(request.urlRequest!, for: .signUpContinue)
 
         let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpContinue).telemetryString()
@@ -111,7 +147,7 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
         XCTAssertThrowsError(try sut.continue(parameters: parameters))
     }
 
-    private func checkBodyParams(_ bodyParams: [String: String]?, for endpoint: MSALNativeAuthEndpoint) {
+    private func checkBodyParams(_ bodyParams: [String: String]?, for endpoint: MSALNativeAuthEndpoint, expectAttributes: Bool = true) {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         var expectedBodyParams: [String: String]!
@@ -122,9 +158,11 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
                 Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
                 Key.username.rawValue: DEFAULT_TEST_ID_TOKEN_USERNAME,
                 Key.challengeType.rawValue: "redirect",
-                Key.attributes.rawValue: "{\"city\":\"dublin\"}",
                 Key.password.rawValue: "1234"
             ]
+            if expectAttributes {
+                expectedBodyParams[Key.attributes.rawValue] = "{\"city\":\"dublin\"}"
+            }
         case .signUpChallenge:
             expectedBodyParams = [
                 Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
@@ -138,6 +176,9 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
                 Key.signUpToken.rawValue: "sign-up-token",
                 Key.password.rawValue: "1234"
             ]
+            if expectAttributes {
+                expectedBodyParams[Key.attributes.rawValue] = "{\"city\":\"dublin\"}"
+            }
         default:
             XCTFail("Case not tested")
         }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
@@ -57,6 +57,17 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
         let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpStart).telemetryString()
         checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
     }
+    
+    func test_signUpStartRequestWithInvalidAttributes_throwAnError() throws {
+        let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            password: "1234",
+            attributes: ["invalid attribute": Data()],
+            context: MSALNativeAuthRequestContext(correlationId: context.correlationId())
+        )
+        
+        XCTAssertThrowsError(try sut.start(parameters: parameters))
+    }
 
     func test_signUpChallengeRequest_is_created_successfully() throws {
         let request = try sut.challenge(token: "sign-up-token", context: context)
@@ -85,6 +96,19 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
 
         let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpContinue).telemetryString()
         checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+    
+    func test_signUpContinueRequestWithInvalidAttributes_throwAnError() throws {
+        let parameters = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: "sign-up-token",
+            password: "1234",
+            oobCode: nil,
+            attributes: ["invalid attribute": Data()],
+            context: context
+        )
+
+        XCTAssertThrowsError(try sut.continue(parameters: parameters))
     }
 
     private func checkBodyParams(_ bodyParams: [String: String]?, for endpoint: MSALNativeAuthEndpoint) {

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
@@ -422,16 +422,16 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     // MARK: - Poll Completion Response
 
     func test_whenResetPasswordPollCompletionSuccessResponse_itReturnsSuccess() {
-        let response: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = .success(.init(status: .succeeded, signInSLT: "signInSLT", expiresIn: nil))
+        let response: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = .success(.init(status: .succeeded, continuationToken: "continuationToken", expiresIn: nil))
 
         let result = sut.validate(response, with: context)
 
-        guard case .success(let status, let slt) = result else {
+        guard case .success(let status, let continuationToken) = result else {
             return XCTFail("Unexpected response")
         }
 
         XCTAssertEqual(status, .succeeded)
-        XCTAssertEqual(slt, "signInSLT")
+        XCTAssertEqual(continuationToken, "continuationToken")
     }
 
     func test_whenResetPasswordPollCompletionErrorResponseIsPasswordTooWeak_itReturnsExpectedError() {

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -76,6 +76,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
         sut.signUpUsingPassword(username: "", password: "", delegate: delegate)
         wait(for: [exp], timeout: 1)
+        XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
         XCTAssertEqual(delegate.error?.type, .invalidUsername)
     }
 
@@ -84,6 +85,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
         sut.signUpUsingPassword(username: "correct", password: "", delegate: delegate)
         wait(for: [exp], timeout: 1)
+        XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
         XCTAssertEqual(delegate.error?.type, .invalidPassword)
     }
 
@@ -106,6 +108,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         wait(for: [exp1, exp2])
 
+        XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
         XCTAssertEqual(delegate.newState?.flowToken, "flowToken")
         XCTAssertEqual(delegate.sentTo, "sentTo")
         XCTAssertEqual(delegate.channelTargetType, .email)
@@ -131,6 +134,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         wait(for: [exp, exp2])
 
+        XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
         XCTAssertEqual(delegate.error?.type, .generalError)
         XCTAssertEqual(
             delegate.error?.errorDescription,
@@ -185,6 +189,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
         sut.signUp(username: "", delegate: delegate)
         wait(for: [exp], timeout: 1)
+        XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
         XCTAssertEqual(delegate.error?.type, .invalidUsername)
     }
 
@@ -207,6 +212,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         wait(for: [exp, exp2])
 
+        XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
         XCTAssertEqual(delegate.newState?.flowToken, "flowToken")
         XCTAssertEqual(delegate.sentTo, "sentTo")
         XCTAssertEqual(delegate.channelTargetType, .email)
@@ -232,6 +238,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         wait(for: [exp, exp2])
 
+        XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
         XCTAssertEqual(delegate.error?.type, .generalError)
         XCTAssertEqual(
             delegate.error?.errorDescription,

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -937,7 +937,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         resetPasswordResponseValidator.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "passwordResetToken 2"))
         resetPasswordResponseValidator.mockValidateResetPasswordContinueFunc(.success(passwordSubmitToken: "passwordSubmitToken"))
         resetPasswordResponseValidator.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken 3", pollInterval: 0))
-        resetPasswordResponseValidator.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, slt: "slt"))
+        resetPasswordResponseValidator.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, continuationToken: "slt"))
 
         let expectedUsername = "username"
         let expectedScopes = "scope1 scope2 openid profile offline_access"


### PR DESCRIPTION
## Proposed changes

Before this PR we were using an empty attribute list as default value when the user didn't specify any attribute. This resulted in adding an empty list in the signUp/start HTTP call

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
I considered other methods for resolving this problem as well. I could just modify the `MSALNativeAuthSignUpRequestProvider` class and add the attributes field in the HTTP request only when the list was not empty. I didn't think this was the right way to solve the issue, because the RequestProvider class should provide the request based on the input parameters, not based to internal logic. So, I used a nil value instead of empty list as default attributes value in the PublicClientApplication class.
