### PR TITLE
Rename classes to match behaviour

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -313,10 +313,10 @@
 		886F516729CCA58900F09471 /* MSALCIAMAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 886F516329CCA58900F09471 /* MSALCIAMAuthority.m */; };
 		88A25EE729E7347400066311 /* MSALCIAMAuthorityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88A25ED229E7185B00066311 /* MSALCIAMAuthorityTests.m */; };
 		8D2733142AD8346D00AD67FD /* MSALNativeAuthCustomErrorSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D2733132AD8346D00AD67FD /* MSALNativeAuthCustomErrorSerializer.swift */; };
-		8D35C8E72A97BD0000BEC29A /* MSALNativeAuthErrorBasicAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D35C8E62A97BD0000BEC29A /* MSALNativeAuthErrorBasicAttributes.swift */; };
+		8D35C8E72A97BD0000BEC29A /* MSALNativeAuthErrorBasicAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D35C8E62A97BD0000BEC29A /* MSALNativeAuthErrorBasicAttribute.swift */; };
 		8D35C8F12A97BD2300BEC29A /* MSALNativeAuthRequiredAttributeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D35C8F02A97BD2300BEC29A /* MSALNativeAuthRequiredAttributeOptions.swift */; };
 		8D61F9A12A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D61F9A02A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift */; };
-		8DDF473F2A98FE1C00126A47 /* MSALNativeAuthRequiredAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDF473E2A98FE1C00126A47 /* MSALNativeAuthRequiredAttributes.swift */; };
+		8DDF473F2A98FE1C00126A47 /* MSALNativeAuthRequiredAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDF473E2A98FE1C00126A47 /* MSALNativeAuthRequiredAttribute.swift */; };
 		94E876CE1E492D6000FB96ED /* MSALAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 94E876CB1E492D6000FB96ED /* MSALAuthority.m */; };
 		960751BB2183E82C00F2BF2F /* MSALAccountIdTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 960751BA2183E82C00F2BF2F /* MSALAccountIdTests.m */; };
 		960751BC2183E82C00F2BF2F /* MSALAccountIdTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 960751BA2183E82C00F2BF2F /* MSALAccountIdTests.m */; };
@@ -1005,7 +1005,7 @@
 		DEE34F89D170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE34F88D170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionStatus.swift */; };
 		DEE34F8CD170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE34F8AD170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift */; };
 		DEE34F8DD170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE34F8BD170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionResponseError.swift */; };
-		DEE34F96D170B71C00BC302A /* MSALNativeAuthRequiredAttributesInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE34F95D170B71C00BC302A /* MSALNativeAuthRequiredAttributesInternal.swift */; };
+		DEE34F96D170B71C00BC302A /* MSALNativeAuthRequiredAttributeInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE34F95D170B71C00BC302A /* MSALNativeAuthRequiredAttributeInternal.swift */; };
 		DEE34FA1D170B71C00BC302A /* MSALNativeAuthResetPasswordRequestProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE34FA0D170B71C00BC302A /* MSALNativeAuthResetPasswordRequestProvider.swift */; };
 		DEF1DD322AA9CBC300D22194 /* MSALNativeAuthESTSApiErrorDescriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF1DD312AA9CBC300D22194 /* MSALNativeAuthESTSApiErrorDescriptions.swift */; };
 		DEF1DD3C2AA9D07000D22194 /* MSALNativeAuthESTSApiErrorDescriptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF1DD3B2AA9D07000D22194 /* MSALNativeAuthESTSApiErrorDescriptionsTests.swift */; };
