### PR TITLE
Rename all tokens to continuation token

### DIFF
--- a/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
@@ -77,9 +77,8 @@ class MSALNativeAuthTokenController: MSALNativeAuthBaseController {
         username: String? = nil,
         password: String? = nil,
         scopes: [String],
-        credentialToken: String? = nil,
+        continuationToken: String? = nil,
         oobCode: String? = nil,
-        signInSLT: String? = nil,
         grantType: MSALNativeAuthGrantType,
         includeChallengeType: Bool = true,
         context: MSIDRequestContext) -> MSIDHttpRequest? {
@@ -87,8 +86,7 @@ class MSALNativeAuthTokenController: MSALNativeAuthBaseController {
                 let params = MSALNativeAuthTokenRequestParameters(
                     context: context,
                     username: username,
-                    credentialToken: credentialToken,
-                    signInSLT: signInSLT,
+                    continuationToken: continuationToken,
                     grantType: grantType,
                     scope: scopes.joinScopes(),
                     password: password,
@@ -114,8 +112,7 @@ class MSALNativeAuthTokenController: MSALNativeAuthBaseController {
                 let params = MSALNativeAuthTokenRequestParameters(
                     context: context,
                     username: nil,
-                    credentialToken: nil,
-                    signInSLT: nil,
+                    continuationToken: nil,
                     grantType: .refreshToken,
                     scope: scopes.joinScopes(),
                     password: nil,

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -305,12 +305,12 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         context: MSIDRequestContext
     ) async -> ResetPasswordSubmitCodeControllerResponse {
         switch response {
-        case .success(let continuationToken):
+        case .success(let newContinuationToken):
             MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/continue request")
             let newState = ResetPasswordRequiredState(
                 controller: self,
                 username: username,
-                continuationToken: continuationToken,
+                continuationToken: newContinuationToken,
                 correlationId: context.correlationId()
             )
             return .init(.passwordRequired(newState: newState),
@@ -381,10 +381,10 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         MSALLogger.log(level: .info, context: context, format: "Finished resetpassword/submit request")
 
         switch response {
-        case .success(let continuationToken, let pollInterval):
+        case .success(let newContinuationToken, let pollInterval):
             return await doPollCompletionLoop(
                 username: username,
-                continuationToken: continuationToken,
+                continuationToken: newContinuationToken,
                 pollInterval: pollInterval,
                 retriesRemaining: kNumberOfTimesToRetryPollCompletionCall,
                 event: event,

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -68,7 +68,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
 
     func resendCode(username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordResendCode, context: context)
-        let response = await performChallengeRequest(passwordResetToken: continuationToken, context: context)
+        let response = await performChallengeRequest(continuationToken: continuationToken, context: context)
         return await handleResendCodeChallengeResponse(response, username: username, event: event, context: context)
     }
 
@@ -82,13 +82,13 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
 
         let params = MSALNativeAuthResetPasswordContinueRequestParameters(
             context: context,
-            passwordResetToken: continuationToken,
+            continuationToken: continuationToken,
             grantType: .oobCode,
             oobCode: code
         )
 
         let response = await performContinueRequest(parameters: params)
-        return await handleSubmitCodeResponse(response, username: username, passwordResetToken: continuationToken, event: event, context: context)
+        return await handleSubmitCodeResponse(response, username: username, continuationToken: continuationToken, event: event, context: context)
     }
 
     func submitPassword(
@@ -101,14 +101,14 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
 
         let params = MSALNativeAuthResetPasswordSubmitRequestParameters(
             context: context,
-            passwordSubmitToken: continuationToken,
+            continuationToken: continuationToken,
             newPassword: password
         )
         let submitRequestResponse = await performSubmitRequest(parameters: params)
         return await handleSubmitPasswordResponse(
             submitRequestResponse,
             username: username,
-            passwordSubmitToken: continuationToken,
+            continuationToken: continuationToken,
             event: event,
             context: context
         )
@@ -142,8 +142,8 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         MSALLogger.log(level: .verbose, context: context, format: "Finished resetpassword/start request")
 
         switch response {
-        case .success(let passwordResetToken):
-            let challengeResponse = await performChallengeRequest(passwordResetToken: passwordResetToken, context: context)
+        case .success(let continuationToken):
+            let challengeResponse = await performChallengeRequest(continuationToken: continuationToken, context: context)
             return await handleChallengeResponse(challengeResponse, username: username, event: event, context: context)
         case .redirect:
             let error = ResetPasswordStartError(type: .browserRequired, message: MSALNativeAuthErrorMessage.browserRequired)
@@ -172,13 +172,13 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
     // MARK: - Challenge Request handling
 
     private func performChallengeRequest(
-        passwordResetToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> MSALNativeAuthResetPasswordChallengeValidatedResponse {
         let request: MSIDHttpRequest
 
         do {
-            request = try requestProvider.challenge(token: passwordResetToken, context: context)
+            request = try requestProvider.challenge(token: continuationToken, context: context)
         } catch {
             MSALLogger.log(level: .error, context: context, format: "Error creating Challenge Request: \(error)")
             return .unexpectedError
@@ -204,7 +204,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 newState: ResetPasswordCodeRequiredState(
                     controller: self,
                     username: username,
-                    flowToken: challengeToken,
+                    continuationToken: challengeToken,
                     correlationId: context.correlationId()
                 ),
                 sentTo: sentTo,
@@ -250,7 +250,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 newState: ResetPasswordCodeRequiredState(
                     controller: self,
                     username: username,
-                    flowToken: challengeToken,
+                    continuationToken: challengeToken,
                     correlationId: context.correlationId()
                 ),
                 sentTo: sentTo,
@@ -300,17 +300,17 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
     private func handleSubmitCodeResponse(
         _ response: MSALNativeAuthResetPasswordContinueValidatedResponse,
         username: String,
-        passwordResetToken: String,
+        continuationToken: String,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
     ) async -> ResetPasswordSubmitCodeControllerResponse {
         switch response {
-        case .success(let passwordSubmitToken):
+        case .success(let continuationToken):
             MSALLogger.log(level: .info, context: context, format: "Successful resetpassword/continue request")
             let newState = ResetPasswordRequiredState(
                 controller: self,
                 username: username,
-                flowToken: passwordSubmitToken,
+                continuationToken: continuationToken,
                 correlationId: context.correlationId()
             )
             return .init(.passwordRequired(newState: newState),
@@ -344,7 +344,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             let state = ResetPasswordCodeRequiredState(
                 controller: self,
                 username: username,
-                flowToken: passwordResetToken,
+                continuationToken: continuationToken,
                 correlationId: context.correlationId()
             )
             return .init(.error(error: error, newState: state))
@@ -374,17 +374,17 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
     private func handleSubmitPasswordResponse(
         _ response: MSALNativeAuthResetPasswordSubmitValidatedResponse,
         username: String,
-        passwordSubmitToken: String,
+        continuationToken: String,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
     ) async -> ResetPasswordSubmitPasswordControllerResponse {
         MSALLogger.log(level: .info, context: context, format: "Finished resetpassword/submit request")
 
         switch response {
-        case .success(let passwordResetToken, let pollInterval):
+        case .success(let continuationToken, let pollInterval):
             return await doPollCompletionLoop(
                 username: username,
-                passwordResetToken: passwordResetToken,
+                continuationToken: continuationToken,
                 pollInterval: pollInterval,
                 retriesRemaining: kNumberOfTimesToRetryPollCompletionCall,
                 event: event,
@@ -400,7 +400,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             let newState = ResetPasswordRequiredState(
                 controller: self,
                 username: username,
-                flowToken: passwordSubmitToken,
+                continuationToken: continuationToken,
                 correlationId: context.correlationId()
             )
             return .init(.error(error: error, newState: newState))
@@ -429,7 +429,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
 
     private func doPollCompletionLoop(
         username: String,
-        passwordResetToken: String,
+        continuationToken: String,
         pollInterval: Int,
         retriesRemaining: Int,
         event: MSIDTelemetryAPIEvent?,
@@ -438,7 +438,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         MSALLogger.log(level: .verbose, context: context, format: "Performing poll completion request")
 
         let pollCompletionResponse = await performPollCompletionRequest(
-            passwordResetToken: passwordResetToken,
+            continuationToken: continuationToken,
             context: context
         )
 
@@ -449,19 +449,19 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             username: username,
             pollInterval: pollInterval,
             retriesRemaining: retriesRemaining,
-            passwordResetToken: passwordResetToken,
+            continuationToken: continuationToken,
             event: event,
             context: context
         )
     }
 
     private func performPollCompletionRequest(
-        passwordResetToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
         let parameters = MSALNativeAuthResetPasswordPollCompletionRequestParameters(
             context: context,
-            passwordResetToken: passwordResetToken
+            continuationToken: continuationToken
         )
         let request: MSIDHttpRequest
 
@@ -487,20 +487,20 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         username: String,
         pollInterval: Int,
         retriesRemaining: Int,
-        passwordResetToken: String,
+        continuationToken: String,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
     ) async -> ResetPasswordSubmitPasswordControllerResponse {
         MSALLogger.log(level: .info, context: context, format: "Finished resetpassword/poll_completion")
 
         switch response {
-        case .success(let status, let continuationToken):
+        case .success(let status, let newContinuationToken):
             switch status {
             case .inProgress,
                  .notStarted:
 
                 return await retryPollCompletion(
-                    passwordResetToken: passwordResetToken,
+                    continuationToken: continuationToken,
                     pollInterval: pollInterval,
                     retriesRemaining: retriesRemaining,
                     username: username,
@@ -511,7 +511,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 let signInAfterResetPasswordState = SignInAfterResetPasswordState(
                     controller: signInController,
                     username: username,
-                    slt: continuationToken,
+                    continuationToken: newContinuationToken,
                     correlationId: context.correlationId()
                 )
                 return .init(.completed(signInAfterResetPasswordState), telemetryUpdate: { [weak self] result in
@@ -534,7 +534,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             let newState = ResetPasswordRequiredState(
                 controller: self,
                 username: username,
-                flowToken: passwordResetToken,
+                continuationToken: continuationToken,
                 correlationId: context.correlationId()
             )
             return .init(.error(error: error, newState: newState))
@@ -561,7 +561,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
     // swiftlint:enable function_body_length
 
     private func retryPollCompletion(
-        passwordResetToken: String,
+        continuationToken: String,
         pollInterval: Int,
         retriesRemaining: Int,
         username: String,
@@ -597,7 +597,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
 
         return await doPollCompletionLoop(
             username: username,
-            passwordResetToken: passwordResetToken,
+            continuationToken: continuationToken,
             pollInterval: pollInterval,
             retriesRemaining: retriesRemaining - 1,
             event: event,

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -66,49 +66,49 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         return await handleStartResponse(response, username: parameters.username, event: event, context: parameters.context)
     }
 
-    func resendCode(username: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
+    func resendCode(username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordResendCode, context: context)
-        let response = await performChallengeRequest(passwordResetToken: passwordResetToken, context: context)
+        let response = await performChallengeRequest(passwordResetToken: continuationToken, context: context)
         return await handleResendCodeChallengeResponse(response, username: username, event: event, context: context)
     }
 
     func submitCode(
         code: String,
         username: String,
-        passwordResetToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> ResetPasswordSubmitCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordSubmitCode, context: context)
 
         let params = MSALNativeAuthResetPasswordContinueRequestParameters(
             context: context,
-            passwordResetToken: passwordResetToken,
+            passwordResetToken: continuationToken,
             grantType: .oobCode,
             oobCode: code
         )
 
         let response = await performContinueRequest(parameters: params)
-        return await handleSubmitCodeResponse(response, username: username, passwordResetToken: passwordResetToken, event: event, context: context)
+        return await handleSubmitCodeResponse(response, username: username, passwordResetToken: continuationToken, event: event, context: context)
     }
 
     func submitPassword(
         password: String,
         username: String,
-        passwordSubmitToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> ResetPasswordSubmitPasswordControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdResetPasswordSubmit, context: context)
 
         let params = MSALNativeAuthResetPasswordSubmitRequestParameters(
             context: context,
-            passwordSubmitToken: passwordSubmitToken,
+            passwordSubmitToken: continuationToken,
             newPassword: password
         )
         let submitRequestResponse = await performSubmitRequest(parameters: params)
         return await handleSubmitPasswordResponse(
             submitRequestResponse,
             username: username,
-            passwordSubmitToken: passwordSubmitToken,
+            passwordSubmitToken: continuationToken,
             event: event,
             context: context
         )

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordControlling.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordControlling.swift
@@ -33,19 +33,19 @@ protocol MSALNativeAuthResetPasswordControlling: AnyObject {
 
     func resetPassword(parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartControllerResponse
 
-    func resendCode(username: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse
+    func resendCode(username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse
 
     func submitCode(
         code: String,
         username: String,
-        passwordResetToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> ResetPasswordSubmitCodeControllerResponse
 
     func submitPassword(
         password: String,
         username: String,
-        passwordSubmitToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> ResetPasswordSubmitPasswordControllerResponse
 }

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -303,11 +303,11 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                     continuationToken: continuationToken,
                     correlationId: context.correlationId()))
             )
-        case .codeRequired(let continuationToken, let sentTo, let channelType, let codeLength):
+        case .codeRequired(let newContinuationToken, let sentTo, let channelType, let codeLength):
             let state = SignInCodeRequiredState(
                 scopes: scopes,
                 controller: self,
-                continuationToken: continuationToken,
+                continuationToken: newContinuationToken,
                 correlationId: context.correlationId()
             )
             return .init(

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -214,7 +214,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
     func submitPassword(
         _ password: String,
         username: String,
-        credentialToken: String,
+        continuationToken: String,
         context: MSALNativeAuthRequestContext,
         scopes: [String]
     ) async -> SignInSubmitPasswordControllerResponse {
@@ -226,7 +226,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             username: username,
             password: password,
             scopes: scopes,
-            credentialToken: credentialToken,
+            credentialToken: continuationToken,
             grantType: .password,
             context: context) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn, submit password: unable to create token request")
@@ -234,7 +234,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 errorType: .generalError,
                 telemetryInfo: telemetryInfo,
                 username: username,
-                credentialToken: credentialToken,
+                credentialToken: continuationToken,
                 scopes: scopes
             )
         }
@@ -260,7 +260,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                             errorType: .generalError,
                             telemetryInfo: telemetryInfo,
                             username: username,
-                            credentialToken: credentialToken,
+                            credentialToken: continuationToken,
                             scopes: scopes
                         ))
                     }
@@ -272,19 +272,19 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 errorType: errorType,
                 telemetryInfo: telemetryInfo,
                 username: username,
-                credentialToken: credentialToken,
+                credentialToken: continuationToken,
                 scopes: scopes
             )
         }
     }
 
     func resendCode(
-        credentialToken: String,
+        continuationToken: String,
         context: MSALNativeAuthRequestContext,
         scopes: [String]
     ) async -> SignInResendCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignInResendCode, context: context)
-        let result = await performAndValidateChallengeRequest(credentialToken: credentialToken, context: context)
+        let result = await performAndValidateChallengeRequest(credentialToken: continuationToken, context: context)
         switch result {
         case .passwordRequired:
             let error = ResendCodeError()
@@ -300,7 +300,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 newState: SignInCodeRequiredState(
                     scopes: scopes,
                     controller: self,
-                    flowToken: credentialToken,
+                    flowToken: continuationToken,
                     correlationId: context.correlationId()))
             )
         case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -96,7 +96,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
 
     func signIn(
         username: String,
-        slt: String?,
+        continuationToken: String?,
         scopes: [String]?,
         context: MSALNativeAuthRequestContext
     ) async -> SignInAfterPreviousFlowControllerResponse {
@@ -105,8 +105,8 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInAfterSignUp, context: context),
             context: context
         )
-        guard let slt = slt else {
-            MSALLogger.log(level: .error, context: context, format: "SignIn after previous flow not available because signInSLT is nil")
+        guard let continuationToken = continuationToken else {
+            MSALLogger.log(level: .error, context: context, format: "SignIn after previous flow not available because continuationToken is nil")
             let error = SignInAfterSignUpError(message: MSALNativeAuthErrorMessage.signInNotAvailable)
             stopTelemetryEvent(telemetryInfo, error: error)
             return .init(.failure(error))
@@ -115,8 +115,8 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         guard let request = createTokenRequest(
             username: username,
             scopes: scopes,
-            signInSLT: slt,
-            grantType: .slt,
+            continuationToken: continuationToken,
+            grantType: .continuationToken,
             context: context
         ) else {
             let error = SignInAfterSignUpError()
@@ -146,7 +146,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
     // swiftlint:disable:next function_body_length
     func submitCode(
         _ code: String,
-        credentialToken: String,
+        continuationToken: String,
         context: MSALNativeAuthRequestContext,
         scopes: [String]
     ) async -> SignInSubmitCodeControllerResponse {
@@ -156,7 +156,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         )
         guard let request = createTokenRequest(
             scopes: scopes,
-            credentialToken: credentialToken,
+            continuationToken: continuationToken,
             oobCode: code,
             grantType: .oobCode,
             includeChallengeType: false,
@@ -167,7 +167,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 errorType: .generalError,
                 telemetryInfo: telemetryInfo,
                 scopes: scopes,
-                credentialToken: credentialToken,
+                continuationToken: continuationToken,
                 context: context
             )
         }
@@ -193,7 +193,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                             errorType: .generalError,
                             telemetryInfo: telemetryInfo,
                             scopes: scopes,
-                            credentialToken: credentialToken,
+                            continuationToken: continuationToken,
                             context: context
                         ))
                     }
@@ -204,7 +204,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 errorType: errorType,
                 telemetryInfo: telemetryInfo,
                 scopes: scopes,
-                credentialToken: credentialToken,
+                continuationToken: continuationToken,
                 context: context
             )
         }
@@ -226,7 +226,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             username: username,
             password: password,
             scopes: scopes,
-            credentialToken: continuationToken,
+            continuationToken: continuationToken,
             grantType: .password,
             context: context) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn, submit password: unable to create token request")
@@ -234,7 +234,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 errorType: .generalError,
                 telemetryInfo: telemetryInfo,
                 username: username,
-                credentialToken: continuationToken,
+                continuationToken: continuationToken,
                 scopes: scopes
             )
         }
@@ -260,7 +260,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                             errorType: .generalError,
                             telemetryInfo: telemetryInfo,
                             username: username,
-                            credentialToken: continuationToken,
+                            continuationToken: continuationToken,
                             scopes: scopes
                         ))
                     }
@@ -272,7 +272,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 errorType: errorType,
                 telemetryInfo: telemetryInfo,
                 username: username,
-                credentialToken: continuationToken,
+                continuationToken: continuationToken,
                 scopes: scopes
             )
         }
@@ -284,7 +284,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         scopes: [String]
     ) async -> SignInResendCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignInResendCode, context: context)
-        let result = await performAndValidateChallengeRequest(credentialToken: continuationToken, context: context)
+        let result = await performAndValidateChallengeRequest(continuationToken: continuationToken, context: context)
         switch result {
         case .passwordRequired:
             let error = ResendCodeError()
@@ -300,11 +300,16 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 newState: SignInCodeRequiredState(
                     scopes: scopes,
                     controller: self,
-                    flowToken: continuationToken,
+                    continuationToken: continuationToken,
                     correlationId: context.correlationId()))
             )
-        case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
-            let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken, correlationId: context.correlationId())
+        case .codeRequired(let continuationToken, let sentTo, let channelType, let codeLength):
+            let state = SignInCodeRequiredState(
+                scopes: scopes,
+                controller: self,
+                continuationToken: continuationToken,
+                correlationId: context.correlationId()
+            )
             return .init(
                 .codeRequired(
                     newState: state,
@@ -323,7 +328,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         errorType: MSALNativeAuthTokenValidatedErrorType,
         telemetryInfo: TelemetryInfo,
         scopes: [String],
-        credentialToken: String,
+        continuationToken: String,
         context: MSALNativeAuthRequestContext
     ) -> SignInSubmitCodeControllerResponse {
         MSALLogger.log(
@@ -331,7 +336,12 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             context: context,
             format: "SignIn completed with errorType: \(errorType)")
         stopTelemetryEvent(telemetryInfo, error: errorType)
-        let state = SignInCodeRequiredState(scopes: scopes, controller: self, flowToken: credentialToken, correlationId: context.correlationId())
+        let state = SignInCodeRequiredState(
+            scopes: scopes,
+            controller: self,
+            continuationToken: continuationToken,
+            correlationId: context.correlationId()
+        )
         return .init(.error(error: errorType.convertToVerifyCodeError(), newState: state))
     }
 
@@ -339,7 +349,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         errorType: MSALNativeAuthTokenValidatedErrorType,
         telemetryInfo: TelemetryInfo,
         username: String,
-        credentialToken: String,
+        continuationToken: String,
         scopes: [String]
     ) -> SignInSubmitPasswordControllerResponse {
         MSALLogger.log(
@@ -351,7 +361,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             scopes: scopes,
             username: username,
             controller: self,
-            flowToken: credentialToken,
+            continuationToken: continuationToken,
             correlationId: telemetryInfo.context.correlationId()
         )
         return .init(.error(error: errorType.convertToPasswordRequiredError(), newState: state))
@@ -378,9 +388,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         telemetryInfo: TelemetryInfo
     ) async -> Result<MSALNativeAuthSignInChallengeValidatedResponse, MSALNativeAuthSignInInitiateValidatedErrorType> {
         switch validatedResponse {
-        case .success(let credentialToken):
+        case .success(let continuationToken):
             let challengeValidatedResponse = await performAndValidateChallengeRequest(
-                credentialToken: credentialToken,
+                continuationToken: continuationToken,
                 context: telemetryInfo.context
             )
             return .success(challengeValidatedResponse)
@@ -458,13 +468,13 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         let scopes = joinScopes(params.scopes)
         let isSignInUsingPassword = params.password != nil
         switch validatedResponse {
-        case .passwordRequired(let credentialToken):
+        case .passwordRequired(let continuationToken):
             if isSignInUsingPassword {
                 guard let request = createTokenRequest(
                     username: params.username,
                     password: params.password,
                     scopes: scopes,
-                    credentialToken: credentialToken,
+                    continuationToken: continuationToken,
                     grantType: .password,
                     context: telemetryInfo.context
                 ) else {
@@ -495,7 +505,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                     scopes: scopes,
                     username: params.username,
                     controller: self,
-                    flowToken: credentialToken,
+                    continuationToken: continuationToken,
                     correlationId: params.context.correlationId()
                 )
 
@@ -503,13 +513,13 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                     self?.stopTelemetryEvent(telemetryInfo.event, context: telemetryInfo.context, delegateDispatcherResult: result)
                 })
             }
-        case .codeRequired(let credentialToken, let sentTo, let channelType, let codeLength):
+        case .codeRequired(let continuationToken, let sentTo, let channelType, let codeLength):
             if isSignInUsingPassword {
                 MSALLogger.log(level: .warning, context: telemetryInfo.context, format: MSALNativeAuthErrorMessage.codeRequiredForPasswordUserLog)
             }
             let state = SignInCodeRequiredState(scopes: scopes,
                                                 controller: self,
-                                                flowToken: credentialToken,
+                                                continuationToken: continuationToken,
                                                 correlationId: params.context.correlationId())
             return .init(
                 .codeRequired(
@@ -531,10 +541,10 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
     }
 
     private func performAndValidateChallengeRequest(
-        credentialToken: String,
+        continuationToken: String,
         context: MSALNativeAuthRequestContext
     ) async -> MSALNativeAuthSignInChallengeValidatedResponse {
-        guard let challengeRequest = createChallengeRequest(credentialToken: credentialToken, context: context) else {
+        guard let challengeRequest = createChallengeRequest(continuationToken: continuationToken, context: context) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: Cannot create Challenge request object")
             return .error(.invalidRequest(message: nil))
         }
@@ -553,13 +563,13 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
     }
 
     private func createChallengeRequest(
-        credentialToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) -> MSIDHttpRequest? {
         do {
             let params = MSALNativeAuthSignInChallengeRequestParameters(
                 context: context,
-                credentialToken: credentialToken
+                continuationToken: continuationToken
             )
             return try signInRequestProvider.challenge(parameters: params, context: context)
         } catch {

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
@@ -37,14 +37,14 @@ protocol MSALNativeAuthSignInControlling {
 
     func signIn(
         username: String,
-        slt: String?,
+        continuationToken: String?,
         scopes: [String]?,
         context: MSALNativeAuthRequestContext
     ) async -> SignInAfterPreviousFlowControllerResponse
 
     func submitCode(
         _ code: String,
-        credentialToken: String,
+        continuationToken: String,
         context: MSALNativeAuthRequestContext,
         scopes: [String]
     ) async -> SignInSubmitCodeControllerResponse
@@ -52,10 +52,10 @@ protocol MSALNativeAuthSignInControlling {
     func submitPassword(
         _ password: String,
         username: String,
-        credentialToken: String,
+        continuationToken: String,
         context: MSALNativeAuthRequestContext,
         scopes: [String]
     ) async -> SignInSubmitPasswordControllerResponse
 
-    func resendCode(credentialToken: String, context: MSALNativeAuthRequestContext, scopes: [String]) async -> SignInResendCodeControllerResponse
+    func resendCode(continuationToken: String, context: MSALNativeAuthRequestContext, scopes: [String]) async -> SignInResendCodeControllerResponse
 }

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -70,54 +70,54 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         return await handleSignUpStartResult(result, username: parameters.username, event: event, context: parameters.context)
     }
 
-    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeControllerResponse {
+    func resendCode(username: String, context: MSIDRequestContext, continuationToken: String) async -> SignUpResendCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpResendCode, context: context)
-        let challengeResult = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
-        return handleResendCodeResult(challengeResult, username: username, event: event, signupToken: signUpToken, context: context)
+        let challengeResult = await performAndValidateChallengeRequest(signUpToken: continuationToken, context: context)
+        return handleResendCodeResult(challengeResult, username: username, event: event, signupToken: continuationToken, context: context)
     }
 
-    func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse {
+    func submitCode(_ code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitCode, context: context)
-        let params = MSALNativeAuthSignUpContinueRequestProviderParams(grantType: .oobCode, signUpToken: signUpToken, oobCode: code, context: context)
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(grantType: .oobCode, signUpToken: continuationToken, oobCode: code, context: context)
 
         let result = await performAndValidateContinueRequest(parameters: params)
-        return await handleSubmitCodeResult(result, username: username, signUpToken: signUpToken, event: event, context: context)
+        return await handleSubmitCodeResult(result, username: username, signUpToken: continuationToken, event: event, context: context)
     }
 
     func submitPassword(
         _ password: String,
         username: String,
-        signUpToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> SignUpSubmitPasswordControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitPassword, context: context)
 
         let params = MSALNativeAuthSignUpContinueRequestProviderParams(
             grantType: .password,
-            signUpToken: signUpToken,
+            signUpToken: continuationToken,
             password: password,
             context: context
         )
         let continueRequestResult = await performAndValidateContinueRequest(parameters: params)
-        return handleSubmitPasswordResult(continueRequestResult, username: username, signUpToken: signUpToken, event: event, context: context)
+        return handleSubmitPasswordResult(continueRequestResult, username: username, signUpToken: continuationToken, event: event, context: context)
     }
 
     func submitAttributes(
         _ attributes: [String: Any],
         username: String,
-        signUpToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> SignUpSubmitAttributesControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitAttributes, context: context)
         let params = MSALNativeAuthSignUpContinueRequestProviderParams(
             grantType: .attributes,
-            signUpToken: signUpToken,
+            signUpToken: continuationToken,
             attributes: attributes,
             context: context
         )
 
         let result = await performAndValidateContinueRequest(parameters: params)
-        return handleSubmitAttributesResult(result, username: username, signUpToken: signUpToken, event: event, context: context)
+        return handleSubmitAttributesResult(result, username: username, signUpToken: continuationToken, event: event, context: context)
     }
 
     // MARK: - Start Request handling

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -73,7 +73,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
     func resendCode(username: String, context: MSIDRequestContext, continuationToken: String) async -> SignUpResendCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpResendCode, context: context)
         let challengeResult = await performAndValidateChallengeRequest(continuationToken: continuationToken, context: context)
-        return handleResendCodeResult(challengeResult, username: username, event: event, signupToken: continuationToken, context: context)
+        return handleResendCodeResult(challengeResult, username: username, event: event, continuationToken: continuationToken, context: context)
     }
 
     func submitCode(
@@ -294,7 +294,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
         username: String,
         event: MSIDTelemetryAPIEvent?,
-        signupToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) -> SignUpResendCodeControllerResponse {
         switch result {
@@ -322,7 +322,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             let newState = SignUpCodeRequiredState(
                 controller: self,
                 username: username,
-                continuationToken: signupToken,
+                continuationToken: continuationToken,
                 correlationId: context.correlationId()
             )
             return .init(.error(error: error, newState: newState))

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -72,16 +72,26 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
 
     func resendCode(username: String, context: MSIDRequestContext, continuationToken: String) async -> SignUpResendCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpResendCode, context: context)
-        let challengeResult = await performAndValidateChallengeRequest(signUpToken: continuationToken, context: context)
+        let challengeResult = await performAndValidateChallengeRequest(continuationToken: continuationToken, context: context)
         return handleResendCodeResult(challengeResult, username: username, event: event, signupToken: continuationToken, context: context)
     }
 
