### PR TITLE
Don't send empty attribute list in SignUp/start

### DIFF
--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
@@ -42,14 +42,11 @@ final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProv
     }
 
     func start(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) throws -> MSIDHttpRequest {
-        guard let attributes = try formatAttributes(parameters.attributes) else {
-            throw MSALNativeAuthInternalError.invalidAttributes
-        }
-
+        let formattedAttributes = try formatAttributes(parameters.attributes)
         let params = MSALNativeAuthSignUpStartRequestParameters(
             username: parameters.username,
             password: parameters.password,
-            attributes: attributes,
+            attributes: formattedAttributes,
             context: parameters.context
         )
 
@@ -74,14 +71,14 @@ final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProv
     }
 
     func `continue`(parameters: MSALNativeAuthSignUpContinueRequestProviderParams) throws -> MSIDHttpRequest {
-        let attributesFormatted = try parameters.attributes.map { try formatAttributes($0) } ?? nil
+        let formattedAttributes = try formatAttributes(parameters.attributes)
 
         let params = MSALNativeAuthSignUpContinueRequestParameters(
             grantType: parameters.grantType,
             signUpToken: parameters.signUpToken,
             password: parameters.password,
             oobCode: parameters.oobCode,
-            attributes: attributesFormatted,
+            attributes: formattedAttributes,
             context: parameters.context
         )
 
@@ -92,7 +89,10 @@ final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProv
         return request
     }
 
-    private func formatAttributes(_ attributes: [String: Any]) throws -> String? {
+    private func formatAttributes(_ attributes: [String: Any]?) throws -> String? {
+        guard let attributes = attributes else {
+            return nil
+        }
         guard JSONSerialization.isValidJSONObject(attributes) else {
             throw MSALNativeAuthInternalError.invalidAttributes
         }

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpStartRequestProviderParameters.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpStartRequestProviderParameters.swift
@@ -25,6 +25,6 @@
 struct MSALNativeAuthSignUpStartRequestProviderParameters {
     let username: String
     let password: String?
-    let attributes: [String: Any]
+    let attributes: [String: Any]?
     let context: MSALNativeAuthRequestContext
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -45,7 +45,7 @@ extension MSALNativeAuthPublicClientApplication {
         let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
             username: username,
             password: password,
-            attributes: attributes ?? [:],
+            attributes: attributes,
             context: context
         )
 
@@ -67,7 +67,7 @@ extension MSALNativeAuthPublicClientApplication {
         let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
             username: username,
             password: nil,
-            attributes: attributes ?? [:],
+            attributes: attributes,
             context: context
         )
 

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
@@ -34,12 +34,15 @@ class MSALNativeAuthSignUpControllerMock: MSALNativeAuthSignUpControlling {
     var submitCodeResult: MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse!
     var submitPasswordResult: MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse!
     var submitAttributesResult: SignUpAttributesRequiredResult!
+    var signUpStartRequestParameters: MSALNativeAuthSignUpStartRequestProviderParameters?
 
     func signUpStartPassword(parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters) async -> MSALNativeAuthSignUpControlling.SignUpStartPasswordControllerResponse {
+        signUpStartRequestParameters = parameters
         return startPasswordResult
     }
 
     func signUpStartCode(parameters: MSAL.MSALNativeAuthSignUpStartRequestProviderParameters) async -> MSALNativeAuthSignUpControlling.SignUpStartCodeControllerResponse {
+        signUpStartRequestParameters = parameters
         return startResult
     }
 

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
@@ -62,7 +62,8 @@ class MSALNativeAuthSignUpRequestProviderMock: MSALNativeAuthSignUpRequestProvid
         XCTAssertEqual(params.username, expectedStartRequestParameters.username)
         XCTAssertEqual(params.password, expectedStartRequestParameters.password)
         XCTAssertEqual(params.context.correlationId(), expectedStartRequestParameters.context.correlationId())
-        XCTAssertEqual(params.attributes["key"] as? String, expectedStartRequestParameters.attributes["key"] as? String)
+        XCTAssertNotNil(params.attributes)
+        XCTAssertEqual(params.attributes?["key"] as? String, expectedStartRequestParameters.attributes?["key"] as? String)
     }
 
     func mockChallengeRequestFunc(_ request: MSIDHttpRequest?, throwError: Bool = false) {

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
@@ -58,6 +58,23 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
         checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
     }
     
+    func test_signUpStartRequestWithNoAttributes_is_created_successfully() throws {
+        let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            password: "1234",
+            attributes: nil,
+            context: MSALNativeAuthRequestContext(correlationId: context.correlationId())
+        )
+
+        let request = try sut.start(parameters: parameters)
+
+        checkBodyParams(request.parameters, for: .signUpStart, expectAttributes: false)
+        checkUrlRequest(request.urlRequest!, for: .signUpStart)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpStart).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+    
     func test_signUpStartRequestWithInvalidAttributes_throwAnError() throws {
         let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
             username: DEFAULT_TEST_ID_TOKEN_USERNAME,
@@ -85,13 +102,32 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
             signUpToken: "sign-up-token",
             password: "1234",
             oobCode: nil,
-            attributes: nil,
+            attributes: ["city": "dublin"],
             context: context
         )
 
         let request = try sut.continue(parameters: parameters)
 
         checkBodyParams(request.parameters, for: .signUpContinue)
+        checkUrlRequest(request.urlRequest!, for: .signUpContinue)
+
+        let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpContinue).telemetryString()
+        checkServerTelemetry(request.serverTelemetry, expectedTelemetryResult: expectedTelemetryResult)
+    }
+    
+    func test_signUpContinueRequestWithNoAttributes_is_created_successfully() throws {
+        let parameters = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .password,
+            signUpToken: "sign-up-token",
+            password: "1234",
+            oobCode: nil,
+            attributes: nil,
+            context: context
+        )
+
+        let request = try sut.continue(parameters: parameters)
+
+        checkBodyParams(request.parameters, for: .signUpContinue, expectAttributes: false)
         checkUrlRequest(request.urlRequest!, for: .signUpContinue)
 
         let expectedTelemetryResult = telemetryProvider.telemetryForSignUp(type: .signUpContinue).telemetryString()