@@ -1592,10 +1592,10 @@
 		886F516329CCA58900F09471 /* MSALCIAMAuthority.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALCIAMAuthority.m; sourceTree = "<group>"; };
 		88A25ED229E7185B00066311 /* MSALCIAMAuthorityTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALCIAMAuthorityTests.m; sourceTree = "<group>"; };
 		8D2733132AD8346D00AD67FD /* MSALNativeAuthCustomErrorSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCustomErrorSerializer.swift; sourceTree = "<group>"; };
-		8D35C8E62A97BD0000BEC29A /* MSALNativeAuthErrorBasicAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthErrorBasicAttributes.swift; sourceTree = "<group>"; };
+		8D35C8E62A97BD0000BEC29A /* MSALNativeAuthErrorBasicAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthErrorBasicAttribute.swift; sourceTree = "<group>"; };
 		8D35C8F02A97BD2300BEC29A /* MSALNativeAuthRequiredAttributeOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequiredAttributeOptions.swift; sourceTree = "<group>"; };
 		8D61F9A02A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequestableTests.swift; sourceTree = "<group>"; };
-		8DDF473E2A98FE1C00126A47 /* MSALNativeAuthRequiredAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequiredAttributes.swift; sourceTree = "<group>"; };
+		8DDF473E2A98FE1C00126A47 /* MSALNativeAuthRequiredAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequiredAttribute.swift; sourceTree = "<group>"; };
 		94E876B01E4556B400FB96ED /* MSAL.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSAL.pch; sourceTree = "<group>"; };
 		94E876CA1E492D6000FB96ED /* MSALAuthority.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSALAuthority.h; sourceTree = "<group>"; };
 		94E876CB1E492D6000FB96ED /* MSALAuthority.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSALAuthority.m; sourceTree = "<group>"; };
@@ -2015,7 +2015,7 @@
 		DEE34F88D170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordPollCompletionStatus.swift; sourceTree = "<group>"; };
 		DEE34F8AD170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift; sourceTree = "<group>"; };
 		DEE34F8BD170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionResponseError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordPollCompletionResponseError.swift; sourceTree = "<group>"; };
-		DEE34F95D170B71C00BC302A /* MSALNativeAuthRequiredAttributesInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequiredAttributesInternal.swift; sourceTree = "<group>"; };
+		DEE34F95D170B71C00BC302A /* MSALNativeAuthRequiredAttributeInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequiredAttributeInternal.swift; sourceTree = "<group>"; };
 		DEE34FA0D170B71C00BC302A /* MSALNativeAuthResetPasswordRequestProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordRequestProvider.swift; sourceTree = "<group>"; };
 		DEF1DD312AA9CBC300D22194 /* MSALNativeAuthESTSApiErrorDescriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthESTSApiErrorDescriptions.swift; sourceTree = "<group>"; };
 		DEF1DD3B2AA9D07000D22194 /* MSALNativeAuthESTSApiErrorDescriptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthESTSApiErrorDescriptionsTests.swift; sourceTree = "<group>"; };
@@ -2501,7 +2501,7 @@
 			isa = PBXGroup;
 			children = (
 				E2CE91372B0D077C0009AEDD /* delegate_dispatcher */,
-				8DDF473E2A98FE1C00126A47 /* MSALNativeAuthRequiredAttributes.swift */,
+				8DDF473E2A98FE1C00126A47 /* MSALNativeAuthRequiredAttribute.swift */,
 				28DCD09629D7171600C4601E /* error */,
 				28DCD09529D7170F00C4601E /* state */,
 				28DCD09029D7165700C4601E /* delegate */,