-    func submitCode(_ code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse {
+    func submitCode(
+        _ code: String,
+        username: String,
+        continuationToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpSubmitCodeControllerResponse {
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitCode, context: context)
-        let params = MSALNativeAuthSignUpContinueRequestProviderParams(grantType: .oobCode, signUpToken: continuationToken, oobCode: code, context: context)
+        let params = MSALNativeAuthSignUpContinueRequestProviderParams(
+            grantType: .oobCode,
+            continuationToken: continuationToken,
+            oobCode: code,
+            context: context
+        )
 
         let result = await performAndValidateContinueRequest(parameters: params)
-        return await handleSubmitCodeResult(result, username: username, signUpToken: continuationToken, event: event, context: context)
+        return await handleSubmitCodeResult(result, username: username, continuationToken: continuationToken, event: event, context: context)
     }
 
     func submitPassword(
@@ -94,12 +104,18 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
 
         let params = MSALNativeAuthSignUpContinueRequestProviderParams(
             grantType: .password,
-            signUpToken: continuationToken,
+            continuationToken: continuationToken,
             password: password,
             context: context
         )
         let continueRequestResult = await performAndValidateContinueRequest(parameters: params)
-        return handleSubmitPasswordResult(continueRequestResult, username: username, signUpToken: continuationToken, event: event, context: context)
+        return handleSubmitPasswordResult(
+            continueRequestResult,
+            username: username,
+            continuationToken: continuationToken,
+            event: event,
+            context: context
+        )
     }
 
     func submitAttributes(
@@ -111,13 +127,13 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignUpSubmitAttributes, context: context)
         let params = MSALNativeAuthSignUpContinueRequestProviderParams(
             grantType: .attributes,
-            signUpToken: continuationToken,
+            continuationToken: continuationToken,
             attributes: attributes,
             context: context
         )
 
         let result = await performAndValidateContinueRequest(parameters: params)
-        return handleSubmitAttributesResult(result, username: username, signUpToken: continuationToken, event: event, context: context)
+        return handleSubmitAttributesResult(result, username: username, continuationToken: continuationToken, event: event, context: context)
     }
 
     // MARK: - Start Request handling
@@ -148,13 +164,13 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         context: MSIDRequestContext
     ) async -> SignUpStartControllerResponse {
         switch result {
-        case .verificationRequired(let signUpToken, let unverifiedAttributes):
+        case .verificationRequired(let continuationToken, let unverifiedAttributes):
             MSALLogger.log(
                 level: .info,
                 context: context,
                 format: "verification_required received from signup/start request for attributes: \(unverifiedAttributes)"
             )
-            let challengeResult = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+            let challengeResult = await performAndValidateChallengeRequest(continuationToken: continuationToken, context: context)
             return handleSignUpChallengeResult(challengeResult, username: username, event: event, context: context)
         case .attributeValidationFailed(let invalidAttributes):
             MSALLogger.log(
@@ -209,13 +225,13 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
     // MARK: - Challenge Request handling
 
     private func performAndValidateChallengeRequest(
-        signUpToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> MSALNativeAuthSignUpChallengeValidatedResponse {
         let request: MSIDHttpRequest
 
         do {
-            request = try requestProvider.challenge(token: signUpToken, context: context)
+            request = try requestProvider.challenge(token: continuationToken, context: context)
         } catch {
             MSALLogger.log(level: .error, context: context, format: "Error while creating Challenge Request: \(error)")
             return .unexpectedError
@@ -234,13 +250,13 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         context: MSIDRequestContext
     ) -> SignUpStartControllerResponse {
         switch result {
-        case .codeRequired(let sentTo, let challengeType, let codeLength, let signUpToken):
+        case .codeRequired(let sentTo, let challengeType, let codeLength, let continuationToken):
             MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge request")
             return SignUpStartControllerResponse(
                 .codeRequired(
                     newState: SignUpCodeRequiredState(controller: self,
                                                       username: username,
-                                                      flowToken: signUpToken,
+                                                      continuationToken: continuationToken,
                                                       correlationId: context.correlationId()),
                     sentTo: sentTo,
                     channelTargetType: challengeType,
@@ -282,13 +298,13 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         context: MSIDRequestContext
     ) -> SignUpResendCodeControllerResponse {
         switch result {
-        case .codeRequired(let sentTo, let challengeType, let codeLength, let signUpToken):
+        case .codeRequired(let sentTo, let challengeType, let codeLength, let continuationToken):
             MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge resendCode request")
             return .init(.codeRequired(
                 newState: SignUpCodeRequiredState(
                     controller: self,
                     username: username,
-                    flowToken: signUpToken,
+                    continuationToken: continuationToken,
                     correlationId: context.correlationId()
                 ),
                 sentTo: sentTo,
@@ -306,7 +322,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             let newState = SignUpCodeRequiredState(
                 controller: self,
                 username: username,
-                flowToken: signupToken,
+                continuationToken: signupToken,
                 correlationId: context.correlationId()
             )
             return .init(.error(error: error, newState: newState))
@@ -330,12 +346,12 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         context: MSIDRequestContext
     ) -> SignUpSubmitCodeControllerResponse {
         switch result {
-        case .passwordRequired(let signUpToken):
+        case .passwordRequired(let continuationToken):
             MSALLogger.log(level: .info, context: context, format: "Successful signup/challenge request after credential_required")
 
             let state = SignUpPasswordRequiredState(controller: self,
                                                     username: username,
-                                                    flowToken: signUpToken,
+                                                    continuationToken: continuationToken,
                                                     correlationId: context.correlationId())
 
             return .init(.passwordRequired(state), telemetryUpdate: { [weak self] result in
@@ -383,13 +399,13 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
     private func handleSubmitCodeResult(
         _ result: MSALNativeAuthSignUpContinueValidatedResponse,
         username: String,
-        signUpToken: String,
+        continuationToken: String,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
     ) async -> SignUpSubmitCodeControllerResponse {
         switch result {
-        case .success(let slt):
-            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+        case .success(let continuationToken):
+            let state = createSignInAfterSignUpStateUsingContinuationToken(continuationToken, username: username, event: event, context: context)
             return .init(.completed(state), telemetryUpdate: { [weak self] result in
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
             })
@@ -398,19 +414,24 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
 
             let error = VerifyCodeError(type: .invalidCode)
             stopTelemetryEvent(event, context: context, error: error)
-            let state = SignUpCodeRequiredState(controller: self, username: username, flowToken: signUpToken, correlationId: context.correlationId())
+            let state = SignUpCodeRequiredState(
+                controller: self,
+                username: username,
+                continuationToken: continuationToken,
+                correlationId: context.correlationId()
+            )
             return .init(.error(error: error, newState: state))
-        case .credentialRequired(let signUpToken):
+        case .credentialRequired(let continuationToken):
             MSALLogger.log(level: .verbose, context: context, format: "credential_required received in signup/continue request")
 
-            let result = await performAndValidateChallengeRequest(signUpToken: signUpToken, context: context)
+            let result = await performAndValidateChallengeRequest(continuationToken: continuationToken, context: context)
             return handlePerformChallengeAfterContinueRequest(result, username: username, event: event, context: context)
-        case .attributesRequired(let signUpToken, let attributes):
+        case .attributesRequired(let continuationToken, let attributes):
             MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
 
             let state = SignUpAttributesRequiredState(controller: self,
                                                       username: username,
-                                                      flowToken: signUpToken,
+                                                      continuationToken: continuationToken,
                                                       correlationId: context.correlationId())
 
             return .init(.attributesRequired(attributes: attributes, newState: state), telemetryUpdate: { [weak self] result in
@@ -437,13 +458,13 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
     private func handleSubmitPasswordResult(
         _ result: MSALNativeAuthSignUpContinueValidatedResponse,
         username: String,
-        signUpToken: String,
+        continuationToken: String,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
     ) -> SignUpSubmitPasswordControllerResponse {
         switch result {
-        case .success(let slt):
-            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+        case .success(let continuationToken):
+            let state = createSignInAfterSignUpStateUsingContinuationToken(continuationToken, username: username, event: event, context: context)
             return .init(.completed(state), telemetryUpdate: { [weak self] result in
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
             })
@@ -458,16 +479,16 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
 
             let state = SignUpPasswordRequiredState(controller: self,
                                                     username: username,
-                                                    flowToken: signUpToken,
+                                                    continuationToken: continuationToken,
                                                     correlationId: context.correlationId())
 
             return .init(.error(error: error, newState: state))
-        case .attributesRequired(let signUpToken, let attributes):
+        case .attributesRequired(let continuationToken, let attributes):
             MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
 
             let state = SignUpAttributesRequiredState(controller: self,
                                                       username: username,
-                                                      flowToken: signUpToken,
+                                                      continuationToken: continuationToken,
                                                       correlationId: context.correlationId())
 
             return .init(.attributesRequired(attributes: attributes, newState: state), telemetryUpdate: { [weak self] result in
@@ -496,17 +517,17 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
     private func handleSubmitAttributesResult(
         _ result: MSALNativeAuthSignUpContinueValidatedResponse,
         username: String,
-        signUpToken: String,
+        continuationToken: String,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
     ) -> SignUpSubmitAttributesControllerResponse {
         switch result {
-        case .success(let slt):
-            let state = createSignInAfterSignUpStateUsingSLT(slt, username: username, event: event, context: context)
+        case .success(let continuationToken):
+            let state = createSignInAfterSignUpStateUsingContinuationToken(continuationToken, username: username, event: event, context: context)
             return .init(.completed(state), telemetryUpdate: { [weak self] result in
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
             })
-        case .attributesRequired(let signUpToken, let attributes):
+        case .attributesRequired(let continuationToken, let attributes):
             let error = AttributesRequiredError()
             MSALLogger.log(level: .error,
                            context: context,
@@ -514,14 +535,14 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             let state = SignUpAttributesRequiredState(
                 controller: self,
                 username: username,
-                flowToken: signUpToken,
+                continuationToken: continuationToken,
                 correlationId: context.correlationId()
             )
             return .init(.attributesRequired(attributes: attributes, state: state), telemetryUpdate: { [weak self] result in
                 // The telemetry event always fails because more attributes are required (we consider this an error after having sent attributes)
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result, controllerError: error)
             })
-        case .attributeValidationFailed(let signUpToken, let invalidAttributes):
+        case .attributeValidationFailed(let continuationToken, let invalidAttributes):
             let message = "attribute_validation_failed from signup/continue submitAttributes request. Make sure these attributes are correct: \(invalidAttributes)" // swiftlint:disable:this line_length
             MSALLogger.log(level: .error, context: context, format: message)
 
@@ -531,7 +552,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             let state = SignUpAttributesRequiredState(
                 controller: self,
                 username: username,
-                flowToken: signUpToken,
+                continuationToken: continuationToken,
                 correlationId: context.correlationId()
             )
             return .init(.attributesInvalid(attributes: invalidAttributes, newState: state), telemetryUpdate: { [weak self] result in
@@ -557,8 +578,8 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         }
     }
 
-    private func createSignInAfterSignUpStateUsingSLT(
-        _ slt: String?,
+    private func createSignInAfterSignUpStateUsingContinuationToken(
+        _ continuationToken: String?,
         username: String,
         event: MSIDTelemetryAPIEvent?,
         context: MSIDRequestContext
@@ -568,7 +589,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         return SignInAfterSignUpState(
             controller: signInController,
             username: username,
-            slt: slt,
+            continuationToken: continuationToken,
             correlationId: context.correlationId()
         )
     }

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
@@ -36,7 +36,12 @@ protocol MSALNativeAuthSignUpControlling: AnyObject {
 
     func resendCode(username: String, context: MSIDRequestContext, continuationToken: String) async -> SignUpResendCodeControllerResponse
 
-    func submitCode(_ code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse
+    func submitCode(
+        _ code: String,
+        username: String,
+        continuationToken: String,
+        context: MSIDRequestContext
+    ) async -> SignUpSubmitCodeControllerResponse
 
     func submitPassword(
         _ password: String,

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
@@ -34,21 +34,21 @@ protocol MSALNativeAuthSignUpControlling: AnyObject {
 
     func signUpStart(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartControllerResponse
 
-    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeControllerResponse
+    func resendCode(username: String, context: MSIDRequestContext, continuationToken: String) async -> SignUpResendCodeControllerResponse
 
-    func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse
+    func submitCode(_ code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> SignUpSubmitCodeControllerResponse
 
     func submitPassword(
         _ password: String,
         username: String,
-        signUpToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> SignUpSubmitPasswordControllerResponse
 
     func submitAttributes(
         _ attributes: [String: Any],
         username: String,
-        signUpToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> SignUpSubmitAttributesControllerResponse
 }

--- a/MSAL/src/native_auth/network/MSALNativeAuthGrantType.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthGrantType.swift
@@ -27,6 +27,6 @@ enum MSALNativeAuthGrantType: String {
     case otp = "passwordless_otp"
     case oobCode = "oob"
     case refreshToken = "refresh_token"
-    case slt
+    case continuationToken = "continuation_token"
     case attributes
 }

--- a/MSAL/src/native_auth/network/MSALNativeAuthRequestParametersKey.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthRequestParametersKey.swift
@@ -32,16 +32,11 @@ enum MSALNativeAuthRequestParametersKey: String {
     case email
     case password
     case scope
-    case credentialToken = "credential_token"
-    case flowToken
+    case continuationToken = "continuation_token"
     case oobCode = "oob"
     case otp
     case customAttributes
-    case signInSLT = "signin_slt"
     case attributes
-    case signUpToken = "signup_token"
-    case passwordResetToken = "password_reset_token"
-    case passwordSubmitToken = "password_submit_token"
     case newPassword = "new_password"
     case clientInfo = "client_info"
     case refreshToken = "refresh_token"

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
@@ -32,7 +32,7 @@ struct MSALNativeAuthResetPasswordContinueResponseError: MSALNativeAuthResponseE
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
     let target: String?
-    let passwordResetToken: String?
+    let continuationToken: String?
 
     enum CodingKeys: String, CodingKey {
         case error
@@ -41,7 +41,7 @@ struct MSALNativeAuthResetPasswordContinueResponseError: MSALNativeAuthResponseE
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
         case target
-        case passwordResetToken = "password_reset_token"
+        case continuationToken = "continuation_token"
     }
 }
 

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
@@ -30,7 +30,7 @@ struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
     let errorCodes: [Int]?
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
-    let signUpToken: String?
+    let continuationToken: String?
     let requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]?
     let unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]?
     let invalidAttributes: [MSALNativeAuthErrorBasicAttributes]?
@@ -41,7 +41,7 @@ struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
         case errorCodes = "error_codes"
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
-        case signUpToken = "signup_token"
+        case continuationToken = "continuation_token"
         case requiredAttributes = "required_attributes"
         case unverifiedAttributes = "unverified_attributes"
         case invalidAttributes = "invalid_attributes"

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
@@ -31,7 +31,7 @@ struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
     let errorCodes: [Int]?
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
-    let signUpToken: String?
+    let continuationToken: String?
     let unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]?
     let invalidAttributes: [MSALNativeAuthErrorBasicAttributes]?
 
@@ -41,7 +41,7 @@ struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
         case errorCodes = "error_codes"
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
-        case signUpToken = "signup_token"
+        case continuationToken = "continuation_token"
         case unverifiedAttributes = "unverified_attributes"
         case invalidAttributes = "invalid_attributes"
     }

--- a/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
@@ -31,7 +31,7 @@ struct MSALNativeAuthTokenResponseError: MSALNativeAuthResponseError {
     let errorCodes: [Int]?
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
-    let credentialToken: String?
+    let continuationToken: String?
 
     enum CodingKeys: String, CodingKey {
         case error
@@ -39,6 +39,6 @@ struct MSALNativeAuthTokenResponseError: MSALNativeAuthResponseError {
         case errorCodes = "error_codes"
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
-        case credentialToken = "credential_token"
+        case continuationToken = "continuation_token"
     }
 }

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParameters.swift
@@ -27,14 +27,14 @@
 struct MSALNativeAuthResetPasswordChallengeRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .resetPasswordChallenge
     let context: MSIDRequestContext
-    let passwordResetToken: String
+    let continuationToken: String
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [
             Key.clientId.rawValue: config.clientId,
-            Key.passwordResetToken.rawValue: passwordResetToken,
+            Key.continuationToken.rawValue: continuationToken,
             Key.challengeType.rawValue: config.challengeTypesString
         ].compactMapValues { $0 }
     }

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParameters.swift
@@ -27,7 +27,7 @@
 struct MSALNativeAuthResetPasswordContinueRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .resetPasswordContinue
     let context: MSIDRequestContext
-    let passwordResetToken: String
+    let continuationToken: String
     let grantType: MSALNativeAuthGrantType
     let oobCode: String?
 
@@ -36,7 +36,7 @@ struct MSALNativeAuthResetPasswordContinueRequestParameters: MSALNativeAuthReque
 
         return [
             Key.clientId.rawValue: config.clientId,
-            Key.passwordResetToken.rawValue: passwordResetToken,
+            Key.continuationToken.rawValue: continuationToken,
             Key.grantType.rawValue: grantType.rawValue,
             Key.oobCode.rawValue: oobCode
         ].compactMapValues { $0 }

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParameters.swift
@@ -27,14 +27,14 @@
 struct MSALNativeAuthResetPasswordPollCompletionRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .resetpasswordPollCompletion
     let context: MSIDRequestContext
-    let passwordResetToken: String
+    let continuationToken: String
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [
             Key.clientId.rawValue: config.clientId,
-            Key.passwordResetToken.rawValue: passwordResetToken
+            Key.continuationToken.rawValue: continuationToken
         ]
     }
 }

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParameters.swift
@@ -27,7 +27,7 @@
 struct MSALNativeAuthResetPasswordSubmitRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .resetPasswordSubmit
     let context: MSIDRequestContext
-    let passwordSubmitToken: String
+    let continuationToken: String
     let newPassword: String
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
@@ -35,7 +35,7 @@ struct MSALNativeAuthResetPasswordSubmitRequestParameters: MSALNativeAuthRequest
 
         return [
             Key.clientId.rawValue: config.clientId,
-            Key.passwordSubmitToken.rawValue: passwordSubmitToken,
+            Key.continuationToken.rawValue: continuationToken,
             Key.newPassword.rawValue: newPassword
         ]
     }

--- a/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParameters.swift
@@ -27,14 +27,14 @@
 struct MSALNativeAuthSignInChallengeRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .signInChallenge
     let context: MSIDRequestContext
-    let credentialToken: String
+    let continuationToken: String
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [
             Key.clientId.rawValue: config.clientId,
-            Key.credentialToken.rawValue: credentialToken,
+            Key.continuationToken.rawValue: continuationToken,
             Key.challengeType.rawValue: config.challengeTypesString
         ].compactMapValues { $0 }
     }

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParameters.swift
@@ -26,7 +26,7 @@
 
 struct MSALNativeAuthSignUpChallengeRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .signUpChallenge
-    let signUpToken: String
+    let continuationToken: String
     let context: MSIDRequestContext
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
@@ -34,7 +34,7 @@ struct MSALNativeAuthSignUpChallengeRequestParameters: MSALNativeAuthRequestable
 
         return [
             Key.clientId.rawValue: config.clientId,
-            Key.signUpToken.rawValue: signUpToken,
+            Key.continuationToken.rawValue: continuationToken,
             Key.challengeType.rawValue: config.challengeTypesString
         ].compactMapValues { $0 }
     }

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParameters.swift
@@ -27,7 +27,7 @@
 struct MSALNativeAuthSignUpContinueRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .signUpContinue
     let grantType: MSALNativeAuthGrantType
-    let signUpToken: String
+    let continuationToken: String
     let password: String?
     let oobCode: String?
     let attributes: String?
@@ -39,7 +39,7 @@ struct MSALNativeAuthSignUpContinueRequestParameters: MSALNativeAuthRequestable 
         return [
             Key.clientId.rawValue: config.clientId,
             Key.grantType.rawValue: grantType.rawValue,
-            Key.signUpToken.rawValue: signUpToken,
+            Key.continuationToken.rawValue: continuationToken,
             Key.password.rawValue: password,
             Key.oobCode.rawValue: oobCode,
             Key.attributes.rawValue: attributes

--- a/MSAL/src/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParameters.swift
@@ -28,8 +28,7 @@ struct MSALNativeAuthTokenRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .token
     let context: MSIDRequestContext
     let username: String?
-    let credentialToken: String?
-    let signInSLT: String?
+    let continuationToken: String?
     let grantType: MSALNativeAuthGrantType
     let scope: String?
     let password: String?
@@ -43,8 +42,7 @@ struct MSALNativeAuthTokenRequestParameters: MSALNativeAuthRequestable {
         var parameters = [
             Key.clientId.rawValue: config.clientId,
             Key.username.rawValue: username,
-            Key.credentialToken.rawValue: credentialToken,
-            Key.signInSLT.rawValue: signInSLT,
+            Key.continuationToken.rawValue: continuationToken,
             Key.grantType.rawValue: grantType.rawValue,
             Key.scope.rawValue: scope,
             Key.password.rawValue: password,

--- a/MSAL/src/native_auth/network/reset_password/MSALNativeAuthResetPasswordRequestProvider.swift
+++ b/MSAL/src/native_auth/network/reset_password/MSALNativeAuthResetPasswordRequestProvider.swift
@@ -86,7 +86,7 @@ final class MSALNativeAuthResetPasswordRequestProvider: MSALNativeAuthResetPassw
     func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
         let requestParams = MSALNativeAuthResetPasswordChallengeRequestParameters(
             context: context,
-            passwordResetToken: token
+            continuationToken: token
         )
 
         let request = MSIDHttpRequest()

--- a/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
+++ b/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
@@ -27,9 +27,9 @@ import Foundation
 struct MSALNativeAuthResendCodeRequestResponse: Decodable {
 
     // MARK: - Variables
-    let credentialToken: String
+    let continuationToken: String
 
     enum CodingKeys: String, CodingKey {
-        case credentialToken = "flowToken"
+        case continuationToken
     }
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordChallengeResponse.swift
@@ -31,6 +31,6 @@ struct MSALNativeAuthResetPasswordChallengeResponse: Decodable {
     let bindingMethod: String?
     let challengeTargetLabel: String?
     let challengeChannel: MSALNativeAuthInternalChannelType?
-    let passwordResetToken: String?
+    let continuationToken: String?
     let codeLength: Int?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordContinueResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordContinueResponse.swift
@@ -27,6 +27,6 @@ import Foundation
 struct MSALNativeAuthResetPasswordContinueResponse: Decodable {
 
     // MARK: - Variables
-    let passwordSubmitToken: String
+    let continuationToken: String
     let expiresIn: Int
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
@@ -27,11 +27,11 @@ import Foundation
 struct MSALNativeAuthResetPasswordStartResponse: Decodable {
 
     // MARK: - Variables
-    let passwordResetToken: String?
+    let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType?
 
     enum CodingKeys: String, CodingKey {
-        case passwordResetToken
+        case continuationToken
         case challengeType
     }
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
@@ -29,9 +29,4 @@ struct MSALNativeAuthResetPasswordStartResponse: Decodable {
     // MARK: - Variables
     let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType?
-
-    enum CodingKeys: String, CodingKey {
-        case continuationToken
-        case challengeType
-    }
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordSubmitResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordSubmitResponse.swift
@@ -27,6 +27,6 @@ import Foundation
 struct MSALNativeAuthResetPasswordSubmitResponse: Decodable {
 
     // MARK: - Variables
-    let passwordResetToken: String
+    let continuationToken: String
     let pollInterval: Int
 }

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInChallengeResponse.swift
@@ -27,7 +27,7 @@ import Foundation
 struct MSALNativeAuthSignInChallengeResponse: Decodable {
 
     // MARK: - Variables
-    let credentialToken: String?
+    let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType
     let bindingMethod: String?
     let challengeTargetLabel: String?

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInInitiateResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInInitiateResponse.swift
@@ -29,9 +29,4 @@ struct MSALNativeAuthSignInInitiateResponse: Decodable {
     // MARK: - Variables
     let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType?
-
-    enum CodingKeys: String, CodingKey {
-        case continuationToken
-        case challengeType
-    }
 }

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInInitiateResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInInitiateResponse.swift
@@ -27,11 +27,11 @@ import Foundation
 struct MSALNativeAuthSignInInitiateResponse: Decodable {
 
     // MARK: - Variables
-    let credentialToken: String?
+    let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType?
 
     enum CodingKeys: String, CodingKey {
-        case credentialToken
+        case continuationToken
         case challengeType
     }
 }

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
@@ -32,9 +32,4 @@ struct MSALNativeAuthSignUpChallengeResponse: Decodable {
     let challengeChannel: MSALNativeAuthInternalChannelType?
     let continuationToken: String?
     let codeLength: Int?
-
-    enum CodingKeys: String, CodingKey {
-        case challengeType, bindingMethod, interval, challengeTargetLabel, challengeChannel, codeLength
-        case continuationToken
-    }
 }

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
@@ -30,12 +30,11 @@ struct MSALNativeAuthSignUpChallengeResponse: Decodable {
     let interval: Int?
     let challengeTargetLabel: String?
     let challengeChannel: MSALNativeAuthInternalChannelType?
-    let signUpToken: String?
+    let continuationToken: String?
     let codeLength: Int?
 
     enum CodingKeys: String, CodingKey {
         case challengeType, bindingMethod, interval, challengeTargetLabel, challengeChannel, codeLength
-        // API returns signup_token not sign_up_token
-        case signUpToken = "signupToken"
+        case continuationToken
     }
 }

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
@@ -27,8 +27,4 @@ import Foundation
 struct MSALNativeAuthSignUpContinueResponse: Decodable {
     let continuationToken: String?
     let expiresIn: Int?
-
-    enum CodingKeys: String, CodingKey {
-        case expiresIn, continuationToken
-    }
 }

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
@@ -25,13 +25,10 @@
 import Foundation
 
 struct MSALNativeAuthSignUpContinueResponse: Decodable {
-    let signinSLT: String?
+    let continuationToken: String?
     let expiresIn: Int?
-    let signupToken: String?
 
     enum CodingKeys: String, CodingKey {
-        case expiresIn, signupToken
-        // API returns signin_slt not sign_in_slt
-        case signinSLT = "signinSlt"
+        case expiresIn, continuationToken
     }
 }

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpStartResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpStartResponse.swift
@@ -25,6 +25,6 @@
 import Foundation
 
 struct MSALNativeAuthSignUpStartResponse: Decodable {
-    let signupToken: String?
+    let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType?
 }

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
@@ -55,8 +55,8 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
                                     with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordStartValidatedResponse {
         if response.challengeType == .redirect {
             return .redirect
-        } else if let passwordResetToken = response.passwordResetToken {
-            return .success(passwordResetToken: passwordResetToken)
+        } else if let continuationToken = response.continuationToken {
+            return .success(continuationToken: continuationToken)
         } else {
             MSALLogger.log(level: .error,
                            context: context,
@@ -117,12 +117,12 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
             if let sentTo = response.challengeTargetLabel,
                let channelTargetType = response.challengeChannel?.toPublicChannelType(),
                let codeLength = response.codeLength,
-               let passwordResetToken = response.passwordResetToken {
+               let continuationToken = response.continuationToken {
                 return .success(
                     sentTo,
                     channelTargetType,
                     codeLength,
-                    passwordResetToken
+                    continuationToken
                 )
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields from backend")
@@ -161,7 +161,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
     private func handleContinueSuccess(
         _ response: MSALNativeAuthResetPasswordContinueResponse
     ) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
-        return .success(passwordSubmitToken: response.passwordSubmitToken)
+        return .success(continuationToken: response.continuationToken)
     }
 
     private func handleContinueError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
@@ -202,7 +202,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
         _ response: MSALNativeAuthResetPasswordSubmitResponse
     ) -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
         return .success(
-            passwordResetToken: response.passwordResetToken,
+            continuationToken: response.continuationToken,
             pollInterval: response.pollInterval
         )
     }

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordValidatedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordValidatedResponses.swift
@@ -23,7 +23,7 @@
 // THE SOFTWARE.
 
 enum MSALNativeAuthResetPasswordStartValidatedResponse {
-    case success(passwordResetToken: String)
+    case success(continuationToken: String)
     case redirect
     case error(MSALNativeAuthResetPasswordStartValidatedErrorType)
     case unexpectedError
@@ -58,14 +58,14 @@ enum MSALNativeAuthResetPasswordChallengeValidatedResponse: Equatable {
 }
 
 enum MSALNativeAuthResetPasswordContinueValidatedResponse: Equatable {
-    case success(passwordSubmitToken: String)
+    case success(continuationToken: String)
     case invalidOOB
     case error(MSALNativeAuthResetPasswordContinueResponseError)
     case unexpectedError
 }
 
 enum MSALNativeAuthResetPasswordSubmitValidatedResponse: Equatable {
-    case success(passwordResetToken: String, pollInterval: Int)
+    case success(continuationToken: String, pollInterval: Int)
     case passwordError(error: MSALNativeAuthResetPasswordSubmitResponseError)
     case error(MSALNativeAuthResetPasswordSubmitResponseError)
     case unexpectedError

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -67,8 +67,8 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
             if initiateResponse.challengeType == .redirect {
                 return .error(.redirect)
             }
-            if let credentialToken = initiateResponse.credentialToken {
-                return .success(credentialToken: credentialToken)
+            if let continuationToken = initiateResponse.continuationToken {
+                return .success(continuationToken: continuationToken)
             }
             MSALLogger.log(level: .error, context: context, format: "SignIn Initiate: challengeType and credential token empty")
             return .error(.invalidServerResponse)
@@ -97,7 +97,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                 format: "SignIn Challenge: Received unexpected challenge type: \(response.challengeType)")
             return .error(.invalidServerResponse)
         case .oob:
-            guard let credentialToken = response.credentialToken,
+            guard let continuationToken = response.continuationToken,
                     let targetLabel = response.challengeTargetLabel,
                     let codeLength = response.codeLength,
                     let channelType = response.challengeChannel else {
@@ -108,19 +108,19 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                 return .error(.invalidServerResponse)
             }
             return .codeRequired(
-                credentialToken: credentialToken,
+                continuationToken: continuationToken,
                 sentTo: targetLabel,
                 channelType: channelType.toPublicChannelType(),
                 codeLength: codeLength)
         case .password:
-            guard let credentialToken = response.credentialToken else {
+            guard let continuationToken = response.continuationToken else {
                 MSALLogger.log(
                     level: .error,
                     context: context,
                     format: "SignIn Challenge: Expected credential token not nil with credential type password")
                 return .error(.invalidServerResponse)
             }
-            return .passwordRequired(credentialToken: credentialToken)
+            return .passwordRequired(continuationToken: continuationToken)
         case .redirect:
             return .error(.redirect)
         }

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -70,7 +70,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
             if let continuationToken = initiateResponse.continuationToken {
                 return .success(continuationToken: continuationToken)
             }
-            MSALLogger.log(level: .error, context: context, format: "SignIn Initiate: challengeType and credential token empty")
+            MSALLogger.log(level: .error, context: context, format: "SignIn Initiate: challengeType and continuation token empty")
             return .error(.invalidServerResponse)
         case .failure(let responseError):
             guard let initiateResponseError = responseError as? MSALNativeAuthSignInInitiateResponseError else {
@@ -117,7 +117,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                 MSALLogger.log(
                     level: .error,
                     context: context,
-                    format: "SignIn Challenge: Expected credential token not nil with credential type password")
+                    format: "SignIn Challenge: Expected continuation token not nil with credential type password")
                 return .error(.invalidServerResponse)
             }
             return .passwordRequired(continuationToken: continuationToken)

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
@@ -25,8 +25,8 @@
 import Foundation
 
 enum MSALNativeAuthSignInChallengeValidatedResponse {
-    case codeRequired(credentialToken: String, sentTo: String, channelType: MSALNativeAuthChannelType, codeLength: Int)
-    case passwordRequired(credentialToken: String)
+    case codeRequired(continuationToken: String, sentTo: String, channelType: MSALNativeAuthChannelType, codeLength: Int)
+    case passwordRequired(continuationToken: String)
     case error(MSALNativeAuthSignInChallengeValidatedErrorType)
 }
 

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInInitiateValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInInitiateValidatedResponse.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 enum MSALNativeAuthSignInInitiateValidatedResponse {
-    case success(credentialToken: String)
+    case success(continuationToken: String)
     case error(MSALNativeAuthSignInInitiateValidatedErrorType)
 }
 

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -140,8 +140,8 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             if let sentTo = response.challengeTargetLabel,
                let channelType = response.challengeChannel?.toPublicChannelType(),
                let codeLength = response.codeLength,
-               let signUpChallengeToken = response.continuationToken {
-                return .codeRequired(sentTo, channelType, codeLength, signUpChallengeToken)
+               let continuationToken = response.continuationToken {
+                return .codeRequired(sentTo, channelType, codeLength, continuationToken)
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/challenge with challenge_type = oob")
                 return .unexpectedError

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -75,8 +75,13 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
 
         switch apiError.error {
         case .verificationRequired:
-            if let signUpToken = apiError.signUpToken, let unverifiedAttributes = apiError.unverifiedAttributes, !unverifiedAttributes.isEmpty {
-                return .verificationRequired(signUpToken: signUpToken, unverifiedAttributes: extractAttributeNames(from: unverifiedAttributes))
+            if let continuationToken = apiError.continuationToken,
+                let unverifiedAttributes = apiError.unverifiedAttributes,
+                !unverifiedAttributes.isEmpty {
+                return .verificationRequired(
+                    continuationToken: continuationToken,
+                    unverifiedAttributes: extractAttributeNames(from: unverifiedAttributes)
+                )
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/start for verification_required error")
                 return .unexpectedError
@@ -135,15 +140,15 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             if let sentTo = response.challengeTargetLabel,
                let channelType = response.challengeChannel?.toPublicChannelType(),
                let codeLength = response.codeLength,
-               let signUpChallengeToken = response.signUpToken {
+               let signUpChallengeToken = response.continuationToken {
                 return .codeRequired(sentTo, channelType, codeLength, signUpChallengeToken)
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/challenge with challenge_type = oob")
                 return .unexpectedError
             }
         case .password:
-            if let signUpToken = response.signUpToken {
-                return .passwordRequired(signUpToken)
+            if let continuationToken = response.continuationToken {
+                return .passwordRequired(continuationToken)
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/challenge with challenge_type = password")
                 return .unexpectedError
@@ -171,14 +176,14 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
     ) -> MSALNativeAuthSignUpContinueValidatedResponse {
         switch result {
         case .success(let response):
-            // Even if the `signInSLT` is nil, the signUp flow is considered successfully completed
-            return .success(response.signinSLT)
+            // Even if the `continuationToken` is nil, the signUp flow is considered successfully completed
+            return .success(response.continuationToken)
         case .failure(let error):
             return handleContinueError(error, with: context)
         }
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func handleContinueError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpContinueValidatedResponse {
         guard let apiError = error as? MSALNativeAuthSignUpContinueResponseError else {
             return .unexpectedError
@@ -193,8 +198,11 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
              .passwordBanned:
             return .invalidUserInput(apiError)
         case .attributeValidationFailed:
-            if let signUpToken = apiError.signUpToken, let invalidAttributes = apiError.invalidAttributes, !invalidAttributes.isEmpty {
-                return .attributeValidationFailed(signUpToken: signUpToken, invalidAttributes: extractAttributeNames(from: invalidAttributes))
+            if let continuationToken = apiError.continuationToken, let invalidAttributes = apiError.invalidAttributes, !invalidAttributes.isEmpty {
+                return .attributeValidationFailed(
+                    continuationToken: continuationToken,
+                    invalidAttributes: extractAttributeNames(from: invalidAttributes)
+                )
             } else {
                 MSALLogger.log(
                     level: .error,
@@ -204,15 +212,20 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
                 return .unexpectedError
             }
         case .credentialRequired:
-            if let signUpToken = apiError.signUpToken {
-                return .credentialRequired(signUpToken: signUpToken)
+            if let continuationToken = apiError.continuationToken {
+                return .credentialRequired(continuationToken: continuationToken)
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/continue for credential_required error")
                 return .unexpectedError
             }
         case .attributesRequired:
-            if let signUpToken = apiError.signUpToken, let requiredAttributes = apiError.requiredAttributes, !requiredAttributes.isEmpty {
-                return .attributesRequired(signUpToken: signUpToken, requiredAttributes: requiredAttributes.map { $0.toRequiredAttributesPublic() })
+            if let continuationToken = apiError.continuationToken,
+                let requiredAttributes = apiError.requiredAttributes,
+                !requiredAttributes.isEmpty {
+                return .attributesRequired(
+                    continuationToken: continuationToken,
+                    requiredAttributes: requiredAttributes.map { $0.toRequiredAttributesPublic() }
+                )
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/continue for attributes_required error")
                 return .unexpectedError
@@ -246,7 +259,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
                     errorCodes: error.errorCodes,
                     errorURI: error.errorURI,
                     innerErrors: error.innerErrors,
-                    signUpToken: error.signUpToken,
+                    continuationToken: error.continuationToken,
                     requiredAttributes: error.requiredAttributes,
                     unverifiedAttributes: error.unverifiedAttributes,
                     invalidAttributes: error.invalidAttributes))

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
@@ -23,7 +23,7 @@
 // THE SOFTWARE.
 
 enum MSALNativeAuthSignUpStartValidatedResponse: Equatable {
-    case verificationRequired(signUpToken: String, unverifiedAttributes: [String])
+    case verificationRequired(continuationToken: String, unverifiedAttributes: [String])
     case attributeValidationFailed(invalidAttributes: [String])
     case redirect
     case error(MSALNativeAuthSignUpStartResponseError)
@@ -42,12 +42,12 @@ enum MSALNativeAuthSignUpChallengeValidatedResponse: Equatable {
 }
 
 enum MSALNativeAuthSignUpContinueValidatedResponse: Equatable {
-    case success(_ signInSLT: String?)
+    case success(_ continuationToken: String?)
     /// error that represents invalidOOB or invalidPassword, depending on which State the input comes from.
     case invalidUserInput(_ error: MSALNativeAuthSignUpContinueResponseError)
-    case credentialRequired(signUpToken: String)
-    case attributesRequired(signUpToken: String, requiredAttributes: [MSALNativeAuthRequiredAttributes])
-    case attributeValidationFailed(signUpToken: String, invalidAttributes: [String])
+    case credentialRequired(continuationToken: String)
+    case attributesRequired(continuationToken: String, requiredAttributes: [MSALNativeAuthRequiredAttributes])
+    case attributeValidationFailed(continuationToken: String, invalidAttributes: [String])
     case error(MSALNativeAuthSignUpContinueResponseError)
     case unexpectedError
 }

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpContinueRequestProviderParams.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpContinueRequestProviderParams.swift
@@ -26,7 +26,7 @@
 
 struct MSALNativeAuthSignUpContinueRequestProviderParams {
     let grantType: MSALNativeAuthGrantType
-    let signUpToken: String
+    let continuationToken: String
     let password: String?
     let oobCode: String?
     let attributes: [String: Any]?
@@ -34,14 +34,14 @@ struct MSALNativeAuthSignUpContinueRequestProviderParams {
 
     init(
         grantType: MSALNativeAuthGrantType,
-        signUpToken: String,
+        continuationToken: String,
         password: String? = nil,
         oobCode: String? = nil,
         attributes: [String: Any]? = nil,
         context: MSIDRequestContext
     ) {
         self.grantType = grantType
-        self.signUpToken = signUpToken
+        self.continuationToken = continuationToken
         self.password = password
         self.oobCode = oobCode
         self.attributes = attributes

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
@@ -59,7 +59,7 @@ final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProv
 
     func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
         let params = MSALNativeAuthSignUpChallengeRequestParameters(
-            signUpToken: token,
+            continuationToken: token,
             context: context
         )
 
@@ -75,7 +75,7 @@ final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProv
 
         let params = MSALNativeAuthSignUpContinueRequestParameters(
             grantType: parameters.grantType,
-            signUpToken: parameters.signUpToken,
+            continuationToken: parameters.continuationToken,
             password: parameters.password,
             oobCode: parameters.oobCode,
             attributes: formattedAttributes,

--- a/MSAL/src/native_auth/public/state_machine/state/MSALNativeAuthBaseState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/MSALNativeAuthBaseState.swift
@@ -26,11 +26,11 @@ import Foundation
 
 @objc
 public class MSALNativeAuthBaseState: NSObject {
-    let flowToken: String
+    let continuationToken: String
     let correlationId: UUID
 
-    init(flowToken: String, correlationId: UUID) {
-        self.flowToken = flowToken
+    init(continuationToken: String, correlationId: UUID) {
+        self.continuationToken = continuationToken
         self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
@@ -28,7 +28,7 @@ extension ResetPasswordCodeRequiredState {
 
     func resendCodeInternal() async -> MSALNativeAuthResetPasswordControlling.ResetPasswordResendCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
-        return await controller.resendCode(username: username, continuationToken: flowToken, context: context)
+        return await controller.resendCode(username: username, continuationToken: continuationToken, context: context)
     }
 
     func submitCodeInternal(code: String) async -> MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitCodeControllerResponse {
@@ -39,7 +39,7 @@ extension ResetPasswordCodeRequiredState {
             return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
         }
 
-        return await controller.submitCode(code: code, username: username, continuationToken: flowToken, context: context)
+        return await controller.submitCode(code: code, username: username, continuationToken: continuationToken, context: context)
     }
 }
 
@@ -53,6 +53,6 @@ extension ResetPasswordRequiredState {
             return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
         }
 
-        return await controller.submitPassword(password: password, username: username, continuationToken: flowToken, context: context)
+        return await controller.submitPassword(password: password, username: username, continuationToken: continuationToken, context: context)
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
@@ -28,7 +28,7 @@ extension ResetPasswordCodeRequiredState {
 
     func resendCodeInternal() async -> MSALNativeAuthResetPasswordControlling.ResetPasswordResendCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
-        return await controller.resendCode(username: username, passwordResetToken: flowToken, context: context)
+        return await controller.resendCode(username: username, continuationToken: flowToken, context: context)
     }
 
     func submitCodeInternal(code: String) async -> MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitCodeControllerResponse {
@@ -39,7 +39,7 @@ extension ResetPasswordCodeRequiredState {
             return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
         }
 
-        return await controller.submitCode(code: code, username: username, passwordResetToken: flowToken, context: context)
+        return await controller.submitCode(code: code, username: username, continuationToken: flowToken, context: context)
     }
 }
 
@@ -53,6 +53,6 @@ extension ResetPasswordRequiredState {
             return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
         }
 
-        return await controller.submitPassword(password: password, username: username, passwordSubmitToken: flowToken, context: context)
+        return await controller.submitPassword(password: password, username: username, continuationToken: flowToken, context: context)
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates.swift
@@ -33,14 +33,14 @@ public class ResetPasswordBaseState: MSALNativeAuthBaseState {
     init(
         controller: MSALNativeAuthResetPasswordControlling,
         username: String,
-        flowToken: String,
+        continuationToken: String,
         inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
         correlationId: UUID
     ) {
         self.controller = controller
         self.username = username
         self.inputValidator = inputValidator
-        super.init(flowToken: flowToken, correlationId: correlationId)
+        super.init(continuationToken: continuationToken, correlationId: correlationId)
     }
 }
 

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterPreviousFlowBaseState+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterPreviousFlowBaseState+Internal.swift
@@ -28,6 +28,6 @@ extension SignInAfterPreviousFlowBaseState {
 
     func signInInternal(scopes: [String]?) async -> MSALNativeAuthSignInControlling.SignInAfterPreviousFlowControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
-        return await controller.signIn(username: username, slt: slt, scopes: scopes, context: context)
+        return await controller.signIn(username: username, continuationToken: continuationToken, scopes: scopes, context: context)
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterPreviousFlowBaseState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterPreviousFlowBaseState.swift
@@ -27,13 +27,13 @@ import Foundation
 @objcMembers public class SignInAfterPreviousFlowBaseState: NSObject {
     let controller: MSALNativeAuthSignInControlling
     let username: String
-    let slt: String? // TODO: Update to continuation_token
+    let continuationToken: String?
     let correlationId: UUID
 
-    init(controller: MSALNativeAuthSignInControlling, username: String, slt: String?, correlationId: UUID) {
+    init(controller: MSALNativeAuthSignInControlling, username: String, continuationToken: String?, correlationId: UUID) {
         self.username = username
         self.controller = controller
-        self.slt = slt
+        self.continuationToken = continuationToken
         self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
@@ -34,14 +34,14 @@ extension SignInCodeRequiredState {
             return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
         }
 
-        return await controller.submitCode(code, credentialToken: flowToken, context: context, scopes: scopes)
+        return await controller.submitCode(code, continuationToken: flowToken, context: context, scopes: scopes)
     }
 
     func resendCodeInternal() async -> MSALNativeAuthSignInControlling.SignInResendCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, resend code requested")
 
-        return await controller.resendCode(credentialToken: flowToken, context: context, scopes: scopes)
+        return await controller.resendCode(continuationToken: flowToken, context: context, scopes: scopes)
     }
 }
 
@@ -56,6 +56,6 @@ extension SignInPasswordRequiredState {
             return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
         }
 
-        return await controller.submitPassword(password, username: username, credentialToken: flowToken, context: context, scopes: scopes)
+        return await controller.submitPassword(password, username: username, continuationToken: flowToken, context: context, scopes: scopes)
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
@@ -34,14 +34,14 @@ extension SignInCodeRequiredState {
             return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
         }
 
-        return await controller.submitCode(code, continuationToken: flowToken, context: context, scopes: scopes)
+        return await controller.submitCode(code, continuationToken: continuationToken, context: context, scopes: scopes)
     }
 
     func resendCodeInternal() async -> MSALNativeAuthSignInControlling.SignInResendCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, resend code requested")
 
-        return await controller.resendCode(continuationToken: flowToken, context: context, scopes: scopes)
+        return await controller.resendCode(continuationToken: continuationToken, context: context, scopes: scopes)
     }
 }
 
@@ -56,6 +56,6 @@ extension SignInPasswordRequiredState {
             return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
         }
 
-        return await controller.submitPassword(password, username: username, continuationToken: flowToken, context: context, scopes: scopes)
+        return await controller.submitPassword(password, username: username, continuationToken: continuationToken, context: context, scopes: scopes)
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
@@ -31,11 +31,11 @@ import Foundation
     init(
         controller: MSALNativeAuthSignInControlling,
         inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
-        flowToken: String,
+        continuationToken: String,
         correlationId: UUID) {
         self.controller = controller
         self.inputValidator = inputValidator
-        super.init(flowToken: flowToken, correlationId: correlationId)
+        super.init(continuationToken: continuationToken, correlationId: correlationId)
     }
 }
 
@@ -48,10 +48,10 @@ import Foundation
         scopes: [String],
         controller: MSALNativeAuthSignInControlling,
         inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
-        flowToken: String,
+        continuationToken: String,
         correlationId: UUID) {
         self.scopes = scopes
-        super.init(controller: controller, inputValidator: inputValidator, flowToken: flowToken, correlationId: correlationId)
+        super.init(controller: controller, inputValidator: inputValidator, continuationToken: continuationToken, correlationId: correlationId)
     }
 
     /// Requests the server to resend the verification code to the user.
@@ -105,11 +105,11 @@ import Foundation
         username: String,
         controller: MSALNativeAuthSignInControlling,
         inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
-        flowToken: String,
+        continuationToken: String,
         correlationId: UUID) {
         self.scopes = scopes
         self.username = username
-        super.init(controller: controller, inputValidator: inputValidator, flowToken: flowToken, correlationId: correlationId)
+        super.init(controller: controller, inputValidator: inputValidator, continuationToken: continuationToken, correlationId: correlationId)
     }
 
     /// Submits the password to the server for verification.

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
@@ -28,7 +28,7 @@ extension SignUpCodeRequiredState {
 
     func resendCodeInternal() async -> MSALNativeAuthSignUpControlling.SignUpResendCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
-        return await controller.resendCode(username: username, context: context, signUpToken: flowToken)
+        return await controller.resendCode(username: username, context: context, continuationToken: flowToken)
     }
 
     func submitCodeInternal(code: String) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
@@ -39,7 +39,7 @@ extension SignUpCodeRequiredState {
             return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
         }
 
-        return await controller.submitCode(code, username: username, signUpToken: flowToken, context: context)
+        return await controller.submitCode(code, username: username, continuationToken: flowToken, context: context)
     }
 }
 
@@ -53,7 +53,7 @@ extension SignUpPasswordRequiredState {
             return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
         }
 
-        return await controller.submitPassword(password, username: username, signUpToken: flowToken, context: context)
+        return await controller.submitPassword(password, username: username, continuationToken: flowToken, context: context)
     }
 }
 
@@ -61,6 +61,6 @@ extension SignUpAttributesRequiredState {
 
     func submitAttributesInternal(attributes: [String: Any]) async -> MSALNativeAuthSignUpControlling.SignUpSubmitAttributesControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
-        return await controller.submitAttributes(attributes, username: username, signUpToken: flowToken, context: context)
+        return await controller.submitAttributes(attributes, username: username, continuationToken: flowToken, context: context)
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
@@ -28,7 +28,7 @@ extension SignUpCodeRequiredState {
 
     func resendCodeInternal() async -> MSALNativeAuthSignUpControlling.SignUpResendCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
-        return await controller.resendCode(username: username, context: context, continuationToken: flowToken)
+        return await controller.resendCode(username: username, context: context, continuationToken: continuationToken)
     }
 
     func submitCodeInternal(code: String) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
@@ -39,7 +39,7 @@ extension SignUpCodeRequiredState {
             return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
         }
 
-        return await controller.submitCode(code, username: username, continuationToken: flowToken, context: context)
+        return await controller.submitCode(code, username: username, continuationToken: continuationToken, context: context)
     }
 }
 
@@ -53,7 +53,7 @@ extension SignUpPasswordRequiredState {
             return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
         }
 
-        return await controller.submitPassword(password, username: username, continuationToken: flowToken, context: context)
+        return await controller.submitPassword(password, username: username, continuationToken: continuationToken, context: context)
     }
 }
 
@@ -61,6 +61,6 @@ extension SignUpAttributesRequiredState {
 
     func submitAttributesInternal(attributes: [String: Any]) async -> MSALNativeAuthSignUpControlling.SignUpSubmitAttributesControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
-        return await controller.submitAttributes(attributes, username: username, continuationToken: flowToken, context: context)
+        return await controller.submitAttributes(attributes, username: username, continuationToken: continuationToken, context: context)
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
@@ -33,14 +33,14 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     init(
         controller: MSALNativeAuthSignUpControlling,
         username: String,
-        flowToken: String,
+        continuationToken: String,
         inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
         correlationId: UUID
     ) {
         self.controller = controller
         self.username = username
         self.inputValidator = inputValidator
-        super.init(flowToken: flowToken, correlationId: correlationId)
+        super.init(continuationToken: continuationToken, correlationId: correlationId)
     }
 }
 

--- a/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordChallengeIntegrationTests.swift
@@ -39,7 +39,7 @@ final class MSALNativeAuthResetPasswordChallengeIntegrationTests: MSALNativeAuth
         )
 
         sut = try provider.challenge(
-            token: "<password-reset-token>",
+            token: "<continuation-token>",
             context: MSALNativeAuthRequestContext(correlationId: correlationId)
         )
     }
@@ -57,7 +57,7 @@ final class MSALNativeAuthResetPasswordChallengeIntegrationTests: MSALNativeAuth
         XCTAssertNotNil(response?.bindingMethod)
         XCTAssertNotNil(response?.challengeTargetLabel)
         XCTAssertNotNil(response?.challengeChannel)
-        XCTAssertNotNil(response?.passwordResetToken)
+        XCTAssertNotNil(response?.continuationToken)
         XCTAssertNotNil(response?.codeLength)
     }
 
@@ -70,7 +70,7 @@ final class MSALNativeAuthResetPasswordChallengeIntegrationTests: MSALNativeAuth
         XCTAssertNil(response?.bindingMethod)
         XCTAssertNil(response?.challengeTargetLabel)
         XCTAssertNil(response?.challengeChannel)
-        XCTAssertNil(response?.passwordResetToken)
+        XCTAssertNil(response?.continuationToken)
         XCTAssertNil(response?.codeLength)
     }
 

--- a/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordContinueIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordContinueIntegrationTests.swift
@@ -42,7 +42,7 @@ final class MSALNativeAuthResetPasswordContinueIntegrationTests: MSALNativeAuthI
 
         sut = try provider.continue(
             parameters: MSALNativeAuthResetPasswordContinueRequestParameters(context: context,
-                                                                             passwordResetToken: "<password-reset-token>",
+                                                                             continuationToken: "<continuation-token>",
                                                                              grantType: .oobCode,
                                                                              oobCode: "0000")
         )
@@ -57,7 +57,7 @@ final class MSALNativeAuthResetPasswordContinueIntegrationTests: MSALNativeAuthI
 
         let response: MSALNativeAuthResetPasswordContinueResponse? = try await performTestSucceed()
 
-        XCTAssertNotNil(response?.passwordSubmitToken)
+        XCTAssertNotNil(response?.continuationToken)
         XCTAssertNotNil(response?.expiresIn)
     }
 
@@ -116,7 +116,7 @@ final class MSALNativeAuthResetPasswordContinueIntegrationTests: MSALNativeAuthI
         errorURI: String? = nil,
         innerErrors: [MSALNativeAuthInnerError]? = nil,
         target: String? = nil,
-        passwordResetToken: String? = nil
+        continuationToken: String? = nil
     ) -> MSALNativeAuthResetPasswordContinueResponseError {
         .init(
             error: error,
@@ -125,7 +125,7 @@ final class MSALNativeAuthResetPasswordContinueIntegrationTests: MSALNativeAuthI
             errorURI: errorURI,
             innerErrors: innerErrors,
             target: target,
-            passwordResetToken: passwordResetToken
+            continuationToken: continuationToken
         )
     }
 }

--- a/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordPollCompletionIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordPollCompletionIntegrationTests.swift
@@ -42,7 +42,7 @@ final class MSALNativeAuthResetPasswordPollCompletionIntegrationTests: MSALNativ
 
         sut = try provider.pollCompletion(
             parameters: MSALNativeAuthResetPasswordPollCompletionRequestParameters(context: context,
-                                                                                   passwordResetToken: "<password-reset-token")
+                                                                                   continuationToken: "<continuation-token")
 
         )
     }

--- a/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordStartIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordStartIntegrationTests.swift
@@ -57,7 +57,7 @@ final class MSALNativeAuthResetPasswordStartIntegrationTests: MSALNativeAuthInte
 
         let response: MSALNativeAuthResetPasswordStartResponse? = try await performTestSucceed()
 
-        XCTAssertNotNil(response?.passwordResetToken)
+        XCTAssertNotNil(response?.continuationToken)
         XCTAssertNil(response?.challengeType)
     }
 
@@ -65,7 +65,7 @@ final class MSALNativeAuthResetPasswordStartIntegrationTests: MSALNativeAuthInte
         try await mockResponse(.challengeTypeRedirect, endpoint: .resetPasswordStart)
         let response: MSALNativeAuthResetPasswordStartResponse? = try await performTestSucceed()
 
-        XCTAssertNil(response?.passwordResetToken)
+        XCTAssertNil(response?.continuationToken)
         XCTAssertEqual(response?.challengeType, .redirect)
     }
 

--- a/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordSubmitIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/reset_password/MSALNativeAuthResetPasswordSubmitIntegrationTests.swift
@@ -42,7 +42,7 @@ final class MSALNativeAuthResetPasswordSubmitIntegrationTests: MSALNativeAuthInt
 
         sut = try provider.submit(
             parameters: MSALNativeAuthResetPasswordSubmitRequestParameters(context: context,
-                                                                           passwordSubmitToken: "<password-submit-token>",
+                                                                           continuationToken: "<continuation-token>",
                                                                            newPassword:"new-password")
         )
     }
@@ -56,7 +56,7 @@ final class MSALNativeAuthResetPasswordSubmitIntegrationTests: MSALNativeAuthInt
 
         let response: MSALNativeAuthResetPasswordSubmitResponse? = try await performTestSucceed()
 
-        XCTAssertNotNil(response?.passwordResetToken)
+        XCTAssertNotNil(response?.continuationToken)
         XCTAssertNotNil(response?.pollInterval)
     }
 

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
@@ -40,7 +40,7 @@ class MSALNativeAuthSignInChallengeIntegrationTests: MSALNativeAuthIntegrationBa
         sut = try provider.challenge(
             parameters: .init(
                 context: context,
-                credentialToken: "Test Credential Token"
+                continuationToken: "Test Credential Token"
             ),
             context: context
         )
@@ -51,7 +51,7 @@ class MSALNativeAuthSignInChallengeIntegrationTests: MSALNativeAuthIntegrationBa
         let response: MSALNativeAuthSignInChallengeResponse? = try await performTestSucceed()
 
         XCTAssertTrue(response?.challengeType == .password)
-        XCTAssertNotNil(response?.credentialToken)
+        XCTAssertNotNil(response?.continuationToken)
     }
 
     func test_succeedRequest_challengeTypeOOB() async throws {
@@ -59,7 +59,7 @@ class MSALNativeAuthSignInChallengeIntegrationTests: MSALNativeAuthIntegrationBa
         let response: MSALNativeAuthSignInChallengeResponse? = try await performTestSucceed()
 
         XCTAssertTrue(response?.challengeType == .oob)
-        XCTAssertNotNil(response?.credentialToken)
+        XCTAssertNotNil(response?.continuationToken)
         XCTAssertNotNil(response?.bindingMethod)
         XCTAssertNotNil(response?.challengeTargetLabel)
         XCTAssertNotNil(response?.codeLength)
@@ -71,7 +71,7 @@ class MSALNativeAuthSignInChallengeIntegrationTests: MSALNativeAuthIntegrationBa
         let response: MSALNativeAuthSignInChallengeResponse? = try await performTestSucceed()
 
         XCTAssertEqual(response?.challengeType, .redirect)
-        XCTAssertNil(response?.credentialToken)
+        XCTAssertNil(response?.continuationToken)
     }
 
 

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInInitiateIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInInitiateIntegrationTests.swift
@@ -53,14 +53,14 @@ class MSALNativeAuthSignInInitiateIntegrationTests: MSALNativeAuthIntegrationBas
             responses: []
         )
         let response: MSALNativeAuthSignInInitiateResponse? = try await performTestSucceed()
-        XCTAssertNotNil(response?.credentialToken)
+        XCTAssertNotNil(response?.continuationToken)
     }
 
     func test_succeedRequest_challengeTypeRedirect() async throws {
         try await mockResponse(.challengeTypeRedirect, endpoint: .signInInitiate)
         let response: MSALNativeAuthSignInInitiateResponse? = try await performTestSucceed()
 
-        XCTAssertNil(response?.credentialToken)
+        XCTAssertNil(response?.continuationToken)
         XCTAssertEqual(response?.challengeType, .redirect)
     }
 

--- a/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpChallengeIntegrationTests.swift
@@ -49,7 +49,7 @@ final class MSALNativeAuthSignUpChallengeIntegrationTests: MSALNativeAuthIntegra
         let response: MSALNativeAuthSignUpChallengeResponse? = try await performTestSucceed()
 
         XCTAssertEqual(response?.challengeType, .password)
-        XCTAssertNotNil(response?.signUpToken)
+        XCTAssertNotNil(response?.continuationToken)
     }
 
     func test_whenSignUpChallengeOOB_succeeds() async throws {
@@ -57,7 +57,7 @@ final class MSALNativeAuthSignUpChallengeIntegrationTests: MSALNativeAuthIntegra
         let response: MSALNativeAuthSignUpChallengeResponse? = try await performTestSucceed()
 
         XCTAssertEqual(response?.challengeType, .oob)
-        XCTAssertNotNil(response?.signUpToken)
+        XCTAssertNotNil(response?.continuationToken)
         XCTAssertNotNil(response?.bindingMethod)
         XCTAssertNotNil(response?.challengeTargetLabel)
         XCTAssertNotNil(response?.codeLength)
@@ -69,7 +69,7 @@ final class MSALNativeAuthSignUpChallengeIntegrationTests: MSALNativeAuthIntegra
         let response: MSALNativeAuthSignUpChallengeResponse? = try await performTestSucceed()
 
         XCTAssertEqual(response?.challengeType, .redirect)
-        XCTAssertNil(response?.signUpToken)
+        XCTAssertNil(response?.continuationToken)
     }
 
     func test_signUpChallenge_unauthorizedClient() async throws {

--- a/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpContinueIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpContinueIntegrationTests.swift
@@ -43,7 +43,7 @@ final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrat
 
         let params = MSALNativeAuthSignUpContinueRequestProviderParams(
             grantType: .password,
-            signUpToken: "<token>",
+            continuationToken: "<token>",
             password: "12345",
             context: context
         )
@@ -54,7 +54,7 @@ final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrat
     func test_signUpContinue_withPassword_succeeds() async throws {
         let params = MSALNativeAuthSignUpContinueRequestProviderParams(
             grantType: .password,
-            signUpToken: "<token>",
+            continuationToken: "<token>",
             password: "12345",
             context: context
         )
@@ -65,7 +65,7 @@ final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrat
     func test_signUpContinue_withOOB_succeeds() async throws {
         let params = MSALNativeAuthSignUpContinueRequestProviderParams(
             grantType: .oobCode,
-            signUpToken: "<token>",
+            continuationToken: "<token>",
             oobCode: "1234",
             context: context
         )
@@ -76,7 +76,7 @@ final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrat
     func test_signUpContinue_withAttributes_succeeds() async throws {
         let params = MSALNativeAuthSignUpContinueRequestProviderParams(
             grantType: .attributes,
-            signUpToken: "<token>",
+            continuationToken: "<token>",
             attributes: ["key": "value"],
             context: context
         )
@@ -181,7 +181,7 @@ final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrat
             expectedError: createError(.attributesRequired)
         )
 
-        XCTAssertNotNil(response.signUpToken)
+        XCTAssertNotNil(response.continuationToken)
     }
 
     func test_signUpContinue_verificationRequired() async throws {
@@ -191,7 +191,7 @@ final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrat
             expectedError: createError(.verificationRequired)
         )
 
-        XCTAssertNotNil(response.signUpToken)
+        XCTAssertNotNil(response.continuationToken)
         XCTAssertNotNil(response.unverifiedAttributes)
     }
 
@@ -202,7 +202,7 @@ final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrat
             expectedError: createError(.attributeValidationFailed)
         )
 
-        XCTAssertNotNil(response.signUpToken)
+        XCTAssertNotNil(response.continuationToken)
     }
 
     func test_signUpContinue_credentialRequired() async throws {
@@ -212,7 +212,7 @@ final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrat
             expectedError: createError(.credentialRequired)
         )
 
-        XCTAssertNotNil(response.signUpToken)
+        XCTAssertNotNil(response.continuationToken)
     }
 
     func performSuccessfulTestCase(with params: MSALNativeAuthSignUpContinueRequestProviderParams) async throws {
@@ -221,8 +221,7 @@ final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrat
 
         let response: MSALNativeAuthSignUpContinueResponse? = try await performTestSucceed()
 
-        XCTAssertNotNil(response?.signinSLT)
-        XCTAssertNil(response?.signupToken)
+        XCTAssertNil(response?.continuationToken)
     }
 
     private func createError(_ error: MSALNativeAuthSignUpContinueOauth2ErrorCode) -> MSALNativeAuthSignUpContinueResponseError {
@@ -232,7 +231,7 @@ final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrat
             errorCodes: nil,
             errorURI: nil,
             innerErrors: nil,
-            signUpToken: nil,
+            continuationToken: nil,
             requiredAttributes: nil,
             unverifiedAttributes: nil,
             invalidAttributes: nil

--- a/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpStartIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpStartIntegrationTests.swift
@@ -52,7 +52,7 @@ final class MSALNativeAuthSignUpStartIntegrationTests: MSALNativeAuthIntegration
         try await mockResponse(.challengeTypeRedirect, endpoint: .signUpStart)
         let response: MSALNativeAuthSignUpStartResponse? = try await performTestSucceed()
 
-        XCTAssertNil(response?.signupToken)
+        XCTAssertNil(response?.continuationToken)
         XCTAssertEqual(response?.challengeType, .redirect)
     }
 
@@ -129,7 +129,7 @@ final class MSALNativeAuthSignUpStartIntegrationTests: MSALNativeAuthIntegration
             expectedError: createError(.attributesRequired)
         )
 
-        XCTAssertNotNil(response.signUpToken)
+        XCTAssertNotNil(response.continuationToken)
     }
 
     func test_signUpStart_verificationRequired() async throws {
@@ -139,7 +139,7 @@ final class MSALNativeAuthSignUpStartIntegrationTests: MSALNativeAuthIntegration
             expectedError: createError(.verificationRequired)
         )
 
-        XCTAssertNotNil(response.signUpToken)
+        XCTAssertNotNil(response.continuationToken)
         XCTAssertNotNil(response.unverifiedAttributes)
     }
 
@@ -150,7 +150,7 @@ final class MSALNativeAuthSignUpStartIntegrationTests: MSALNativeAuthIntegration
             expectedError: createError(.attributeValidationFailed)
         )
 
-        XCTAssertNotNil(response.signUpToken)
+        XCTAssertNotNil(response.continuationToken)
     }
 
     func test_signUpStart_unsupportedAuthMethod() async throws {
@@ -180,7 +180,7 @@ final class MSALNativeAuthSignUpStartIntegrationTests: MSALNativeAuthIntegration
             errorCodes: nil,
             errorURI: nil,
             innerErrors: nil,
-            signUpToken: nil,
+            continuationToken: nil,
             unverifiedAttributes: nil,
             invalidAttributes: nil
         )

--- a/MSAL/test/integration/native_auth/requests/token/MSALNativeAuthTokenIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/token/MSALNativeAuthTokenIntegrationTests.swift
@@ -41,7 +41,6 @@ class MSALNativeAuthTokenIntegrationTests: MSALNativeAuthIntegrationBaseTests {
                 context: context,
                 username: "test@contoso.com",
                 continuationToken: nil,
-                continuationToken: nil,
                 grantType: .otp,
                 scope: nil,
                 password: nil,
@@ -71,7 +70,6 @@ class MSALNativeAuthTokenIntegrationTests: MSALNativeAuthIntegrationBaseTests {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         let parameters = MSALNativeAuthTokenRequestParameters(context: context,
                                                               username: "test@contoso.com",
-                                                              continuationToken: nil,
                                                               continuationToken: nil,
                                                               grantType: .otp,
                                                               scope: "test & alt test",

--- a/MSAL/test/integration/native_auth/requests/token/MSALNativeAuthTokenIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/token/MSALNativeAuthTokenIntegrationTests.swift
@@ -40,8 +40,8 @@ class MSALNativeAuthTokenIntegrationTests: MSALNativeAuthIntegrationBaseTests {
             parameters: .init(
                 context: context,
                 username: "test@contoso.com",
-                credentialToken: nil,
-                signInSLT: nil,
+                continuationToken: nil,
+                continuationToken: nil,
                 grantType: .otp,
                 scope: nil,
                 password: nil,
@@ -71,8 +71,8 @@ class MSALNativeAuthTokenIntegrationTests: MSALNativeAuthIntegrationBaseTests {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         let parameters = MSALNativeAuthTokenRequestParameters(context: context,
                                                               username: "test@contoso.com",
-                                                              credentialToken: nil,
-                                                              signInSLT: nil,
+                                                              continuationToken: nil,
+                                                              continuationToken: nil,
                                                               grantType: .otp,
                                                               scope: "test & alt test",
                                                               password: nil,
@@ -122,7 +122,7 @@ class MSALNativeAuthTokenIntegrationTests: MSALNativeAuthIntegrationBaseTests {
         try await perform_testFail(
             endpoint: .signInToken,
             response: .invalidPassword,
-            expectedError: Error(error: .invalidGrant, errorDescription: nil, errorCodes: [MSALNativeAuthESTSApiErrorCodes.invalidCredentials.rawValue], errorURI: nil, innerErrors: nil, credentialToken: nil)
+            expectedError: Error(error: .invalidGrant, errorDescription: nil, errorCodes: [MSALNativeAuthESTSApiErrorCodes.invalidCredentials.rawValue], errorURI: nil, innerErrors: nil, continuationToken: nil)
         )
     }
 
@@ -130,7 +130,7 @@ class MSALNativeAuthTokenIntegrationTests: MSALNativeAuthIntegrationBaseTests {
         try await perform_testFail(
             endpoint: .signInToken,
             response: .invalidOOBValue,
-            expectedError: Error(error: .invalidGrant, errorDescription: nil, errorCodes: [MSALNativeAuthESTSApiErrorCodes.invalidOTP.rawValue], errorURI: nil, innerErrors: nil, credentialToken: nil)
+            expectedError: Error(error: .invalidGrant, errorDescription: nil, errorCodes: [MSALNativeAuthESTSApiErrorCodes.invalidOTP.rawValue], errorURI: nil, innerErrors: nil, continuationToken: nil)
         )
     }
 
@@ -176,6 +176,6 @@ class MSALNativeAuthTokenIntegrationTests: MSALNativeAuthIntegrationBaseTests {
     }
 
     private func createError(_ code: MSALNativeAuthTokenOauth2ErrorCode) -> Error {
-        .init(error: code, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        .init(error: code, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil)
     }
 }

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
@@ -114,7 +114,7 @@ final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
 
-        requestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: nil, signInSLT: nil, grantType: MSALNativeAuthGrantType.refreshToken, scope: "" , password: nil, oobCode: nil, includeChallengeType: true, refreshToken: "refreshToken")
+        requestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, continuationToken: nil, grantType: MSALNativeAuthGrantType.refreshToken, scope: "" , password: nil, oobCode: nil, includeChallengeType: true, refreshToken: "refreshToken")
         requestProviderMock.throwingRefreshTokenError = ErrorMock.error
 
         let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .generalError))

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
@@ -82,7 +82,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenResetPasswordStart_returnsSuccess_it_callsChallenge() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
-        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        validatorMock.mockValidateResetPasswordStartFunc(.success(continuationToken: "continuationToken"))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateResetPasswordChallengeFunc(.unexpectedError)
@@ -164,7 +164,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenResetPasswordStart_challenge_cantCreateRequest_it_returns_unexpectedError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
-        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        validatorMock.mockValidateResetPasswordStartFunc(.success(continuationToken: "continuationToken"))
         requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
 
@@ -188,10 +188,10 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenResetPasswordStart_challenge_succeeds_it_returnsCorrectError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
-        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        validatorMock.mockValidateResetPasswordStartFunc(.success(continuationToken: "continuationToken"))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
-        validatorMock.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "resetPasswordToken"))
+        validatorMock.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "continuationToken"))
 
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordStartValidatorHelper(exp)
@@ -202,7 +202,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
 
         await fulfillment(of: [exp])
         XCTAssertTrue(helper.onResetPasswordCodeRequiredCalled)
-        XCTAssertEqual(helper.newState?.flowToken, "resetPasswordToken")
+        XCTAssertEqual(helper.newState?.continuationToken, "continuationToken")
         XCTAssertEqual(helper.sentTo, "sentTo")
         XCTAssertEqual(helper.channelTargetType, .email)
         XCTAssertEqual(helper.codeLength, 4)
@@ -214,7 +214,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenResetPasswordStart_challenge_returns_redirect_it_returnsRedirectError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
-        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        validatorMock.mockValidateResetPasswordStartFunc(.success(continuationToken: "continuationToken"))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateResetPasswordChallengeFunc(.redirect)
@@ -239,7 +239,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenResetPasswordStart_challenge_returns_error_it_returnsCorrectError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
-        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        validatorMock.mockValidateResetPasswordStartFunc(.success(continuationToken: "continuationToken"))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         let error : MSALNativeAuthResetPasswordChallengeValidatedResponse = .error(
@@ -272,7 +272,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenValidatorInResetPasswordStart_challenge_returns_unexpectedError_it_returnsGeneralError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = resetPasswordStartParams
-        validatorMock.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
+        validatorMock.mockValidateResetPasswordStartFunc(.success(continuationToken: "continuationToken"))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateResetPasswordChallengeFunc(.unexpectedError)
@@ -303,7 +303,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", continuationToken: "passwordResetToken", context: contextMock)
+        let result = await sut.resendCode(username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordResendCodeError(result)
 
         await fulfillment(of: [exp])
@@ -320,18 +320,18 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
 
-        validatorMock.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "flowToken response"))
+        validatorMock.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "continuationToken response"))
 
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", continuationToken: "passwordResetToken", context: contextMock)
+        let result = await sut.resendCode(username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         helper.onResetPasswordResendCodeRequired(result)
 
         await fulfillment(of: [exp])
         XCTAssertTrue(helper.onResetPasswordResendCodeRequiredCalled)
-        XCTAssertEqual(helper.newState?.flowToken, "flowToken response")
+        XCTAssertEqual(helper.newState?.continuationToken, "continuationToken response")
         XCTAssertEqual(helper.sentTo, "sentTo")
         XCTAssertEqual(helper.channelTargetType, .email)
         XCTAssertEqual(helper.codeLength, 4)
@@ -355,7 +355,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", continuationToken: "passwordResetToken", context: contextMock)
+        let result = await sut.resendCode(username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordResendCodeError(result)
 
         await fulfillment(of: [exp])
@@ -376,7 +376,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", continuationToken: "passwordResetToken", context: contextMock)
+        let result = await sut.resendCode(username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordResendCodeError(result)
 
         await fulfillment(of: [exp])
@@ -397,7 +397,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", continuationToken: "passwordResetToken", context: contextMock)
+        let result = await sut.resendCode(username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordResendCodeError(result)
 
         await fulfillment(of: [exp])
@@ -419,7 +419,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "passwordResetToken", context: contextMock)
+        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordVerifyCodeError(result)
 
         await fulfillment(of: [exp])
@@ -434,12 +434,12 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenResetPasswordSubmitCode_succeeds_it_returnsPasswordRequired() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
-        validatorMock.mockValidateResetPasswordContinueFunc(.success(passwordSubmitToken: ""))
+        validatorMock.mockValidateResetPasswordContinueFunc(.success(continuationToken: ""))
 
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "passwordResetToken", context: contextMock)
+        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         helper.onPasswordRequired(result)
 
@@ -460,12 +460,12 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "passwordResetToken", context: contextMock)
+        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordVerifyCodeError(result)
 
         await fulfillment(of: [exp])
         XCTAssertTrue(helper.onResetPasswordVerifyCodeErrorCalled)
-        XCTAssertEqual(helper.newCodeRequiredState?.flowToken, "passwordResetToken")
+        XCTAssertEqual(helper.newCodeRequiredState?.continuationToken, "continuationToken")
         XCTAssertNil(helper.newPasswordRequiredState)
         XCTAssertEqual(helper.error?.type, .invalidCode)
 
@@ -482,18 +482,18 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
                                                              errorURI: nil,
                                                              innerErrors: nil,
                                                              target: nil,
-                                                             passwordResetToken: nil))
+                                                             continuationToken: nil))
         validatorMock.mockValidateResetPasswordContinueFunc(error)
 
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "passwordResetToken", context: contextMock)
+        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordVerifyCodeError(result)
 
         await fulfillment(of: [exp])
         XCTAssertTrue(helper.onResetPasswordVerifyCodeErrorCalled)
-        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newCodeRequiredState?.continuationToken)
         XCTAssertNil(helper.newPasswordRequiredState)
         XCTAssertEqual(helper.error?.type, .generalError)
 
@@ -508,12 +508,12 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "passwordResetToken", context: contextMock)
+        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordVerifyCodeError(result)
 
         await fulfillment(of: [exp])
         XCTAssertTrue(helper.onResetPasswordVerifyCodeErrorCalled)
-        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newCodeRequiredState?.continuationToken)
         XCTAssertNil(helper.newPasswordRequiredState)
         XCTAssertEqual(helper.error?.type, .generalError)
 
@@ -529,7 +529,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -543,7 +543,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenSubmitPassword_succeeds_it_returnsCompleted() async {
         requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
-        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, continuationToken: nil))
@@ -551,7 +551,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         helper.onResetPasswordCompleted(result)
 
@@ -578,12 +578,12 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
         XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
-        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "passwordSubmitToken")
+        XCTAssertEqual(helper.newPasswordRequiredState?.continuationToken, "continuationToken")
         XCTAssertEqual(helper.error?.type, .invalidPassword)
         XCTAssertEqual(helper.error?.errorDescription, "Password too weak")
 
@@ -605,7 +605,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -624,7 +624,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -640,7 +640,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenSubmitPassword_pollCompletion_returns_failed_it_returnsResetPasswordRequiredError() async {
         requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
-        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.unexpectedError)
@@ -648,7 +648,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -661,7 +661,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenSubmitPassword_pollCompletion_returns_unexpectedError_it_returnsCorrectError() async {
         requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
-        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.unexpectedError)
@@ -669,7 +669,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -682,7 +682,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenSubmitPassword_pollCompletion_returns_passwordError_it_returnsCorrectError() async {
         requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
-        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         let error : MSALNativeAuthResetPasswordPollCompletionValidatedResponse =
@@ -699,12 +699,12 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
         XCTAssertTrue(helper.onResetPasswordRequiredErrorCalled)
-        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "passwordResetToken")
+        XCTAssertEqual(helper.newPasswordRequiredState?.continuationToken, "continuationToken")
         XCTAssertEqual(helper.error?.type, .invalidPassword)
         XCTAssertEqual(helper.error?.errorDescription, "Password banned")
 
@@ -714,7 +714,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenSubmitPassword_pollCompletion_returns_error_it_returnsCorrectError() async {
         requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
-        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         let error : MSALNativeAuthResetPasswordPollCompletionValidatedResponse = .error(
@@ -729,7 +729,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -743,7 +743,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenSubmitPassword_pollCompletion_returns_notStarted_it_returnsCorrectErrorAfterRetries() async {
         requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
-        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 1))
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken", pollInterval: 1))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
 
@@ -754,7 +754,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -767,7 +767,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenSubmitPassword_pollCompletion_returns_failed_it_returnsError() async {
         requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
-        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .failed, continuationToken: ""))
@@ -777,7 +777,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -790,7 +790,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
     func test_whenSubmitPassword_pollCompletion_returns_inProgress_it_returnsErrorAfterRetries() async {
         requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
-        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .inProgress, continuationToken: "<continuationToken>"))
@@ -800,7 +800,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -831,7 +831,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
 
         requestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedSubmitRequestParameters = expectedSubmitParams()
-        validatorMock.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken", pollInterval: 0))
+        validatorMock.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken", pollInterval: 0))
         requestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedPollCompletionParameters = expectedPollCompletionParameters()
         validatorMock.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, continuationToken: continuationToken))
@@ -839,7 +839,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: username, continuationToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: username, continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
 
         helper.onResetPasswordCompleted(result)
@@ -851,13 +851,13 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
 
         let exp2 = expectation(description: "SignInAfterResetPassword expectation")
         signInControllerMock.expectation = exp2
-        signInControllerMock.signInSLTResult = .init(.failure(.init()))
+        signInControllerMock.continuationTokenResult = .init(.failure(.init()))
 
         helper.signInAfterResetPasswordState?.signIn(delegate: SignInAfterResetPasswordDelegateStub())
         await fulfillment(of: [exp2], timeout: 1)
 
         XCTAssertEqual(signInControllerMock.username, username)
-        XCTAssertEqual(signInControllerMock.slt, continuationToken)
+        XCTAssertEqual(signInControllerMock.continuationToken, continuationToken)
     }
 
     // MARK: - Common Methods
@@ -927,39 +927,39 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         return helper
     }
 
-    private func expectedChallengeParams(token: String = "passwordResetToken") -> (token: String, context: MSIDRequestContext) {
+    private func expectedChallengeParams(token: String = "continuationToken") -> (token: String, context: MSIDRequestContext) {
         return (token: token, context: contextMock)
     }
 
     private func expectedContinueParams(
         grantType: MSALNativeAuthGrantType = .oobCode,
-        token: String = "passwordResetToken",
+        token: String = "continuationToken",
         oobCode: String? = "1234"
     ) -> MSALNativeAuthResetPasswordContinueRequestParameters {
         .init(
             context: contextMock,
-            passwordResetToken: token,
+            continuationToken: token,
             grantType: grantType,
             oobCode: oobCode
         )
     }
 
     private func expectedSubmitParams(
-        token: String = "passwordSubmitToken",
+        token: String = "continuationToken",
         password: String = "password"
     ) -> MSALNativeAuthResetPasswordSubmitRequestParameters {
         .init(
             context: contextMock,
-            passwordSubmitToken: token,
+            continuationToken: token,
             newPassword: password)
     }
 
     private func expectedPollCompletionParameters(
-        token: String = "passwordResetToken"
+        token: String = "continuationToken"
     ) -> MSALNativeAuthResetPasswordPollCompletionRequestParameters {
         .init(
             context: contextMock,
-            passwordResetToken: token)
+            continuationToken: token)
     }
 
     private func prepareMockRequestsForPollCompletionRetries(_ count: Int) {

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
@@ -303,7 +303,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", passwordResetToken: "passwordResetToken", context: contextMock)
+        let result = await sut.resendCode(username: "", continuationToken: "passwordResetToken", context: contextMock)
         helper.onResetPasswordResendCodeError(result)
 
         await fulfillment(of: [exp])
@@ -325,7 +325,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", passwordResetToken: "passwordResetToken", context: contextMock)
+        let result = await sut.resendCode(username: "", continuationToken: "passwordResetToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         helper.onResetPasswordResendCodeRequired(result)
 
@@ -355,7 +355,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", passwordResetToken: "passwordResetToken", context: contextMock)
+        let result = await sut.resendCode(username: "", continuationToken: "passwordResetToken", context: contextMock)
         helper.onResetPasswordResendCodeError(result)
 
         await fulfillment(of: [exp])
@@ -376,7 +376,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", passwordResetToken: "passwordResetToken", context: contextMock)
+        let result = await sut.resendCode(username: "", continuationToken: "passwordResetToken", context: contextMock)
         helper.onResetPasswordResendCodeError(result)
 
         await fulfillment(of: [exp])
@@ -397,7 +397,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", passwordResetToken: "passwordResetToken", context: contextMock)
+        let result = await sut.resendCode(username: "", continuationToken: "passwordResetToken", context: contextMock)
         helper.onResetPasswordResendCodeError(result)
 
         await fulfillment(of: [exp])
@@ -419,7 +419,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode(code: "1234", username: "", passwordResetToken: "passwordResetToken", context: contextMock)
+        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "passwordResetToken", context: contextMock)
         helper.onResetPasswordVerifyCodeError(result)
 
         await fulfillment(of: [exp])
@@ -439,7 +439,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode(code: "1234", username: "", passwordResetToken: "passwordResetToken", context: contextMock)
+        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "passwordResetToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         helper.onPasswordRequired(result)
 
@@ -460,7 +460,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode(code: "1234", username: "", passwordResetToken: "passwordResetToken", context: contextMock)
+        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "passwordResetToken", context: contextMock)
         helper.onResetPasswordVerifyCodeError(result)
 
         await fulfillment(of: [exp])
@@ -488,7 +488,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode(code: "1234", username: "", passwordResetToken: "passwordResetToken", context: contextMock)
+        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "passwordResetToken", context: contextMock)
         helper.onResetPasswordVerifyCodeError(result)
 
         await fulfillment(of: [exp])
@@ -508,7 +508,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode(code: "1234", username: "", passwordResetToken: "passwordResetToken", context: contextMock)
+        let result = await sut.submitCode(code: "1234", username: "", continuationToken: "passwordResetToken", context: contextMock)
         helper.onResetPasswordVerifyCodeError(result)
 
         await fulfillment(of: [exp])
@@ -529,7 +529,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -551,7 +551,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         helper.onResetPasswordCompleted(result)
 
@@ -578,7 +578,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -605,7 +605,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -624,7 +624,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -648,7 +648,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -669,7 +669,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -699,7 +699,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -729,7 +729,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -754,7 +754,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -777,7 +777,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -800,7 +800,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: "", passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: "", continuationToken: "passwordSubmitToken", context: contextMock)
         helper.onResetPasswordRequiredError(result)
 
         await fulfillment(of: [exp])
