### PR TITLE
Add co-ownership of MSAL project file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,8 @@
 # Unless a later match takes precedence, these users will be requested
 # for review whenever someone opens a pull request.
 *       @AzureAD/AppleIdentityTeam
+# @AzureAD/AppleIdentityTeam and @AzureAD/MSAL-ObjC-CIAM will be the co-owners of the MSAL.project file
+/MSAL/MSAL.xcodeproj/project.pbxproj @AzureAD/AppleIdentityTeam @AzureAD/MSAL-ObjC-CIAM
 # @AzureAD/MSAL-ObjC-CIAM owns any files in the */native_auth
 # directories and any of its subdirectories.
 /MSAL/src/native_auth/ @AzureAD/MSAL-ObjC-CIAM


### PR DESCRIPTION
## Proposed changes

The proposed change in this PR is to modify the CODEOWNERS file to include co-ownership between the MSAL Apple team and the Native Auth (CIAM) team for the MSAL.project file. This change is being made to ensure that any future PRs that modify the MSAL.project file do not require the review and approval of the MSAL Apple team alone but can also be reviewed and approved by the Native Auth (CIAM) team.
## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