@@ -111,7 +147,7 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
         XCTAssertThrowsError(try sut.continue(parameters: parameters))
     }
 
-    private func checkBodyParams(_ bodyParams: [String: String]?, for endpoint: MSALNativeAuthEndpoint) {
+    private func checkBodyParams(_ bodyParams: [String: String]?, for endpoint: MSALNativeAuthEndpoint, expectAttributes: Bool = true) {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         var expectedBodyParams: [String: String]!
@@ -122,9 +158,11 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
                 Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
                 Key.username.rawValue: DEFAULT_TEST_ID_TOKEN_USERNAME,
                 Key.challengeType.rawValue: "redirect",
-                Key.attributes.rawValue: "{\"city\":\"dublin\"}",
                 Key.password.rawValue: "1234"
             ]
+            if expectAttributes {
+                expectedBodyParams[Key.attributes.rawValue] = "{\"city\":\"dublin\"}"
+            }
         case .signUpChallenge:
             expectedBodyParams = [
                 Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
@@ -138,6 +176,9 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
                 Key.signUpToken.rawValue: "sign-up-token",
                 Key.password.rawValue: "1234"
             ]
+            if expectAttributes {
+                expectedBodyParams[Key.attributes.rawValue] = "{\"city\":\"dublin\"}"
+            }
         default:
             XCTFail("Case not tested")
         }

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -95,6 +95,25 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         XCTAssertEqual(delegate.channelTargetType, .email)
         XCTAssertEqual(delegate.codeLength, 1)
     }
+    
+    func testSignUpPassword_whenNoAttributesAreSpecified_AttributesShouldBeNil() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
+
+        let expectedResult: SignUpPasswordStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken"),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controllerFactoryMock.signUpController.startPasswordResult = .init(expectedResult)
+
+        sut.signUpUsingPassword(username: "correct", password: "correct", delegate: delegate)
+
+        wait(for: [exp])
+
+        XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
+    }
 
     func testSignUpPassword_delegate_whenSendAttributes_shouldReturnAttributesInvalid() {
         let exp = expectation(description: "sign-up public interface")
@@ -157,6 +176,25 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         XCTAssertEqual(delegate.sentTo, "sentTo")
         XCTAssertEqual(delegate.channelTargetType, .email)
         XCTAssertEqual(delegate.codeLength, 1)
+    }
+    
+    func testSignUp_whenNoAttributesAreSpecified_AttributesShouldBeNil() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
+
+        let expectedResult: SignUpStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken"),
+            sentTo: "sentTo",
+            channelTargetType: .email,
+            codeLength: 1
+        )
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult)
+
+        sut.signUp(username: "correct", delegate: delegate)
+
+        wait(for: [exp])
+
+        XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
     }
 
     func testSignUp_delegate_whenSendAttributes_shouldReturnAttributesInvalid() {

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -113,6 +113,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         wait(for: [exp])
 
         XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
+        XCTAssertNotNil(controllerFactoryMock.signUpController.signUpStartRequestParameters)
     }
 
     func testSignUpPassword_delegate_whenSendAttributes_shouldReturnAttributesInvalid() {
@@ -195,6 +196,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         wait(for: [exp])
 
         XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
+        XCTAssertNotNil(controllerFactoryMock.signUpController.signUpStartRequestParameters)
     }
 
     func testSignUp_delegate_whenSendAttributes_shouldReturnAttributesInvalid() {

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -114,7 +114,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
 
         let expectedResult: SignUpPasswordStartResult = .codeRequired(
-            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken"),
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: UUID()),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -197,7 +197,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
 
         let expectedResult: SignUpStartResult = .codeRequired(
-            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken"),
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: UUID()),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1


### PR DESCRIPTION
## Proposed changes

Before this PR we were using an empty attribute list as default value when the user didn't specify any attribute. This resulted in adding an empty list in the signUp/start HTTP call

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

I considered other methods for resolving this problem as well. I could just modify the `MSALNativeAuthSignUpRequestProvider` class and add the attributes field in the HTTP request only when the list was not empty. I didn't think this was the right way to solve the issue, because the `RequestProvider` class should provide the request based on the input parameters, not based to internal logic. So, I used a nil value instead of empty list as default attributes value in the `PublicClientApplication` class.