@@ -839,7 +839,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "ResetPasswordController expectation")
         let helper = prepareResetPasswordSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword(password: "password", username: username, passwordSubmitToken: "passwordSubmitToken", context: contextMock)
+        let result = await sut.submitPassword(password: "password", username: username, continuationToken: "passwordSubmitToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
 
         helper.onResetPasswordCompleted(result)

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -98,18 +98,18 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let expectedScopes = "scope1 scope2 openid profile offline_access"
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedCredentialToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
 
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
 
@@ -127,17 +127,17 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let expectedScopes = "scope1 openid profile offline_access"
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedCredentialToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
         tokenRequestProviderMock.throwingTokenError = ErrorMock.error
 
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
@@ -153,17 +153,17 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
 
         let expectation = expectation(description: "SignInController")
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedCredentialToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -190,17 +190,17 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
 
         let expectation = expectation(description: "SignInController")
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedCredentialToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -226,11 +226,11 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let credentialToken = "invalid token"
+        let continuationToken = "invalid token"
 
         let expectation = expectation(description: "SignInController")
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
         signInResponseValidatorMock.challengeValidatedResponse = .error(.invalidToken(message: nil))
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -274,19 +274,19 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedCredentialToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        tokenRequestProviderMock.expectedCredentialToken = credentialToken
+        tokenRequestProviderMock.expectedCredentialToken = continuationToken
 
         let expectation = expectation(description: "SignInController")
 
@@ -309,17 +309,17 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
 
         let expectation = expectation(description: "SignInController")
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedCredentialToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation)
@@ -343,17 +343,17 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
 
         let expectation = expectation(description: "SignInController")
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedCredentialToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation)
@@ -377,7 +377,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let sentTo = "sentTo"
         let channelTargetType = MSALNativeAuthChannelType.email
         let codeLength = 4
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let expectation = expectation(description: "SignInController")
@@ -385,13 +385,13 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedCredentialToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedSentTo: sentTo, expectedChannelTargetType: channelTargetType, expectedCodeLength: codeLength)
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
         result.telemetryUpdate?(.success(()))
