### PR TITLE
Include Swift code into reference doc

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
+# To build manually run "sudo sh build_docs.sh"
+# As MSAL is a mixed Objective-C and Swift project we need to use SourceKitten to
+# first extract the doc comments from the source before building with Jazzy. For more
+# details see https://github.com/realm/jazzy?tab=readme-ov-file#mixed-objective-c--swift
 gem install jazzy
 echo -e "Copying MSAL public files"
 mkdir docs.temp
 mkdir docs.temp/MSAL
 cp `find MSAL/src/public` docs.temp/MSAL
+cp `find MSAL/src/native_auth/public` docs.temp/MSAL
 cp README.md docs.temp/
-cd docs.temp
-echo -e "Generating MSAL documentation"
-jazzy --objc --umbrella-header MSAL/MSAL.h --framework-root . --sdk iphonesimulator --author Microsoft\ Corporation --author_url https://aka.ms/azuread  --github_url https://github.com/AzureAD/microsoft-authentication-library-for-objc --theme fullwidth
 
+echo -e "Generating MSAL documentation"
+# Generate Swift SourceKitten output
+sourcekitten doc -- -workspace MSAL.xcworkspace -scheme "MSAL (iOS Framework)" -configuration Debug RUN_CLANG_STATIC_ANALYZER=NO -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -destination 'platform=iOS Simulator' > docs.temp/swiftDoc.json
+
+# Generate Objective-C SourceKitten output
+cd docs.temp
+sourcekitten doc --objc $(pwd)/MSAL/MSAL.h -- -x objective-c  -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator) \-I $(pwd) -fmodules > objcDoc.json
+cd ..
+
+# Feed both outputs to Jazzy as a comma-separated list
+jazzy --module MSAL --sourcekitten-sourcefile docs.temp/swiftDoc.json,docs.temp/objcDoc.json --author Microsoft\ Corporation --author_url https://aka.ms/azuread --github_url https://github.com/AzureAD/microsoft-authentication-library-for-objc --theme fullwidth


### PR DESCRIPTION
## Proposed changes

- Changed build_docs.sh to add Swift code to reference doc using https://github.com/realm/jazzy#mixed-objective-c--swift
- A new branch was created which contains the latest script from https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/1969 including all comments

## Type of change

- [x] Feature work
- [ ] Bug fix
- [x] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

