### PR TITLE
Print warning on console if URL scheme is not configured

### DIFF
--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
@@ -43,6 +43,7 @@ enum MSALNativeAuthErrorMessage {
     static let invalidCode = "Invalid code"
     static let refreshTokenExpired = "Refresh token is expired"
     static let tokenNotFound = "Token not found"
+    static let redirectUriNotSetWarning = "WARNING ⚠️: redirectUri not set during MSAL Native Auth initialization. Production apps must correctly configure a redirect URI and call acquireToken in response to all browserRequired errors. See https://learn.microsoft.com/entra/identity-platform/redirect-uris-ios"
 }
 
 // swiftlint:enable line_length

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -83,7 +83,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         self.inputValidator = MSALNativeAuthInputValidator()
 
         if config.redirectUri == nil {
-            print(MSALNativeAuthErrorMessage.redirectUriNotSetWarning)
+            MSALLogger.log(level: .warning, context: nil, format: MSALNativeAuthErrorMessage.redirectUriNotSetWarning)
         }
 
         try super.init(configuration: config)
@@ -122,7 +122,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         )
 
         if redirectUri == nil {
-            print(MSALNativeAuthErrorMessage.redirectUriNotSetWarning)
+            MSALLogger.log(level: .warning, context: nil, format: MSALNativeAuthErrorMessage.redirectUriNotSetWarning)
         }
 
         // we need to bypass redirect URI validation because we don't need a redirect URI for Native Auth scenarios

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -82,6 +82,10 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         self.cacheAccessorFactory = MSALNativeAuthCacheAccessorFactory()
         self.inputValidator = MSALNativeAuthInputValidator()
 
+        if config.redirectUri == nil {
+            print(MSALNativeAuthErrorMessage.redirectUriNotSetWarning)
+        }
+
         try super.init(configuration: config)
     }
 
@@ -116,6 +120,10 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
             redirectUri: redirectUri,
             authority: ciamAuthority
         )
+
+        if redirectUri == nil {
+            print(MSALNativeAuthErrorMessage.redirectUriNotSetWarning)
+        }
 
         // we need to bypass redirect URI validation because we don't need a redirect URI for Native Auth scenarios
         configuration.bypassRedirectURIValidation = redirectUri == nil


### PR DESCRIPTION
## Proposed changes

Updated public initializers of MSALNativeAuthPublicClientApplication to output a message when redirectUri is not set.

Note: To actually see this warning message the developer will need to have the MSAL logging callback configured correctly as [described here](https://learn.microsoft.com/en-us/entra/identity-platform/msal-logging-ios).

The message can be updated to point to a more relevant documentation page in the future (GA timeline?)

To test: Use this version of the library in the default sample app.  If a redirectUri is configured correctly the message will not be output.

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

https://identitydivision.visualstudio.com/Engineering/_boards/board/t/DevExDub%20-B2C/Backlog%20items/?workitem=2649566