@@ -403,21 +403,21 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_afterSignInWithCodeSubmitCode_signInShouldCompleteSuccessfully() {
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let expectation = expectation(description: "SignInController")
 
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: defaultScopes, password: nil, oobCode: "code", includeChallengeType: false, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.oobCode, scope: defaultScopes, password: nil, oobCode: "code", includeChallengeType: false, refreshToken: nil)
 
         let userAccountResult = MSALNativeAuthUserAccountResultStub.result
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
         cacheAccessorMock.mockUserAccounts = [MSALNativeAuthUserAccountResultStub.account]
         cacheAccessorMock.expectedMSIDTokenResult = tokenResult
 
-        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), flowToken: credentialToken, correlationId: defaultUUID)
+        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), continuationToken: continuationToken, correlationId: defaultUUID)
         state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedUserAccountResult: userAccountResult))
 
         wait(for: [expectation], timeout: 1)
@@ -427,19 +427,19 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_afterSignInWithCodeSubmitCode_whenTokenCacheIsNotValid_it_shouldReturnCorrectError() {
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let expectation = expectation(description: "SignInController")
 
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: defaultScopes, password: nil, oobCode: "code", includeChallengeType: false, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.oobCode, scope: defaultScopes, password: nil, oobCode: "code", includeChallengeType: false, refreshToken: nil)
 
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
         cacheAccessorMock.expectedMSIDTokenResult = nil
 
-        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), flowToken: credentialToken, correlationId: defaultUUID)
+        let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), continuationToken: continuationToken, correlationId: defaultUUID)
         state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)))
 
         wait(for: [expectation], timeout: 1)
@@ -484,7 +484,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError(message: nil)
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: "credentialToken")
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: "continuationToken")
         
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
 
@@ -509,15 +509,15 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     
     func test_whenSignInWithCodePasswordIsRequired_newStateIsPropagatedToUser() async {
         let expectedUsername = "username"
-        let expectedCredentialToken = "credentialToken"
+        let expectedCredentialToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let expectation = expectation(description: "SignInController")
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: expectedCredentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: expectedCredentialToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: expectedCredentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: expectedCredentialToken)
         
         let helper = SignInCodeStartWithPasswordRequiredTestsValidatorHelper(expectation: expectation)
 
@@ -528,20 +528,20 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         await fulfillment(of: [expectation], timeout: 1)
         checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: true)
-        XCTAssertEqual(helper.passwordRequiredState?.flowToken, expectedCredentialToken)
+        XCTAssertEqual(helper.passwordRequiredState?.continuationToken, expectedCredentialToken)
     }
 
     func test_whenSignInWithCodePasswordIsRequired_newStateIsPropagatedToUser_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
         let expectedUsername = "username"
-        let expectedCredentialToken = "credentialToken"
+        let expectedCredentialToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let expectation = expectation(description: "SignInController")
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: expectedCredentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: expectedCredentialToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: expectedCredentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: expectedCredentialToken)
 
         let helper = SignInCodeStartWithPasswordRequiredTestsValidatorHelper(expectation: expectation)
 
@@ -552,20 +552,20 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         await fulfillment(of: [expectation], timeout: 1)
         checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
-        XCTAssertEqual(helper.passwordRequiredState?.flowToken, expectedCredentialToken)
+        XCTAssertEqual(helper.passwordRequiredState?.continuationToken, expectedCredentialToken)
     }
     
     func test_whenSignInWithCodeSubmitPassword_signInIsCompletedSuccessfully() async {
         let expectedUsername = "username"
         let expectedPassword = "password"
-        let expectedCredentialToken = "credentialToken"
+        let expectedCredentialToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let exp = expectation(description: "SignInController")
         
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: expectedCredentialToken, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
 
         let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedUserAccountResult: MSALNativeAuthUserAccountResultStub.result)
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
@@ -573,7 +573,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         cacheAccessorMock.mockUserAccounts = [MSALNativeAuthUserAccountResultStub.account]
         cacheAccessorMock.expectedMSIDTokenResult = tokenResult
 
-        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken, correlationId: defaultUUID)
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, continuationToken: expectedCredentialToken, correlationId: defaultUUID)
         state.submitPassword(password: expectedPassword, delegate: mockDelegate)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -586,21 +586,21 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     func test_whenSignInWithCodeSubmitPassword_whenTokenCacheIsNotValid_it_shouldReturnCorrectError() async {
         let expectedUsername = "username"
         let expectedPassword = "password"
-        let expectedCredentialToken = "credentialToken"
+        let expectedCredentialToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let exp = expectation(description: "SignInController")
 
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: expectedCredentialToken, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
 
         let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
         tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
         cacheAccessorMock.expectedMSIDTokenResult = nil
 
-        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken, correlationId: defaultUUID)
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, continuationToken: expectedCredentialToken, correlationId: defaultUUID)
         state.submitPassword(password: expectedPassword, delegate: mockDelegate)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -610,7 +610,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     func test_whenSignInWithCodeSubmitPasswordTokenRequestCreationFail_errorShouldBeReturned() async {
         let expectedUsername = "username"
         let expectedPassword = "password"
-        let expectedCredentialToken = "credentialToken"
+        let expectedCredentialToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let exp = expectation(description: "SignInController")
@@ -620,7 +620,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         
         let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
 
-        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken, correlationId: defaultUUID)
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, continuationToken: expectedCredentialToken, correlationId: defaultUUID)
         state.submitPassword(password: expectedPassword, delegate: mockDelegate)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -646,7 +646,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_signInWithCodeSubmitCodeTokenRequestFailCreation_errorShouldBeReturned() {
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let expectation = expectation(description: "SignInController")
@@ -654,7 +654,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil)
 
-        let state = SignInCodeRequiredState(scopes: [], controller: sut, flowToken: credentialToken, correlationId: defaultUUID)
+        let state = SignInCodeRequiredState(scopes: [], controller: sut, continuationToken: continuationToken, correlationId: defaultUUID)
         state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)))
 
         wait(for: [expectation], timeout: 1)
@@ -683,21 +683,21 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let sentTo = "sentTo"
         let channelTargetType = MSALNativeAuthChannelType.email
         let codeLength = 4
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let expectation = expectation(description: "SignInController")
 
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedCredentialToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation, expectedSentTo: sentTo, expectedChannelTargetType: channelTargetType, expectedCodeLength: codeLength)
 
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
 
-        let result = await sut.resendCode(continuationToken: credentialToken, context: expectedContext, scopes: [])
+        let result = await sut.resendCode(continuationToken: continuationToken, context: expectedContext, scopes: [])
         result.telemetryUpdate?(.success(()))
 
         helper.onSignInResendCodeCodeRequired(result)
@@ -715,7 +715,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
 
-        let result = await sut.resendCode(continuationToken: "credentialToken", context: expectedContext, scopes: [])
+        let result = await sut.resendCode(continuationToken: "continuationToken", context: expectedContext, scopes: [])
 
         helper.onSignInResendCodeError(result)
 
@@ -725,7 +725,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_signInWithCodeResendCodePasswordRequired_shouldReturnAnError() async {
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let expectation = expectation(description: "SignInController")
@@ -735,9 +735,9 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
 
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
 
-        let result = await sut.resendCode(continuationToken: credentialToken, context: expectedContext, scopes: [])
+        let result = await sut.resendCode(continuationToken: continuationToken, context: expectedContext, scopes: [])
 
         helper.onSignInResendCodeError(result)
 
@@ -747,7 +747,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_signInWithCodeResendCodeChallengeReturnError_shouldReturnAnError() async {
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let expectation = expectation(description: "SignInController")
@@ -759,27 +759,27 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInResponseValidatorMock.challengeValidatedResponse = .error(.userNotFound(message: nil))
 
-        let result = await sut.resendCode(continuationToken: credentialToken, context: expectedContext, scopes: [])
+        let result = await sut.resendCode(continuationToken: continuationToken, context: expectedContext, scopes: [])
 
         helper.onSignInResendCodeError(result)
 
         await fulfillment(of: [expectation], timeout: 1)
         XCTAssertNotNil(helper.newSignInCodeRequiredState)
-        XCTAssertEqual(helper.newSignInCodeRequiredState?.flowToken, credentialToken)
+        XCTAssertEqual(helper.newSignInCodeRequiredState?.continuationToken, continuationToken)
         checkTelemetryEventResult(id: .telemetryApiIdSignInResendCode, isSuccessful: false)
     }
     
-    // MARK: signIn using SLT
+    // MARK: signIn using ContinuationToken
     
-    func test_whenSignInWithSLT_signInIsCompletedSuccessfully() {
-        let slt = "signInSLT"
+    func test_whenSignInWithContinuationToken_signInIsCompletedSuccessfully() {
+        let continuationToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let expectation = expectation(description: "SignInController")
         
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: "", credentialToken: nil, signInSLT: slt, grantType: .slt, scope: defaultScopes, password: nil, oobCode: nil, includeChallengeType: false, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: "", continuationToken: continuationToken, grantType: .continuationToken, scope: defaultScopes, password: nil, oobCode: nil, includeChallengeType: false, refreshToken: nil)
 
         let userAccountResult = MSALNativeAuthUserAccountResultStub.result
         let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedUserAccountResult: userAccountResult)
@@ -788,7 +788,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         cacheAccessorMock.expectedMSIDTokenResult = tokenResult
         
-        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt, correlationId: defaultUUID)
+        let state = SignInAfterSignUpState(controller: sut, username: "", continuationToken: continuationToken, correlationId: defaultUUID)
         state.signIn(delegate: mockDelegate)
 
         wait(for: [expectation], timeout: 1)
@@ -796,8 +796,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         checkTelemetryEventResult(id: .telemetryApiIdSignInAfterSignUp, isSuccessful: true)
     }
     
-    func test_whenSignInWithSLTTokenRequestCreationFail_errorShouldBeReturned() {
-        let slt = "signInSLT"
+    func test_whenSignInWithContinuationTokenTokenRequestCreationFail_errorShouldBeReturned() {
+        let continuationToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let exp = expectation(description: "SignInController")
@@ -807,7 +807,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         
         let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: exp, expectedError: SignInAfterSignUpError())
 
-        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt, correlationId: defaultUUID)
+        let state = SignInAfterSignUpState(controller: sut, username: "", continuationToken: continuationToken, correlationId: defaultUUID)
         state.signIn(delegate: mockDelegate)
         
         wait(for: [exp], timeout: 1)
@@ -815,8 +815,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         checkTelemetryEventResult(id: .telemetryApiIdSignInAfterSignUp, isSuccessful: false)
     }
     
-    func test_whenSignInWithSLTTokenReturnError_shouldReturnAnError() {
-        let slt = "signInSLT"
+    func test_whenSignInWithContinuationTokenTokenReturnError_shouldReturnAnError() {
+        let continuationToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let expectation = expectation(description: "SignInController")
@@ -828,7 +828,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         tokenResponseValidatorMock.tokenValidatedResponse = .error(.invalidClient(message: "Invalid Client ID"))
 
-        let state = SignInAfterSignUpState(controller: sut, username: "", slt: slt, correlationId: defaultUUID)
+        let state = SignInAfterSignUpState(controller: sut, username: "", continuationToken: continuationToken, correlationId: defaultUUID)
         state.signIn(delegate: mockDelegate)
 
         wait(for: [expectation], timeout: 1)
@@ -836,12 +836,12 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         checkTelemetryEventResult(id: .telemetryApiIdSignInAfterSignUp, isSuccessful: false)
     }
     
-    func test_whenSignInWithSLTHaveTokenNil_shouldReturnAnError() {        
+    func test_whenSignInWithContinuationTokenHaveTokenNil_shouldReturnAnError() {
         let expectation = expectation(description: "SignInController")
 
         let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Sign In is not available at this point, please use the standalone sign in methods"))
 
-        let state = SignInAfterSignUpState(controller: sut, username: "username", slt: nil, correlationId: defaultUUID)
+        let state = SignInAfterSignUpState(controller: sut, username: "username", continuationToken: nil, correlationId: defaultUUID)
         state.signIn(delegate: mockDelegate)
 
         wait(for: [expectation], timeout: 1)
@@ -853,7 +853,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     // MARK: private methods
 
     private func checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: VerifyCodeError.ErrorType, validatorError: MSALNativeAuthTokenValidatedErrorType) {
-        let expectedCredentialToken = "credentialToken"
+        let expectedCredentialToken = "continuationToken"
         let expectedOOBCode = "code"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
@@ -861,11 +861,11 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: "", password: nil, oobCode: expectedOOBCode, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, continuationToken: expectedCredentialToken, grantType: MSALNativeAuthGrantType.oobCode, scope: "", password: nil, oobCode: expectedOOBCode, includeChallengeType: true, refreshToken: nil)
         let mockDelegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedError: VerifyCodeError(type: delegateError))
         tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
         
-        let state = SignInCodeRequiredState(scopes: [], controller: sut, flowToken: expectedCredentialToken, correlationId: defaultUUID)
+        let state = SignInCodeRequiredState(scopes: [], controller: sut, continuationToken: expectedCredentialToken, correlationId: defaultUUID)
         state.submitCode(code: expectedOOBCode, delegate: mockDelegate)
 
         wait(for: [exp], timeout: 1)
@@ -877,18 +877,18 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     private func checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError, validatorError: MSALNativeAuthTokenValidatedErrorType) async {
         let expectedUsername = "username"
         let expectedPassword = "password"
-        let expectedCredentialToken = "credentialToken"
+        let expectedCredentialToken = "continuationToken"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
 
         let exp = expectation(description: "SignInController")
         
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, credentialToken: expectedCredentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: expectedCredentialToken, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
         let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: publicError)
         tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
 
