### PR TITLE
Reuse MSAL initialised cache for Native Auth flows

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -415,6 +415,7 @@
 		9B6EECEF2A3146ED008ABA50 /* MSALNativeAuthResetPasswordResponseValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6EECEE2A3146ED008ABA50 /* MSALNativeAuthResetPasswordResponseValidatorTests.swift */; };
 		9B839A102A4D7CF600BCC6F6 /* MSAL.docc in Sources */ = {isa = PBXBuildFile; fileRef = 9B839A0F2A4D7CF600BCC6F6 /* MSAL.docc */; };
 		9B839A112A4D7CF600BCC6F6 /* MSAL.docc in Sources */ = {isa = PBXBuildFile; fileRef = 9B839A0F2A4D7CF600BCC6F6 /* MSAL.docc */; };
+		9B9D05E82B4FFBEC00024E6E /* MSALNativeAuthCacheAccessorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B9D05E72B4FFBEC00024E6E /* MSALNativeAuthCacheAccessorFactory.swift */; };
 		9BB5180B2A2A2B5B00D6276A /* MSALNativeAuthResetPasswordControllerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB518032A2A2B5B00D6276A /* MSALNativeAuthResetPasswordControllerSpy.swift */; };
 		9BD2763D2A0D3DBD00FBD033 /* MSALNativeAuthResetPasswordController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD2763C2A0D3DBD00FBD033 /* MSALNativeAuthResetPasswordController.swift */; };
 		9BD2765A2A0E7E6F00FBD033 /* ResetPasswordTestValidatorHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD276582A0E7E6700FBD033 /* ResetPasswordTestValidatorHelpers.swift */; };
