### PR TITLE
Add additional error code when keyId doesn't match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+[TBD]
+* Add additional error codes for PSSO KeyId missmatch (#1946)
+
 ## [1.2.20]
 * Updated common core submodule with changes for platform sso and mapping broker version in token result 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-[TBD]
+[1.2.21]
 * Add additional error codes for PSSO KeyId missmatch (#1946)
 
 ## [1.2.20]

--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -111,6 +111,7 @@ static NSSet *s_recoverableErrorCode;
                                    @(MSIDErrorJITTroubleshootingResultUnknown) : @(MSALErrorJITTroubleshootingResultUnknown),
                                    @(MSIDErrorJITTroubleshootingAcquireToken) : @(MSALErrorJITTroubleshootingAcquireToken),
                                    @(MSIDErrorDeviceNotPSSORegistered) : @(MSALErrorDeviceNotPSSORegistered),
+                                   @(MSIDErrorPSSOKeyIdMissmatch) : @(MSALErrorPSSOKeyIdMissmatch),
                                    
                                    // Oauth2 errors
                                    @(MSIDErrorServerOauth) : @(MSALInternalErrorAuthorizationFailed),

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -495,4 +495,8 @@ typedef NS_ENUM(NSInteger, MSALInternalError)
      */
     MSALErrorDeviceNotPSSORegistered                    = -42736,
     
+    /**
+     // In PSSO, KeyId stored in passkey provider storage does not match NGC key, needs to configure and retry
+     */
+    MSALErrorPSSOKeyIdMissmatch                         = -42737,
 };


### PR DESCRIPTION
## Proposed changes

Add additional error code when keyId doesn't match.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