-        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, flowToken: expectedCredentialToken, correlationId: defaultUUID)
+        let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, continuationToken: expectedCredentialToken, correlationId: defaultUUID)
         state.submitPassword(password: expectedPassword, delegate: mockDelegate)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -905,7 +905,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInRequestProviderMock.mockInitiateRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInRequestProviderMock.mockChallengeRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: "credentialToken")
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: "continuationToken")
         signInResponseValidatorMock.challengeValidatedResponse = .error(validatorError)
         
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
@@ -945,15 +945,15 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedUsername = "username"
         let expectedPassword = "password"
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
         
         signInRequestProviderMock.mockInitiateRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInRequestProviderMock.mockChallengeRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = credentialToken
+        signInRequestProviderMock.expectedCredentialToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         let expectation = expectation(description: "SignInController")

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -697,7 +697,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
 
-        let result = await sut.resendCode(credentialToken: credentialToken, context: expectedContext, scopes: [])
+        let result = await sut.resendCode(continuationToken: credentialToken, context: expectedContext, scopes: [])
         result.telemetryUpdate?(.success(()))
 
         helper.onSignInResendCodeCodeRequired(result)
@@ -715,7 +715,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
 
-        let result = await sut.resendCode(credentialToken: "credentialToken", context: expectedContext, scopes: [])
+        let result = await sut.resendCode(continuationToken: "credentialToken", context: expectedContext, scopes: [])
 
         helper.onSignInResendCodeError(result)
 
@@ -737,7 +737,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(credentialToken: credentialToken)
 
-        let result = await sut.resendCode(credentialToken: credentialToken, context: expectedContext, scopes: [])
+        let result = await sut.resendCode(continuationToken: credentialToken, context: expectedContext, scopes: [])
 
         helper.onSignInResendCodeError(result)
 
@@ -759,7 +759,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInResponseValidatorMock.challengeValidatedResponse = .error(.userNotFound(message: nil))
 
-        let result = await sut.resendCode(credentialToken: credentialToken, context: expectedContext, scopes: [])
+        let result = await sut.resendCode(continuationToken: credentialToken, context: expectedContext, scopes: [])
 
         helper.onSignInResendCodeError(result)
 

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
@@ -96,7 +96,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartPassword_returnsVerificationRequired_it_returnsChallenge() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
@@ -192,7 +192,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                    errorCodes: nil,
                                                    errorURI: nil,
                                                    innerErrors: nil,
-                                                   signUpToken: nil,
+                                                   continuationToken: nil,
                                                    unverifiedAttributes: nil,
                                                    invalidAttributes: nil))
         validatorMock.mockValidateSignUpStartFunc(error)
@@ -223,7 +223,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                    errorCodes: nil,
                                                    errorURI: nil,
                                                    innerErrors: nil,
-                                                   signUpToken: nil,
+                                                   continuationToken: nil,
                                                    unverifiedAttributes: nil,
                                                    invalidAttributes: nil))
         validatorMock.mockValidateSignUpStartFunc(invalidUsername)
@@ -254,7 +254,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                    errorCodes: nil,
                                                    errorURI: nil,
                                                    innerErrors: nil,
-                                                   signUpToken: nil,
+                                                   continuationToken: nil,
                                                    unverifiedAttributes: nil,
                                                    invalidAttributes: nil))
         validatorMock.mockValidateSignUpStartFunc(invalidClientId)
@@ -303,7 +303,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartPassword_challenge_cantCreateRequest_it_returns_unexpectedError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
 
@@ -327,10 +327,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartPassword_challenge_succeeds_it_continuesTheFlow() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
-        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "continuationToken 2"))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpPasswordStartValidatorHelper(exp)
@@ -341,7 +341,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeRequiredCalled)
-        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.newState?.continuationToken, "continuationToken 2")
         XCTAssertEqual(helper.sentTo, "sentTo")
         XCTAssertEqual(helper.channelTargetType, .email)
         XCTAssertEqual(helper.codeLength, 4)
@@ -353,7 +353,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartPassword_challenge_returns_passwordRequired_it_returnsCorrectError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired(""))
@@ -378,7 +378,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartPassword_challenge_returns_redirect_it_returnsCorrectError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.redirect)
@@ -403,7 +403,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartPassword_challenge_returns_error_it_returnsCorrectError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
@@ -435,7 +435,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenValidatorInSignUpStartPassword_challenge_returns_unexpectedError_it_returnsGeneralError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartPasswordParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
@@ -483,7 +483,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartCode_returnsVerificationRequired_it_returnsChallenge() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
@@ -577,7 +577,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                    errorCodes: nil,
                                                    errorURI: nil,
                                                    innerErrors: nil,
-                                                   signUpToken: nil,
+                                                   continuationToken: nil,
                                                    unverifiedAttributes: nil,
                                                    invalidAttributes: nil))
         validatorMock.mockValidateSignUpStartFunc(error)
@@ -608,7 +608,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                    errorCodes: nil,
                                                    errorURI: nil,
                                                    innerErrors: nil,
-                                                   signUpToken: nil,
+                                                   continuationToken: nil,
                                                    unverifiedAttributes: nil,
                                                    invalidAttributes: nil))
         validatorMock.mockValidateSignUpStartFunc(invalidUsername)
@@ -639,7 +639,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                    errorCodes: nil,
                                                    errorURI: nil,
                                                    innerErrors: nil,
-                                                   signUpToken: nil,
+                                                   continuationToken: nil,
                                                    unverifiedAttributes: nil,
                                                    invalidAttributes: nil))
         validatorMock.mockValidateSignUpStartFunc(invalidClientId)
@@ -688,7 +688,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartCode_challenge_cantCreateRequest_it_returns_unexpectedError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
 
@@ -712,10 +712,10 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartCode_challenge_succeeds_it_continuesTheFlow() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken 1", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken 1", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 1")
-        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "continuationToken 1")
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "continuationToken 2"))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpCodeStartValidatorHelper(exp)
@@ -726,7 +726,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpCodeRequiredCalled)
-        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.newState?.continuationToken, "continuationToken 2")
         XCTAssertEqual(helper.sentTo, "sentTo")
         XCTAssertEqual(helper.channelTargetType, .email)
         XCTAssertEqual(helper.codeLength, 4)
@@ -738,7 +738,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartCode_challenge_succeedsPassword_it_returnsCorrectError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired(""))
@@ -763,7 +763,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartCode_challenge_returns_redirect_it_returnsCorrectError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.redirect)
@@ -788,7 +788,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpStartCode_challenge_returns_error_it_returnsCorrectError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
@@ -820,7 +820,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenValidatorInSignUpStartCode_challenge_it_returns_unexpectedError_returnsGeneralError() async {
         requestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedStartRequestParameters = signUpStartCodeParams
-        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""]))
+        validatorMock.mockValidateSignUpStartFunc(.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""]))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
@@ -851,7 +851,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "continuationToken")
         helper.onSignUpResendCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -867,18 +867,18 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpResendCode_succeeds_it_continuesTheFlow() async {
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams()
-        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken"))
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "continuationToken"))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "continuationToken")
         result.telemetryUpdate?(.success(()))
         helper.onSignUpResendCodeCodeRequired(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpResendCodeCodeRequiredCalled)
-        XCTAssertEqual(helper.newState?.flowToken, "signUpToken")
+        XCTAssertEqual(helper.newState?.continuationToken, "continuationToken")
         XCTAssertEqual(helper.sentTo, "sentTo")
         XCTAssertEqual(helper.channelTargetType, .email)
         XCTAssertEqual(helper.codeLength, 4)
@@ -889,13 +889,13 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
     func test_whenSignUpResendCode_succeedsPassword_it_returnsCorrectError() async {
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
-        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 1"))
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "continuationToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("continuationToken 1"))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken 2")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "continuationToken 2")
         helper.onSignUpResendCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -922,7 +922,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "continuationToken")
         helper.onSignUpResendCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -943,7 +943,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "continuationToken")
         helper.onSignUpResendCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -964,7 +964,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "continuationToken")
         helper.onSignUpResendCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -986,7 +986,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1007,7 +1007,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpCompleted(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1028,7 +1028,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                       errorCodes: nil,
                                                       errorURI: nil,
                                                       innerErrors: nil,
-                                                      signUpToken: nil,
+                                                      continuationToken: nil,
                                                       requiredAttributes: nil,
                                                       unverifiedAttributes: nil,
                                                       invalidAttributes: nil))
@@ -1038,13 +1038,13 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
         XCTAssertNil(helper.newAttributesRequiredState)
-        XCTAssertEqual(helper.newCodeRequiredState?.flowToken, "signUpToken")
+        XCTAssertEqual(helper.newCodeRequiredState?.continuationToken, "continuationToken")
         XCTAssertNil(helper.newPasswordRequiredState)
         XCTAssertEqual(helper.error?.type, .invalidCode)
 
@@ -1053,20 +1053,20 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
     func test_whenSignUpSubmitCode_returns_attributesRequired_it_returnsAttributesRequired() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken", requiredAttributes: []))
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(continuationToken: "continuationToken", requiredAttributes: []))
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
 
         helper.onSignUpAttributesRequired(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
-        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken")
+        XCTAssertEqual(helper.newAttributesRequiredState?.continuationToken, "continuationToken")
         XCTAssertNil(helper.newCodeRequiredState)
         XCTAssertNil(helper.newPasswordRequiredState)
         XCTAssertNil(helper.error)
@@ -1076,20 +1076,20 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
     func test_whenSignUpSubmitCode_returns_attributesRequired_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken", requiredAttributes: []))
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(continuationToken: "continuationToken", requiredAttributes: []))
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.failure(.init(message: "error")))
 
         helper.onSignUpAttributesRequired(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
-        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken")
+        XCTAssertEqual(helper.newAttributesRequiredState?.continuationToken, "continuationToken")
         XCTAssertNil(helper.newCodeRequiredState)
         XCTAssertNil(helper.newPasswordRequiredState)
         XCTAssertNil(helper.error)
@@ -1100,12 +1100,12 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitCode_returns_attributeValidationFailed_returnsCorrectError() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
-        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["name"]))
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(continuationToken: "continuationToken 2", invalidAttributes: ["name"]))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         
         helper.onSignUpVerifyCodeError(result)
@@ -1127,7 +1127,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                       errorCodes: nil,
                                                       errorURI: nil,
                                                       innerErrors: nil,
-                                                      signUpToken: nil,
+                                                      continuationToken: nil,
                                                       requiredAttributes: nil,
                                                       unverifiedAttributes: nil,
                                                       invalidAttributes: nil))
@@ -1136,13 +1136,13 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
         XCTAssertNil(helper.newAttributesRequiredState)
-        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newCodeRequiredState?.continuationToken)
         XCTAssertNil(helper.newPasswordRequiredState)
         XCTAssertEqual(helper.error?.type, .generalError)
 
@@ -1157,13 +1157,13 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpVerifyCodeErrorCalled)
         XCTAssertNil(helper.newAttributesRequiredState)
-        XCTAssertNil(helper.newCodeRequiredState?.flowToken)
+        XCTAssertNil(helper.newCodeRequiredState?.continuationToken)
         XCTAssertNil(helper.newPasswordRequiredState)
         XCTAssertEqual(helper.error?.type, .generalError)
 
@@ -1175,9 +1175,9 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
-        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(continuationToken: "continuationToken 2"))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "continuationToken 2")
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
 
         XCTAssertFalse(requestProviderMock.challengeCalled)
@@ -1185,7 +1185,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1197,14 +1197,14 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andCantCreateRequest() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
-        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(continuationToken: "continuationToken 2"))
         requestProviderMock.mockChallengeRequestFunc(nil, throwError: true)
-        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "continuationToken 2")
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1220,17 +1220,17 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andSucceeds() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
-        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(continuationToken: "continuationToken 2"))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
-        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 3"))
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "continuationToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("continuationToken 3"))
 
         XCTAssertFalse(requestProviderMock.challengeCalled)
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
 
         helper.onSignUpPasswordRequired(result)
@@ -1240,7 +1240,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         XCTAssertTrue(helper.onSignUpPasswordRequiredCalled)
         XCTAssertNil(helper.newAttributesRequiredState)
         XCTAssertNil(helper.newCodeRequiredState)
-        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken 3")
+        XCTAssertEqual(helper.newPasswordRequiredState?.continuationToken, "continuationToken 3")
         XCTAssertNil(helper.error)
 
         checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: true)
@@ -1249,17 +1249,17 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
-        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(continuationToken: "continuationToken 2"))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
-        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("signUpToken 3"))
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "continuationToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.passwordRequired("continuationToken 3"))
 
         XCTAssertFalse(requestProviderMock.challengeCalled)
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.failure(.init(message: "error")))
 
         helper.onSignUpPasswordRequired(result)
@@ -1269,7 +1269,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         XCTAssertTrue(helper.onSignUpPasswordRequiredCalled)
         XCTAssertNil(helper.newAttributesRequiredState)
         XCTAssertNil(helper.newCodeRequiredState)
-        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken 3")
+        XCTAssertEqual(helper.newPasswordRequiredState?.continuationToken, "continuationToken 3")
         XCTAssertNil(helper.error)
 
         checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitCode, isSuccessful: false)
@@ -1277,18 +1277,18 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andSucceedOOB_returnsCorrectError() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(continuationToken: "continuationToken 2"))
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
-        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("", .email, 4, "signUpToken 3"))
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "continuationToken 2")
+        validatorMock.mockValidateSignUpChallengeFunc(.codeRequired("", .email, 4, "continuationToken 3"))
 
         XCTAssertFalse(requestProviderMock.challengeCalled)
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1301,9 +1301,9 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andRedirects() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
-        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(continuationToken: "continuationToken 2"))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "continuationToken 2")
         validatorMock.mockValidateSignUpChallengeFunc(.redirect)
 
         XCTAssertFalse(requestProviderMock.challengeCalled)
@@ -1311,7 +1311,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1327,9 +1327,9 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andReturnsError() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
-        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(continuationToken: "continuationToken 2"))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "continuationToken 2")
         let error : MSALNativeAuthSignUpChallengeValidatedResponse = .error(
             MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken,
                                                        errorDescription: nil,
@@ -1343,7 +1343,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1359,9 +1359,9 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitCode_returns_credentialRequired_it_returnsChallengeEndpoint_andReturnsUnexpectedError() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams()
-        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(continuationToken: "continuationToken 2"))
         requestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "signUpToken 2")
+        requestProviderMock.expectedChallengeRequestParameters = expectedChallengeParams(token: "continuationToken 2")
         validatorMock.mockValidateSignUpChallengeFunc(.unexpectedError)
 
         XCTAssertFalse(requestProviderMock.challengeCalled)
@@ -1369,7 +1369,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1391,7 +1391,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpPasswordRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1406,12 +1406,12 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSubmitPassword_succeeds_it_continuesTheFlow() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
-        validatorMock.mockValidateSignUpContinueFunc(.success("signInSLT"))
+        validatorMock.mockValidateSignUpContinueFunc(.success("continuationToken"))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpCompleted(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1432,7 +1432,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                       errorCodes: nil,
                                                       errorURI: nil,
                                                       innerErrors: nil,
-                                                      signUpToken: nil,
+                                                      continuationToken: nil,
                                                       requiredAttributes: nil,
                                                       unverifiedAttributes: nil,
                                                       invalidAttributes: nil))
@@ -1441,13 +1441,13 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpPasswordRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpPasswordRequiredErrorCalled)
         XCTAssertNil(helper.newAttributesRequiredState)
-        XCTAssertEqual(helper.newPasswordRequiredState?.flowToken, "signUpToken")
+        XCTAssertEqual(helper.newPasswordRequiredState?.continuationToken, "continuationToken")
         XCTAssertEqual(helper.error?.type, .invalidPassword)
         XCTAssertEqual(helper.error?.errorDescription, "Password too weak")
 
@@ -1457,19 +1457,19 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitPassword_returns_attributesRequired_it_returnsCorrectError() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
-        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(continuationToken: "continuationToken 2", requiredAttributes: []))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
 
         helper.onSignUpAttributesRequired(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
-        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.newAttributesRequiredState?.continuationToken, "continuationToken 2")
         XCTAssertNil(helper.newPasswordRequiredState)
         XCTAssertNil(helper.error)
 
@@ -1479,19 +1479,19 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitPassword_returns_attributesRequired_butTelemetryUpdateFails_it_updatesTelemetryCorrectly() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
-        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(continuationToken: "continuationToken 2", requiredAttributes: []))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.failure(.init(message: "error")))
 
         helper.onSignUpAttributesRequired(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
-        XCTAssertEqual(helper.newAttributesRequiredState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.newAttributesRequiredState?.continuationToken, "continuationToken 2")
         XCTAssertNil(helper.newPasswordRequiredState)
         XCTAssertNil(helper.error)
 
@@ -1507,7 +1507,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                       errorCodes: nil,
                                                       errorURI: nil,
                                                       innerErrors: nil,
-                                                      signUpToken: nil,
+                                                      continuationToken: nil,
                                                       requiredAttributes: nil,
                                                       unverifiedAttributes: nil,
                                                       invalidAttributes: nil))
@@ -1516,7 +1516,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpPasswordRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1531,12 +1531,12 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitPassword_returns_credentialRequired_it_returnsCorrectError() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
-        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(continuationToken: "continuationToken 2"))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpPasswordRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1556,7 +1556,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpPasswordRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1571,12 +1571,12 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
     func test_whenSignUpSubmitPassword_returns_attributeValidationFailed_it_returnsCorrectError() async {
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
-        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["key"]))
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(continuationToken: "continuationToken 2", invalidAttributes: ["key"]))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
 
         helper.onSignUpPasswordRequiredError(result)
@@ -1602,7 +1602,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpAttributesRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1624,7 +1624,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpCompleted(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1648,7 +1648,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                       errorCodes: nil,
                                                       errorURI: nil,
                                                       innerErrors: nil,
-                                                      signUpToken: nil,
+                                                      continuationToken: nil,
                                                       requiredAttributes: nil,
                                                       unverifiedAttributes: nil,
                                                       invalidAttributes: nil))
@@ -1657,7 +1657,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpAttributesRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1680,7 +1680,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
                                                       errorCodes: nil,
                                                       errorURI: nil,
                                                       innerErrors: nil,
-                                                      signUpToken: nil,
+                                                      continuationToken: nil,
                                                       requiredAttributes: nil,
                                                       unverifiedAttributes: nil,
                                                       invalidAttributes: nil))
@@ -1689,7 +1689,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpAttributesRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1706,18 +1706,18 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
             oobCode: nil,
             attributes: ["key": "value"]
         )
-        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(signUpToken: "signUpToken 2", requiredAttributes: []))
+        validatorMock.mockValidateSignUpContinueFunc(.attributesRequired(continuationToken: "continuationToken 2", requiredAttributes: []))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         helper.onSignUpAttributesRequired(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpAttributesRequiredCalled)
-        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.newState?.continuationToken, "continuationToken 2")
 
         checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
     }
@@ -1729,12 +1729,12 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
             oobCode: nil,
             attributes: ["key": "value"]
         )
-        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(signUpToken: "signUpToken 2"))
+        validatorMock.mockValidateSignUpContinueFunc(.credentialRequired(continuationToken: "continuationToken 2"))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpAttributesRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1756,7 +1756,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpAttributesRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1773,28 +1773,28 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
             oobCode: nil,
             attributes: ["key": "value"]
         )
-        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(signUpToken: "signUpToken 2", invalidAttributes: ["attribute"]))
+        validatorMock.mockValidateSignUpContinueFunc(.attributeValidationFailed(continuationToken: "continuationToken 2", invalidAttributes: ["attribute"]))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "continuationToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         helper.onSignUpAttributesValidationFailed(result)
 
         await fulfillment(of: [exp], timeout: 1)
         XCTAssertTrue(helper.onSignUpInvalidAttributesCalled)
-        XCTAssertEqual(helper.newState?.flowToken, "signUpToken 2")
+        XCTAssertEqual(helper.newState?.continuationToken, "continuationToken 2")
         XCTAssertEqual(helper.invalidAttributes, ["attribute"])
 
         checkTelemetryEventResult(id: .telemetryApiIdSignUpSubmitAttributes, isSuccessful: false)
     }
 
-    // MARK: - Sign-in with SLT (Short-Lived Token)
+    // MARK: - Sign-in with ContinuationToken
 