@@ -1662,6 +1663,7 @@
 		9B61C91B2A27E57C00CE9E3A /* MSALNativeAuthResetPasswordResponseValidatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordResponseValidatorMock.swift; sourceTree = "<group>"; };
 		9B6EECEE2A3146ED008ABA50 /* MSALNativeAuthResetPasswordResponseValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordResponseValidatorTests.swift; sourceTree = "<group>"; };
 		9B839A0F2A4D7CF600BCC6F6 /* MSAL.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = MSAL.docc; sourceTree = "<group>"; };
+		9B9D05E72B4FFBEC00024E6E /* MSALNativeAuthCacheAccessorFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCacheAccessorFactory.swift; sourceTree = "<group>"; };
 		9BB518032A2A2B5B00D6276A /* MSALNativeAuthResetPasswordControllerSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordControllerSpy.swift; sourceTree = "<group>"; };
 		9BD2763C2A0D3DBD00FBD033 /* MSALNativeAuthResetPasswordController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordController.swift; sourceTree = "<group>"; };
 		9BD276562A0E7DEC00FBD033 /* ResetPasswordCodeSentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordCodeSentStateTests.swift; sourceTree = "<group>"; };
@@ -3717,6 +3719,7 @@
 		DEE34F41D170B71C00BC302A /* factories */ = {
 			isa = PBXGroup;
 			children = (
+				9B9D05E72B4FFBEC00024E6E /* MSALNativeAuthCacheAccessorFactory.swift */,
 				28D5B05C2A028D2B0066E32B /* MSALNativeAuthControllerFactory.swift */,
 				DEE34F43D170B71C00BC302A /* MSALNativeAuthResultFactory.swift */,
 			);
@@ -5643,6 +5646,7 @@
 				23A68A7C20F538B90071E435 /* MSALB2CAuthority.m in Sources */,
 				DEE34F48D170B71C00BC302A /* MSALNativeAuthResultFactory.swift in Sources */,
 				6077D4A922498D87001798A2 /* MSALTenantProfile.m in Sources */,
+				9B9D05E82B4FFBEC00024E6E /* MSALNativeAuthCacheAccessorFactory.swift in Sources */,
 				A0274CD824B54A4E00BD198D /* MSALDevicePopManagerUtil.m in Sources */,
 				DE9245122A38736600C0389F /* CredentialsDelegates.swift in Sources */,
 				B223B0C022ADFACB00FB8713 /* MSALLegacySharedAccount.m in Sources */,

--- a/MSAL/src/native_auth/cache/MSALNativeAuthCacheAccessor.swift
+++ b/MSAL/src/native_auth/cache/MSALNativeAuthCacheAccessor.swift
@@ -25,7 +25,7 @@
 import Foundation
 @_implementationOnly import MSAL_Private
 
-class MSALNativeAuthCacheAccessor: MSALNativeAuthCacheInterface {
+final class MSALNativeAuthCacheAccessor: MSALNativeAuthCacheInterface {
     private let tokenCacheAccessor: MSIDDefaultTokenCacheAccessor
 
     private let accountMetadataCache: MSIDAccountMetadataCacheAccessor

--- a/MSAL/src/native_auth/cache/MSALNativeAuthCacheAccessor.swift
+++ b/MSAL/src/native_auth/cache/MSALNativeAuthCacheAccessor.swift
@@ -26,15 +26,17 @@ import Foundation
 @_implementationOnly import MSAL_Private
 
 class MSALNativeAuthCacheAccessor: MSALNativeAuthCacheInterface {
+    private let tokenCacheAccessor: MSIDDefaultTokenCacheAccessor
 
-    private let tokenCacheAccessor: MSIDDefaultTokenCacheAccessor = {
-        let dataSource = MSIDKeychainTokenCache()
-        return MSIDDefaultTokenCacheAccessor(dataSource: dataSource, otherCacheAccessors: [])
-    }()
+    private let accountMetadataCache: MSIDAccountMetadataCacheAccessor
 
-    private let accountMetadataCache: MSIDAccountMetadataCacheAccessor = MSIDAccountMetadataCacheAccessor(dataSource: MSIDKeychainTokenCache())
     private let externalAccountProvider: MSALExternalAccountHandler = MSALExternalAccountHandler()
     private let validator = MSIDTokenResponseValidator()
+
+    init(tokenCache: MSIDDefaultTokenCacheAccessor, accountMetadataCache: MSIDAccountMetadataCacheAccessor) {
+        self.tokenCacheAccessor = tokenCache
+        self.accountMetadataCache = accountMetadataCache
+    }
 
     func getTokens(
         account: MSALAccount,

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -50,13 +50,13 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
         )
     }
 
-    convenience init(config: MSALNativeAuthConfiguration) {
-        let factory = MSALNativeAuthResultFactory(config: config)
+    convenience init(config: MSALNativeAuthConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
+        let factory = MSALNativeAuthResultFactory(config: config, cacheAccessor: cacheAccessor)
         self.init(
             clientId: config.clientId,
             requestProvider: MSALNativeAuthTokenRequestProvider(
                 requestConfigurator: MSALNativeAuthRequestConfigurator(config: config)),
-            cacheAccessor: MSALNativeAuthCacheAccessor(),
+            cacheAccessor: cacheAccessor,
             factory: factory,
             responseValidator: MSALNativeAuthTokenResponseValidator(factory: factory,
                                                                     msidValidator: MSIDTokenResponseValidator())

--- a/MSAL/src/native_auth/controllers/factories/MSALNativeAuthCacheAccessorFactory.swift
+++ b/MSAL/src/native_auth/controllers/factories/MSALNativeAuthCacheAccessorFactory.swift
@@ -22,33 +22,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 @_implementationOnly import MSAL_Private
 
-protocol MSALNativeAuthCacheInterface {
-    init(tokenCache: MSIDDefaultTokenCacheAccessor, accountMetadataCache: MSIDAccountMetadataCacheAccessor)
+protocol MSALNativeAuthCacheAccessorBuildable {
+    func makeCacheAccessor(
+        tokenCache: MSIDDefaultTokenCacheAccessor,
+        accountMetadataCache: MSIDAccountMetadataCacheAccessor
+    ) -> MSALNativeAuthCacheAccessor
+}
 
-    func getTokens(
-        account: MSALAccount,
-        configuration: MSIDConfiguration,
-        context: MSIDRequestContext) throws -> MSALNativeAuthTokens
-
-    func getAllAccounts(configuration: MSIDConfiguration) throws -> [MSALAccount]
-
-    func validateAndSaveTokensAndAccount(
-        tokenResponse: MSIDTokenResponse,
-        configuration: MSIDConfiguration,
-        context: MSIDRequestContext) throws -> MSIDTokenResult?
-
-    func removeTokens(
-        accountIdentifier: MSIDAccountIdentifier,
-        authority: MSIDAuthority,
-        clientId: String,
-        context: MSIDRequestContext) throws
-
-    func clearCache(
-        accountIdentifier: MSIDAccountIdentifier,
-        authority: MSIDAuthority,
-        clientId: String,
-        context: MSIDRequestContext) throws
+final class MSALNativeAuthCacheAccessorFactory: MSALNativeAuthCacheAccessorBuildable {
+    func makeCacheAccessor(
+        tokenCache: MSIDDefaultTokenCacheAccessor,
+        accountMetadataCache: MSIDAccountMetadataCacheAccessor
+    ) -> MSALNativeAuthCacheAccessor {
+        return MSALNativeAuthCacheAccessor(tokenCache: tokenCache, accountMetadataCache: accountMetadataCache)
+    }
 }

--- a/MSAL/src/native_auth/controllers/factories/MSALNativeAuthControllerFactory.swift
+++ b/MSAL/src/native_auth/controllers/factories/MSALNativeAuthControllerFactory.swift
@@ -23,10 +23,10 @@
 // THE SOFTWARE.
 
 protocol MSALNativeAuthControllerBuildable {
-    func makeSignUpController() -> MSALNativeAuthSignUpControlling
-    func makeSignInController() -> MSALNativeAuthSignInControlling
-    func makeResetPasswordController() -> MSALNativeAuthResetPasswordControlling
-    func makeCredentialsController() -> MSALNativeAuthCredentialsControlling
+    func makeSignUpController(cacheAccessor: MSALNativeAuthCacheInterface) -> MSALNativeAuthSignUpControlling
+    func makeSignInController(cacheAccessor: MSALNativeAuthCacheInterface) -> MSALNativeAuthSignInControlling
+    func makeResetPasswordController(cacheAccessor: MSALNativeAuthCacheInterface) -> MSALNativeAuthResetPasswordControlling
+    func makeCredentialsController(cacheAccessor: MSALNativeAuthCacheInterface) -> MSALNativeAuthCredentialsControlling
 }
 
 final class MSALNativeAuthControllerFactory: MSALNativeAuthControllerBuildable {
@@ -36,19 +36,19 @@ final class MSALNativeAuthControllerFactory: MSALNativeAuthControllerBuildable {
         self.config = config
     }
 
-    func makeSignUpController() -> MSALNativeAuthSignUpControlling {
-        return MSALNativeAuthSignUpController(config: config)
+    func makeSignUpController(cacheAccessor: MSALNativeAuthCacheInterface) -> MSALNativeAuthSignUpControlling {
+        return MSALNativeAuthSignUpController(config: config, cacheAccessor: cacheAccessor)
     }
 
-    func makeSignInController() -> MSALNativeAuthSignInControlling {
-        return MSALNativeAuthSignInController(config: config)
+    func makeSignInController(cacheAccessor: MSALNativeAuthCacheInterface) -> MSALNativeAuthSignInControlling {
+        return MSALNativeAuthSignInController(config: config, cacheAccessor: cacheAccessor)
     }
 
-    func makeResetPasswordController() -> MSALNativeAuthResetPasswordControlling {
-        return MSALNativeAuthResetPasswordController(config: config)
+    func makeResetPasswordController(cacheAccessor: MSALNativeAuthCacheInterface) -> MSALNativeAuthResetPasswordControlling {
+        return MSALNativeAuthResetPasswordController(config: config, cacheAccessor: cacheAccessor)
     }
 
-    func makeCredentialsController() -> MSALNativeAuthCredentialsControlling {
-        return MSALNativeAuthCredentialsController(config: config)
+    func makeCredentialsController(cacheAccessor: MSALNativeAuthCacheInterface) -> MSALNativeAuthCredentialsControlling {
+        return MSALNativeAuthCredentialsController(config: config, cacheAccessor: cacheAccessor)
     }
 }

--- a/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
+++ b/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
@@ -38,9 +38,11 @@ protocol MSALNativeAuthResultBuildable {
 final class MSALNativeAuthResultFactory: MSALNativeAuthResultBuildable {
 
     let config: MSALNativeAuthConfiguration
+    let cacheAccessor: MSALNativeAuthCacheInterface
 
-    init(config: MSALNativeAuthConfiguration) {
+    init(config: MSALNativeAuthConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
         self.config = config
+        self.cacheAccessor = cacheAccessor
     }
 
     func makeUserAccountResult(tokenResult: MSIDTokenResult, context: MSIDRequestContext) -> MSALNativeAuthUserAccountResult? {
@@ -79,11 +81,11 @@ final class MSALNativeAuthResultFactory: MSALNativeAuthResultBuildable {
         let authTokens = MSALNativeAuthTokens(accessToken: tokenResult.accessToken,
                                               refreshToken: refreshToken,
                                               rawIdToken: tokenResult.rawIdToken)
-        return .init(account: account, authTokens: authTokens, configuration: config, cacheAccessor: MSALNativeAuthCacheAccessor())
+        return .init(account: account, authTokens: authTokens, configuration: config, cacheAccessor: cacheAccessor)
     }
 
     func makeUserAccountResult(account: MSALAccount, authTokens: MSALNativeAuthTokens) -> MSALNativeAuthUserAccountResult? {
-        return .init(account: account, authTokens: authTokens, configuration: config, cacheAccessor: MSALNativeAuthCacheAccessor())
+        return .init(account: account, authTokens: authTokens, configuration: config, cacheAccessor: cacheAccessor)
     }
 
     func makeMSIDConfiguration(scopes: [String]) -> MSIDConfiguration {

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -46,7 +46,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         super.init(clientId: config.clientId)
     }
 
-    convenience init(config: MSALNativeAuthConfiguration) {
+    convenience init(config: MSALNativeAuthConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
         self.init(
             config: config,
             requestProvider: MSALNativeAuthResetPasswordRequestProvider(
@@ -54,7 +54,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 telemetryProvider: MSALNativeAuthTelemetryProvider()
             ),
             responseValidator: MSALNativeAuthResetPasswordResponseValidator(),
-            signInController: MSALNativeAuthSignInController(config: config)
+            signInController: MSALNativeAuthSignInController(config: config, cacheAccessor: cacheAccessor)
         )
     }
 

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -55,15 +55,15 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         )
     }
 
-    convenience init(config: MSALNativeAuthConfiguration) {
-        let factory = MSALNativeAuthResultFactory(config: config)
+    convenience init(config: MSALNativeAuthConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
+        let factory = MSALNativeAuthResultFactory(config: config, cacheAccessor: cacheAccessor)
         self.init(
             clientId: config.clientId,
             signInRequestProvider: MSALNativeAuthSignInRequestProvider(
                 requestConfigurator: MSALNativeAuthRequestConfigurator(config: config)),
             tokenRequestProvider: MSALNativeAuthTokenRequestProvider(
                 requestConfigurator: MSALNativeAuthRequestConfigurator(config: config)),
-            cacheAccessor: MSALNativeAuthCacheAccessor(),
+            cacheAccessor: cacheAccessor,
             factory: factory,
             signInResponseValidator: MSALNativeAuthSignInResponseValidator(),
             tokenResponseValidator: MSALNativeAuthTokenResponseValidator(

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -48,7 +48,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         super.init(clientId: config.clientId)
     }
 
-    convenience init(config: MSALNativeAuthConfiguration) {
+    convenience init(config: MSALNativeAuthConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
         self.init(
             config: config,
             requestProvider: MSALNativeAuthSignUpRequestProvider(
@@ -56,7 +56,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 telemetryProvider: MSALNativeAuthTelemetryProvider()
             ),
             responseValidator: MSALNativeAuthSignUpResponseValidator(),
-            signInController: MSALNativeAuthSignInController(config: config)
+            signInController: MSALNativeAuthSignInController(config: config, cacheAccessor: cacheAccessor)
         )
     }
 

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -40,7 +40,7 @@ extension MSALNativeAuthPublicClientApplication {
             return .init(.error(SignUpStartError(type: .invalidPassword)))
         }
 
-        let controller = controllerFactory.makeSignUpController()
+        let controller = controllerFactory.makeSignUpController(cacheAccessor: cacheAccessor)
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
@@ -66,7 +66,7 @@ extension MSALNativeAuthPublicClientApplication {
             return .init(.error(SignInStartError(type: .invalidCredentials)))
         }
 
-        let controller = controllerFactory.makeSignInController()
+        let controller = controllerFactory.makeSignInController(cacheAccessor: cacheAccessor)
 
         let params = MSALNativeAuthSignInParameters(
             username: username,
@@ -85,7 +85,7 @@ extension MSALNativeAuthPublicClientApplication {
             return .init(.error(ResetPasswordStartError(type: .invalidUsername)))
         }
 
-        let controller = controllerFactory.makeResetPasswordController()
+        let controller = controllerFactory.makeResetPasswordController(cacheAccessor: cacheAccessor)
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         return await controller.resetPassword(

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -108,14 +108,14 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
 
     init(
         controllerFactory: MSALNativeAuthControllerBuildable,
+        cacheAccessorFactory: MSALNativeAuthCacheAccessorBuildable,
         inputValidator: MSALNativeAuthInputValidating,
-        internalChallengeTypes: [MSALNativeAuthInternalChallengeType],
-        cacheAccessorFactory: MSALNativeAuthCacheAccessorBuildable
+        internalChallengeTypes: [MSALNativeAuthInternalChallengeType]
     ) {
         self.controllerFactory = controllerFactory
+        self.cacheAccessorFactory = cacheAccessorFactory
         self.inputValidator = inputValidator
         self.internalChallengeTypes = internalChallengeTypes
-        self.cacheAccessorFactory = cacheAccessorFactory
 
         super.init()
     }

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -30,6 +30,9 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
     let controllerFactory: MSALNativeAuthControllerBuildable
     let inputValidator: MSALNativeAuthInputValidating
     private let internalChallengeTypes: [MSALNativeAuthInternalChallengeType]
+    
+    lazy var cacheAccessor =
+        MSALNativeAuthCacheAccessor(tokenCache: self.tokenCache, accountMetadataCache: self.accountMetadataCache)
 
     /// Initialize a MSALNativePublicClientApplication with a given configuration and challenge types
     /// - Parameters:
@@ -226,7 +229,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
     /// - Parameter correlationId: Optional. UUID to correlate this request with the server for debugging.
     /// - Returns: An object representing the account information if present in the local cache.
     public func getNativeAuthUserAccount(correlationId: UUID? = nil) -> MSALNativeAuthUserAccountResult? {
-        let controller = controllerFactory.makeCredentialsController()
+        let controller = controllerFactory.makeCredentialsController(cacheAccessor: cacheAccessor)
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         return controller.retrieveUserAccountResult(context: context)

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -30,9 +30,11 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
     let controllerFactory: MSALNativeAuthControllerBuildable
     let inputValidator: MSALNativeAuthInputValidating
     private let internalChallengeTypes: [MSALNativeAuthInternalChallengeType]
-    
-    lazy var cacheAccessor =
-        MSALNativeAuthCacheAccessor(tokenCache: self.tokenCache, accountMetadataCache: self.accountMetadataCache)
+
+    private var cacheAccessorFactory: MSALNativeAuthCacheAccessorBuildable
+    lazy var cacheAccessor: MSALNativeAuthCacheAccessor = {
+        return cacheAccessorFactory.makeCacheAccessor(tokenCache: tokenCache, accountMetadataCache: accountMetadataCache)
+    }()
 
     /// Initialize a MSALNativePublicClientApplication with a given configuration and challenge types
     /// - Parameters:
@@ -57,6 +59,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         nativeConfiguration.sliceConfig = config.sliceConfig
 
         self.controllerFactory = MSALNativeAuthControllerFactory(config: nativeConfiguration)
+        self.cacheAccessorFactory = MSALNativeAuthCacheAccessorFactory()
         self.inputValidator = MSALNativeAuthInputValidator()
 
         try super.init(configuration: config)
@@ -85,6 +88,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         )
 
         self.controllerFactory = MSALNativeAuthControllerFactory(config: nativeConfiguration)
+        self.cacheAccessorFactory = MSALNativeAuthCacheAccessorFactory()
         self.inputValidator = MSALNativeAuthInputValidator()
 
         let configuration = MSALPublicClientApplicationConfig(
@@ -105,11 +109,13 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
     init(
         controllerFactory: MSALNativeAuthControllerBuildable,
         inputValidator: MSALNativeAuthInputValidating,
-        internalChallengeTypes: [MSALNativeAuthInternalChallengeType]
+        internalChallengeTypes: [MSALNativeAuthInternalChallengeType],
+        cacheAccessorFactory: MSALNativeAuthCacheAccessorBuildable
     ) {
         self.controllerFactory = controllerFactory
         self.inputValidator = inputValidator
         self.internalChallengeTypes = internalChallengeTypes
+        self.cacheAccessorFactory = cacheAccessorFactory
 
         super.init()
     }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -35,7 +35,7 @@ extension MSALNativeAuthUserAccountResult {
         if let accessToken = self.authTokens.accessToken {
             if forceRefresh || accessToken.isExpired() {
                 let controllerFactory = MSALNativeAuthControllerFactory(config: configuration)
-                let credentialsController = controllerFactory.makeCredentialsController()
+                let credentialsController = controllerFactory.makeCredentialsController(cacheAccessor: cacheAccessor)
                 return await credentialsController.refreshToken(context: context, authTokens: authTokens)
             } else {
                 return .init(.success(accessToken.accessToken))

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -28,7 +28,8 @@ extension MSALNativeAuthUserAccountResult {
 
     func getAccessTokenInternal(
         forceRefresh: Bool,
-        correlationId: UUID?
+        correlationId: UUID?,
+        cacheAccessor: MSALNativeAuthCacheInterface
     ) async -> MSALNativeAuthCredentialsControlling.RefreshTokenCredentialControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -31,7 +31,7 @@ import Foundation
 
     let authTokens: MSALNativeAuthTokens
     let configuration: MSALNativeAuthConfiguration
-    private let cacheAccessor: MSALNativeAuthCacheInterface
+    let cacheAccessor: MSALNativeAuthCacheInterface
 
     /// Get the ID token for the account.
     @objc public var idToken: String? {

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -31,7 +31,7 @@ import Foundation
 
     let authTokens: MSALNativeAuthTokens
     let configuration: MSALNativeAuthConfiguration
-    let cacheAccessor: MSALNativeAuthCacheInterface
+    private let cacheAccessor: MSALNativeAuthCacheInterface
 
     /// Get the ID token for the account.
     @objc public var idToken: String? {
@@ -87,7 +87,11 @@ import Foundation
     ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
     @objc public func getAccessToken(forceRefresh: Bool = false, correlationId: UUID? = nil, delegate: CredentialsDelegate) {
         Task {
-            let controllerResponse = await getAccessTokenInternal(forceRefresh: forceRefresh, correlationId: correlationId)
+            let controllerResponse = await getAccessTokenInternal(
+                forceRefresh: forceRefresh,
+                correlationId: correlationId,
+                cacheAccessor: cacheAccessor
+            )
             let delegateDispatcher = CredentialsDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {

--- a/MSAL/test/unit/native_auth/cache/MSALNativeAuthCacheAccessorTest.swift
+++ b/MSAL/test/unit/native_auth/cache/MSALNativeAuthCacheAccessorTest.swift
@@ -27,7 +27,15 @@ import XCTest
 @_implementationOnly import MSAL_Private
 
 final class MSALNativeAuthCacheAccessorTest: XCTestCase {
-    private let cacheAccessor = MSALNativeAuthCacheAccessor()
+    private let tokenCache: MSIDDefaultTokenCacheAccessor = {
+            let dataSource = MSIDKeychainTokenCache()
+            return MSIDDefaultTokenCacheAccessor(dataSource: dataSource, otherCacheAccessors: [])
+        }()
+
+    private let accountMetadataCache: MSIDAccountMetadataCacheAccessor = MSIDAccountMetadataCacheAccessor(dataSource: MSIDKeychainTokenCache())
+
+    private lazy var cacheAccessor = MSALNativeAuthCacheAccessor(tokenCache: tokenCache, accountMetadataCache: accountMetadataCache)
+
     private lazy var parameters = getParameters()
     private lazy var contextStub = ContextStub()
     

--- a/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
@@ -42,7 +42,7 @@ final class MSALNativeAuthResultFactoryTests: XCTestCase {
     ]
 
     override func setUpWithError() throws {
-        sut = .init(config: MSALNativeAuthConfigStubs.configuration, cacheAccessor: MSALNativeAuthCacheAccessorStub())
+        sut = .init(config: MSALNativeAuthConfigStubs.configuration, cacheAccessor: MSALNativeAuthCacheAccessorMock())
     }
 
     func test_makeMsidConfiguration() {
@@ -115,44 +115,5 @@ final class MSALNativeAuthResultFactoryTests: XCTestCase {
         XCTAssertEqual(accountResult.expiresOn, expiresOn)
         XCTAssertEqual(accountResult.scopes, scopes)
         XCTAssertNil(accountResult.account.accountClaims)
-    }
-}
-
-private class MSALNativeAuthCacheAccessorStub: MSALNativeAuthCacheInterface {
-    var tokenCache: MSIDDefaultTokenCacheAccessor
-    var accountMetadataCache: MSIDAccountMetadataCacheAccessor
-
-    required init(tokenCache: MSIDDefaultTokenCacheAccessor, accountMetadataCache: MSIDAccountMetadataCacheAccessor) {
-        self.tokenCache = tokenCache
-        self.accountMetadataCache = accountMetadataCache
-    }
-
-    convenience init() {
-        let dataSource = MSIDKeychainTokenCache()
-        let tokenCache = MSIDDefaultTokenCacheAccessor(dataSource: dataSource, otherCacheAccessors: [])
-
-        let accountMetadataCache = MSIDAccountMetadataCacheAccessor(dataSource: MSIDKeychainTokenCache())
-
-        self.init(tokenCache: tokenCache!, accountMetadataCache: accountMetadataCache!)
-    }
-
-    func getTokens(account: MSALAccount, configuration: MSIDConfiguration, context: MSIDRequestContext) throws -> MSAL.MSALNativeAuthTokens {
-        return MSALNativeAuthTokens(accessToken: nil,
-                                    refreshToken: nil,
-                                    rawIdToken: nil)
-    }
-
-    func getAllAccounts(configuration: MSIDConfiguration) throws -> [MSALAccount] {
-        return [MSALNativeAuthUserAccountResultStub.account]
-    }
-
-    func validateAndSaveTokensAndAccount(tokenResponse: MSIDTokenResponse, configuration: MSIDConfiguration, context: MSIDRequestContext) throws -> MSIDTokenResult? {
-        return MSIDTokenResult()
-    }
-
-    func removeTokens(accountIdentifier: MSIDAccountIdentifier, authority: MSIDAuthority, clientId: String, context: MSIDRequestContext) throws {
-    }
-
-    func clearCache(accountIdentifier: MSIDAccountIdentifier, authority: MSIDAuthority, clientId: String, context: MSIDRequestContext) throws {
     }
 }

--- a/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
@@ -119,6 +119,23 @@ final class MSALNativeAuthResultFactoryTests: XCTestCase {
 }
 
 private class MSALNativeAuthCacheAccessorStub: MSALNativeAuthCacheInterface {
+    var tokenCache: MSIDDefaultTokenCacheAccessor
+    var accountMetadataCache: MSIDAccountMetadataCacheAccessor
+
+    required init(tokenCache: MSIDDefaultTokenCacheAccessor, accountMetadataCache: MSIDAccountMetadataCacheAccessor) {
+        self.tokenCache = tokenCache
+        self.accountMetadataCache = accountMetadataCache
+    }
+
+    convenience init() {
+        let dataSource = MSIDKeychainTokenCache()
+        let tokenCache = MSIDDefaultTokenCacheAccessor(dataSource: dataSource, otherCacheAccessors: [])
+
+        let accountMetadataCache = MSIDAccountMetadataCacheAccessor(dataSource: MSIDKeychainTokenCache())
+
+        self.init(tokenCache: tokenCache!, accountMetadataCache: accountMetadataCache!)
+    }
+
     func getTokens(account: MSALAccount, configuration: MSIDConfiguration, context: MSIDRequestContext) throws -> MSAL.MSALNativeAuthTokens {
         return MSALNativeAuthTokens(accessToken: nil,
                                     refreshToken: nil,

--- a/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
@@ -42,7 +42,7 @@ final class MSALNativeAuthResultFactoryTests: XCTestCase {
     ]
 
     override func setUpWithError() throws {
-        sut = .init(config: MSALNativeAuthConfigStubs.configuration)
+        sut = .init(config: MSALNativeAuthConfigStubs.configuration, cacheAccessor: MSALNativeAuthCacheAccessorStub())
     }
 
     func test_makeMsidConfiguration() {
@@ -115,5 +115,27 @@ final class MSALNativeAuthResultFactoryTests: XCTestCase {
         XCTAssertEqual(accountResult.expiresOn, expiresOn)
         XCTAssertEqual(accountResult.scopes, scopes)
         XCTAssertNil(accountResult.account.accountClaims)
+    }
+}
+
+private class MSALNativeAuthCacheAccessorStub: MSALNativeAuthCacheInterface {
+    func getTokens(account: MSALAccount, configuration: MSIDConfiguration, context: MSIDRequestContext) throws -> MSAL.MSALNativeAuthTokens {
+        return MSALNativeAuthTokens(accessToken: nil,
+                                    refreshToken: nil,
+                                    rawIdToken: nil)
+    }
+
+    func getAllAccounts(configuration: MSIDConfiguration) throws -> [MSALAccount] {
+        return [MSALNativeAuthUserAccountResultStub.account]
+    }
+
+    func validateAndSaveTokensAndAccount(tokenResponse: MSIDTokenResponse, configuration: MSIDConfiguration, context: MSIDRequestContext) throws -> MSIDTokenResult? {
+        return MSIDTokenResult()
+    }
+
+    func removeTokens(accountIdentifier: MSIDAccountIdentifier, authority: MSIDAuthority, clientId: String, context: MSIDRequestContext) throws {
+    }
+
+    func clearCache(accountIdentifier: MSIDAccountIdentifier, authority: MSIDAuthority, clientId: String, context: MSIDRequestContext) throws {
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthCacheMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthCacheMocks.swift
@@ -27,6 +27,23 @@ import XCTest
 @_implementationOnly import MSAL_Private
 
 class MSALNativeAuthCacheAccessorMock: MSALNativeAuthCacheInterface {
+    var tokenCache: MSIDDefaultTokenCacheAccessor
+    var accountMetadataCache: MSIDAccountMetadataCacheAccessor
+
+    required init(tokenCache: MSIDDefaultTokenCacheAccessor, accountMetadataCache: MSIDAccountMetadataCacheAccessor) {
+        self.tokenCache = tokenCache
+        self.accountMetadataCache = accountMetadataCache
+    }
+
+    convenience init() {
+        let dataSource = MSIDKeychainTokenCache()
+        let tokenCache = MSIDDefaultTokenCacheAccessor(dataSource: dataSource, otherCacheAccessors: [])
+
+        let accountMetadataCache = MSIDAccountMetadataCacheAccessor(dataSource: MSIDKeychainTokenCache())
+
+        self.init(tokenCache: tokenCache!, accountMetadataCache: accountMetadataCache!)
+    }
+
     enum E: Error {
         case notImplemented
         case noAccount

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
@@ -125,3 +125,15 @@ class MSALNativeAuthControllerProtocolFactoryMock: MSALNativeAuthControllerBuild
         return credentialsController
     }
 }
+
+class MSALNativeAuthCacheAccessorFactoryMock: MSALNativeAuthCacheAccessorBuildable {
+    var tokenCache: MSIDDefaultTokenCacheAccessor?
+    var accountMetadataCache: MSIDAccountMetadataCacheAccessor?
+
+    func makeCacheAccessor(tokenCache: MSIDDefaultTokenCacheAccessor, accountMetadataCache: MSIDAccountMetadataCacheAccessor) -> MSAL.MSALNativeAuthCacheAccessor {
+        self.tokenCache = tokenCache
+        self.accountMetadataCache = accountMetadataCache
+
+        return MSALNativeAuthCacheAccessor(tokenCache: tokenCache, accountMetadataCache: accountMetadataCache)
+    }
+}

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
@@ -75,19 +75,19 @@ class MSALNativeAuthControllerFactoryMock: MSALNativeAuthControllerBuildable {
     var resetPasswordController = MSALNativeAuthResetPasswordControllerMock()
     var credentialsController = MSALNativeAuthCredentialsControllerMock()
 
-    func makeSignUpController() -> MSAL.MSALNativeAuthSignUpControlling {
+    func makeSignUpController(cacheAccessor: MSAL.MSALNativeAuthCacheInterface) -> MSAL.MSALNativeAuthSignUpControlling {
         return signUpController
     }
 
-    func makeSignInController() -> MSAL.MSALNativeAuthSignInControlling {
+    func makeSignInController(cacheAccessor: MSAL.MSALNativeAuthCacheInterface) -> MSAL.MSALNativeAuthSignInControlling {
         return signInController
     }
 
-    func makeResetPasswordController() -> MSAL.MSALNativeAuthResetPasswordControlling {
+    func makeResetPasswordController(cacheAccessor: MSAL.MSALNativeAuthCacheInterface) -> MSAL.MSALNativeAuthResetPasswordControlling {
         return resetPasswordController
     }
 
-    func makeCredentialsController() -> MSAL.MSALNativeAuthCredentialsControlling {
+    func makeCredentialsController(cacheAccessor: MSAL.MSALNativeAuthCacheInterface) -> MSAL.MSALNativeAuthCredentialsControlling {
         return credentialsController
     }
 }
@@ -109,19 +109,19 @@ class MSALNativeAuthControllerProtocolFactoryMock: MSALNativeAuthControllerBuild
         self.credentialsController = credentialsController
     }
     
-    func makeSignUpController() -> MSAL.MSALNativeAuthSignUpControlling {
+    func makeSignUpController(cacheAccessor: MSAL.MSALNativeAuthCacheInterface) -> MSAL.MSALNativeAuthSignUpControlling {
         return signUpController
     }
     
-    func makeSignInController() -> MSAL.MSALNativeAuthSignInControlling {
+    func makeSignInController(cacheAccessor: MSAL.MSALNativeAuthCacheInterface) -> MSAL.MSALNativeAuthSignInControlling {
         return signInController
     }
     
-    func makeResetPasswordController() -> MSAL.MSALNativeAuthResetPasswordControlling {
+    func makeResetPasswordController(cacheAccessor: MSAL.MSALNativeAuthCacheInterface) -> MSAL.MSALNativeAuthResetPasswordControlling {
         return resetPasswordController
     }
     
-    func makeCredentialsController() -> MSAL.MSALNativeAuthCredentialsControlling {
+    func makeCredentialsController(cacheAccessor: MSAL.MSALNativeAuthCacheInterface) -> MSAL.MSALNativeAuthCredentialsControlling {
         return credentialsController
     }
 }

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -48,9 +48,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactoryMock,
+            cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [], 
-            cacheAccessorFactory: cacheAccessorFactoryMock
+            internalChallengeTypes: []
         )
         
         authority = try! MSALCIAMAuthority(url: authorityURL!)
@@ -610,9 +610,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactory,
+            cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
-            cacheAccessorFactory: cacheAccessorFactoryMock
+            internalChallengeTypes: []
         )
         
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
@@ -712,9 +712,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactory,
+            cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
-            cacheAccessorFactory: cacheAccessorFactoryMock
+            internalChallengeTypes: []
         )
         
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
@@ -804,9 +804,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactory,
+            cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
-            cacheAccessorFactory: cacheAccessorFactoryMock
+            internalChallengeTypes: []
         )
         
         // Correlation Id is validated internally against contextMock on both initiate and challenge in the
@@ -894,9 +894,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactory,
+            cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
-            cacheAccessorFactory: cacheAccessorFactoryMock
+            internalChallengeTypes: []
         )
         
         // Correlation Id is validated internally against contextMock on both initiate and challenge in the
@@ -995,9 +995,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactory,
+            cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
-            cacheAccessorFactory: cacheAccessorFactoryMock
+            internalChallengeTypes: []
         )
         
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -32,6 +32,7 @@ import XCTest
 final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
     private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let cacheAccessorFactoryMock = MSALNativeAuthCacheAccessorFactoryMock()
     private var sut: MSALNativeAuthPublicClientApplication!
     private var correlationId: UUID = UUID()
 
@@ -48,7 +49,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: []
+            internalChallengeTypes: [], 
+            cacheAccessorFactory: cacheAccessorFactoryMock
         )
         
         authority = try! MSALCIAMAuthority(url: authorityURL!)
@@ -65,6 +67,11 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
     func testInit_whenPassingNilRedirectUri_itShouldNotThrowError() {
         XCTAssertNoThrow(try MSALNativeAuthPublicClientApplication(clientId: "genericClient", tenantSubdomain: "genericTenenat", challengeTypes: [.OOB]))
+    }
+
+    func testInit_nativeAuthCacheAccessor_itShouldUseConfigFromSuperclass() {
+        XCTAssertEqual(sut.tokenCache, cacheAccessorFactoryMock.tokenCache)
+        XCTAssertEqual(sut.accountMetadataCache, cacheAccessorFactoryMock.accountMetadataCache)
     }
 
     // MARK: - Delegates
@@ -604,7 +611,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactory,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: []
+            internalChallengeTypes: [],
+            cacheAccessorFactory: cacheAccessorFactoryMock
         )
         
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
@@ -705,7 +713,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactory,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: []
+            internalChallengeTypes: [],
+            cacheAccessorFactory: cacheAccessorFactoryMock
         )
         
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
@@ -796,7 +805,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactory,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: []
+            internalChallengeTypes: [],
+            cacheAccessorFactory: cacheAccessorFactoryMock
         )
         
         // Correlation Id is validated internally against contextMock on both initiate and challenge in the
@@ -885,7 +895,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactory,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: []
+            internalChallengeTypes: [],
+            cacheAccessorFactory: cacheAccessorFactoryMock
         )
         
         // Correlation Id is validated internally against contextMock on both initiate and challenge in the
@@ -985,7 +996,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         sut = MSALNativeAuthPublicClientApplication(
             controllerFactory: controllerFactory,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: []
+            internalChallengeTypes: [],
+            cacheAccessorFactory: cacheAccessorFactoryMock
         )
         
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the


### PR DESCRIPTION
## Proposed changes

MSALPublicClientApplication initialises the cache and keeps references to `tokenCache` and `accountMetadataCache` for the lifetime of the application. This PR updates the SDK to reuse this correctly configured cache for all Native Auth flows by modifying `MSALNativeAuthCacheAccessor` to no longer initialise the caches each time it needs them, and by modifying all controllers that need access to the cache to take a reference to the cacheAccessor during initialisation.

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

To verify this fix you need to use a non-default value for the `keychainSharingGroup`. This can by achived by modifying the Native Auth sample app to initialise NativeAuth using a MSALPublicApplicationConfig with non-default cache configuration, e.g.

```swift
            let ciamAuthority = try MSALCIAMAuthority(url: url)

            let configuration = MSALPublicClientApplicationConfig(
                clientId: Configuration.clientId,
                redirectUri: nil,
                authority: ciamAuthority
            )

            configuration.cacheConfig.keychainSharingGroup = Bundle.main.bundleIdentifier!

            nativeAuth = try MSALNativeAuthPublicClientApplication(
                configuration: configuration,
                challengeTypes: [.OOB])
```


This PR replaces the original https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/1924 as there were too many complex conflicts to resolve due to changes across the project.  This PR also addresses the comments in the previous PR @diegojerezba.