@@ -4042,8 +4042,8 @@
 		E2C61FD829DECE8900F15203 /* sign_up */ = {
 			isa = PBXGroup;
 			children = (
-				DEE34F95D170B71C00BC302A /* MSALNativeAuthRequiredAttributesInternal.swift */,
-				8D35C8E62A97BD0000BEC29A /* MSALNativeAuthErrorBasicAttributes.swift */,
+				DEE34F95D170B71C00BC302A /* MSALNativeAuthRequiredAttributeInternal.swift */,
+				8D35C8E62A97BD0000BEC29A /* MSALNativeAuthErrorBasicAttribute.swift */,
 				8D35C8F02A97BD2300BEC29A /* MSALNativeAuthRequiredAttributeOptions.swift */,
 				E2C61FE029DECEDB00F15203 /* MSALNativeAuthSignUpStartOauth2ErrorCode.swift */,
 				E2C61FE329DED15800F15203 /* MSALNativeAuthSignUpStartResponseError.swift */,
@@ -5583,7 +5583,7 @@
 				DE1D8AA829E6B7D900E11D48 /* MSALNativeAuthRequestConfigurator.swift in Sources */,
 				DEF1DD322AA9CBC300D22194 /* MSALNativeAuthESTSApiErrorDescriptions.swift in Sources */,
 				DE0D65BF29D30BAE005798B1 /* MSALNativeAuthResponseError.swift in Sources */,
-				8DDF473F2A98FE1C00126A47 /* MSALNativeAuthRequiredAttributes.swift in Sources */,
+				8DDF473F2A98FE1C00126A47 /* MSALNativeAuthRequiredAttribute.swift in Sources */,
 				285F36082A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift in Sources */,
 				DEE34F8CD170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift in Sources */,
 				232D68CC223DB00500594BBD /* MSALTokenParameters.m in Sources */,
@@ -5716,7 +5716,7 @@
 				E2C872C3294CDEE800C4F580 /* MSALNativeAuthRequestable.swift in Sources */,
 				1E72193B24773D1B00AB9B67 /* MSALHttpMethod.m in Sources */,
 				E243F69D29D1D9B400DAC60F /* MSALNativeAuthSignUpChallengeResponse.swift in Sources */,
-				DEE34F96D170B71C00BC302A /* MSALNativeAuthRequiredAttributesInternal.swift in Sources */,
+				DEE34F96D170B71C00BC302A /* MSALNativeAuthRequiredAttributeInternal.swift in Sources */,
 				289E15592948E601006104D9 /* MSALNativeAuthCacheInterface.swift in Sources */,
 				289E156D2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift in Sources */,
 				E2C61FE729DED73700F15203 /* MSALNativeAuthSignUpChallengeResponseError.swift in Sources */,
@@ -5759,7 +5759,7 @@
 				E22427DB2B0594670006C55E /* CredentialsDelegateDispatcher.swift in Sources */,
 				B26756C622921C42000F01D7 /* MSALAADOauth2Provider.m in Sources */,
 				DEE34F12D170B71C00BC302A /* MSALNativeAuthResetPasswordStartRequestParameters.swift in Sources */,
-				8D35C8E72A97BD0000BEC29A /* MSALNativeAuthErrorBasicAttributes.swift in Sources */,
+				8D35C8E72A97BD0000BEC29A /* MSALNativeAuthErrorBasicAttribute.swift in Sources */,
 				28DCD09229D7166F00C4601E /* SignUpDelegates.swift in Sources */,
 				DE0D656F29BF72F7005798B1 /* MSALNativeAuthSignInInitiateRequestParameters.swift in Sources */,
 				E2F626AA2A780F8200C4A303 /* SignInStates+Internal.swift in Sources */,

--- a/MSAL/src/native_auth/controllers/responses/SignUpResults.swift
+++ b/MSAL/src/native_auth/controllers/responses/SignUpResults.swift
@@ -33,7 +33,7 @@ enum SignUpStartResult {
 enum SignUpVerifyCodeResult {
     case completed(SignInAfterSignUpState)
     case passwordRequired(SignUpPasswordRequiredState)
-    case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+    case attributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState)
     case error(error: VerifyCodeError, newState: SignUpCodeRequiredState?)
 }
 
@@ -41,13 +41,13 @@ typealias SignUpResendCodeResult = CodeRequiredGenericResult<SignUpCodeRequiredS
 
 enum SignUpPasswordRequiredResult {
     case completed(SignInAfterSignUpState)
-    case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+    case attributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState)
     case error(error: PasswordRequiredError, newState: SignUpPasswordRequiredState?)
 }
 
 enum SignUpAttributesRequiredResult {
     case completed(SignInAfterSignUpState)
-    case attributesRequired(attributes: [MSALNativeAuthRequiredAttributes], state: SignUpAttributesRequiredState)
+    case attributesRequired(attributes: [MSALNativeAuthRequiredAttribute], state: SignUpAttributesRequiredState)
     case attributesInvalid(attributes: [String], newState: SignUpAttributesRequiredState)
     case error(error: AttributesRequiredError)
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthErrorBasicAttribute.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthErrorBasicAttribute.swift
@@ -24,18 +24,10 @@
 
 import Foundation
 
-@objc
-public class MSALNativeAuthRequiredAttributes: NSObject {
-    public let name: String
-    public let type: String
-    public let required: Bool
-    public let regex: String?
+class MSALNativeAuthErrorBasicAttribute: NSObject, Decodable {
+    let name: String
 
-    init(name: String, type: String, required: Bool, regex: String? = nil) {
+    init(name: String) {
         self.name = name
-        self.type = type
-        self.required = required
-        self.regex = regex
-        super.init()
     }
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthRequiredAttributeInternal.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthRequiredAttributeInternal.swift
@@ -24,10 +24,24 @@
 
 import Foundation
 
-class MSALNativeAuthErrorBasicAttributes: NSObject, Decodable {
+class MSALNativeAuthRequiredAttributeInternal: NSObject, Decodable {
     let name: String
+    let type: String
+    let required: Bool
+    let options: MSALNativeAuthRequiredAttributeOptions?
 
-    init(name: String) {
+    init(name: String, type: String, required: Bool, options: MSALNativeAuthRequiredAttributeOptions? = nil) {
         self.name = name
+        self.type = type
+        self.required = required
+        self.options = options
+    }
+
+    override var description: String {
+        return "\(name)"
+    }
+
+    func toRequiredAttributePublic() -> MSALNativeAuthRequiredAttribute {
+        MSALNativeAuthRequiredAttribute(name: name, type: type, required: required, regex: options?.regex)
     }
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
@@ -32,9 +32,9 @@ struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
     let continuationToken: String?
-    let requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]?
-    let unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]?
-    let invalidAttributes: [MSALNativeAuthErrorBasicAttributes]?
+    let requiredAttributes: [MSALNativeAuthRequiredAttributeInternal]?
+    let unverifiedAttributes: [MSALNativeAuthErrorBasicAttribute]?
+    let invalidAttributes: [MSALNativeAuthErrorBasicAttribute]?
 
     enum CodingKeys: String, CodingKey {
         case error

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
@@ -33,8 +33,8 @@ struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
     let continuationToken: String?
-    let unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]?
-    let invalidAttributes: [MSALNativeAuthErrorBasicAttributes]?
+    let unverifiedAttributes: [MSALNativeAuthErrorBasicAttribute]?
+    let invalidAttributes: [MSALNativeAuthErrorBasicAttribute]?
 
     enum CodingKeys: String, CodingKey {
         case error

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -191,7 +191,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
                 !requiredAttributes.isEmpty {
                 return .attributesRequired(
                     continuationToken: continuationToken,
-                    requiredAttributes: requiredAttributes.map { $0.toRequiredAttributesPublic() }
+                    requiredAttributes: requiredAttributes.map { $0.toRequiredAttributePublic() }
                 )
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/continue for attributes_required error")
@@ -249,7 +249,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
         return knownErrorCode == .invalidRequestParameter && errorDescription.contains(knownErrorDescription)
     }
 
-    private func extractAttributeNames(from attributes: [MSALNativeAuthErrorBasicAttributes]) -> [String] {
+    private func extractAttributeNames(from attributes: [MSALNativeAuthErrorBasicAttribute]) -> [String] {
         return attributes.map { $0.name }
     }
 }

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
@@ -46,7 +46,7 @@ enum MSALNativeAuthSignUpContinueValidatedResponse: Equatable {
     /// error that represents invalidOOB or invalidPassword, depending on which State the input comes from.
     case invalidUserInput(_ error: MSALNativeAuthSignUpContinueResponseError)
     case credentialRequired(continuationToken: String)
-    case attributesRequired(continuationToken: String, requiredAttributes: [MSALNativeAuthRequiredAttributes])
+    case attributesRequired(continuationToken: String, requiredAttributes: [MSALNativeAuthRequiredAttribute])
     case attributeValidationFailed(invalidAttributes: [String])
     case error(MSALNativeAuthSignUpContinueResponseError)
     case unexpectedError

--- a/MSAL/src/native_auth/public/state_machine/MSALNativeAuthRequiredAttribute.swift
+++ b/MSAL/src/native_auth/public/state_machine/MSALNativeAuthRequiredAttribute.swift
@@ -24,24 +24,18 @@
 
 import Foundation
 
-class MSALNativeAuthRequiredAttributesInternal: NSObject, Decodable {
-    let name: String
-    let type: String
-    let required: Bool
-    let options: MSALNativeAuthRequiredAttributeOptions?
+@objc
+public class MSALNativeAuthRequiredAttribute: NSObject {
+    public let name: String
+    public let type: String
+    public let required: Bool
+    public let regex: String?
 
-    init(name: String, type: String, required: Bool, options: MSALNativeAuthRequiredAttributeOptions? = nil) {
+    init(name: String, type: String, required: Bool, regex: String? = nil) {
         self.name = name
         self.type = type
         self.required = required
-        self.options = options
-    }
-
-    override var description: String {
-        return "\(name)"
-    }
-
-    func toRequiredAttributesPublic() -> MSALNativeAuthRequiredAttributes {
-        MSALNativeAuthRequiredAttributes(name: name, type: type, required: required, regex: options?.regex)
+        self.regex = regex
+        super.init()
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/delegate/SignUpDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/SignUpDelegates.swift
@@ -61,7 +61,7 @@ public protocol SignUpVerifyCodeDelegate {
     /// - Parameters:
     ///   - attributes: List of required attributes.
     ///   - newState: An object representing the new state of the flow with follow on methods.
-    @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+    @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState)
 
     /// Notifies the delegate that a password is required from the user to continue.
     /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpVerifyCodeError(error:newState:)`` will be called.
@@ -110,7 +110,7 @@ public protocol SignUpPasswordRequiredDelegate {
     /// - Parameters:
     ///   - attributes: List of required attributes.
     ///   - newState: An object representing the new state of the flow with follow on methods.
-    @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+    @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState)
 
     /// Notifies the delegate that the sign up operation completed successfully.
     /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpPasswordRequiredError(error:newState:)`` will be called.
@@ -129,7 +129,7 @@ public protocol SignUpAttributesRequiredDelegate {
     /// - Parameters:
     ///     - attributes:  List of required attributes.
     ///     - newState: An object representing the new state of the flow with follow on methods.
-    @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState)
+    @MainActor @objc optional func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState)
 
     /// Notifies the delegate that invalid attributes were sent.
     /// - Note: If a flow requires this optional method and it is not implemented, then ``onSignUpAttributesRequiredError(error:)`` will be called.

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignUpDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignUpDelegateDispatchers.swift
@@ -56,7 +56,7 @@ final class SignUpStartDelegateDispatcher: DelegateDispatcher<SignUpStartDelegat
 
 final class SignUpVerifyCodeDelegateDispatcher: DelegateDispatcher<SignUpVerifyCodeDelegate> {
 
-    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) async {
+    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState) async {
         if let onSignUpAttributesRequired = delegate.onSignUpAttributesRequired {
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)
@@ -111,7 +111,7 @@ final class SignUpResendCodeDelegateDispatcher: DelegateDispatcher<SignUpResendC
 
 final class SignUpPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignUpPasswordRequiredDelegate> {
 
-    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) async {
+    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState) async {
         if let onSignUpAttributesRequired = delegate.onSignUpAttributesRequired {
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)
@@ -136,7 +136,7 @@ final class SignUpPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignUpP
 
 final class SignUpAttributesRequiredDelegateDispatcher: DelegateDispatcher<SignUpAttributesRequiredDelegate> {
 
-    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) async {
+    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState) async {
         if let onSignUpAttributesRequired = delegate.onSignUpAttributesRequired {
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/SignUpDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/SignUpDelegateSpies.swift
@@ -112,7 +112,7 @@ class SignUpVerifyCodeDelegateSpy: SignUpVerifyCodeDelegate {
         expectation.fulfill()
     }
 
-    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) {
+    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState) {
         onSignUpAttributesRequiredCalled = true
         attributesRequiredNewState = newState
 
@@ -186,7 +186,7 @@ class SignUpPasswordRequiredDelegateSpy: SignUpPasswordRequiredDelegate {
         expectation.fulfill()
     }
 
-    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: SignUpAttributesRequiredState) {
+    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState) {
         onSignUpAttributesRequiredCalled = true
         attributesRequiredState = newState
 
@@ -227,7 +227,7 @@ class SignUpAttributesRequiredDelegateSpy: SignUpAttributesRequiredDelegate {
         expectation.fulfill()
     }
     
-    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttribute], newState: MSAL.SignUpAttributesRequiredState) {
         onSignUpAttributesRequiredErrorCalled = true
         attributesRequiredState = newState
         expectation.fulfill()

--- a/MSAL/test/unit/native_auth/mock/SignUpDelegateSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/SignUpDelegateSpies.swift
@@ -175,7 +175,7 @@ class SignUpVerifyCodeDelegateSpy: SignUpVerifyCodeDelegate {
     private(set) var newAttributesRequiredState: SignUpAttributesRequiredState?
     private(set) var newPasswordRequiredState: SignUpPasswordRequiredState?
     private(set) var newSignInAfterSignUpState: SignInAfterSignUpState?
-    private(set) var newAttributesRequired: [MSALNativeAuthRequiredAttributes]?
+    private(set) var newAttributesRequired: [MSALNativeAuthRequiredAttribute]?
 
     init(expectation: XCTestExpectation? = nil) {
         self.expectation = expectation
@@ -190,7 +190,7 @@ class SignUpVerifyCodeDelegateSpy: SignUpVerifyCodeDelegate {
         expectation?.fulfill()
     }
 
-    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+    func onSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: MSAL.SignUpAttributesRequiredState) {
         onSignUpAttributesRequiredCalled = true
         newAttributesRequired = attributes
         newAttributesRequiredState = newState
@@ -225,7 +225,7 @@ class SignUpPasswordRequiredDelegateSpy: SignUpPasswordRequiredDelegate {
     private(set) var newPasswordRequiredState: SignUpPasswordRequiredState?
     private(set) var newAttributesRequiredState: SignUpAttributesRequiredState?
     private(set) var signInAfterSignUpState: SignInAfterSignUpState?
-    private(set) var newAttributesRequired: [MSALNativeAuthRequiredAttributes]?
+    private(set) var newAttributesRequired: [MSALNativeAuthRequiredAttribute]?
 
     init(expectation: XCTestExpectation? = nil) {
         self.expectation = expectation
@@ -240,7 +240,7 @@ class SignUpPasswordRequiredDelegateSpy: SignUpPasswordRequiredDelegate {
         expectation?.fulfill()
     }
 
-    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttribute], newState: MSAL.SignUpAttributesRequiredState) {
         onSignUpAttributesRequiredCalled = true
         newAttributesRequiredState = newState
         newAttributesRequired = attributes
@@ -265,7 +265,7 @@ class SignUpAttributesRequiredDelegateSpy: SignUpAttributesRequiredDelegate {
     private(set) var onSignUpCompletedCalled = false
     private(set) var error: AttributesRequiredError?
     private(set) var newState: SignUpAttributesRequiredState?
-    private(set) var attributes: [MSAL.MSALNativeAuthRequiredAttributes]?
+    private(set) var attributes: [MSAL.MSALNativeAuthRequiredAttribute]?
     private(set) var invalidAttributes: [String]?
     private(set) var newSignInAfterSignUpState: SignInAfterSignUpState?
 
@@ -289,7 +289,7 @@ class SignUpAttributesRequiredDelegateSpy: SignUpAttributesRequiredDelegate {
         expectation?.fulfill()
     }
     
-    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttributes], newState: MSAL.SignUpAttributesRequiredState) {
+    func onSignUpAttributesRequired(attributes: [MSAL.MSALNativeAuthRequiredAttribute], newState: MSAL.SignUpAttributesRequiredState) {
         self.attributes = attributes
         self.newState = newState
         onSignUpAttributesRequiredCalled = true

--- a/MSAL/test/unit/native_auth/mock/SignUpTestsValidatorHelpers.swift
+++ b/MSAL/test/unit/native_auth/mock/SignUpTestsValidatorHelpers.swift
@@ -214,7 +214,7 @@ class SignUpAttributesRequiredTestsValidatorHelper {
     private(set) var error: AttributesRequiredError?
     private(set) var newState: SignUpAttributesRequiredState?
     private(set) var signInAfterSignUpState: SignInAfterSignUpState?
-    private(set) var attributes: [MSALNativeAuthRequiredAttributes]?
+    private(set) var attributes: [MSALNativeAuthRequiredAttribute]?
     private(set) var invalidAttributes: [String]?
 
     init(expectation: XCTestExpectation? = nil) {

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthErrorRequiredAttributesTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthErrorRequiredAttributesTests.swift
@@ -28,12 +28,12 @@ import XCTest
 final class MSALNativeAuthErrorRequiredAttributesTests: XCTestCase {
 
     func test_toString_requiredTrue() {
-        let sut = MSALNativeAuthRequiredAttributesInternal(name: "aName", type: "", required: true)
+        let sut = MSALNativeAuthRequiredAttributeInternal(name: "aName", type: "", required: true)
         XCTAssertEqual(sut.description, "aName")
     }
 
     func test_toString_requiredFalse() {
-        let sut = MSALNativeAuthRequiredAttributesInternal(name: "aName", type: "", required: false)
+        let sut = MSALNativeAuthRequiredAttributeInternal(name: "aName", type: "", required: false)
         XCTAssertEqual(sut.description, "aName")
     }
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
@@ -81,7 +81,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         let error = createSignUpStartError(
             error: .invalidGrant,
             subError: .attributeValidationFailed,
-            invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "city")]
+            invalidAttributes: [MSALNativeAuthErrorBasicAttribute(name: "city")]
         )
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
 
@@ -132,7 +132,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpStartErrorResponseIs_invalidRequestWithInvalidUsernameErrorDescription_it_returns_expectedError() {
-        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let attributes = [MSALNativeAuthErrorBasicAttribute(name: "attribute")]
         let errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidRequestParameter.rawValue, Int.max]
 
         let apiError = createSignUpStartError(
@@ -155,7 +155,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
     
     func test_whenSignUpStartErrorResponseIs_invalidRequestWithInvalidClientIdErrorDescription_it_returns_expectedError() {
-        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let attributes = [MSALNativeAuthErrorBasicAttribute(name: "attribute")]
         let errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidRequestParameter.rawValue, Int.max]
         
         let apiError = createSignUpStartError(
@@ -178,7 +178,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpStartErrorResponseIs_invalidRequestWithGenericErrorCode_it_returns_expectedError() {
-        let attributes = [MSALNativeAuthErrorBasicAttributes(name: "attribute")]
+        let attributes = [MSALNativeAuthErrorBasicAttribute(name: "attribute")]
         let errorCodes = [Int.max]
 
         let apiError = createSignUpStartError(
@@ -460,7 +460,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_it_returns_expectedError() {
-        let result = buildContinueErrorResponse(expectedError: .invalidGrant, expectedSubError: .attributeValidationFailed, invalidAttributes: [MSALNativeAuthErrorBasicAttributes(name: "email")])
+        let result = buildContinueErrorResponse(expectedError: .invalidGrant, expectedSubError: .attributeValidationFailed, invalidAttributes: [MSALNativeAuthErrorBasicAttribute(name: "email")])
 
         guard case .attributeValidationFailed(let invalidAttributes) = result else {
             return XCTFail("Unexpected response")
@@ -602,8 +602,8 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         expectedError: MSALNativeAuthSignUpContinueOauth2ErrorCode,
         expectedSubError: MSALNativeAuthSubErrorCode? = nil,
         expectedContinuationToken: String? = nil,
-        requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]? = nil,
-        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
+        requiredAttributes: [MSALNativeAuthRequiredAttributeInternal]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil,
         errorCodes: [Int]? = nil
     ) -> MSALNativeAuthSignUpContinueValidatedResponse {
         let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .failure(
@@ -628,8 +628,8 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         errorURI: String? = nil,
         innerErrors: [MSALNativeAuthInnerError]? = nil,
         continuationToken: String? = nil,
-        unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
-        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil
+        unverifiedAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil
     ) -> MSALNativeAuthSignUpStartResponseError {
         .init(
             error: error,
@@ -668,9 +668,9 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         errorURI: String? = nil,
         innerErrors: [MSALNativeAuthInnerError]? = nil,
         continuationToken: String? = nil,
-        requiredAttributes: [MSALNativeAuthRequiredAttributesInternal]? = nil,
-        unverifiedAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil,
-        invalidAttributes: [MSALNativeAuthErrorBasicAttributes]? = nil
+        requiredAttributes: [MSALNativeAuthRequiredAttributeInternal]? = nil,
+        unverifiedAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil
     ) -> MSALNativeAuthSignUpContinueResponseError {
         .init(
             error: error,

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
@@ -49,7 +49,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+        let expectedAttributes: [MSALNativeAuthRequiredAttribute] = [
             .init(name: "attribute1", type: "", required: true),
             .init(name: "attribute2", type: "", required: true),
         ]
@@ -77,7 +77,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+        let expectedAttributes: [MSALNativeAuthRequiredAttribute] = [
             .init(name: "attribute1", type: "", required: true),
             .init(name: "attribute2", type: "", required: true),
         ]

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
@@ -49,7 +49,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+        let expectedAttributes: [MSALNativeAuthRequiredAttribute] = [
             .init(name: "attribute1", type: "", required: true),
             .init(name: "attribute2", type: "", required: true),
         ]
@@ -77,7 +77,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+        let expectedAttributes: [MSALNativeAuthRequiredAttribute] = [
             .init(name: "attribute1", type: "", required: true),
             .init(name: "attribute2", type: "", required: true),
         ]

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
@@ -49,7 +49,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+        let expectedAttributes: [MSALNativeAuthRequiredAttribute] = [
             .init(name: "attribute1", type: "", required: true),
             .init(name: "attribute2", type: "", required: true),
         ]
@@ -77,7 +77,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+        let expectedAttributes: [MSALNativeAuthRequiredAttribute] = [
             .init(name: "attribute1", type: "", required: true),
             .init(name: "attribute2", type: "", required: true),
         ]

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
@@ -97,7 +97,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
         let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
-        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+        let expectedAttributes: [MSALNativeAuthRequiredAttribute] = [
             .init(name: "anAttribute", type: "aType", required: true)
         ]
 
@@ -119,7 +119,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         let exp = expectation(description: "sign-up states")
         let exp2 = expectation(description: "telemetry expectation")
         let expectedState = SignUpAttributesRequiredState(controller: MSALNativeAuthSignUpControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
-        let expectedAttributes: [MSALNativeAuthRequiredAttributes] = [
+        let expectedAttributes: [MSALNativeAuthRequiredAttribute] = [
             .init(name: "anAttribute", type: "aType", required: true)
         ]
 


### PR DESCRIPTION
## Proposed changes
Some of the classes were named incorrectly because even though they were supposed to describe an object they were referring a plural of them
- Renamed MSALNativeAuthErrorBasicAttributes to MSALNativeAuthErrorBasicAttribute
- Renamed MSALNativeAuthRequiredAttributes to MSALNativeAuthRequiredAttribute
- Renamed MSALNativeAuthRequiredAttributesInternal to MSALNativeAuthRequiredAttributeInternal

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