-    func test_whenSignUpSucceeds_and_userCallsSignInWithSLT_signUpControllerPassesCorrectParams() async {
+    func test_whenSignUpSucceeds_and_userCallsSignInWithContinuationToken_signUpControllerPassesCorrectParams() async {
         let username = "username"
-        let slt = "signInSLT"
+        let continuationToken = "continuationToken"
 
         class SignInAfterSignUpDelegateStub: SignInAfterSignUpDelegate {
             func onSignInAfterSignUpError(error: MSAL.SignInAfterSignUpError) {}
@@ -1803,12 +1803,12 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
         requestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         requestProviderMock.expectedContinueRequestParameters = expectedContinueParams(grantType: .password, password: "password", oobCode: nil)
-        validatorMock.mockValidateSignUpContinueFunc(.success(slt))
+        validatorMock.mockValidateSignUpContinueFunc(.success(continuationToken))
 
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: username, continuationToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: username, continuationToken: "continuationToken", context: contextMock)
         helper.onSignUpCompleted(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1821,12 +1821,12 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
         let exp2 = expectation(description: "SignInAfterSignUp expectation")
         signInControllerMock.expectation = exp2
-        signInControllerMock.signInSLTResult = .init(.failure(.init()))
+        signInControllerMock.continuationTokenResult = .init(.failure(.init()))
         helper.signInAfterSignUpState?.signIn(delegate: SignInAfterSignUpDelegateStub())
         await fulfillment(of: [exp2], timeout: 1)
 
         XCTAssertEqual(signInControllerMock.username, username)
-        XCTAssertEqual(signInControllerMock.slt, slt)
+        XCTAssertEqual(signInControllerMock.continuationToken, continuationToken)
     }
 
     // MARK: - Common Methods
@@ -1924,20 +1924,20 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         return helper
     }
 
-    private func expectedChallengeParams(token: String = "signUpToken") -> (token: String, context: MSIDRequestContext) {
+    private func expectedChallengeParams(token: String = "continuationToken") -> (token: String, context: MSIDRequestContext) {
         return (token: token, context: contextMock)
     }
 
     private func expectedContinueParams(
         grantType: MSALNativeAuthGrantType = .oobCode,
-        token: String = "signUpToken",
+        token: String = "continuationToken",
         password: String? = nil,
         oobCode: String? = "1234",
         attributes: [String: Any]? = nil
     ) -> MSALNativeAuthSignUpContinueRequestProviderParams {
         .init(
             grantType: grantType,
-            signUpToken: token,
+            continuationToken: token,
             password: password,
             oobCode: oobCode,
             attributes: attributes,

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
@@ -851,7 +851,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken")
         helper.onSignUpResendCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -872,7 +872,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken")
         result.telemetryUpdate?(.success(()))
         helper.onSignUpResendCodeCodeRequired(result)
 
@@ -895,7 +895,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken 2")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken 2")
         helper.onSignUpResendCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -922,7 +922,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken")
         helper.onSignUpResendCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -943,7 +943,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken")
         helper.onSignUpResendCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -964,7 +964,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpResendCodeValidatorHelper(exp)
 
-        let result = await sut.resendCode(username: "", context: contextMock, signUpToken: "signUpToken")
+        let result = await sut.resendCode(username: "", context: contextMock, continuationToken: "signUpToken")
         helper.onSignUpResendCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -986,7 +986,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1007,7 +1007,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpCompleted(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1038,7 +1038,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1059,7 +1059,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
 
         helper.onSignUpAttributesRequired(result)
@@ -1082,7 +1082,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         result.telemetryUpdate?(.failure(.init(message: "error")))
 
         helper.onSignUpAttributesRequired(result)
@@ -1105,7 +1105,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         
         helper.onSignUpVerifyCodeError(result)
@@ -1136,7 +1136,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1157,7 +1157,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1185,7 +1185,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1204,7 +1204,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1230,7 +1230,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
 
         helper.onSignUpPasswordRequired(result)
@@ -1259,7 +1259,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         result.telemetryUpdate?(.failure(.init(message: "error")))
 
         helper.onSignUpPasswordRequired(result)
@@ -1288,7 +1288,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1311,7 +1311,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1343,7 +1343,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1369,7 +1369,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitCodeValidatorHelper(exp)
 
-        let result = await sut.submitCode("1234", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitCode("1234", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpVerifyCodeError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1391,7 +1391,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpPasswordRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1411,7 +1411,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpCompleted(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1441,7 +1441,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpPasswordRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1462,7 +1462,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
 
         helper.onSignUpAttributesRequired(result)
@@ -1484,7 +1484,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
         result.telemetryUpdate?(.failure(.init(message: "error")))
 
         helper.onSignUpAttributesRequired(result)
@@ -1516,7 +1516,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpPasswordRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1536,7 +1536,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpPasswordRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1556,7 +1556,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpPasswordRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1576,7 +1576,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: "", continuationToken: "signUpToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
 
         helper.onSignUpPasswordRequiredError(result)
@@ -1602,7 +1602,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpAttributesRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1624,7 +1624,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpCompleted(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1657,7 +1657,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpAttributesRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1689,7 +1689,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpAttributesRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1711,7 +1711,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         helper.onSignUpAttributesRequired(result)
 
@@ -1734,7 +1734,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpAttributesRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1756,7 +1756,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpAttributesRequiredError(result)
 
         await fulfillment(of: [exp], timeout: 1)
@@ -1778,7 +1778,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitAttributesValidatorHelper(exp)
 
-        let result = await sut.submitAttributes(["key": "value"], username: "", signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitAttributes(["key": "value"], username: "", continuationToken: "signUpToken", context: contextMock)
         result.telemetryUpdate?(.success(()))
         helper.onSignUpAttributesValidationFailed(result)
 
@@ -1808,7 +1808,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp = expectation(description: "SignUpController expectation")
         let helper = prepareSignUpSubmitPasswordValidatorHelper(exp)
 
-        let result = await sut.submitPassword("password", username: username, signUpToken: "signUpToken", context: contextMock)
+        let result = await sut.submitPassword("password", username: username, continuationToken: "signUpToken", context: contextMock)
         helper.onSignUpCompleted(result)
 
         await fulfillment(of: [exp], timeout: 1)

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
@@ -90,7 +90,7 @@ class MSALNativeAuthSignInResponseValidatorMock: MSALNativeAuthSignInResponseVal
         checkConfAndContext(context)
         if case .success(let successChallengeResponse) = result, let expectedChallengeResponse = expectedChallengeResponse {
             XCTAssertEqual(successChallengeResponse.challengeType, expectedChallengeResponse.challengeType)
-            XCTAssertEqual(successChallengeResponse.credentialToken, expectedChallengeResponse.credentialToken)
+            XCTAssertEqual(successChallengeResponse.continuationToken, expectedChallengeResponse.continuationToken)
             XCTAssertEqual(successChallengeResponse.challengeTargetLabel, expectedChallengeResponse.challengeTargetLabel)
             XCTAssertEqual(successChallengeResponse.challengeChannel, expectedChallengeResponse.challengeChannel)
             XCTAssertEqual(successChallengeResponse.codeLength, expectedChallengeResponse.codeLength)
@@ -106,7 +106,7 @@ class MSALNativeAuthSignInResponseValidatorMock: MSALNativeAuthSignInResponseVal
         checkConfAndContext(context)
         if case .success(let successInitiateResponse) = result, let expectedInitiateResponse = expectedInitiateResponse {
             XCTAssertEqual(successInitiateResponse.challengeType, expectedInitiateResponse.challengeType)
-            XCTAssertEqual(successInitiateResponse.credentialToken, expectedInitiateResponse.credentialToken)
+            XCTAssertEqual(successInitiateResponse.continuationToken, expectedInitiateResponse.continuationToken)
         }
         if case .failure(let initiateResponseError) = result, let expectedInitiateResponseError = expectedResponseError {
             XCTAssertTrue(type(of: initiateResponseError) == type(of: expectedInitiateResponseError))
@@ -202,7 +202,7 @@ class MSALNativeAuthSignInRequestProviderMock: MSALNativeAuthSignInRequestProvid
     func challenge(parameters: MSAL.MSALNativeAuthSignInChallengeRequestParameters, context: MSIDRequestContext) throws -> MSIDHttpRequest {
         checkContext(context)
         if let expectedCredentialToken = expectedCredentialToken {
-            XCTAssertEqual(expectedCredentialToken, parameters.credentialToken)
+            XCTAssertEqual(expectedCredentialToken, parameters.continuationToken)
         }
         if let request = requestChallenge {
             return request
@@ -240,8 +240,8 @@ class MSALNativeAuthTokenRequestProviderMock: MSALNativeAuthTokenRequestProvidin
         checkContext(context)
         if let expectedTokenParams = expectedTokenParams {
             XCTAssertEqual(expectedTokenParams.username, parameters.username)
-            XCTAssertEqual(expectedTokenParams.credentialToken, parameters.credentialToken)
-            XCTAssertEqual(expectedTokenParams.signInSLT, parameters.signInSLT)
+            XCTAssertEqual(expectedTokenParams.continuationToken, parameters.continuationToken)
+            XCTAssertEqual(expectedTokenParams.continuationToken, parameters.continuationToken)
             XCTAssertEqual(expectedTokenParams.grantType, parameters.grantType)
             XCTAssertEqual(expectedTokenParams.scope, parameters.scope)
             XCTAssertEqual(expectedTokenParams.password, parameters.password)
@@ -266,8 +266,8 @@ class MSALNativeAuthTokenRequestProviderMock: MSALNativeAuthTokenRequestProvidin
         checkContext(context)
         if let expectedTokenParams = expectedTokenParams {
             XCTAssertEqual(expectedTokenParams.username, parameters.username)
-            XCTAssertEqual(expectedTokenParams.credentialToken, parameters.credentialToken)
-            XCTAssertEqual(expectedTokenParams.signInSLT, parameters.signInSLT)
+            XCTAssertEqual(expectedTokenParams.continuationToken, parameters.continuationToken)
+            XCTAssertEqual(expectedTokenParams.continuationToken, parameters.continuationToken)
             XCTAssertEqual(expectedTokenParams.grantType, parameters.grantType)
             XCTAssertEqual(expectedTokenParams.scope, parameters.scope)
             XCTAssertEqual(expectedTokenParams.password, parameters.password)

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthResetPasswordControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthResetPasswordControllerMock.swift
@@ -37,15 +37,15 @@ class MSALNativeAuthResetPasswordControllerMock: MSALNativeAuthResetPasswordCont
         return resetPasswordResponse
     }
 
-    func resendCode(username: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
+    func resendCode(username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
         return resendCodeResponse
     }
 
-    func submitCode(code: String, username: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
+    func submitCode(code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
         return submitCodeResponse
     }
 
-    func submitPassword(password: String, username: String, passwordSubmitToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
+    func submitPassword(password: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
         return submitPasswordResponse
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
@@ -49,15 +49,15 @@ class MSALNativeAuthSignInControllerMock: MSALNativeAuthSignInControlling {
         return signInSLTResult
     }
 
-    func submitCode(_ code: String, credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInSubmitCodeControllerResponse {
+    func submitCode(_ code: String, continuationToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInSubmitCodeControllerResponse {
         submitCodeResult
     }
 
-    func submitPassword(_ password: String, username: String, credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInSubmitPasswordControllerResponse {
+    func submitPassword(_ password: String, username: String, continuationToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInSubmitPasswordControllerResponse {
         return submitPasswordResult
     }
 
-    func resendCode(credentialToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInResendCodeControllerResponse {
+    func resendCode(continuationToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInResendCodeControllerResponse {
         return resendCodeResult
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
@@ -28,11 +28,11 @@ import XCTest
 class MSALNativeAuthSignInControllerMock: MSALNativeAuthSignInControlling {
 
     private(set) var username: String?
-    private(set) var slt: String?
+    private(set) var continuationToken: String?
     var expectation: XCTestExpectation?
 
     var signInStartResult: MSALNativeAuthSignInControlling.SignInControllerResponse!
-    var signInSLTResult: SignInAfterPreviousFlowControllerResponse!
+    var continuationTokenResult: SignInAfterPreviousFlowControllerResponse!
     var submitCodeResult: SignInSubmitCodeControllerResponse!
     var submitPasswordResult: SignInSubmitPasswordControllerResponse!
     var resendCodeResult: SignInResendCodeControllerResponse!
@@ -41,12 +41,12 @@ class MSALNativeAuthSignInControllerMock: MSALNativeAuthSignInControlling {
         return signInStartResult
     }
 
-    func signIn(username: String, slt: String?, scopes: [String]?, context: MSAL.MSALNativeAuthRequestContext) async -> SignInAfterPreviousFlowControllerResponse {
+    func signIn(username: String, continuationToken: String?, scopes: [String]?, context: MSAL.MSALNativeAuthRequestContext) async -> SignInAfterPreviousFlowControllerResponse {
         self.username = username
-        self.slt = slt
+        self.continuationToken = continuationToken
         expectation?.fulfill()
 
-        return signInSLTResult
+        return continuationTokenResult
     }
 
     func submitCode(_ code: String, continuationToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String]) async -> SignInSubmitCodeControllerResponse {

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
@@ -40,19 +40,19 @@ class MSALNativeAuthSignUpControllerMock: MSALNativeAuthSignUpControlling {
         return startResult
     }
 
-    func resendCode(username: String, context: MSIDRequestContext, signUpToken: String) async -> SignUpResendCodeControllerResponse {
+    func resendCode(username: String, context: MSIDRequestContext, continuationToken: String) async -> SignUpResendCodeControllerResponse {
         return resendCodeResult
     }
 
-    func submitCode(_ code: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
+    func submitCode(_ code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
         return submitCodeResult
     }
 
-    func submitPassword(_ password: String, username: String, signUpToken: String, context: MSIDRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
+    func submitPassword(_ password: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
         return submitPasswordResult
     }
 
-    func submitAttributes(_ attributes: [String : Any], username: String, signUpToken: String, context: MSIDRequestContext) async -> SignUpSubmitAttributesControllerResponse {
+    func submitAttributes(_ attributes: [String : Any], username: String, continuationToken: String, context: MSIDRequestContext) async -> SignUpSubmitAttributesControllerResponse {
         return submitAttributesResult
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
@@ -61,7 +61,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
     func resendCode(
         username: String,
         context: MSIDRequestContext,
-        signUpToken: String
+        continuationToken: String
     ) async -> SignUpResendCodeControllerResponse {
         self.context = context
         resendCodeCalled = true
@@ -72,7 +72,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
     func submitCode(
         _ code: String,
         username: String,
-        signUpToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
         self.context = context
@@ -84,7 +84,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
     func submitPassword(
         _ password: String,
         username: String,
-        signUpToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
         self.context = context
@@ -96,7 +96,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
     func submitAttributes(
         _ attributes: [String: Any],
         username: String,
-        signUpToken: String,
+        continuationToken: String,
         context: MSIDRequestContext
     ) async -> SignUpSubmitAttributesControllerResponse {
         self.context = context

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
@@ -109,7 +109,7 @@ class MSALNativeAuthSignUpRequestProviderMock: MSALNativeAuthSignUpRequestProvid
 
     private func checkContinueParameters(_ params: MSALNativeAuthSignUpContinueRequestProviderParams) {
         XCTAssertEqual(params.grantType, expectedContinueRequestParameters.grantType)
-        XCTAssertEqual(params.signUpToken, expectedContinueRequestParameters.signUpToken)
+        XCTAssertEqual(params.continuationToken, expectedContinueRequestParameters.continuationToken)
         XCTAssertEqual(params.password, expectedContinueRequestParameters.password)
         XCTAssertEqual(params.oobCode, expectedContinueRequestParameters.oobCode)
         XCTAssertEqual(params.attributes?["key"] as? String, expectedContinueRequestParameters.attributes?["key"] as? String)

--- a/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
@@ -48,8 +48,8 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         return .init(.error(.init(type: .generalError)))
     }
 
-    func resendCode(username: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
-        self.flowToken = passwordResetToken
+    func resendCode(username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
+        self.flowToken = continuationToken
         self.username = username
         self.context = context
         resendCodeCalled = true
@@ -58,8 +58,8 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         return .init(.error(error: .init(), newState: nil))
     }
 
-    func submitCode(code: String, username: String, passwordResetToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
-        self.flowToken = passwordResetToken
+    func submitCode(code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
+        self.flowToken = continuationToken
         self.username = username
         self.context = context
         submitCodeCalled = true
@@ -68,8 +68,8 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         return .init(.error(error: .init(type: .generalError), newState: nil))
     }
 
-    func submitPassword(password: String, username: String, passwordSubmitToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
-        self.flowToken = passwordSubmitToken
+    func submitPassword(password: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
+        self.flowToken = continuationToken
         self.username = username
         self.context = context
         submitPasswordCalled = true

--- a/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
@@ -29,7 +29,7 @@ import XCTest
 class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordControlling {
     private let expectation: XCTestExpectation
     private(set) var context: MSIDRequestContext?
-    private(set) var flowToken: String?
+    private(set) var continuationToken: String?
     private(set) var resetPasswordCalled = false
     private(set) var resendCodeCalled = false
     private(set) var submitCodeCalled = false
@@ -49,7 +49,7 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
     }
 
     func resendCode(username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
-        self.flowToken = continuationToken
+        self.continuationToken = continuationToken
         self.username = username
         self.context = context
         resendCodeCalled = true
@@ -59,7 +59,7 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
     }
 
     func submitCode(code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
-        self.flowToken = continuationToken
+        self.continuationToken = continuationToken
         self.username = username
         self.context = context
         submitCodeCalled = true
@@ -69,7 +69,7 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
     }
 
     func submitPassword(password: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
-        self.flowToken = continuationToken
+        self.continuationToken = continuationToken
         self.username = username
         self.context = context
         submitPasswordCalled = true

--- a/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordRequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordRequestProviderMock.swift
@@ -114,7 +114,7 @@ class MSALNativeAuthResetPasswordRequestProviderMock: MSALNativeAuthResetPasswor
 
     private func checkParameters(_ params: MSALNativeAuthResetPasswordContinueRequestParameters) {
         XCTAssertEqual(params.grantType, expectedContinueRequestParameters.grantType)
-        XCTAssertEqual(params.passwordResetToken, expectedContinueRequestParameters.passwordResetToken)
+        XCTAssertEqual(params.continuationToken, expectedContinueRequestParameters.continuationToken)
         XCTAssertEqual(params.oobCode, expectedContinueRequestParameters.oobCode)
         XCTAssertEqual(params.context.correlationId(), expectedContinueRequestParameters.context.correlationId())
     }
@@ -145,7 +145,7 @@ class MSALNativeAuthResetPasswordRequestProviderMock: MSALNativeAuthResetPasswor
     }
 
     private func checkParameters(_ params: MSALNativeAuthResetPasswordSubmitRequestParameters) {
-        XCTAssertEqual(params.passwordSubmitToken, expectedSubmitRequestParameters.passwordSubmitToken)
+        XCTAssertEqual(params.continuationToken, expectedSubmitRequestParameters.continuationToken)
         XCTAssertEqual(params.newPassword, expectedSubmitRequestParameters.newPassword)
         XCTAssertEqual(params.context.correlationId(), expectedSubmitRequestParameters.context.correlationId())
     }
@@ -176,7 +176,7 @@ class MSALNativeAuthResetPasswordRequestProviderMock: MSALNativeAuthResetPasswor
     }
 
     private func checkParameters(_ params: MSALNativeAuthResetPasswordPollCompletionRequestParameters) {
-        XCTAssertEqual(params.passwordResetToken, expectedPollCompletionParameters.passwordResetToken)
+        XCTAssertEqual(params.continuationToken, expectedPollCompletionParameters.continuationToken)
         XCTAssertEqual(params.context.correlationId(), expectedPollCompletionParameters.context.correlationId())
     }
 }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
@@ -75,7 +75,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let request = MSIDHttpRequest()
         let params = MSALNativeAuthSignInChallengeRequestParameters(context: context,
-                                                                    credentialToken: "Test Credential Token")
+                                                                    continuationToken: "Test Credential Token")
         let sut = MSALNativeAuthRequestConfigurator(config: config)
         try sut.configure(configuratorType: .signIn(.challenge(params)),
                           request: request,
@@ -83,7 +83,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "credential_token": "Test Credential Token",
+            "continuation_token": "Test Credential Token",
             "challenge_type": "otp"
         ]
 
@@ -103,8 +103,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
         let request = MSIDHttpRequest()
         let params = MSALNativeAuthTokenRequestParameters(context: context,
                                                           username: DEFAULT_TEST_ID_TOKEN_USERNAME,
-                                                          credentialToken: "Test Credential Token",
-                                                          signInSLT: "Test SignIn SLT",
+                                                          continuationToken: "Test Continuation Token",
                                                           grantType: .password,
                                                           scope: "<scope-1>",
                                                           password: "password",
@@ -120,8 +119,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
             "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
-            "credential_token": "Test Credential Token",
-            "signin_slt": "Test SignIn SLT",
+            "continuation_token": "Test Continuation Token",
             "grant_type": "password",
             "challenge_type": "password",
             "scope": "<scope-1>",
@@ -176,7 +174,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
         )
 
         let request = MSIDHttpRequest()
-        let params = MSALNativeAuthSignUpChallengeRequestParameters(signUpToken: "<sign-up-token>",
+        let params = MSALNativeAuthSignUpChallengeRequestParameters(continuationToken: "<continuation-token>",
                                                                     context: context)
 
         let sut = MSALNativeAuthRequestConfigurator(config: config)
@@ -186,7 +184,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "signup_token": "<sign-up-token>",
+            "continuation_token": "<continuation-token>",
             "challenge_type": "password oob redirect"
         ]
 
@@ -205,7 +203,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let request = MSIDHttpRequest()
         let params = MSALNativeAuthSignUpContinueRequestParameters(grantType: .oobCode,
-                                                                   signUpToken: "<sign-up-token>",
+                                                                   continuationToken: "<continuation-token>",
                                                                    password: "<strong-password>",
                                                                    oobCode: "0000",
                                                                    attributes: "<attributes>",
@@ -218,7 +216,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "signup_token": "<sign-up-token>",
+            "continuation_token": "<continuation-token>",
             "password": "<strong-password>",
             "oob": "0000",
             "grant_type": "oob",
@@ -269,7 +267,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let request = MSIDHttpRequest()
         let params = MSALNativeAuthResetPasswordChallengeRequestParameters(context: context,
-                                                                           passwordResetToken: "<password-reset-token>")
+                                                                           continuationToken: "<continuation-token>")
 
         let sut = MSALNativeAuthRequestConfigurator(config: config)
         try sut.configure(configuratorType: .resetPassword(.challenge(params)),
@@ -278,7 +276,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "password_reset_token": "<password-reset-token>",
+            "continuation_token": "<continuation-token>",
             "challenge_type": "password oob redirect"
         ]
 
@@ -297,7 +295,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let request = MSIDHttpRequest()
         let params = MSALNativeAuthResetPasswordContinueRequestParameters(context: context,
-                                                                          passwordResetToken: "<password-reset-token>",
+                                                                          continuationToken: "<continuation-token>",
                                                                           grantType: .oobCode,
                                                                           oobCode: "0000")
 
@@ -308,7 +306,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "password_reset_token": "<password-reset-token>",
+            "continuation_token": "<continuation-token>",
             "grant_type": "oob",
             "oob": "0000"
         ]
@@ -328,7 +326,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let request = MSIDHttpRequest()
         let params = MSALNativeAuthResetPasswordSubmitRequestParameters(context: context,
-                                                                        passwordSubmitToken: "<password-submit-token>",
+                                                                        continuationToken: "<continuation-token>",
                                                                         newPassword:"new-password")
 
         let sut = MSALNativeAuthRequestConfigurator(config: config)
@@ -338,7 +336,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "password_submit_token": "<password-submit-token>",
+            "continuation_token": "<continuation-token>",
             "new_password": "new-password"
         ]
 
@@ -357,7 +355,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let request = MSIDHttpRequest()
         let params = MSALNativeAuthResetPasswordPollCompletionRequestParameters(context: context,
-                                                                                passwordResetToken: "<password-reset-token")
+                                                                                continuationToken: "<continuation-token")
 
         let sut = MSALNativeAuthRequestConfigurator(config: config)
         try sut.configure(configuratorType: .resetPassword(.pollCompletion(params)),
@@ -366,7 +364,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "password_reset_token": "<password-reset-token"
+            "continuation_token": "<continuation-token"
         ]
 
         XCTAssertEqual(request.parameters, expectedBodyParams)
@@ -385,8 +383,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
         let request = MSIDHttpRequest()
         let params = MSALNativeAuthTokenRequestParameters(context: context,
                                                           username: nil,
-                                                          credentialToken: nil,
-                                                          signInSLT: nil,
+                                                          continuationToken: nil,
                                                           grantType: .refreshToken,
                                                           scope: "<scope-1>",
                                                           password: nil,

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestErrorHandlerTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestErrorHandlerTests.swift
@@ -230,7 +230,7 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
         dictionary["error"] = "verification_required"
         dictionary["error_description"] = "AADSTS55102: Verification required."
         dictionary["error_uri"] = HttpModuleMockConfigurator.baseUrl.absoluteString
-        dictionary["signup_token"] = "abcdef"
+        dictionary["continuation_token"] = "abcdef"
 
         let data = try JSONSerialization.data(withJSONObject: dictionary)
 
@@ -252,7 +252,7 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
             XCTAssertEqual(error.error, MSALNativeAuthSignUpStartOauth2ErrorCode.verificationRequired)
             XCTAssertEqual(error.errorDescription, "AADSTS55102: Verification required.")
             XCTAssertEqual(error.errorURI, HttpModuleMockConfigurator.baseUrl.absoluteString)
-            XCTAssertEqual(error.signUpToken, "abcdef")
+            XCTAssertEqual(error.continuationToken, "abcdef")
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
@@ -87,7 +87,7 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
     }
 
     func test_signUpChallengeRequest_is_created_successfully() throws {
-        let request = try sut.challenge(token: "sign-up-token", context: context)
+        let request = try sut.challenge(token: "continuation-token", context: context)
 
         checkBodyParams(request.parameters, for: .signUpChallenge)
         checkUrlRequest(request.urlRequest!, for: .signUpChallenge)
@@ -99,7 +99,7 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
     func test_signUpContinueRequest_is_created_successfully() throws {
         let parameters = MSALNativeAuthSignUpContinueRequestProviderParams(
             grantType: .password,
-            signUpToken: "sign-up-token",
+            continuationToken: "continuation-token",
             password: "1234",
             oobCode: nil,
             attributes: ["city": "dublin"],
@@ -118,7 +118,7 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
     func test_signUpContinueRequestWithNoAttributes_is_created_successfully() throws {
         let parameters = MSALNativeAuthSignUpContinueRequestProviderParams(
             grantType: .password,
-            signUpToken: "sign-up-token",
+            continuationToken: "continuation-token",
             password: "1234",
             oobCode: nil,
             attributes: nil,
@@ -137,7 +137,7 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
     func test_signUpContinueRequestWithInvalidAttributes_throwAnError() throws {
         let parameters = MSALNativeAuthSignUpContinueRequestProviderParams(
             grantType: .password,
-            signUpToken: "sign-up-token",
+            continuationToken: "continuation-token",
             password: "1234",
             oobCode: nil,
             attributes: ["invalid attribute": Data()],
@@ -166,14 +166,14 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
         case .signUpChallenge:
             expectedBodyParams = [
                 Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
-                Key.signUpToken.rawValue: "sign-up-token",
+                Key.continuationToken.rawValue: "continuation-token",
                 Key.challengeType.rawValue: "redirect"
             ]
         case .signUpContinue:
             expectedBodyParams = [
                 Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
                 Key.grantType.rawValue: "password",
-                Key.signUpToken.rawValue: "sign-up-token",
+                Key.continuationToken.rawValue: "continuation-token",
                 Key.password.rawValue: "1234"
             ]
             if expectAttributes {

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
@@ -33,42 +33,42 @@ final class MSALNativeAuthResetPasswordContinueResponseErrorTests: XCTestCase {
     // MARK: - to toVerifyCodePublicError tests
     
     func test_toResetPasswordStartPublicError_invalidRequest() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
         let error = sut.toVerifyCodePublicError()
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
     }
     
     func test_toResetPasswordStartPublicError_invalidClient() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
         let error = sut.toVerifyCodePublicError()
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResetPasswordStartPublicError_invalidGrant() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidGrant, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidGrant, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
         let error = sut.toVerifyCodePublicError()
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
     
     func test_toResetPasswordStartPublicError_expiredToken() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
         let error = sut.toVerifyCodePublicError()
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .verificationRequired, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .verificationRequired, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
         let error = sut.toVerifyCodePublicError()
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
     }
     
     func test_toResetPasswordStartPublicError_invalidOOBValue() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidOOBValue, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, passwordResetToken: nil)
+        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidOOBValue, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
         let error = sut.toVerifyCodePublicError()
         XCTAssertEqual(error.type, .invalidCode)
         XCTAssertNotNil(error.errorDescription)

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
@@ -219,21 +219,21 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
     // MARK: private methods
     
     private func testSignUpContinueErrorToVerifyCode(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?, expectedErrorType: VerifyCodeError.ErrorType) {
-        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
         let error = sut.toVerifyCodePublicError()
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpContinueErrorToPasswordRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
-        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
         let error = sut.toPasswordRequiredPublicError()
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpContinueErrorToAttributesRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, description: String?) {
-        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
         let error = sut.toAttributesRequiredPublicError()
         XCTAssertEqual(error.errorDescription, description)
     }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
@@ -87,7 +87,7 @@ final class MSALNativeAuthSignUpStartResponseErrorTests: XCTestCase {
     // MARK: private methods
     
     private func testSignUpStartErrorToSignUpStart(code: MSALNativeAuthSignUpStartOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartError.ErrorType) {
-        sut = MSALNativeAuthSignUpStartResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, signUpToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
+        sut = MSALNativeAuthSignUpStartResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
         let error = sut.toSignUpStartPublicError()
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift
@@ -40,7 +40,7 @@ final class MSALNativeAuthResetPasswordChallengeRequestParametersTest: XCTestCas
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
         let parameters = MSALNativeAuthResetPasswordChallengeRequestParameters(
             context: MSALNativeAuthRequestContextMock(),
-            passwordResetToken: "<password-reset-token>"
+            continuationToken: "<continuation-token>"
         )
 
         var resultUrl: URL? = nil
@@ -52,14 +52,14 @@ final class MSALNativeAuthResetPasswordChallengeRequestParametersTest: XCTestCas
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
         let params = MSALNativeAuthResetPasswordChallengeRequestParameters(
             context: MSALNativeAuthRequestContextMock(),
-            passwordResetToken: "<password-reset-token>"
+            continuationToken: "<continuation-token>"
         )
 
         let body = params.makeRequestBody(config: config)
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "password_reset_token": "<password-reset-token>",
+            "continuation_token": "<continuation-token>",
             "challenge_type": "password oob redirect"
         ]
 
@@ -70,14 +70,14 @@ final class MSALNativeAuthResetPasswordChallengeRequestParametersTest: XCTestCas
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .redirect]))
         let params = MSALNativeAuthResetPasswordChallengeRequestParameters(
             context: MSALNativeAuthRequestContextMock(),
-            passwordResetToken: "<password-reset-token>"
+            continuationToken: "<continuation-token>"
         )
 
         let body = params.makeRequestBody(config: config)
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "password_reset_token": "<password-reset-token>",
+            "continuation_token": "<continuation-token>",
             "challenge_type": "password redirect"
         ]
 

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParametersTest.swift
@@ -40,7 +40,7 @@ final class MSALNativeAuthResetPasswordContinueRequestParametersTest: XCTestCase
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
         let parameters = MSALNativeAuthResetPasswordContinueRequestParameters(
             context: context,
-            passwordResetToken: "<password-reset-token>",
+            continuationToken: "<continuation-token>",
             grantType: .oobCode,
             oobCode: "0000"
         )
@@ -54,7 +54,7 @@ final class MSALNativeAuthResetPasswordContinueRequestParametersTest: XCTestCase
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
         let params = MSALNativeAuthResetPasswordContinueRequestParameters(
             context: context,
-            passwordResetToken: "<password-reset-token>",
+            continuationToken: "<continuation-token>",
             grantType: .oobCode,
             oobCode: "0000"
         )
@@ -63,7 +63,7 @@ final class MSALNativeAuthResetPasswordContinueRequestParametersTest: XCTestCase
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "password_reset_token": "<password-reset-token>",
+            "continuation_token": "<continuation-token>",
             "grant_type": "oob",
             "oob": "0000"
         ]
@@ -75,7 +75,7 @@ final class MSALNativeAuthResetPasswordContinueRequestParametersTest: XCTestCase
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
         let params = MSALNativeAuthResetPasswordContinueRequestParameters(
             context: context,
-            passwordResetToken: "<password-reset-token>",
+            continuationToken: "<continuation-token>",
             grantType: .oobCode,
             oobCode: nil
         )
@@ -84,7 +84,7 @@ final class MSALNativeAuthResetPasswordContinueRequestParametersTest: XCTestCase
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "password_reset_token": "<password-reset-token>",
+            "continuation_token": "<continuation-token>",
             "grant_type": "oob"
         ]
 

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParametersTest.swift
@@ -40,7 +40,7 @@ final class MSALNativeAuthResetPasswordPollCompletionRequestParametersTest: XCTe
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
         let parameters = MSALNativeAuthResetPasswordPollCompletionRequestParameters(
             context: context,
-            passwordResetToken: "<password-reset-token"
+            continuationToken: "<continuation-token"
         )
 
         var resultUrl: URL? = nil
@@ -52,14 +52,14 @@ final class MSALNativeAuthResetPasswordPollCompletionRequestParametersTest: XCTe
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
         let params = MSALNativeAuthResetPasswordPollCompletionRequestParameters(
             context: context,
-            passwordResetToken: "<password-reset-token"
+            continuationToken: "<continuation-token"
         )
 
         let body = params.makeRequestBody(config: config)
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "password_reset_token": "<password-reset-token"
+            "continuation_token": "<continuation-token"
         ]
 
         XCTAssertEqual(body, expectedBodyParams)

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParametersTest.swift
@@ -40,7 +40,7 @@ final class MSALNativeAuthResetPasswordSubmitRequestParametersTest: XCTestCase {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
         let parameters = MSALNativeAuthResetPasswordSubmitRequestParameters(
             context: context,
-            passwordSubmitToken: "<password-submit-token>",
+            continuationToken: "<continuation-token>",
             newPassword:"new-password"
         )
 
@@ -53,7 +53,7 @@ final class MSALNativeAuthResetPasswordSubmitRequestParametersTest: XCTestCase {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
         let params = MSALNativeAuthResetPasswordSubmitRequestParameters(
             context: context,
-            passwordSubmitToken: "<password-submit-token>",
+            continuationToken: "<continuation-token>",
             newPassword:"new-password"
         )
 
@@ -61,7 +61,7 @@ final class MSALNativeAuthResetPasswordSubmitRequestParametersTest: XCTestCase {
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "password_submit_token": "<password-submit-token>",
+            "continuation_token": "<continuation-token>",
             "new_password": "new-password"
         ]
 

--- a/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParametersTest.swift
@@ -39,7 +39,7 @@ final class MSALNativeAuthSignInChallengeRequestParametersTest: XCTestCase {
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
         let parameters = MSALNativeAuthSignInChallengeRequestParameters(context: MSALNativeAuthRequestContextMock(),
-                                                                        credentialToken: "Test Credential Token")
+                                                                        continuationToken: "Test Credential Token")
         var resultUrl: URL? = nil
         XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
         XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/oauth2/v2.0/challenge")
@@ -49,14 +49,14 @@ final class MSALNativeAuthSignInChallengeRequestParametersTest: XCTestCase {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.otp]))
         let params = MSALNativeAuthSignInChallengeRequestParameters(
             context: context,
-            credentialToken: "Test Credential Token"
+            continuationToken: "Test Credential Token"
         )
 
         let body = params.makeRequestBody(config: config)
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "credential_token": "Test Credential Token",
+            "continuation_token": "Test Credential Token",
             "challenge_type": "otp"
         ]
 
@@ -67,14 +67,14 @@ final class MSALNativeAuthSignInChallengeRequestParametersTest: XCTestCase {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .redirect]))
         let params = MSALNativeAuthSignInChallengeRequestParameters(
             context: context,
-            credentialToken: "Test Credential Token"
+            continuationToken: "Test Credential Token"
         )
 
         let body = params.makeRequestBody(config: config)
 
         let expectedBodyParams = [
             "client_id": config.clientId,
-            "credential_token": params.credentialToken,
+            "continuation_token": params.continuationToken,
             "challenge_type": "password redirect",
         ]
 

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParametersTest.swift
@@ -39,7 +39,7 @@ final class MSALNativeAuthSignUpChallengeRequestParametersTest: XCTestCase {
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.redirect]))
         let parameters = MSALNativeAuthSignUpChallengeRequestParameters(
-            signUpToken: "token",
+            continuationToken: "token",
             context: MSALNativeAuthRequestContextMock()
         )
         var resultUrl: URL? = nil
@@ -50,7 +50,7 @@ final class MSALNativeAuthSignUpChallengeRequestParametersTest: XCTestCase {
     func test_allChallengeTypes_shouldCreateCorrectBodyRequest() throws {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect]))
         let params = MSALNativeAuthSignUpChallengeRequestParameters(
-            signUpToken: "<sign-up-token>",
+            continuationToken: "<continuation-token>",
             context: context
         )
 
@@ -58,7 +58,7 @@ final class MSALNativeAuthSignUpChallengeRequestParametersTest: XCTestCase {
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "signup_token": "<sign-up-token>",
+            "continuation_token": "<continuation-token>",
             "challenge_type": "password oob redirect"
         ]
 

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParametersTest.swift
@@ -40,7 +40,7 @@ final class MSALNativeAuthSignUpContinueRequestParametersTest: XCTestCase {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
         let parameters = MSALNativeAuthSignUpContinueRequestParameters(
             grantType: .oobCode,
-            signUpToken: "token",
+            continuationToken: "token",
             password: nil,
             oobCode: "1234",
             attributes: nil,
@@ -55,7 +55,7 @@ final class MSALNativeAuthSignUpContinueRequestParametersTest: XCTestCase {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: []))
         let params = MSALNativeAuthSignUpContinueRequestParameters(
             grantType: .oobCode,
-            signUpToken: "<sign-up-token>",
+            continuationToken: "<continuation-token>",
             password: "<strong-password>",
             oobCode: "0000",
             attributes: "<attributes>",
@@ -66,7 +66,7 @@ final class MSALNativeAuthSignUpContinueRequestParametersTest: XCTestCase {
 
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
-            "signup_token": "<sign-up-token>",
+            "continuation_token": "<continuation-token>",
             "password": "<strong-password>",
             "oob": "0000",
             "grant_type": "oob",

--- a/MSAL/test/unit/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParametersTest.swift
@@ -39,8 +39,7 @@ final class MSALNativeAuthTokenRequestParametersTest: XCTestCase {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))
         let parameters = MSALNativeAuthTokenRequestParameters(context: MSALNativeAuthRequestContextMock(),
                                                                     username: "username",
-                                                                    credentialToken: "Test Credential Token",
-                                                                    signInSLT: "Test SignIn SLT",
+                                                                    continuationToken: "Test Credential Token",
                                                                     grantType: .password,
                                                                     scope: "scope",
                                                                     password: "password",
@@ -57,8 +56,7 @@ final class MSALNativeAuthTokenRequestParametersTest: XCTestCase {
         let params = MSALNativeAuthTokenRequestParameters(
             context: context,
             username: DEFAULT_TEST_ID_TOKEN_USERNAME,
-            credentialToken: "Test Credential Token",
-            signInSLT: "Test SignIn SLT",
+            continuationToken: "Test continuation Token",
             grantType: .password,
             scope: "<scope-1>",
             password: "password",
@@ -72,8 +70,7 @@ final class MSALNativeAuthTokenRequestParametersTest: XCTestCase {
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
             "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
-            "credential_token": "Test Credential Token",
-            "signin_slt": "Test SignIn SLT",
+            "continuation_token": "Test continuation Token",
             "grant_type": "password",
             "challenge_type": "password",
             "scope": "<scope-1>",
@@ -90,8 +87,7 @@ final class MSALNativeAuthTokenRequestParametersTest: XCTestCase {
         let params = MSALNativeAuthTokenRequestParameters(
             context: context,
             username: nil,
-            credentialToken: nil,
-            signInSLT: nil,
+            continuationToken: nil,
             grantType: .password,
             scope: nil,
             password: nil,

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
@@ -42,7 +42,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
 
     func test_whenResetPasswordStartSuccessResponseContainsRedirect_itReturnsRedirect() {
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .success(
-            .init(passwordResetToken: nil, challengeType: .redirect)
+            .init(continuationToken: nil, challengeType: .redirect)
         )
 
         let result = sut.validate(response, with: context)
@@ -53,7 +53,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
 
     func test_whenResetPasswordStartSuccessResponseDoesNotContainsTokenOrRedirect_itReturnsUnexpectedError() {
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .success(
-            .init(passwordResetToken: nil, challengeType: .otp)
+            .init(continuationToken: nil, challengeType: .otp)
         )
 
         let result = sut.validate(response, with: context)
@@ -64,16 +64,16 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
 
     func test_whenResetPasswordStartSuccessResponseContainsToken_itReturnsSuccess() {
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .success(
-            .init(passwordResetToken: "passwordResetToken", challengeType: .otp)
+            .init(continuationToken: "continuationToken", challengeType: .otp)
         )
 
         let result = sut.validate(response, with: context)
 
-        guard case .success(let passwordResetToken) = result else {
+        guard case .success(let continuationToken) = result else {
             return XCTFail("Unexpected response")
         }
 
-        XCTAssertEqual(passwordResetToken, "passwordResetToken")
+        XCTAssertEqual(continuationToken, "continuationToken")
     }
 
     func test_whenResetPasswordStartErrorResponseIsNotExpected_itReturnsUnexpectedError() {
@@ -153,7 +153,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             bindingMethod: nil,
             challengeTargetLabel: "challenge-type-label",
             challengeChannel: .email,
-            passwordResetToken: "token",
+            continuationToken: "token",
             codeLength: nil)
         )
 
@@ -167,20 +167,20 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             bindingMethod: nil,
             challengeTargetLabel: "challenge-type-label",
             challengeChannel: .email,
-            passwordResetToken: "token",
+            continuationToken: "token",
             codeLength: 6)
         )
 
         let result = sut.validate(response, with: context)
 
-        guard case .success(let sentTo, let channelTargetType, let codeLength, let passwordResetToken) = result else {
+        guard case .success(let sentTo, let channelTargetType, let codeLength, let continuationToken) = result else {
             return XCTFail("Unexpected response")
         }
 
         XCTAssertEqual(sentTo, "challenge-type-label")
         XCTAssertEqual(channelTargetType, .email)
         XCTAssertEqual(codeLength, 6)
-        XCTAssertEqual(passwordResetToken, "token")
+        XCTAssertEqual(continuationToken, "token")
     }
 
     func test_whenResetPasswordChallengeSuccessResponseOmitsSomeAttributes_itReturnsUnexpectedError() {
@@ -189,7 +189,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             bindingMethod: nil,
             challengeTargetLabel: "challenge-type-label",
             challengeChannel: .email,
-            passwordResetToken: nil,
+            continuationToken: nil,
             codeLength: 6)
         )
 
@@ -203,7 +203,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             bindingMethod: nil,
             challengeTargetLabel: "challenge-type-label",
             challengeChannel: .none,
-            passwordResetToken: nil,
+            continuationToken: nil,
             codeLength: 6)
         )
 
@@ -235,15 +235,15 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     // MARK: - Continue Response
 
     func test_whenResetPasswordContinueSuccessResponseContainsValidAttributesAndOOB_itReturnsSuccess() {
-        let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .success(.init(passwordSubmitToken: "passwordSubmitToken", expiresIn: 300))
+        let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .success(.init(continuationToken: "continuationToken", expiresIn: 300))
 
         let result = sut.validate(response, with: context)
 
-        guard case .success(let passwordSubmitToken) = result else {
+        guard case .success(let continuationToken) = result else {
             return XCTFail("Unexpected response")
         }
 
-        XCTAssertEqual(passwordSubmitToken, "passwordSubmitToken")
+        XCTAssertEqual(continuationToken, "continuationToken")
     }
 
     func test_whenResetPasswordContinueErrorResponseIsNotExpected_itReturnsUnexpectedError() {
@@ -312,15 +312,15 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     // MARK: - Submit Response
 
     func test_whenResetPasswordSubmitSuccessResponseContainsToken_itReturnsSuccess() {
-        let response: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = .success(.init(passwordResetToken: "passwordResetToken", pollInterval: 1))
+        let response: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = .success(.init(continuationToken: "continuationToken", pollInterval: 1))
 
         let result = sut.validate(response, with: context)
 
-        guard case .success(let passwordResetToken, let pollInterval) = result else {
+        guard case .success(let continuationToken, let pollInterval) = result else {
             return XCTFail("Unexpected response")
         }
 
-        XCTAssertEqual(passwordResetToken, "passwordResetToken")
+        XCTAssertEqual(continuationToken, "continuationToken")
         XCTAssertEqual(pollInterval, 1)
     }
 
@@ -538,7 +538,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .failure(
             createResetPasswordContinueError(
                 error: expectedError,
-                passwordResetToken: expectedPasswordResetToken
+                continuationToken: expectedPasswordResetToken
             )
         )
 
@@ -612,7 +612,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         errorURI: String? = nil,
         innerErrors: [MSALNativeAuthInnerError]? = nil,
         target: String? = nil,
-        passwordResetToken: String? = nil
+        continuationToken: String? = nil
     ) -> MSALNativeAuthResetPasswordContinueResponseError {
         .init(
             error: error,
@@ -621,7 +621,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             errorURI: errorURI,
             innerErrors: innerErrors,
             target: target,
-            passwordResetToken: passwordResetToken
+            continuationToken: continuationToken
         )
     }
 

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
@@ -533,12 +533,12 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
 
     private func buildContinueErrorResponse(
         expectedError: MSALNativeAuthResetPasswordContinueOauth2ErrorCode,
-        expectedPasswordResetToken: String? = nil
+        expectedContinuationToken: String? = nil
     ) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
         let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .failure(
             createResetPasswordContinueError(
                 error: expectedError,
-                continuationToken: expectedPasswordResetToken
+                continuationToken: expectedContinuationToken
             )
         )
 

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
@@ -45,7 +45,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     
     func test_whenChallengeTypeRedirect_validationShouldReturnRedirectError() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: nil, challengeType: .redirect, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: nil, challengeType: .redirect, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
         let result = sut.validate(context: context, result: .success(challengeResponse))
         if case .error(.redirect) = result {} else {
             XCTFail("Unexpected result: \(result)")
@@ -54,17 +54,17 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     
     func test_whenChallengeTypePassword_validationShouldReturnPasswordRequired() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let credentialToken = "credentialToken"
-        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
+        let continuationToken = "continuationToken"
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
         let result = sut.validate(context: context, result: .success(challengeResponse))
-        if case .passwordRequired(credentialToken: credentialToken) = result {} else {
+        if case .passwordRequired(continuationToken: continuationToken) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }
     
     func test_whenChallengeTypePasswordAndNoCredentialToken_validationShouldFail() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: nil, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: nil, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
         let result = sut.validate(context: context, result: .success(challengeResponse))
         if case .error(.invalidServerResponse) = result {} else {
             XCTFail("Unexpected result: \(result)")
@@ -73,39 +73,39 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     
     func test_whenChallengeTypeOOB_validationShouldReturnCodeRequired() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
         let targetLabel = "targetLabel"
         let codeLength = 4
         let channelType = MSALNativeAuthInternalChannelType.email
-        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
         let result = sut.validate(context: context, result: .success(challengeResponse))
-        if case .codeRequired(credentialToken: credentialToken, sentTo: targetLabel, channelType: .email, codeLength: codeLength) = result {} else {
+        if case .codeRequired(continuationToken: continuationToken, sentTo: targetLabel, channelType: .email, codeLength: codeLength) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }
     
     func test_whenChallengeTypeOOBButMissingAttributes_validationShouldFail() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let credentialToken = "credentialToken"
+        let continuationToken = "continuationToken"
         let targetLabel = "targetLabel"
         let codeLength = 4
         let channelType = MSALNativeAuthInternalChannelType.email
-        let missingCredentialToken = MSALNativeAuthSignInChallengeResponse(credentialToken: nil, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
+        let missingCredentialToken = MSALNativeAuthSignInChallengeResponse(continuationToken: nil, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
         var result = sut.validate(context: context, result: .success(missingCredentialToken))
         if case .error(.invalidServerResponse) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
-        let missingTargetLabel = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: channelType, codeLength: codeLength, interval: nil)
+        let missingTargetLabel = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: channelType, codeLength: codeLength, interval: nil)
         result = sut.validate(context: context, result: .success(missingTargetLabel))
         if case .error(.invalidServerResponse) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
-        let missingChannelType = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: nil, codeLength: codeLength, interval: nil)
+        let missingChannelType = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: nil, codeLength: codeLength, interval: nil)
         result = sut.validate(context: context, result: .success(missingChannelType))
         if case .error(.invalidServerResponse) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
-        let missingCodeLength = MSALNativeAuthSignInChallengeResponse(credentialToken: credentialToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: nil, interval: nil)
+        let missingCodeLength = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: nil, interval: nil)
         result = sut.validate(context: context, result: .success(missingCodeLength))
         if case .error(.invalidServerResponse) = result {} else {
             XCTFail("Unexpected result: \(result)")
@@ -114,7 +114,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     
     func test_whenChallengeTypeOTP_validationShouldFail() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let challengeResponse = MSALNativeAuthSignInChallengeResponse(credentialToken: "something", challengeType: .otp, bindingMethod: nil, challengeTargetLabel: "some", challengeChannel: .email, codeLength: 2, interval: nil)
+        let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: "something", challengeType: .otp, bindingMethod: nil, challengeTargetLabel: "some", challengeChannel: .email, codeLength: 2, interval: nil)
         let result = sut.validate(context: context, result: .success(challengeResponse))
         if case .error(.invalidServerResponse) = result {} else {
             XCTFail("Unexpected result: \(result)")
@@ -125,17 +125,17 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     
     func test_whenInitiateResponseIsValid_validationShouldBeSuccessful() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let credentialToken = "credentialToken"
-        let initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: credentialToken, challengeType: nil)
+        let continuationToken = "continuationToken"
+        let initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: continuationToken, challengeType: nil)
         let result = sut.validate(context: context, result: .success(initiateResponse))
-        if case .success(credentialToken: credentialToken) = result {} else {
+        if case .success(continuationToken: continuationToken) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }
     
     func test_whenInitiateResponseIsInvalid_validationShouldFail() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: nil)
+        let initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: nil)
         let result = sut.validate(context: context, result: .success(initiateResponse))
         if case .error(.invalidServerResponse) = result {} else {
             XCTFail("Unexpected result: \(result)")
@@ -144,7 +144,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     
     func test_whenInitiateChallengeTypeIsRedirect_validationShouldReturnRedirectError() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .redirect)
+        let initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .redirect)
         let result = sut.validate(context: context, result: .success(initiateResponse))
         if case .error(.redirect) = result {} else {
             XCTFail("Unexpected result: \(result)")
@@ -153,17 +153,17 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     
     func test_whenInitiateChallengeTypeIsInvalid_validationShouldFail() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        var initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .oob)
+        var initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .oob)
         var result = sut.validate(context: context, result: .success(initiateResponse))
         if case .error(.invalidServerResponse) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
-        initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .otp)
+        initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .otp)
         result = sut.validate(context: context, result: .success(initiateResponse))
         if case .error(.invalidServerResponse) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
-        initiateResponse = MSALNativeAuthSignInInitiateResponse(credentialToken: nil, challengeType: .password)
+        initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .password)
         result = sut.validate(context: context, result: .success(initiateResponse))
         if case .error(.invalidServerResponse) = result {} else {
             XCTFail("Unexpected result: \(result)")

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
@@ -42,7 +42,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
 
     func test_whenSignUpStartSuccessResponseContainsRedirect_it_returns_redirect() {
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .success(
-            .init(signupToken: nil, challengeType: .redirect)
+            .init(continuationToken: nil, challengeType: .redirect)
         )
 
         let result = sut.validate(response, with: context)
@@ -51,7 +51,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
 
     func test_whenSignUpStartSuccessResponseDoesNotContainsTokenOrRedirect_it_returns_unexpectedError() {
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .success(
-            .init(signupToken: nil, challengeType: .otp)
+            .init(continuationToken: nil, challengeType: .otp)
         )
 
         let result = sut.validate(response, with: context)
@@ -68,25 +68,25 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     func test_whenSignUpStart_verificationRequiredErrorWithSignUpTokenAndUnverifiedAttributes_it_returns_verificationRequired() {
         let error = createSignUpStartError(
             error: .verificationRequired,
-            signUpToken: "sign-up token",
+            continuationToken: "sign-up token",
             unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes(name: "username")]
         )
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
 
-        guard case .verificationRequired(let signUpToken, let unverifiedAttributes) = result else {
+        guard case .verificationRequired(let continuationToken, let unverifiedAttributes) = result else {
             return XCTFail("Unexpected response")
         }
 
-        XCTAssertEqual(signUpToken, "sign-up token")
+        XCTAssertEqual(continuationToken, "sign-up token")
         XCTAssertEqual(unverifiedAttributes.first, "username")
     }
 
     func test_whenSignUpStart_verificationRequiredErrorWithSignUpToken_but_unverifiedAttributesIsEmpty_it_returns_unexpectedError() {
         let error = createSignUpStartError(
             error: .verificationRequired,
-            signUpToken: "sign-up token",
+            continuationToken: "sign-up token",
             unverifiedAttributes: []
         )
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
@@ -98,7 +98,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     func test_whenSignUpStart_verificationRequiredErrorWithSignUpToken_but_unverifiedAttributesIsNil_it_returns_unexpectedError() {
         let error = createSignUpStartError(
             error: .verificationRequired,
-            signUpToken: "sign-up token",
+            continuationToken: "sign-up token",
             unverifiedAttributes: nil
         )
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
@@ -146,7 +146,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpStart_expectedVerificationRequiredErrorWithoutSignUpToken_it_returns_unexpectedError() {
-        let error = createSignUpStartError(error: .verificationRequired, signUpToken: nil)
+        let error = createSignUpStartError(error: .verificationRequired, continuationToken: nil)
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -175,7 +175,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             errorDescription: "username parameter is empty or not valid",
             errorCodes: errorCodes,
             errorURI: "aURI",
-            signUpToken: "aToken",
+            continuationToken: "aToken",
             unverifiedAttributes: attributes,
             invalidAttributes: attributes
         )
@@ -198,7 +198,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             errorDescription: "client_id parameter is empty or not valid",
             errorCodes: errorCodes,
             errorURI: "aURI",
-            signUpToken: "aToken",
+            continuationToken: "aToken",
             unverifiedAttributes: attributes,
             invalidAttributes: attributes
         )
@@ -221,7 +221,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             errorDescription: "aDescription",
             errorCodes: errorCodes,
             errorURI: "aURI",
-            signUpToken: "aToken",
+            continuationToken: "aToken",
             unverifiedAttributes: attributes,
             invalidAttributes: attributes
         )
@@ -237,7 +237,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         XCTAssertEqual(resultError.errorDescription, "aDescription")
         XCTAssertEqual(resultError.errorCodes, errorCodes)
         XCTAssertEqual(resultError.errorURI, "aURI")
-        XCTAssertEqual(resultError.signUpToken, "aToken")
+        XCTAssertEqual(resultError.continuationToken, "aToken")
         XCTAssertEqual(resultError.unverifiedAttributes, attributes)
         XCTAssertEqual(resultError.invalidAttributes, attributes)
     }
@@ -251,7 +251,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             interval: nil,
             challengeTargetLabel: "challenge-type-label",
             challengeChannel: nil,
-            signUpToken: "token",
+            continuationToken: "token",
             codeLength: nil)
         )
 
@@ -266,7 +266,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             interval: nil,
             challengeTargetLabel: "challenge-type-label",
             challengeChannel: nil,
-            signUpToken: "token",
+            continuationToken: "token",
             codeLength: nil)
         )
 
@@ -281,20 +281,20 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             interval: nil,
             challengeTargetLabel: "challenge-type-label",
             challengeChannel: .email,
-            signUpToken: "token",
+            continuationToken: "token",
             codeLength: 6)
         )
 
         let result = sut.validate(response, with: context)
 
-        guard case .codeRequired(let displayName, let displayType, let codeLength, let signUpToken) = result else {
+        guard case .codeRequired(let displayName, let displayType, let codeLength, let continuationToken) = result else {
             return XCTFail("Unexpected response")
         }
 
         XCTAssertEqual(displayName, "challenge-type-label")
         XCTAssertEqual(displayType, .email)
         XCTAssertEqual(codeLength, 6)
-        XCTAssertEqual(signUpToken, "token")
+        XCTAssertEqual(continuationToken, "token")
     }
 
     func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndPassword_it_returns_success() {
@@ -304,17 +304,17 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             interval: nil,
             challengeTargetLabel: "challenge-type-label",
             challengeChannel: .email,
-            signUpToken: "token",
+            continuationToken: "token",
             codeLength: nil)
         )
 
         let result = sut.validate(response, with: context)
 
-        guard case .passwordRequired(let signUpToken) = result else {
+        guard case .passwordRequired(let continuationToken) = result else {
             return XCTFail("Unexpected response")
         }
 
-        XCTAssertEqual(signUpToken, "token")
+        XCTAssertEqual(continuationToken, "token")
     }
 
     func test_whenSignUpChallengeSuccessResponseContainsPassword_but_noToken_it_returns_unexpectedError() {
@@ -324,7 +324,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             interval: nil,
             challengeTargetLabel: "challenge-type-label",
             challengeChannel: .email,
-            signUpToken: nil,
+            continuationToken: nil,
             codeLength: nil)
         )
 
@@ -339,7 +339,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             interval: nil,
             challengeTargetLabel: "challenge-type-label",
             challengeChannel: nil,
-            signUpToken: "token",
+            continuationToken: "token",
             codeLength: 6)
         )
 
@@ -354,7 +354,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             interval: nil,
             challengeTargetLabel: "challenge-type-label",
             challengeChannel: nil,
-            signUpToken: nil,
+            continuationToken: nil,
             codeLength: 6)
         )
 
@@ -385,18 +385,18 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
 
     // MARK: - Continue Response
 
-    func test_whenSignUpStartSuccessResponseContainsSLT_it_returns_success() {
+    func test_whenSignUpStartSuccessResponseContainsContinuationToken_it_returns_success() {
         let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .success(
-            .init(signinSLT: "<signin_slt>", expiresIn: nil, signupToken: nil)
+            .init(continuationToken: "<continuationToken>", expiresIn: nil)
         )
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .success("<signin_slt>"))
+        XCTAssertEqual(result, .success("<continuationToken>"))
     }
 
-    func test_whenSignUpStartSuccessResponseButDoesNotContainSLT_it_returns_successWithNoSLT() throws {
+    func test_whenSignUpStartSuccessResponseButDoesNotContainContinuationToken_it_returns_successWithNoContinuationToken() throws {
         let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .success(
-            .init(signinSLT: nil, expiresIn: nil, signupToken: nil)
+            .init(continuationToken: nil, expiresIn: nil)
         )
 
         let result = sut.validate(response, with: context)
@@ -411,7 +411,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpContinueErrorResponseIs_invalidOOBValue_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .invalidOOBValue, expectedSignUpToken: "sign-up-token")
+        let result = buildContinueErrorResponse(expectedError: .invalidOOBValue, expectedContinuationToken: "continuation-token")
 
         guard case .invalidUserInput(let error) = result else {
             return XCTFail("Unexpected response")
@@ -422,7 +422,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpContinueErrorResponseIs_passwordTooWeak_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .passwordTooWeak, expectedSignUpToken: "sign-up-token")
+        let result = buildContinueErrorResponse(expectedError: .passwordTooWeak, expectedContinuationToken: "continuation-token")
 
         guard case .invalidUserInput(let error) = result else {
             return XCTFail("Unexpected response")
@@ -433,7 +433,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpContinueErrorResponseIs_passwordTooShort_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .passwordTooShort, expectedSignUpToken: "sign-up-token")
+        let result = buildContinueErrorResponse(expectedError: .passwordTooShort, expectedContinuationToken: "continuation-token")
 
         guard case .invalidUserInput(let error) = result else {
             return XCTFail("Unexpected response")
@@ -444,7 +444,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpContinueErrorResponseIs_passwordTooLong_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .passwordTooLong, expectedSignUpToken: "sign-up-token")
+        let result = buildContinueErrorResponse(expectedError: .passwordTooLong, expectedContinuationToken: "continuation-token")
 
         guard case .invalidUserInput(let error) = result else {
             return XCTFail("Unexpected response")
@@ -455,7 +455,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpContinueErrorResponseIs_passwordRecentlyUsed_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .passwordRecentlyUsed, expectedSignUpToken: "sign-up-token")
+        let result = buildContinueErrorResponse(expectedError: .passwordRecentlyUsed, expectedContinuationToken: "continuation-token")
 
         guard case .invalidUserInput(let error) = result else {
             return XCTFail("Unexpected response")
@@ -466,7 +466,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpContinueErrorResponseIs_passwordBanned_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .passwordBanned, expectedSignUpToken: "sign-up-token")
+        let result = buildContinueErrorResponse(expectedError: .passwordBanned, expectedContinuationToken: "continuation-token")
 
         guard case .invalidUserInput(let error) = result else {
             return XCTFail("Unexpected response")
@@ -477,26 +477,26 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, expectedSignUpToken: "sign-up-token", invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "email")])
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, expectedContinuationToken: "continuation-token", invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "email")])
 
-        guard case .attributeValidationFailed(let signUpToken, let invalidAttributes) = result else {
+        guard case .attributeValidationFailed(let continuationToken, let invalidAttributes) = result else {
             return XCTFail("Unexpected response")
         }
 
-        XCTAssertEqual(signUpToken, "sign-up-token")
+        XCTAssertEqual(continuationToken, "continuation-token")
         XCTAssertEqual(invalidAttributes.first, "email")
     }
     
     func test_whenSignUpContinueErrorResponseIs_invalidRequestWithInvalidOTPErrorCode_it_returns_expectedError() {
-        let signUpToken = "sign-up-token"
+        let continuationToken = "continuation-token"
         var errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidOTP.rawValue, Int.max]
-        var result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        var result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedContinuationToken: continuationToken, errorCodes: errorCodes)
         checkInvalidOOBValue()
         errorCodes = [MSALNativeAuthESTSApiErrorCodes.incorrectOTP.rawValue]
-        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedContinuationToken: continuationToken, errorCodes: errorCodes)
         checkInvalidOOBValue()
         errorCodes = [MSALNativeAuthESTSApiErrorCodes.OTPNoCacheEntryForUser.rawValue]
-        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: signUpToken, errorCodes: errorCodes)
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedContinuationToken: continuationToken, errorCodes: errorCodes)
         checkInvalidOOBValue()
         func checkInvalidOOBValue() {
             guard case .invalidUserInput(let error) = result else {
@@ -508,7 +508,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             XCTAssertNil(error.errorDescription)
             XCTAssertNil(error.errorURI)
             XCTAssertNil(error.innerErrors)
-            XCTAssertEqual(error.signUpToken, signUpToken)
+            XCTAssertEqual(error.continuationToken, continuationToken)
             XCTAssertNil(error.requiredAttributes)
             XCTAssertNil(error.unverifiedAttributes)
             XCTAssertNil(error.invalidAttributes)
@@ -517,11 +517,11 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
     
     func test_whenSignUpContinueErrorResponseIs_invalidRequestWithGenericErrorCode_it_returns_expectedError() {
-        var result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue])
+        var result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedContinuationToken: "continuation-token", errorCodes: [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue])
         checkValidatedErrorResult()
-        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [Int.max])
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedContinuationToken: "continuation-token", errorCodes: [Int.max])
         checkValidatedErrorResult()
-        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedSignUpToken: "sign-up-token", errorCodes: [MSALNativeAuthESTSApiErrorCodes.userNotHaveAPassword.rawValue])
+        result = buildContinueErrorResponse(expectedError: .invalidRequest, expectedContinuationToken: "continuation-token", errorCodes: [MSALNativeAuthESTSApiErrorCodes.userNotHaveAPassword.rawValue])
         checkValidatedErrorResult()
         func checkValidatedErrorResult() {
             guard case .error(let error) = result else {
@@ -534,8 +534,8 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
     
 
-    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_signUpTokenIsNil_it_returns_unexpectedError() {
-        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, expectedSignUpToken: nil, invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "email")])
+    func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_continuationTokenIsNil_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributeValidationFailed, expectedContinuationToken: nil, invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "email")])
 
         XCTAssertEqual(result, .unexpectedError)
     }
@@ -553,47 +553,47 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpContinueErrorResponseIs_credentialRequired_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedSignUpToken: "sign-up-token")
+        let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedContinuationToken: "continuation-token")
 
-        guard case .credentialRequired(let signUpToken) = result else {
+        guard case .credentialRequired(let continuationToken) = result else {
             return XCTFail("Unexpected response")
         }
 
-        XCTAssertEqual(signUpToken, "sign-up-token")
+        XCTAssertEqual(continuationToken, "continuation-token")
     }
 
-    func test_whenSignUpContinueErrorResponseIs_credentialRequired_but_signUpToken_isNil_it_returns_unexpectedError() {
-        let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedSignUpToken: nil)
+    func test_whenSignUpContinueErrorResponseIs_credentialRequired_but_continuationToken_isNil_it_returns_unexpectedError() {
+        let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedContinuationToken: nil)
         XCTAssertEqual(result, .unexpectedError)
     }
 
     func test_whenSignUpContinueErrorResponseIs_attributesRequired_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedContinuationToken: "continuation-token", requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
 
-        guard case .attributesRequired(let signUpToken, let requiredAttributes) = result else {
+        guard case .attributesRequired(let continuationToken, let requiredAttributes) = result else {
             return XCTFail("Unexpected response")
         }
 
-        XCTAssertEqual(signUpToken, "sign-up-token")
+        XCTAssertEqual(continuationToken, "continuation-token")
         XCTAssertEqual(requiredAttributes.count, 2)
         XCTAssertEqual(requiredAttributes[0].name, "email")
         XCTAssertEqual(requiredAttributes[1].name, "city")
     }
 
-    func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_signUpToken_IsNil_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: nil, requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
+    func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_continuationToken_IsNil_it_returns_expectedError() {
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedContinuationToken: nil, requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
 
         XCTAssertEqual(result, .unexpectedError)
     }
 
     func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_requiredAttributesIsNil_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: nil)
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedContinuationToken: "continuation-token", requiredAttributes: nil)
 
         XCTAssertEqual(result, .unexpectedError)
     }
 
     func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_requiredAttributes_IsEmpty_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedSignUpToken: "sign-up-token", requiredAttributes: [])
