### PR TITLE
Fix invalid attributes crash

### DIFF
--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
@@ -93,6 +93,9 @@ final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProv
     }
 
     private func formatAttributes(_ attributes: [String: Any]) throws -> String? {
+        guard JSONSerialization.isValidJSONObject(attributes) else {
+            throw MSALNativeAuthInternalError.invalidAttributes
+        }
         let data = try JSONSerialization.data(withJSONObject: attributes)
         return String(data: data, encoding: .utf8)
     }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
@@ -57,6 +57,17 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
         let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpStart).telemetryString()
         checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
     }
+    
+    func test_signUpStartRequestWithInvalidAttributes_throwAnError() throws {
+        let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            password: "1234",
+            attributes: ["invalid attribute": Data()],
+            context: MSALNativeAuthRequestContext(correlationId: context.correlationId())
+        )
+        
+        XCTAssertThrowsError(try sut.start(parameters: parameters))
+    }
 
     func test_signUpChallengeRequest_is_created_successfully() throws {
         let request = try sut.challenge(token: "sign-up-token", context: context)
@@ -85,6 +96,19 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
 
         let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpContinue).telemetryString()
         checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+    
+    func test_signUpContinueRequestWithInvalidAttributes_throwAnError() throws {
+        let parameters = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: "sign-up-token",
+            password: "1234",
+            oobCode: nil,
+            attributes: ["invalid attribute": Data()],
+            context: context
+        )
+
+        XCTAssertThrowsError(try sut.continue(parameters: parameters))
     }
 
     private func checkBodyParams(_ bodyParams: [String: String]?, for endpoint: MSALNativeAuthEndpoint) {


### PR DESCRIPTION
## Proposed changes

This PR contains the changes to handle the parsing of invalid attributes in a gracefully way. Before this change our code thown a "NSInvalidArgumentException" that was not caught in swift and resulted in crash of the mobile application.

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information


Before to call the JSONDecorer.data function, we know check if the object to decode is a valid JSON.