+        let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedContinuationToken: "continuation-token", requiredAttributes: [])
 
         XCTAssertEqual(result, .unexpectedError)
     }
@@ -660,7 +660,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
 
     private func buildContinueErrorResponse(
         expectedError: MSALNativeAuthSignUpContinueOauth2ErrorCode,
-        expectedSignUpToken: String? = nil,
+        expectedContinuationToken: String? = nil,
         requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]? = nil,
         invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
         errorCodes: [Int]? = nil
@@ -669,7 +669,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             createSignUpContinueError(
                 error: expectedError,
                 errorCodes: errorCodes,
-                signUpToken: expectedSignUpToken,
+                continuationToken: expectedContinuationToken,
                 requiredAttributes: requiredAttributes,
                 invalidAttributes: invalidAttributes
             )
@@ -684,7 +684,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,
         innerErrors: [MSALNativeAuthInnerError]? = nil,
-        signUpToken: String? = nil,
+        continuationToken: String? = nil,
         unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
         invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil
     ) -> MSALNativeAuthSignUpStartResponseError {
@@ -694,7 +694,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             errorCodes: errorCodes,
             errorURI: errorURI,
             innerErrors: innerErrors,
-            signUpToken: signUpToken,
+            continuationToken: continuationToken,
             unverifiedAttributes: unverifiedAttributes,
             invalidAttributes: invalidAttributes
         )
@@ -722,7 +722,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,
         innerErrors: [MSALNativeAuthInnerError]? = nil,
-        signUpToken: String? = nil,
+        continuationToken: String? = nil,
         requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]? = nil,
         unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
         invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil
@@ -733,7 +733,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             errorCodes: errorCodes,
             errorURI: errorURI,
             innerErrors: innerErrors,
-            signUpToken: signUpToken,
+            continuationToken: continuationToken,
             requiredAttributes: requiredAttributes,
             unverifiedAttributes: unverifiedAttributes,
             invalidAttributes: invalidAttributes

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
@@ -68,7 +68,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     func test_whenSignUpStart_verificationRequiredErrorWithSignUpTokenAndUnverifiedAttributes_it_returns_verificationRequired() {
         let error = createSignUpStartError(
             error: .verificationRequired,
-            continuationToken: "sign-up token",
+            continuationToken: "continuation-token",
             unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes(name: "username")]
         )
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
@@ -79,14 +79,14 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
 
-        XCTAssertEqual(continuationToken, "sign-up token")
+        XCTAssertEqual(continuationToken, "continuation-token")
         XCTAssertEqual(unverifiedAttributes.first, "username")
     }
 
     func test_whenSignUpStart_verificationRequiredErrorWithSignUpToken_but_unverifiedAttributesIsEmpty_it_returns_unexpectedError() {
         let error = createSignUpStartError(
             error: .verificationRequired,
-            continuationToken: "sign-up token",
+            continuationToken: "continuation-token",
             unverifiedAttributes: []
         )
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
@@ -98,7 +98,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     func test_whenSignUpStart_verificationRequiredErrorWithSignUpToken_but_unverifiedAttributesIsNil_it_returns_unexpectedError() {
         let error = createSignUpStartError(
             error: .verificationRequired,
-            continuationToken: "sign-up token",
+            continuationToken: "continuation-token",
             unverifiedAttributes: nil
         )
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
@@ -88,7 +88,7 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
 
         let errorCodes: [Int] = [unknownErrorCode1, unknownErrorCode2]
 
-        let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: nil, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: nil, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, continuationToken: nil)
         
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
@@ -103,7 +103,7 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
     }
     
     func test_invalidClient_isProperlyHandled() {
-        let error = MSALNativeAuthTokenResponseError(error: .invalidClient, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        let error = MSALNativeAuthTokenResponseError(error: .invalidClient, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil)
         
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
@@ -118,7 +118,7 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
     }
     
     func test_unauthorizedClient_isProperlyHandled() {
-        let error = MSALNativeAuthTokenResponseError(error: .unauthorizedClient, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        let error = MSALNativeAuthTokenResponseError(error: .unauthorizedClient, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil)
         
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
@@ -171,7 +171,7 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
             return XCTFail("Unexpected Error")
         }
         func checkErrorCodes() -> MSALNativeAuthTokenValidatedErrorType? {
-            let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+            let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, continuationToken: nil)
             
             let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
             
@@ -191,7 +191,7 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
 
         let errorCodes: [Int] = [unknownErrorCode1, knownErrorCode, unknownErrorCode2]
 
-        let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: nil, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+        let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, errorDescription: nil, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, continuationToken: nil)
         
         let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
         
@@ -214,7 +214,7 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
         checkErrorCodes()
         func checkErrorCodes() {
             let description = "description"
-            let error = MSALNativeAuthTokenResponseError(error: .invalidRequest, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+            let error = MSALNativeAuthTokenResponseError(error: .invalidRequest, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, continuationToken: nil)
             
             let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
             let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
@@ -239,7 +239,7 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
         errorCodes = [MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue]
         checkErrorCodes()
         func checkErrorCodes() {
-            let error = MSALNativeAuthTokenResponseError(error: .invalidRequest, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, credentialToken: nil)
+            let error = MSALNativeAuthTokenResponseError(error: .invalidRequest, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, continuationToken: nil)
             
             let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
             let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -93,7 +93,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignUpPasswordStartDelegateSpy(expectation: exp1)
 
         let expectedResult: SignUpStartResult = .codeRequired(
-            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId),
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -116,7 +116,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: exp)
         
         let expectedResult: SignUpStartResult = .codeRequired(
-            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId),
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -192,7 +192,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
 
         let expectedResult: SignUpStartResult = .codeRequired(
-            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId),
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -215,7 +215,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: exp)
 
         let expectedResult: SignUpStartResult = .codeRequired(
-            newState: .init(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId),
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -332,7 +332,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         delegate.expectedChannelTargetType = .email
 
         let expectedResult: SignInStartResult = .codeRequired(
-            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "", correlationId: correlationId),
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -355,7 +355,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .codeRequired(
-            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "", correlationId: correlationId),
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -388,7 +388,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         delegate.expectedChannelTargetType = .email
 
         let expectedResult: SignInStartResult = .codeRequired(
-            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "", correlationId: correlationId),
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -410,7 +410,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .codeRequired(
-            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "", correlationId: correlationId),
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -431,7 +431,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         let delegate = SignInCodeStartDelegateWithPasswordRequiredSpy(expectation: exp1)
 
-        let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
         let expectedResult: SignInStartResult = .passwordRequired(newState: expectedState)
 
         controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
@@ -442,7 +442,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         wait(for: [exp1, exp2], timeout: 1)
 
-        XCTAssertEqual(delegate.passwordRequiredState?.flowToken, expectedState.flowToken)
+        XCTAssertEqual(delegate.passwordRequiredState?.continuationToken, expectedState.continuationToken)
     }
 
     func testSignIn_delegate_whenPasswordIsRequiredButUserHasNotImplementedOptionalDelegate_shouldReturnError() {
@@ -453,7 +453,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = SignInCodeStartDelegateSpy(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .passwordRequired(
-            newState: SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, flowToken: "", correlationId: correlationId)
+            newState: SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, continuationToken: "", correlationId: correlationId)
         )
 
         controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
@@ -481,7 +481,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = ResetPasswordStartDelegateSpy(expectation: exp1)
 
         let expectedResult: ResetPasswordStartResult = .codeRequired(
-            newState: .init(controller: controllerFactoryMock.resetPasswordController, username: "username", flowToken: "flowToken", correlationId: correlationId),
+            newState: .init(controller: controllerFactoryMock.resetPasswordController, username: "username", continuationToken: "continuationToken", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -494,7 +494,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         wait(for: [exp1, exp2], timeout: 1)
 
-        XCTAssertEqual(delegate.newState?.flowToken, "flowToken")
+        XCTAssertEqual(delegate.newState?.continuationToken, "continuationToken")
         XCTAssertEqual(delegate.newState?.username, "username")
         XCTAssertEqual(delegate.sentTo, "sentTo")
         XCTAssertEqual(delegate.channelTargetType, .email)
@@ -507,7 +507,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let delegate = ResetPasswordStartDelegateOptionalMethodsNotImplemented(expectation: exp)
 
         let expectedResult: ResetPasswordStartResult = .codeRequired(
-            newState: .init(controller: controllerFactoryMock.resetPasswordController, username: "username", flowToken: "flowToken", correlationId: correlationId),
+            newState: .init(controller: controllerFactoryMock.resetPasswordController, username: "username", continuationToken: "continuationToken", correlationId: correlationId),
             sentTo: "sentTo",
             channelTargetType: .email,
             codeLength: 1
@@ -546,12 +546,12 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         signUpRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signUpRequestProviderMock.expectedChallengeRequestParameters = expectedSignUpChallengeParams()
         signUpRequestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        signUpRequestProviderMock.expectedContinueRequestParameters = expectedSignUpContinueParams(token: "signUpToken 2")
+        signUpRequestProviderMock.expectedContinueRequestParameters = expectedSignUpContinueParams(token: "continuationToken 2")
         
         let signUpResponseValidatorMock = MSALNativeAuthSignUpResponseValidatorMock()
-        signUpResponseValidatorMock.mockValidateSignUpStartFunc((.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""])))
-        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
-        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success("signInSLT"))
+        signUpResponseValidatorMock.mockValidateSignUpStartFunc((.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""])))
+        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "continuationToken 2"))
+        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success("continuationToken"))
         
         let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
         
@@ -565,7 +565,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         tokenResponse.refreshToken = "refreshToken"
         
         let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: expectedUsername, credentialToken: nil, signInSLT: "signInSLT", grantType: MSALNativeAuthGrantType.slt, scope: expectedScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: expectedUsername, continuationToken: "continuationToken", grantType: MSALNativeAuthGrantType.continuationToken, scope: expectedScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil)
         tokenRequestProviderMock.expectedContext = contextMock
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         
@@ -647,12 +647,12 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         signUpRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signUpRequestProviderMock.expectedChallengeRequestParameters = expectedSignUpChallengeParams()
         signUpRequestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        signUpRequestProviderMock.expectedContinueRequestParameters = expectedSignUpContinueParams(token: "signUpToken 2")
+        signUpRequestProviderMock.expectedContinueRequestParameters = expectedSignUpContinueParams(token: "continuationToken 2")
         
         let signUpResponseValidatorMock = MSALNativeAuthSignUpResponseValidatorMock()
-        signUpResponseValidatorMock.mockValidateSignUpStartFunc((.verificationRequired(signUpToken: "signUpToken", unverifiedAttributes: [""])))
-        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "signUpToken 2"))
-        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success("signInSLT"))
+        signUpResponseValidatorMock.mockValidateSignUpStartFunc((.verificationRequired(continuationToken: "continuationToken", unverifiedAttributes: [""])))
+        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "continuationToken 2"))
+        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success("continuationToken"))
         
         let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
         
@@ -666,7 +666,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         tokenResponse.refreshToken = "refreshToken"
         
         let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: expectedUsername, credentialToken: nil, signInSLT: "signInSLT", grantType: MSALNativeAuthGrantType.slt, scope: expectedScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: expectedUsername, continuationToken: "continuationToken", grantType: MSALNativeAuthGrantType.continuationToken, scope: expectedScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil)
         tokenRequestProviderMock.expectedContext = contextMock
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         
@@ -745,13 +745,13 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         signInRequestProviderMock.expectedUsername = "username"
         
         signInRequestProviderMock.expectedContext = contextMock
-        let credentialToken = "<credentialToken>"
+        let continuationToken = "<continuationToken>"
         let expectedSentTo = "sentTo"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
         let signInResponseValidatorMock = MSALNativeAuthSignInResponseValidatorMock()
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
         
         let expectedScopes = "scope1 scope2 openid profile offline_access"
         
@@ -762,7 +762,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         tokenResponse.refreshToken = "refreshToken"
         
         let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: expectedScopes, password: nil, oobCode: "1234", includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: nil, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.oobCode, scope: expectedScopes, password: nil, oobCode: "1234", includeChallengeType: true, refreshToken: nil)
         tokenRequestProviderMock.expectedContext = contextMock
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         
@@ -830,7 +830,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         signInRequestProviderMock.expectedUsername = "username"
         signInRequestProviderMock.expectedContext = contextMock
         
-        let credentialToken = "<credentialToken>"
+        let continuationToken = "<continuationToken>"
         let expectedSentTo = "sentTo"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
@@ -839,8 +839,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         delegateCodeStart.expectedCodeLength = expectedCodeLength
         
         let signInResponseValidatorMock = MSALNativeAuthSignInResponseValidatorMock()
-        signInResponseValidatorMock.initiateValidatedResponse = .success(credentialToken: credentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(credentialToken: credentialToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
         
         let expectedScopes = "scope1 scope2 openid profile offline_access"
         
@@ -851,7 +851,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         tokenResponse.refreshToken = "refreshToken"
         
         let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: nil, credentialToken: credentialToken, signInSLT: nil, grantType: MSALNativeAuthGrantType.oobCode, scope: expectedScopes, password: nil, oobCode: "1234", includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: nil, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.oobCode, scope: expectedScopes, password: nil, oobCode: "1234", includeChallengeType: true, refreshToken: nil)
         tokenRequestProviderMock.expectedContext = contextMock
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         
@@ -920,20 +920,20 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         resetPasswordRequestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         resetPasswordRequestProviderMock.expectedStartRequestParameters = expectedResetPasswordStartParams
         resetPasswordRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        resetPasswordRequestProviderMock.expectedChallengeRequestParameters = expectedResetPasswordChallengeParams(token: "passwordResetToken")
+        resetPasswordRequestProviderMock.expectedChallengeRequestParameters = expectedResetPasswordChallengeParams(token: "continuationToken")
         resetPasswordRequestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        resetPasswordRequestProviderMock.expectedContinueRequestParameters = expectedResetPasswordContinueParams(token: "passwordResetToken 2")
+        resetPasswordRequestProviderMock.expectedContinueRequestParameters = expectedResetPasswordContinueParams(token: "continuationToken 2")
         resetPasswordRequestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        resetPasswordRequestProviderMock.expectedSubmitRequestParameters = expectedResetPasswordSubmitParams(token: "passwordSubmitToken")
+        resetPasswordRequestProviderMock.expectedSubmitRequestParameters = expectedResetPasswordSubmitParams(token: "continuationToken")
         resetPasswordRequestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        resetPasswordRequestProviderMock.expectedPollCompletionParameters = expectedResetPasswordPollCompletionParameters(token: "passwordResetToken 3")
+        resetPasswordRequestProviderMock.expectedPollCompletionParameters = expectedResetPasswordPollCompletionParameters(token: "continuationToken 3")
         
         let resetPasswordResponseValidator = MSALNativeAuthResetPasswordResponseValidatorMock()
-        resetPasswordResponseValidator.mockValidateResetPasswordStartFunc(.success(passwordResetToken: "passwordResetToken"))
-        resetPasswordResponseValidator.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "passwordResetToken 2"))
-        resetPasswordResponseValidator.mockValidateResetPasswordContinueFunc(.success(passwordSubmitToken: "passwordSubmitToken"))
-        resetPasswordResponseValidator.mockValidateResetPasswordSubmitFunc(.success(passwordResetToken: "passwordResetToken 3", pollInterval: 0))
-        resetPasswordResponseValidator.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, continuationToken: "slt"))
+        resetPasswordResponseValidator.mockValidateResetPasswordStartFunc(.success(continuationToken: "continuationToken"))
+        resetPasswordResponseValidator.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "continuationToken 2"))
+        resetPasswordResponseValidator.mockValidateResetPasswordContinueFunc(.success(continuationToken: "continuationToken"))
+        resetPasswordResponseValidator.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken 3", pollInterval: 0))
+        resetPasswordResponseValidator.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, continuationToken: "continuationToken"))
 
         let expectedUsername = "username"
         let expectedScopes = "scope1 scope2 openid profile offline_access"
@@ -944,7 +944,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         cacheAccessorMock.expectedMSIDTokenResult = tokenResult
 
         let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
-        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: expectedUsername, credentialToken: nil, signInSLT: "slt", grantType: .slt, scope: expectedScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: expectedUsername, continuationToken: "continuationToken", grantType: .continuationToken, scope: expectedScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil)
         tokenRequestProviderMock.expectedContext = contextMock
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
 
@@ -1038,20 +1038,20 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         )
     }
     
-    private func expectedSignUpChallengeParams(token: String = "signUpToken") -> (token: String, context: MSIDRequestContext) {
+    private func expectedSignUpChallengeParams(token: String = "continuationToken") -> (token: String, context: MSIDRequestContext) {
         return (token: token, context: contextMock)
     }
     
     private func expectedSignUpContinueParams(
         grantType: MSALNativeAuthGrantType = .oobCode,
-        token: String = "signUpToken",
+        token: String = "continuationToken",
         password: String? = nil,
         oobCode: String? = "1234",
         attributes: [String: Any]? = nil
     ) -> MSALNativeAuthSignUpContinueRequestProviderParams {
         .init(
             grantType: grantType,
-            signUpToken: token,
+            continuationToken: token,
             password: password,
             oobCode: oobCode,
             attributes: attributes,
@@ -1066,38 +1066,38 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         )
     }
     
-    private func expectedResetPasswordChallengeParams(token: String = "passwordResetToken") -> (token: String, context: MSIDRequestContext) {
+    private func expectedResetPasswordChallengeParams(token: String = "continuationToken") -> (token: String, context: MSIDRequestContext) {
         return (token: token, context: contextMock)
     }
     
     private func expectedResetPasswordContinueParams(
         grantType: MSALNativeAuthGrantType = .oobCode,
-        token: String = "passwordResetToken",
+        token: String = "continuationToken",
         oobCode: String? = "1234"
     ) -> MSALNativeAuthResetPasswordContinueRequestParameters {
         .init(
             context: contextMock,
-            passwordResetToken: token,
+            continuationToken: token,
             grantType: grantType,
             oobCode: oobCode
         )
     }
     
     private func expectedResetPasswordSubmitParams(
-        token: String = "passwordSubmitToken",
+        token: String = "continuationToken",
         password: String = "password"
     ) -> MSALNativeAuthResetPasswordSubmitRequestParameters {
         .init(
             context: contextMock,
-            passwordSubmitToken: token,
+            continuationToken: token,
             newPassword: password)
     }
 
     private func expectedResetPasswordPollCompletionParameters(
-        token: String = "passwordResetToken"
+        token: String = "continuationToken"
     ) -> MSALNativeAuthResetPasswordPollCompletionRequestParameters {
         .init(
             context: contextMock,
-            passwordResetToken: token)
+            continuationToken: token)
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordRequiredDelegateDispatcherTests.swift
@@ -52,7 +52,7 @@ final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
         let expectedState = SignInAfterResetPasswordState(
             controller: signInControllerMock,
             username: "username",
-            slt: "slt",
+            continuationToken: "continuationToken",
             correlationId: correlationId
         )
 
@@ -80,7 +80,7 @@ final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
         let expectedState = SignInAfterResetPasswordState(
             controller: signInControllerMock,
             username: "username",
-            slt: "slt",
+            continuationToken: "continuationToken",
             correlationId: correlationId
         )
 

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordResendCodeDelegateDispatcherTests.swift
@@ -49,7 +49,7 @@ final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
@@ -82,7 +82,7 @@ final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordStartDelegateDispatcherTests.swift
@@ -49,7 +49,7 @@ final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "username", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "username", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
@@ -82,7 +82,7 @@ final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "username", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = ResetPasswordCodeRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "username", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordVerifyCodeDelegateDispatcherTests.swift
@@ -49,7 +49,7 @@ final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = ResetPasswordRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "username", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = ResetPasswordRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "username", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchPasswordRequired(newState: expectedState)
 
@@ -71,7 +71,7 @@ final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = ResetPasswordRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "username", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = ResetPasswordRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "username", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchPasswordRequired(newState: expectedState)
 

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordStartDelegateDispatcherTests.swift
@@ -49,7 +49,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
@@ -83,7 +83,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInResendCodeDelegateDispatcherTests.swift
@@ -40,7 +40,7 @@ final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInResendCodeCodeRequired_whenDelegateMethodsAreImplemented() async {
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
@@ -79,7 +79,7 @@ final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInStartDelegateDispatcherTests.swift
@@ -39,7 +39,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCodeRequired_whenDelegateMethodsAreImplemented() async {
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
@@ -82,7 +82,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
@@ -113,7 +113,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInPasswordRequiredState(scopes: [], username: "username", controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignInPasswordRequiredState(scopes: [], username: "username", controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignInPasswordRequired(newState: expectedState)
 
@@ -136,7 +136,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInPasswordRequiredState(scopes: [], username: "username", controller: controllerFactoryMock.signInController, flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignInPasswordRequiredState(scopes: [], username: "username", controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignInPasswordRequired(newState: expectedState)
 

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
@@ -54,7 +54,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
             .init(name: "attribute2", type: "", required: true),
         ]
 
-        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
 
@@ -82,7 +82,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
             .init(name: "attribute2", type: "", required: true),
         ]
 
-        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
 
@@ -106,7 +106,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedAttributeNames = ["attribute1", "attribute2"]
 
-        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, newState: expectedState)
 
@@ -131,7 +131,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedAttributeNames = ["attribute1", "attribute2"]
 
-        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, newState: expectedState)
 
@@ -153,7 +153,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpCompleted(newState: expectedState)
 
@@ -175,7 +175,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpCompleted(newState: expectedState)
 

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
@@ -54,7 +54,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
             .init(name: "attribute2", type: "", required: true),
         ]
 
-        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
 
@@ -82,7 +82,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
             .init(name: "attribute2", type: "", required: true),
         ]
 
-        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
 
@@ -105,7 +105,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpCompleted(newState: expectedState)
 
@@ -127,7 +127,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpCompleted(newState: expectedState)
 

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordStartDelegateDispatcherTests.swift
@@ -49,7 +49,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
@@ -82,7 +82,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpResendCodeDelegateDispatcherTests.swift
@@ -49,7 +49,7 @@ final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
@@ -82,7 +82,7 @@ final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpStartDelegateDispatcherTests.swift
@@ -49,7 +49,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
@@ -82,7 +82,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpCodeRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedSentTo = "user@contoso.com"
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
@@ -54,7 +54,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
             .init(name: "attribute2", type: "", required: true),
         ]
 
-        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
 
@@ -82,7 +82,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
             .init(name: "attribute2", type: "", required: true),
         ]
 
-        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
 
@@ -105,7 +105,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignUpPasswordRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpPasswordRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpPasswordRequired(newState: expectedState)
 
@@ -127,7 +127,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignUpPasswordRequiredState(controller: controllerFactoryMock.signUpController, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = SignUpPasswordRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpPasswordRequired(newState: expectedState)
 
@@ -150,7 +150,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpCompleted(newState: expectedState)
 
@@ -172,7 +172,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", slt: "flowToken", correlationId: correlationId)
+        let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         await sut.dispatchSignUpCompleted(newState: expectedState)
 

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
@@ -36,7 +36,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
         try super.setUpWithError()
 
         controller = .init()
-        sut = ResetPasswordCodeRequiredState(controller: controller, username: "username", flowToken: "<token>", correlationId: correlationId)
+        sut = ResetPasswordCodeRequiredState(controller: controller, username: "username", continuationToken: "<token>", correlationId: correlationId)
     }
 
     // MARK: - Delegates
@@ -45,7 +45,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
 
     func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
         let expectedError = ResendCodeError(message: "test error")
-        let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: ResetPasswordResendCodeResult = .error(error: expectedError, newState: expectedState)
         controller.resendCodeResponse = .init(expectedResult)
@@ -63,7 +63,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
     func test_resendCode_delegate_success_shouldReturnCodeRequired() {
         let exp = expectation(description: "reset password states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: ResetPasswordResendCodeResult = .codeRequired(
             newState: expectedState,
@@ -80,7 +80,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
         sut.resendCode(delegate: delegate)
         wait(for: [exp, exp2])
 
-        XCTAssertEqual(delegate.newState?.flowToken, expectedState.flowToken)
+        XCTAssertEqual(delegate.newState?.continuationToken, expectedState.continuationToken)
         XCTAssertEqual(delegate.sentTo, "sentTo")
         XCTAssertEqual(delegate.channelTargetType, .email)
         XCTAssertEqual(delegate.codeLength, 1)
@@ -89,7 +89,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
     func test_resendCode_delegate_success_whenOptionalMethodNotImplemented_shouldReturnCorrectError() {
         let exp = expectation(description: "reset password states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: ResetPasswordResendCodeResult = .codeRequired(
             newState: expectedState,
@@ -113,7 +113,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
 
     func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
         let expectedError = VerifyCodeError(type: .invalidCode)
-        let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: ResetPasswordSubmitCodeResult = .error(error: expectedError, newState: expectedState)
         controller.submitCodeResponse = .init(expectedResult)
@@ -131,7 +131,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
     func test_submitCode_delegate_success_shouldReturnPasswordRequired() {
         let exp = expectation(description: "reset password states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = ResetPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = ResetPasswordRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: ResetPasswordSubmitCodeResult = .passwordRequired(newState: expectedState)
         controller.submitCodeResponse = .init(expectedResult, telemetryUpdate: { _ in
@@ -149,7 +149,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
     func test_submitCode_delegate_success_whenOptionalMethodsNotImplemented_shouldReturnCorrectError() {
         let exp = expectation(description: "reset password states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = ResetPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = ResetPasswordRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: ResetPasswordSubmitCodeResult = .passwordRequired(newState: expectedState)
         controller.submitCodeResponse = .init(expectedResult, telemetryUpdate: { _ in

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
         XCTAssertNil(controllerSpy.context)
         XCTAssertFalse(controllerSpy.submitPasswordCalled)
 
-        let sut = ResetPasswordRequiredState(controller: controllerSpy, username: "username", flowToken: "<token>", correlationId: correlationId)
+        let sut = ResetPasswordRequiredState(controller: controllerSpy, username: "username", continuationToken: "<token>", correlationId: correlationId)
         sut.submitPassword(password: "1234", delegate: ResetPasswordRequiredDelegateSpy())
 
         wait(for: [exp], timeout: 1)
@@ -53,10 +53,10 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
 
     func test_submitPassword_delegate_whenError_shouldReturnCorrectError() {
         controllerMock = MSALNativeAuthResetPasswordControllerMock()
-        let sut = ResetPasswordRequiredState(controller: controllerMock, username: "username", flowToken: "<token>", correlationId: correlationId)
+        let sut = ResetPasswordRequiredState(controller: controllerMock, username: "username", continuationToken: "<token>", correlationId: correlationId)
 
         let expectedError = PasswordRequiredError(type: .invalidPassword, message: nil)
-        let expectedState = ResetPasswordRequiredState(controller: controllerMock, username: "username", flowToken: "flowToken", correlationId: correlationId)
+        let expectedState = ResetPasswordRequiredState(controller: controllerMock, username: "username", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.error(error: expectedError, newState: expectedState))
         controllerMock.submitPasswordResponse = expectedResult
@@ -75,8 +75,8 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
         let exp = expectation(description: "reset password states")
         let exp2 = expectation(description: "telemetry expectation")
         controllerMock = MSALNativeAuthResetPasswordControllerMock()
-        let sut = ResetPasswordRequiredState(controller: controllerMock, username: "", flowToken: "<token>", correlationId: correlationId)
-        let expectedState = SignInAfterResetPasswordState(controller: controllerFactoryMock.signInController, username: "", slt: nil, correlationId: correlationId)
+        let sut = ResetPasswordRequiredState(controller: controllerMock, username: "", continuationToken: "<token>", correlationId: correlationId)
+        let expectedState = SignInAfterResetPasswordState(controller: controllerFactoryMock.signInController, username: "", continuationToken: nil, correlationId: correlationId)
 
         let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.completed(expectedState), telemetryUpdate: { _ in
             exp2.fulfill()
@@ -96,8 +96,8 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
         let exp = expectation(description: "reset password states")
         let exp2 = expectation(description: "telemetry expectation")
         controllerMock = MSALNativeAuthResetPasswordControllerMock()
-        let sut = ResetPasswordRequiredState(controller: controllerMock, username: "", flowToken: "<token>", correlationId: correlationId)
-        let state = SignInAfterResetPasswordState(controller: controllerFactoryMock.signInController, username: "", slt: nil, correlationId: correlationId)
+        let sut = ResetPasswordRequiredState(controller: controllerMock, username: "", continuationToken: "<token>", correlationId: correlationId)
+        let state = SignInAfterResetPasswordState(controller: controllerFactoryMock.signInController, username: "", continuationToken: nil, correlationId: correlationId)
 
         let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.completed(state), telemetryUpdate: { _ in
             exp2.fulfill()

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
@@ -35,7 +35,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
         super.setUp()
 
         controller = .init()
-        sut = .init(scopes: [], controller: controller, flowToken: "flowToken", correlationId: correlationId)
+        sut = .init(scopes: [], controller: controller, continuationToken: "continuationToken", correlationId: correlationId)
     }
 
     // MARK: - Delegates
@@ -46,7 +46,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
         let exp = expectation(description: "sign-in states")
 
         let expectedError = ResendCodeError(message: "test error")
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignInResendCodeResult = .error(
             error: expectedError,
@@ -60,13 +60,13 @@ final class SignInCodeRequiredStateTests: XCTestCase {
         wait(for: [exp])
 
         XCTAssertEqual(delegate.newSignInResendCodeError, expectedError)
-        XCTAssertEqual(delegate.newSignInCodeRequiredState?.flowToken, expectedState.flowToken)
+        XCTAssertEqual(delegate.newSignInCodeRequiredState?.continuationToken, expectedState.continuationToken)
     }
 
     func test_resendCode_delegate_success_shouldReturnSignInResendCodeCodeRequired() {
         let exp = expectation(description: "sign-in states")
         let exp2 = expectation(description: "expectation Telemetry")
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignInResendCodeResult = .codeRequired(
             newState: expectedState,
@@ -82,13 +82,13 @@ final class SignInCodeRequiredStateTests: XCTestCase {
 
         sut.resendCode(delegate: delegate)
         wait(for: [exp, exp2])
-        XCTAssertEqual(delegate.newSignInCodeRequiredState?.flowToken, expectedState.flowToken)
+        XCTAssertEqual(delegate.newSignInCodeRequiredState?.continuationToken, expectedState.continuationToken)
     }
 
     func test_resendCode_delegate_success_butMethodNotImplemented_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-in states")
         let exp2 = expectation(description: "expectation Telemetry")
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2", correlationId: UUID())
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, continuationToken: "continuationToken 2", correlationId: UUID())
 
         let expectedResult: SignInResendCodeResult = .codeRequired(
             newState: expectedState,
@@ -112,7 +112,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
     func test_submitCode_delegate_withError_shouldReturnSignInVerifyCodeError() {
         let exp = expectation(description: "sign-in states")
         let expectedError = VerifyCodeError(type: .invalidCode)
-        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignInVerifyCodeResult = .error(
             error: expectedError,

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
@@ -35,14 +35,14 @@ final class SignInPasswordRequiredStateTests: XCTestCase {
         super.setUp()
 
         controller = .init()
-        sut = .init(scopes: [], username: "username", controller: controller, flowToken: "flowToken", correlationId: correlationId)
+        sut = .init(scopes: [], username: "username", controller: controller, continuationToken: "continuationToken", correlationId: correlationId)
     }
 
     // MARK: - Delegates
 
     func test_submitPassword_delegate_withError_shouldReturnError() {
         let expectedError = PasswordRequiredError(type: .invalidPassword)
-        let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controller, flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controller, continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignInPasswordRequiredResult = .error(
             error: expectedError,
@@ -56,7 +56,7 @@ final class SignInPasswordRequiredStateTests: XCTestCase {
         sut.submitPassword(password: "invalid password", delegate: delegate)
         wait(for: [exp])
 
-        XCTAssertEqual(delegate.newPasswordRequiredState?.flowToken, expectedState.flowToken)
+        XCTAssertEqual(delegate.newPasswordRequiredState?.continuationToken, expectedState.continuationToken)
     }
 
     func test_submitPassword_delegate_success_shouldReturnSuccess() {

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
@@ -37,7 +37,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         try super.setUpWithError()
 
         controller = .init()
-        sut = SignUpAttributesRequiredState(controller: controller, username: "<username>", flowToken: "<token>", correlationId: correlationId)
+        sut = SignUpAttributesRequiredState(controller: controller, username: "<username>", continuationToken: "<token>", correlationId: correlationId)
     }
 
     // MARK: - Delegate
@@ -60,7 +60,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     func test_submitPassword_delegate_whenSuccess_shouldReturnCompleted() {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: correlationId)
+        let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: SignUpAttributesRequiredResult = .completed(expectedState)
         controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
@@ -78,7 +78,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     func test_submitPassword_delegate_whenSuccess_butMethodNotImplemented_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: UUID())
+        let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", continuationToken: "continuationToken", correlationId: UUID())
 
         let expectedResult: SignUpAttributesRequiredResult = .completed(expectedState)
         controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
@@ -96,7 +96,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     func test_submitPassword_delegate_whenAttributesRequired_shouldReturnAttributesRequired() {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
             .init(name: "anAttribute", type: "aType", required: true)
         ]
@@ -118,7 +118,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     func test_submitPassword_delegate_whenAttributesRequired_butMethodNotImplemented_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
             .init(name: "anAttribute", type: "aType", required: true)
         ]
@@ -139,7 +139,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     func test_submitPassword_delegate_whenAttributesAreInvalid_shouldReturnAttributesInvalid() {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedAttributes = ["anAttribute"]
 
         let expectedResult: SignUpAttributesRequiredResult = .attributesInvalid(attributes: expectedAttributes, newState: expectedState)
@@ -159,7 +159,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     func test_submitPassword_delegate_whenAttributesAreInvalid_butMethodNotImplemented_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", flowToken: "slt", correlationId: correlationId)
+        let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let expectedAttributes = ["anAttribute"]
 
         let expectedResult: SignUpAttributesRequiredResult = .attributesInvalid(attributes: expectedAttributes, newState: expectedState)

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
@@ -36,7 +36,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         try super.setUpWithError()
 
         controller = .init()
-        sut = SignUpCodeRequiredState(controller: controller, username: "<username>", flowToken: "<token>", correlationId: correlationId)
+        sut = SignUpCodeRequiredState(controller: controller, username: "<username>", continuationToken: "<token>", correlationId: correlationId)
     }
 
     // MARK: - Delegates
@@ -61,7 +61,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     func test_resendCode_delegate_success_shouldReturnCodeRequired() {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpResendCodeResult = .codeRequired(
             newState: expectedState,
@@ -78,7 +78,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         sut.resendCode(delegate: delegate)
         wait(for: [exp, exp2])
 
-        XCTAssertEqual(delegate.newState?.flowToken, expectedState.flowToken)
+        XCTAssertEqual(delegate.newState?.continuationToken, expectedState.continuationToken)
         XCTAssertEqual(delegate.sentTo, "sentTo")
         XCTAssertEqual(delegate.channelTargetType, .email)
         XCTAssertEqual(delegate.codeLength, 1)
@@ -87,7 +87,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     func test_resendCode_delegate_success_butMethodNotImplemented() {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpResendCodeResult = .codeRequired(
             newState: expectedState,
@@ -111,7 +111,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
 
     func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
         let expectedError = VerifyCodeError(type: .invalidCode)
-        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = SignUpCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpVerifyCodeResult = .error(
             error: expectedError,
@@ -126,11 +126,11 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         wait(for: [exp])
 
         XCTAssertEqual(delegate.error, expectedError)
-        XCTAssertEqual(delegate.newCodeRequiredState?.flowToken, expectedState.flowToken)
+        XCTAssertEqual(delegate.newCodeRequiredState?.continuationToken, expectedState.continuationToken)
     }
 
     func test_submitCode_delegate_whenPasswordRequired_AndUserHasImplementedOptionalDelegate_shouldReturnPasswordRequired() {
-        let expectedPasswordRequiredState = SignUpPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedPasswordRequiredState = SignUpPasswordRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
@@ -152,7 +152,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
 
-        let expectedResult: SignUpVerifyCodeResult = .passwordRequired(.init(controller: controller, username: "", flowToken: "", correlationId: correlationId))
+        let expectedResult: SignUpVerifyCodeResult = .passwordRequired(.init(controller: controller, username: "", continuationToken: "", correlationId: correlationId))
         controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
             exp2.fulfill()
         })
@@ -170,7 +170,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_whenAttributesRequired_AndUserHasImplementedOptionalDelegate_shouldReturnAttributesRequired() {
-        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
@@ -192,7 +192,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
 
-        let expectedResult: SignUpVerifyCodeResult = .attributesRequired(attributes: [], newState: .init(controller: controller, username: "", flowToken: "", correlationId: correlationId))
+        let expectedResult: SignUpVerifyCodeResult = .attributesRequired(attributes: [], newState: .init(controller: controller, username: "", continuationToken: "", correlationId: correlationId))
         controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
             exp2.fulfill()
         })
@@ -212,7 +212,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     func test_submitCode_delegate_whenSuccess_shouldReturnAccountResult() {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: correlationId)
+        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: SignUpVerifyCodeResult = .completed(expectedSignInAfterSignUpState)
         controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
@@ -230,7 +230,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     func test_submitCode_delegate_whenSuccess_ButUserHasNotImplementedOptionalDelegate_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
-        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: correlationId)
+        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let result: SignUpVerifyCodeResult = .completed(expectedSignInAfterSignUpState)
         controller.submitCodeResult = .init(result, telemetryUpdate: { _ in
             exp2.fulfill()

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
@@ -37,14 +37,14 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
         try super.setUpWithError()
 
         controller = .init()
-        sut = SignUpPasswordRequiredState(controller: controller, username: "<username>", flowToken: "<token>", correlationId: correlationId)
+        sut = SignUpPasswordRequiredState(controller: controller, username: "<username>", continuationToken: "<token>", correlationId: correlationId)
     }
 
     // MARK: - Delegate
 
     func test_submitPassword_delegate_whenError_shouldReturnPasswordRequiredError() {
         let expectedError = PasswordRequiredError(type: .invalidPassword)
-        let expectedState = SignUpPasswordRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedState = SignUpPasswordRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpPasswordRequiredResult = .error(error: expectedError, newState: expectedState)
         controller.submitPasswordResult = .init(expectedResult)
@@ -56,11 +56,11 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
         wait(for: [exp])
 
         XCTAssertEqual(delegate.error, expectedError)
-        XCTAssertEqual(delegate.newPasswordRequiredState?.flowToken, expectedState.flowToken)
+        XCTAssertEqual(delegate.newPasswordRequiredState?.continuationToken, expectedState.continuationToken)
     }
 
     func test_submitCode_delegate_whenAttributesRequired_AndUserHasImplementedOptionalDelegate_shouldReturnAttributesRequired() {
-        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
@@ -79,7 +79,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_whenAttributesRequired_ButUserHasNotImplementedOptionalDelegate_shouldReturnPasswordRequiredError() {
-        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", flowToken: "flowToken 2", correlationId: correlationId)
+        let expectedAttributesRequiredState = SignUpAttributesRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "exp telemetry is called")
@@ -99,7 +99,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_whenSuccess_shouldReturnSignUpCompleted() {
-        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: correlationId)
+        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
@@ -118,7 +118,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
     }
 
     func test_submitCode_delegate_whenSuccess_ButUserHasNotImplementedOptionalDelegate_shouldReturnCorrectError() {
-        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", slt: "slt", correlationId: correlationId)
+        let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")


### PR DESCRIPTION
## Proposed changes

For network requests, responses, errors and tests rename all instances of signUpToken, credentialToken, flowToken, passwordResetToken, passwordSubmitToken to credentialToken, signInSLT or any other spellings of it.

For states renamed flowToken to continuationToken

Tests have been changed they all follow the format "<specific_token>" including "signin_slt"

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

Copy of this PR: https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/1922