### PR TITLE
Use correlationId from all responses. Add correlationId and errorCodes to public errors. 

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1059,6 +1059,7 @@
 		E235613429C9D528000E01CA /* MSALNativeAuthInternalChallengeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E235613329C9D528000E01CA /* MSALNativeAuthInternalChallengeType.swift */; };
 		E23E955F29D4B9F7001DC59C /* MSALNativeAuthSignUpChallengeIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23E955E29D4B9F7001DC59C /* MSALNativeAuthSignUpChallengeIntegrationTests.swift */; };
 		E23E956929D5BD6B001DC59C /* MSALNativeAuthSignUpRequestProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23E956829D5BD6B001DC59C /* MSALNativeAuthSignUpRequestProviderTests.swift */; };
+		E24320752B58428E005290D0 /* MSALNativeAuthResponseHeadersSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24320742B58428E005290D0 /* MSALNativeAuthResponseHeadersSerializable.swift */; };
 		E243F69429D1976700DAC60F /* MSALNativeAuthSignUpStartResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E243F69329D1976700DAC60F /* MSALNativeAuthSignUpStartResponse.swift */; };
 		E243F69A29D1CC6500DAC60F /* MSALNativeAuthSignUpChallengeRequestParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E243F69929D1CC6500DAC60F /* MSALNativeAuthSignUpChallengeRequestParameters.swift */; };
 		E243F69D29D1D9B400DAC60F /* MSALNativeAuthSignUpChallengeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E243F69C29D1D9B400DAC60F /* MSALNativeAuthSignUpChallengeResponse.swift */; };
@@ -1075,6 +1076,7 @@
 		E25E6E5A2AA7727D0094461E /* MSALNativeAuthCredentialsControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E6E592AA7727D0094461E /* MSALNativeAuthCredentialsControllerMock.swift */; };
 		E25EA4EC2A4C9B75004C8E40 /* MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26E391A2A4C2BE200063C07 /* MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift */; };
 		E26097C32948FC4D0060DD7C /* MSALNativeAuthLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26097C22948FC4D0060DD7C /* MSALNativeAuthLogging.swift */; };
+		E265943A2B60268400723C1A /* MSALNativeAuthResponseHeadersSerializableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26594392B60268400723C1A /* MSALNativeAuthResponseHeadersSerializableTests.swift */; };
 		E26E39242A4C2D7400063C07 /* SignUpDelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26E39232A4C2D7400063C07 /* SignUpDelegateSpies.swift */; };
 		E272C4EC2A4447520013B805 /* MSALNativeAuthSignUpUsernameEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E272C4EA2A4447520013B805 /* MSALNativeAuthSignUpUsernameEndToEndTests.swift */; };
 		E27332C02A153E6500E1B054 /* MSALNativeAuthErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27332BF2A153E6500E1B054 /* MSALNativeAuthErrorMessage.swift */; };
@@ -2071,6 +2073,7 @@
 		E235613329C9D528000E01CA /* MSALNativeAuthInternalChallengeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalChallengeType.swift; sourceTree = "<group>"; };
 		E23E955E29D4B9F7001DC59C /* MSALNativeAuthSignUpChallengeIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpChallengeIntegrationTests.swift; sourceTree = "<group>"; };
 		E23E956829D5BD6B001DC59C /* MSALNativeAuthSignUpRequestProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpRequestProviderTests.swift; sourceTree = "<group>"; };
+		E24320742B58428E005290D0 /* MSALNativeAuthResponseHeadersSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResponseHeadersSerializable.swift; sourceTree = "<group>"; };
 		E243F69329D1976700DAC60F /* MSALNativeAuthSignUpStartResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpStartResponse.swift; sourceTree = "<group>"; };
 		E243F69929D1CC6500DAC60F /* MSALNativeAuthSignUpChallengeRequestParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpChallengeRequestParameters.swift; sourceTree = "<group>"; };
 		E243F69C29D1D9B400DAC60F /* MSALNativeAuthSignUpChallengeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpChallengeResponse.swift; sourceTree = "<group>"; };
@@ -2086,6 +2089,7 @@
 		E25E6E592AA7727D0094461E /* MSALNativeAuthCredentialsControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCredentialsControllerMock.swift; sourceTree = "<group>"; };
 		E26097C22948FC4D0060DD7C /* MSALNativeAuthLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthLogging.swift; sourceTree = "<group>"; };
 		E26097C62948FC720060DD7C /* MSALNativeAuthServerTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthServerTelemetry.swift; sourceTree = "<group>"; };
+		E26594392B60268400723C1A /* MSALNativeAuthResponseHeadersSerializableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResponseHeadersSerializableTests.swift; sourceTree = "<group>"; };
 		E26E391A2A4C2BE200063C07 /* MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift; sourceTree = "<group>"; };
 		E26E39232A4C2D7400063C07 /* SignUpDelegateSpies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpDelegateSpies.swift; sourceTree = "<group>"; };
 		E272C4EA2A4447520013B805 /* MSALNativeAuthSignUpUsernameEndToEndTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpUsernameEndToEndTests.swift; sourceTree = "<group>"; };
@@ -2434,6 +2438,7 @@
 				E23E956829D5BD6B001DC59C /* MSALNativeAuthSignUpRequestProviderTests.swift */,
 				DEDD6F0729E83FD20017989F /* MSALNativeAuthRequestConfiguratorTests.swift */,
 				8D61F9A02A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift */,
+				E26594392B60268400723C1A /* MSALNativeAuthResponseHeadersSerializableTests.swift */,
 			);
 			path = network;
 			sourceTree = "<group>";
@@ -4088,6 +4093,7 @@
 				8D2733132AD8346D00AD67FD /* MSALNativeAuthCustomErrorSerializer.swift */,
 				E2ACA49B2953576C00E98964 /* MSALNativeAuthUrlRequestSerializer.swift */,
 				DE1D8AA729E6B7D900E11D48 /* MSALNativeAuthRequestConfigurator.swift */,
+				E24320742B58428E005290D0 /* MSALNativeAuthResponseHeadersSerializable.swift */,
 				E2C872C1294CDEAB00C4F580 /* parameters */,
 				DE0FECA92993AD3700B139A8 /* responses */,
 				DEDB29A229DDA992008DA85B /* errors */,
@@ -5674,6 +5680,7 @@
 				96B5E6F42256D197002232F9 /* MSALExtraQueryParameters.m in Sources */,
 				886F516429CCA58900F09471 /* MSALCIAMAuthority.m in Sources */,
 				B223B0C622AE215D00FB8713 /* MSALLegacySharedAccountFactory.m in Sources */,
+				E24320752B58428E005290D0 /* MSALNativeAuthResponseHeadersSerializable.swift in Sources */,
 				DEE34F72D170B71C00BC302A /* MSALNativeAuthResetPasswordChallengeResponseError.swift in Sources */,
 				E2B8532F2A153651007A4776 /* MSALNativeAuthSignUpStartRequestProviderParameters.swift in Sources */,
 				B26756CC22921C5B000F01D7 /* MSALB2COauth2Provider.m in Sources */,
@@ -5906,6 +5913,7 @@
 				DE94C9E229F19AA200C1EC1F /* MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift in Sources */,
 				E2CE91102B0BA3E80009AEDD /* AttributesRequiredErrorTests.swift in Sources */,
 				E2F5BE8E29893A4100C67EC7 /* MSALNativeAuthEndpointTests.swift in Sources */,
+				E265943A2B60268400723C1A /* MSALNativeAuthResponseHeadersSerializableTests.swift in Sources */,
 				287F64F0298186EA00ED90BD /* MSALNativeAuthInputValidatorTest.swift in Sources */,
 				8D61F9A12A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift in Sources */,
 				E22427E42B0650CD0006C55E /* SignUpPasswordStartDelegateDispatcherTests.swift in Sources */,

--- a/MSAL/module.modulemap
+++ b/MSAL/module.modulemap
@@ -90,6 +90,7 @@ module MSAL_Private {
     header "src/MSALAccountId+Internal.h"
     header "IdentityCore/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.h"
     header "IdentityCore/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.h"
+    header "IdentityCore/IdentityCore/src/MSIDOAuth2Constants.h"
     export *
 }
 

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
@@ -163,4 +163,11 @@ class MSALNativeAuthBaseController {
             }
         }
     }
+
+    func updateContext(_ previousContext: MSIDRequestContext, with correlationId: UUID?) -> MSALNativeAuthRequestContext {
+        return MSALNativeAuthRequestContext(
+            correlationId: correlationId ?? previousContext.correlationId(),
+            telemetryRequestId: previousContext.telemetryRequestId()
+        )
+    }
 }

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -93,7 +93,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
             context: context
         ) else {
             stopTelemetryEvent(telemetryEvent, context: context, error: MSALNativeAuthInternalError.invalidRequest)
-            return .init(.failure(RetrieveAccessTokenError(type: .generalError)))
+            return .init(.failure(RetrieveAccessTokenError(type: .generalError, correlationId: context.correlationId())))
         }
         let config = factory.makeMSIDConfiguration(scopes: scopes)
         let response = await performAndValidateTokenRequest(request, config: config, context: context)
@@ -156,7 +156,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 config: config
             )
         case .error(let errorType):
-            let error = errorType.convertToRetrieveAccessTokenError()
+            let error = errorType.convertToRetrieveAccessTokenError(context: context)
             MSALLogger.log(
                 level: .error,
                 context: context,
@@ -183,7 +183,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 self?.stopTelemetryEvent(telemetryEvent, context: context, delegateDispatcherResult: result)
             })
         } catch {
-            let error = RetrieveAccessTokenError(type: .generalError)
+            let error = RetrieveAccessTokenError(type: .generalError, correlationId: context.correlationId())
             MSALLogger.log(
                 level: .error,
                 context: context,

--- a/MSAL/src/native_auth/network/MSALNativeAuthCustomErrorSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthCustomErrorSerializer.swift
@@ -26,9 +26,12 @@ import Foundation
 
 @_implementationOnly import MSAL_Private
 
-final class MSALNativeAuthCustomErrorSerializer<T: Decodable & Error>: NSObject, MSIDResponseSerialization {
+// swiftlint:disable:next line_length
+final class MSALNativeAuthCustomErrorSerializer<T: Decodable & Error & MSALNativeAuthResponseHeadersSerializable>: NSObject, MSIDResponseSerialization {
     func responseObject(for httpResponse: HTTPURLResponse?, data: Data?, context: MSIDRequestContext?) throws -> Any {
-        let customError = try JSONDecoder().decode(T.self, from: data ?? Data())
+        var customError = try JSONDecoder().decode(T.self, from: data ?? Data())
+        customError.headers = customError.serializeHeaders(from: httpResponse)
+
         // the successfuly constructed "customError" needs to be thrown, since the previous "try" command just validates the object (error) decoding
         throw customError
     }

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseErrorHandler.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseErrorHandler.swift
@@ -26,7 +26,8 @@ import Foundation
 
 @_implementationOnly import MSAL_Private
 
-final class MSALNativeAuthResponseErrorHandler<T: Decodable & Error>: NSObject, MSIDHttpRequestErrorHandling {
+// swiftlint:disable:next line_length
+final class MSALNativeAuthResponseErrorHandler<T: Decodable & Error & MSALNativeAuthResponseHeadersSerializable>: NSObject, MSIDHttpRequestErrorHandling {
 
     // swiftlint:disable:next function_parameter_count
     func handleError(

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseSerializer.swift
@@ -24,7 +24,7 @@
 
 @_implementationOnly import MSAL_Private
 
-final class MSALNativeAuthResponseSerializer<T: Decodable>: NSObject, MSIDResponseSerialization {
+final class MSALNativeAuthResponseSerializer<T: Decodable & MSALNativeAuthResponseHeadersSerializable>: NSObject, MSIDResponseSerialization {
 
     func responseObject(for httpResponse: HTTPURLResponse?, data: Data?, context: MSIDRequestContext?) throws -> Any {
         guard let data = data else {
@@ -34,6 +34,9 @@ final class MSALNativeAuthResponseSerializer<T: Decodable>: NSObject, MSIDRespon
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
 
-        return try decoder.decode(T.self, from: data)
+        var object = try decoder.decode(T.self, from: data)
+        object.headers = object.serializeHeaders(from: httpResponse)
+
+        return object
     }
 }

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthResponseError.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-protocol MSALNativeAuthResponseError: Error, Decodable, Equatable {
+protocol MSALNativeAuthResponseError: Error, Decodable, Equatable, MSALNativeAuthResponseHeadersSerializable {
     associatedtype ErrorCode: RawRepresentable where ErrorCode.RawValue == String
 
     var error: ErrorCode? { get }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+@_implementationOnly import MSAL_Private
 
 struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthResponseError {
 
@@ -33,9 +33,10 @@ struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthRes
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
     let target: String?
+    var headers: [String: String]?
 
     enum CodingKeys: String, CodingKey {
-        case error
+        case error, headers
         case subError = "suberror"
         case errorDescription = "error_description"
         case errorCodes = "error_codes"
@@ -47,20 +48,26 @@ struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthRes
 
 extension MSALNativeAuthResetPasswordPollCompletionResponseError {
 
-    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+    func toPasswordRequiredPublicError(context: MSIDRequestContext) -> PasswordRequiredError {
         switch error {
         case .invalidGrant:
-            if let subError, subError.isAnyPasswordError {
-                return .init(type: .invalidPassword, message: errorDescription)
-            } else {
-                return .init(type: .generalError, message: errorDescription)
-            }
+            return .init(
+                type: subError?.isAnyPasswordError == true ? .invalidPassword : .generalError,
+                message: errorDescription,
+                correlationId: getHeaderCorrelationId() ?? context.correlationId(),
+                errorCodes: errorCodes ?? []
+            )
         case .unauthorizedClient,
              .expiredToken,
              .invalidRequest,
              .userNotFound,
              .none:
-            return .init(type: .generalError, message: errorDescription)
+            return .init(
+                type: .generalError,
+                message: errorDescription,
+                correlationId: getHeaderCorrelationId() ?? context.correlationId(),
+                errorCodes: errorCodes ?? []
+            )
             
         }
     }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartResponseError.swift
@@ -32,9 +32,10 @@ struct MSALNativeAuthResetPasswordStartResponseError: MSALNativeAuthResponseErro
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
     let target: String?
+    var headers: [String: String]?
 
     enum CodingKeys: String, CodingKey {
-        case error
+        case error, headers
         case errorDescription = "error_description"
         case errorCodes = "error_codes"
         case errorURI = "error_uri"

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
@@ -31,9 +31,10 @@ struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
     let errorCodes: [Int]?
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
+    var headers: [String: String]?
 
     enum CodingKeys: String, CodingKey {
-        case error
+        case error, headers
         case errorDescription = "error_description"
         case errorCodes = "error_codes"
         case errorURI = "error_uri"

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+@_implementationOnly import MSAL_Private
 
 struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
     let error: MSALNativeAuthSignUpChallengeOauth2ErrorCode?
@@ -30,9 +30,10 @@ struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
     let errorCodes: [Int]?
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
+    var headers: [String: String]?
 
     enum CodingKeys: String, CodingKey {
-        case error
+        case error, headers
         case errorDescription = "error_description"
         case errorCodes = "error_codes"
         case errorURI = "error_uri"
@@ -42,36 +43,46 @@ struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
 
 extension MSALNativeAuthSignUpChallengeResponseError {
 
-    func toSignUpStartPublicError() -> SignUpStartError {
+    func toSignUpStartPublicError(context: MSIDRequestContext) -> SignUpStartError {
         switch error {
         case .unauthorizedClient,
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
              .none:
-            return .init(type: .generalError, message: errorDescription)
+            return .init(
+                type: .generalError,
+                message: errorDescription,
+                correlationId: getHeaderCorrelationId() ?? context.correlationId(),
+                errorCodes: errorCodes ?? []
+            )
         }
     }
 
-    func toResendCodePublicError() -> ResendCodeError {
+    func toResendCodePublicError(context: MSIDRequestContext) -> ResendCodeError {
         switch error {
         case .unauthorizedClient,
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
              .none:
-            return .init(message: errorDescription)
+            return .init(message: errorDescription, correlationId: getHeaderCorrelationId() ?? context.correlationId(), errorCodes: errorCodes ?? [])
         }
     }
 
-    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+    func toPasswordRequiredPublicError(context: MSIDRequestContext) -> PasswordRequiredError {
         switch error {
         case .unauthorizedClient,
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
              .none:
-            return .init(type: .generalError, message: errorDescription)
+            return .init(
+                type: .generalError,
+                message: errorDescription,
+                correlationId: getHeaderCorrelationId() ?? context.correlationId(),
+                errorCodes: errorCodes ?? []
+            )
         }
     }
 }

--- a/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
@@ -33,9 +33,10 @@ struct MSALNativeAuthTokenResponseError: MSALNativeAuthResponseError {
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
     let continuationToken: String?
+    var headers: [String: String]?
 
     enum CodingKeys: String, CodingKey {
-        case error
+        case error, headers
         case subError = "suberror"
         case errorDescription = "error_description"
         case errorCodes = "error_codes"

--- a/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestContext.swift
+++ b/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestContext.swift
@@ -27,10 +27,11 @@
 final class MSALNativeAuthRequestContext: MSIDRequestContext {
 
     private let _correlationId: UUID
-    private let _telemetryRequestId: String = MSIDTelemetry.sharedInstance().generateRequestId()
+    private let _telemetryRequestId: String
 
-    init(correlationId: UUID? = nil) {
-        _correlationId = correlationId ?? UUID()
+    init(correlationId: UUID = UUID(), telemetryRequestId: String = MSIDTelemetry.sharedInstance().generateRequestId()) {
+        _correlationId = correlationId
+        _telemetryRequestId = telemetryRequestId
     }
 
     func correlationId() -> UUID {

--- a/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
+++ b/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
@@ -24,12 +24,9 @@
 
 import Foundation
 
-struct MSALNativeAuthResendCodeRequestResponse: Decodable {
+struct MSALNativeAuthResendCodeRequestResponse: Decodable, MSALNativeAuthResponseHeadersSerializable {
 
     // MARK: - Variables
     let continuationToken: String
-
-    enum CodingKeys: String, CodingKey {
-        case continuationToken
-    }
+    var headers: [String: String]?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordChallengeResponse.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-struct MSALNativeAuthResetPasswordChallengeResponse: Decodable {
+struct MSALNativeAuthResetPasswordChallengeResponse: Decodable, MSALNativeAuthResponseHeadersSerializable {
 
     // MARK: - Variables
     let challengeType: MSALNativeAuthInternalChallengeType
@@ -33,4 +33,5 @@ struct MSALNativeAuthResetPasswordChallengeResponse: Decodable {
     let challengeChannel: MSALNativeAuthInternalChannelType?
     let continuationToken: String?
     let codeLength: Int?
+    var headers: [String: String]?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordContinueResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordContinueResponse.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-struct MSALNativeAuthResetPasswordContinueResponse: Decodable {
+struct MSALNativeAuthResetPasswordContinueResponse: Decodable, MSALNativeAuthResponseHeadersSerializable {
 
     // MARK: - Variables
     let continuationToken: String
     let expiresIn: Int
+    var headers: [String: String]?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordPollCompletionResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordPollCompletionResponse.swift
@@ -24,10 +24,11 @@
 
 import Foundation
 
-struct MSALNativeAuthResetPasswordPollCompletionResponse: Decodable {
+struct MSALNativeAuthResetPasswordPollCompletionResponse: Decodable, MSALNativeAuthResponseHeadersSerializable {
 
     // MARK: - Variables
     let status: MSALNativeAuthResetPasswordPollCompletionStatus
     let continuationToken: String?
     let expiresIn: Int?
+    var headers: [String: String]?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-struct MSALNativeAuthResetPasswordStartResponse: Decodable {
+struct MSALNativeAuthResetPasswordStartResponse: Decodable, MSALNativeAuthResponseHeadersSerializable {
 
     // MARK: - Variables
     let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType?
+    var headers: [String: String]?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordSubmitResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordSubmitResponse.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-struct MSALNativeAuthResetPasswordSubmitResponse: Decodable {
+struct MSALNativeAuthResetPasswordSubmitResponse: Decodable, MSALNativeAuthResponseHeadersSerializable {
 
     // MARK: - Variables
     let continuationToken: String
     let pollInterval: Int
+    var headers: [String: String]?
 }

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInChallengeResponse.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-struct MSALNativeAuthSignInChallengeResponse: Decodable {
+struct MSALNativeAuthSignInChallengeResponse: Decodable, MSALNativeAuthResponseHeadersSerializable {
 
     // MARK: - Variables
     let continuationToken: String?
@@ -34,4 +34,5 @@ struct MSALNativeAuthSignInChallengeResponse: Decodable {
     let challengeChannel: MSALNativeAuthInternalChannelType?
     let codeLength: Int?
     let interval: Int?
+    var headers: [String: String]?
 }

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInInitiateResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInInitiateResponse.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-struct MSALNativeAuthSignInInitiateResponse: Decodable {
+struct MSALNativeAuthSignInInitiateResponse: Decodable, MSALNativeAuthResponseHeadersSerializable {
 
     // MARK: - Variables
     let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType?
+    var headers: [String: String]?
 }

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-struct MSALNativeAuthSignUpChallengeResponse: Decodable {
+struct MSALNativeAuthSignUpChallengeResponse: Decodable, MSALNativeAuthResponseHeadersSerializable {
     let challengeType: MSALNativeAuthInternalChallengeType?
     let bindingMethod: String?
     let interval: Int?
@@ -32,4 +32,5 @@ struct MSALNativeAuthSignUpChallengeResponse: Decodable {
     let challengeChannel: MSALNativeAuthInternalChannelType?
     let continuationToken: String?
     let codeLength: Int?
+    var headers: [String: String]?
 }

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
@@ -24,7 +24,8 @@
 
 import Foundation
 
-struct MSALNativeAuthSignUpContinueResponse: Decodable {
+struct MSALNativeAuthSignUpContinueResponse: Decodable, MSALNativeAuthResponseHeadersSerializable {
     let continuationToken: String?
     let expiresIn: Int?
+    var headers: [String: String]?
 }

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpStartResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpStartResponse.swift
@@ -24,7 +24,8 @@
 
 import Foundation
 
-struct MSALNativeAuthSignUpStartResponse: Decodable {
+struct MSALNativeAuthSignUpStartResponse: Decodable, MSALNativeAuthResponseHeadersSerializable {
     let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType?
+    var headers: [String: String]?
 }

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
@@ -23,8 +23,8 @@
 // THE SOFTWARE.
 
 enum MSALNativeAuthSignUpStartValidatedResponse: Equatable {
-    case success(continuationToken: String)
-    case attributeValidationFailed(invalidAttributes: [String])
+    case success(continuationToken: String, correlationId: UUID?)
+    case attributeValidationFailed(error: MSALNativeAuthSignUpStartResponseError, invalidAttributes: [String])
     case redirect
     case error(MSALNativeAuthSignUpStartResponseError)
     // TODO: Special errors handled separately. Remove after refactor validated error handling
@@ -34,20 +34,26 @@ enum MSALNativeAuthSignUpStartValidatedResponse: Equatable {
 }
 
 enum MSALNativeAuthSignUpChallengeValidatedResponse: Equatable {
-    case codeRequired(_ sentTo: String, _ channelType: MSALNativeAuthChannelType, _ codeLength: Int, _ signUpChallengeToken: String)
-    case passwordRequired(_ signUpChallengeToken: String)
+    case codeRequired(
+        _ sentTo: String,
+        _ channelType: MSALNativeAuthChannelType,
+        _ codeLength: Int,
+        _ signUpChallengeToken: String,
+        _ correlationId: UUID?
+    )
+    case passwordRequired(_ signUpChallengeToken: String, correlationId: UUID?)
     case redirect
     case error(MSALNativeAuthSignUpChallengeResponseError)
     case unexpectedError(message: String?)
 }
 
 enum MSALNativeAuthSignUpContinueValidatedResponse: Equatable {
-    case success(_ continuationToken: String?)
+    case success(continuationToken: String?, correlationId: UUID?)
     /// error that represents invalidOOB or invalidPassword, depending on which State the input comes from.
     case invalidUserInput(_ error: MSALNativeAuthSignUpContinueResponseError)
-    case credentialRequired(continuationToken: String)
-    case attributesRequired(continuationToken: String, requiredAttributes: [MSALNativeAuthRequiredAttribute])
-    case attributeValidationFailed(invalidAttributes: [String])
+    case credentialRequired(continuationToken: String, correlationId: UUID?)
+    case attributesRequired(continuationToken: String, requiredAttributes: [MSALNativeAuthRequiredAttribute], correlationId: UUID?)
+    case attributeValidationFailed(error: MSALNativeAuthSignUpContinueResponseError, invalidAttributes: [String])
     case error(MSALNativeAuthSignUpContinueResponseError)
     case unexpectedError(message: String?)
 }

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -95,43 +95,41 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
         _ responseError: MSALNativeAuthTokenResponseError) -> MSALNativeAuthTokenValidatedResponse {
             switch responseError.error {
             case .invalidRequest:
-                return handleInvalidRequestErrorCodes(responseError.errorCodes, errorDescription: responseError.errorDescription, context: context)
+                return handleInvalidRequestErrorCodes(apiError: responseError, context: context)
             case .invalidClient,
                 .unauthorizedClient:
-                return .error(.unauthorizedClient(message: responseError.errorDescription))
+                return .error(.unauthorizedClient(responseError))
             case .invalidGrant:
                 if responseError.subError == .invalidOOBValue {
-                    return .error(.invalidOOBCode(message: responseError.errorDescription))
+                    return .error(.invalidOOBCode(responseError))
                 } else {
-                    return handleInvalidGrantErrorCodes(responseError.errorCodes, errorDescription: responseError.errorDescription, context: context)
+                    return handleInvalidGrantErrorCodes(apiError: responseError, context: context)
                 }
             case .expiredToken:
-                return .error(.expiredToken(message: responseError.errorDescription))
+                return .error(.expiredToken(responseError))
             case .expiredRefreshToken:
-                return .error(.expiredRefreshToken(message: responseError.errorDescription))
+                return .error(.expiredRefreshToken(responseError))
             case .unsupportedChallengeType:
-                return .error(.unsupportedChallengeType(message: responseError.errorDescription))
+                return .error(.unsupportedChallengeType(responseError))
             case .invalidScope:
-                return .error(.invalidScope(message: responseError.errorDescription))
+                return .error(.invalidScope(responseError))
             case .authorizationPending:
-                return .error(.authorizationPending(message: responseError.errorDescription))
+                return .error(.authorizationPending(responseError))
             case .slowDown:
-                return .error(.slowDown(message: responseError.errorDescription))
+                return .error(.slowDown(responseError))
             case .userNotFound:
-                return .error(.userNotFound(message: responseError.errorDescription))
+                return .error(.userNotFound(responseError))
             case .none:
                 return .error(.unexpectedError(message: responseError.errorDescription))
             }
         }
 
     private func handleInvalidRequestErrorCodes(
-        _ errorCodes: [Int]?,
-        errorDescription: String?,
+        apiError: MSALNativeAuthTokenResponseError,
         context: MSALNativeAuthRequestContext
     ) -> MSALNativeAuthTokenValidatedResponse {
         return handleInvalidResponseErrorCodes(
-            errorCodes,
-            errorDescription: errorDescription,
+            apiError,
             context: context,
             useInvalidRequestAsDefaultResult: true,
             errorCodesConverterFunction: convertInvalidRequestErrorCodeToErrorType
@@ -139,38 +137,31 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
     }
 
     private func handleInvalidGrantErrorCodes(
-        _ errorCodes: [Int]?,
-        errorDescription: String?,
+        apiError: MSALNativeAuthTokenResponseError,
         context: MSALNativeAuthRequestContext
     ) -> MSALNativeAuthTokenValidatedResponse {
-        return handleInvalidResponseErrorCodes(
-            errorCodes,
-            errorDescription: errorDescription,
-            context: context,
-            errorCodesConverterFunction: convertInvalidGrantErrorCodeToErrorType
-        )
+        return handleInvalidResponseErrorCodes(apiError, context: context, errorCodesConverterFunction: convertInvalidGrantErrorCodeToErrorType)
     }
 
     private func handleInvalidResponseErrorCodes(
-        _ errorCodes: [Int]?,
-        errorDescription: String?,
+        _ apiError: MSALNativeAuthTokenResponseError,
         context: MSALNativeAuthRequestContext,
         useInvalidRequestAsDefaultResult: Bool = false,
-        errorCodesConverterFunction: (MSALNativeAuthESTSApiErrorCodes, String?) -> MSALNativeAuthTokenValidatedErrorType
+        errorCodesConverterFunction: (MSALNativeAuthESTSApiErrorCodes, MSALNativeAuthTokenResponseError) -> MSALNativeAuthTokenValidatedErrorType
     ) -> MSALNativeAuthTokenValidatedResponse {
-        guard var errorCodes = errorCodes, !errorCodes.isEmpty else {
+        guard var errorCodes = apiError.errorCodes, !errorCodes.isEmpty else {
             MSALLogger.log(level: .error, context: context, format: "/token error - Empty error_codes received")
-            return useInvalidRequestAsDefaultResult ? .error(.invalidRequest(message: errorDescription)) : .error(.generalError)
+            return useInvalidRequestAsDefaultResult ? .error(.invalidRequest(apiError)) : .error(.generalError)
         }
 
         let validatedResponse: MSALNativeAuthTokenValidatedResponse
         let firstErrorCode = errorCodes.removeFirst()
 
         if let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: firstErrorCode) {
-            validatedResponse = .error(errorCodesConverterFunction(knownErrorCode, errorDescription))
+            validatedResponse = .error(errorCodesConverterFunction(knownErrorCode, apiError))
         } else {
             MSALLogger.log(level: .error, context: context, format: "/token error - Unknown code received in error_codes: \(firstErrorCode)")
-            validatedResponse = useInvalidRequestAsDefaultResult ? .error(.invalidRequest(message: errorDescription)) : .error(.generalError)
+            validatedResponse = useInvalidRequestAsDefaultResult ? .error(.invalidRequest(apiError)) : .error(.generalError)
         }
 
         // Log the rest of error_codes
@@ -192,15 +183,15 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
 
     private func convertInvalidGrantErrorCodeToErrorType(
         _ errorCode: MSALNativeAuthESTSApiErrorCodes,
-        errorDescription: String?
+        _ apiError: MSALNativeAuthTokenResponseError
     ) -> MSALNativeAuthTokenValidatedErrorType {
         switch errorCode {
         case .userNotFound:
-            return .userNotFound(message: errorDescription)
+            return .userNotFound(apiError)
         case .invalidCredentials:
-            return .invalidPassword(message: errorDescription)
+            return .invalidPassword(apiError)
         case .strongAuthRequired:
-            return .strongAuthRequired(message: errorDescription)
+            return .strongAuthRequired(apiError)
         case .userNotHaveAPassword,
              .invalidRequestParameter:
             return .generalError
@@ -209,7 +200,7 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
 
     private func convertInvalidRequestErrorCodeToErrorType(
         _ errorCode: MSALNativeAuthESTSApiErrorCodes,
-        errorDescription: String?
+        _ apiError: MSALNativeAuthTokenResponseError
     ) -> MSALNativeAuthTokenValidatedErrorType {
         switch errorCode {
         case .userNotFound,
@@ -217,7 +208,7 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
             .strongAuthRequired,
             .userNotHaveAPassword,
             .invalidRequestParameter:
-            return .invalidRequest(message: errorDescription)
+            return .invalidRequest(apiError)
         }
     }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -30,14 +30,14 @@ extension MSALNativeAuthPublicClientApplication {
         username: String,
         password: String?,
         attributes: [String: Any]?,
-        correlationId: UUID?
+        correlationId: UUID
     ) async -> MSALNativeAuthSignUpControlling.SignUpStartControllerResponse {
         guard inputValidator.isInputValid(username) else {
-            return .init(.error(SignUpStartError(type: .invalidUsername)))
+            return .init(.error(SignUpStartError(type: .invalidUsername, correlationId: correlationId)))
         }
 
         if let password = password, !inputValidator.isInputValid(password) {
-            return .init(.error(SignUpStartError(type: .invalidPassword)))
+            return .init(.error(SignUpStartError(type: .invalidPassword, correlationId: correlationId)))
         }
 
         let controller = controllerFactory.makeSignUpController(cacheAccessor: cacheAccessor)
@@ -56,14 +56,14 @@ extension MSALNativeAuthPublicClientApplication {
         username: String,
         password: String?,
         scopes: [String]?,
-        correlationId: UUID?
+        correlationId: UUID
     ) async -> MSALNativeAuthSignInControlling.SignInControllerResponse {
         guard inputValidator.isInputValid(username) else {
-            return .init(.error(SignInStartError(type: .invalidUsername)))
+            return .init(.error(SignInStartError(type: .invalidUsername, correlationId: correlationId)))
         }
 
         if let password = password, !inputValidator.isInputValid(password) {
-            return .init(.error(SignInStartError(type: .invalidCredentials)))
+            return .init(.error(SignInStartError(type: .invalidCredentials, correlationId: correlationId)))
         }
 
         let controller = controllerFactory.makeSignInController(cacheAccessor: cacheAccessor)
@@ -79,10 +79,10 @@ extension MSALNativeAuthPublicClientApplication {
 
     func resetPasswordInternal(
         username: String,
-        correlationId: UUID?
+        correlationId: UUID
     ) async -> MSALNativeAuthResetPasswordControlling.ResetPasswordStartControllerResponse {
         guard inputValidator.isInputValid(username) else {
-            return .init(.error(ResetPasswordStartError(type: .invalidUsername)))
+            return .init(.error(ResetPasswordStartError(type: .invalidUsername, correlationId: correlationId)))
         }
 
         let controller = controllerFactory.makeResetPasswordController(cacheAccessor: cacheAccessor)

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -165,13 +165,20 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: SignUpStartDelegate
     ) {
         Task {
+            let correlationId = correlationId ?? .init()
+
             let controllerResponse = await signUpInternal(
                 username: username,
                 password: password,
                 attributes: attributes,
                 correlationId: correlationId
             )
-            let delegateDispatcher = SignUpStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+
+            let delegateDispatcher = SignUpStartDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -204,6 +211,8 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: SignInStartDelegate
     ) {
         Task {
+            let correlationId = correlationId ?? .init()
+
             let controllerResponse = await signInInternal(
                 username: username,
                 password: password,
@@ -211,7 +220,11 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                 correlationId: correlationId
             )
 
-            let delegateDispatcher = SignInStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = SignInStartDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -242,8 +255,15 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: ResetPasswordStartDelegate
     ) {
         Task {
+            let correlationId = correlationId ?? .init()
+
             let controllerResponse = await resetPasswordInternal(username: username, correlationId: correlationId)
-            let delegateDispatcher = ResetPasswordStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+
+            let delegateDispatcher = ResetPasswordStartDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -263,6 +283,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
     /// - Parameter correlationId: Optional. UUID to correlate this request with the server for debugging.
     /// - Returns: An object representing the account information if present in the local cache.
     public func getNativeAuthUserAccount(correlationId: UUID? = nil) -> MSALNativeAuthUserAccountResult? {
+        let correlationId = correlationId ?? .init()
         let controller = controllerFactory.makeCredentialsController(cacheAccessor: cacheAccessor)
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -28,7 +28,7 @@ extension MSALNativeAuthUserAccountResult {
 
     func getAccessTokenInternal(
         forceRefresh: Bool,
-        correlationId: UUID?,
+        correlationId: UUID,
         cacheAccessor: MSALNativeAuthCacheInterface
     ) async -> MSALNativeAuthCredentialsControlling.RefreshTokenCredentialControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
@@ -43,7 +43,7 @@ extension MSALNativeAuthUserAccountResult {
             }
         } else {
             MSALLogger.log(level: .error, context: context, format: "Retrieve Access Token: Existing token not found")
-            return .init(.failure(RetrieveAccessTokenError(type: .tokenNotFound)))
+            return .init(.failure(RetrieveAccessTokenError(type: .tokenNotFound, correlationId: correlationId)))
         }
     }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -87,12 +87,19 @@ import Foundation
     ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
     @objc public func getAccessToken(forceRefresh: Bool = false, correlationId: UUID? = nil, delegate: CredentialsDelegate) {
         Task {
+            let correlationId = correlationId ?? .init()
+
             let controllerResponse = await getAccessTokenInternal(
                 forceRefresh: forceRefresh,
                 correlationId: correlationId,
                 cacheAccessor: cacheAccessor
             )
-            let delegateDispatcher = CredentialsDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            
+            let delegateDispatcher = CredentialsDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .success(let accessToken):

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
@@ -31,7 +31,11 @@ final class CredentialsDelegateDispatcher: DelegateDispatcher<CredentialsDelegat
             telemetryUpdate?(.success(()))
             await onAccessTokenRetrieveCompleted(accessToken)
         } else {
-            let error = RetrieveAccessTokenError(type: .generalError, message: requiredErrorMessage(for: "onAccessTokenRetrieveCompleted"))
+            let error = RetrieveAccessTokenError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onAccessTokenRetrieveCompleted"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onAccessTokenRetrieveError(error: error)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/DelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/DelegateDispatcher.swift
@@ -26,10 +26,12 @@ import Foundation
 
 class DelegateDispatcher<T> {
     let delegate: T
+    let correlationId: UUID
     let telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?
 
-    init(delegate: T, telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?) {
+    init(delegate: T, correlationId: UUID, telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?) {
         self.delegate = delegate
+        self.correlationId = correlationId
         self.telemetryUpdate = telemetryUpdate
     }
 

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/ResetPasswordDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/ResetPasswordDelegateDispatchers.swift
@@ -36,7 +36,11 @@ final class ResetPasswordStartDelegateDispatcher: DelegateDispatcher<ResetPasswo
             telemetryUpdate?(.success(()))
             await onResetPasswordCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = ResetPasswordStartError(type: .generalError, message: requiredErrorMessage(for: "onResetPasswordCodeRequired"))
+            let error = ResetPasswordStartError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onResetPasswordCodeRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onResetPasswordStartError(error: error)
         }
@@ -50,7 +54,7 @@ final class ResetPasswordVerifyCodeDelegateDispatcher: DelegateDispatcher<ResetP
             telemetryUpdate?(.success(()))
             await onPasswordRequired(newState)
         } else {
-            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onPasswordRequired"))
+            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onPasswordRequired"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onResetPasswordVerifyCodeError(error: error, newState: nil)
         }
@@ -69,7 +73,7 @@ final class ResetPasswordResendCodeDelegateDispatcher: DelegateDispatcher<ResetP
             telemetryUpdate?(.success(()))
             await onResetPasswordResendCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = ResendCodeError(message: requiredErrorMessage(for: "onResetPasswordResendCodeRequired"))
+            let error = ResendCodeError(message: requiredErrorMessage(for: "onResetPasswordResendCodeRequired"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onResetPasswordResendCodeError(error: error, newState: nil)
         }
@@ -83,7 +87,11 @@ final class ResetPasswordRequiredDelegateDispatcher: DelegateDispatcher<ResetPas
             telemetryUpdate?(.success(()))
             await onResetPasswordCompleted(newState)
         } else {
-            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onResetPasswordCompleted"))
+            let error = PasswordRequiredError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onResetPasswordCompleted"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onResetPasswordRequiredError(error: error, newState: nil)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterResetPasswordDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterResetPasswordDelegateDispatcher.swift
@@ -31,7 +31,7 @@ final class SignInAfterResetPasswordDelegateDispatcher: DelegateDispatcher<SignI
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
         } else {
-            let error = SignInAfterResetPasswordError(message: requiredErrorMessage(for: "onSignInCompleted"))
+            let error = SignInAfterResetPasswordError(message: requiredErrorMessage(for: "onSignInCompleted"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignInAfterResetPasswordError(error: error)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterSignUpDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterSignUpDelegateDispatcher.swift
@@ -31,7 +31,7 @@ final class SignInAfterSignUpDelegateDispatcher: DelegateDispatcher<SignInAfterS
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
         } else {
-            let error = SignInAfterSignUpError(message: requiredErrorMessage(for: "onSignInCompleted"))
+            let error = SignInAfterSignUpError(message: requiredErrorMessage(for: "onSignInCompleted"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignInAfterSignUpError(error: error)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInDelegateDispatchers.swift
@@ -36,7 +36,11 @@ final class SignInStartDelegateDispatcher: DelegateDispatcher<SignInStartDelegat
             telemetryUpdate?(.success(()))
             await onSignInCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = SignInStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInCodeRequired"))
+            let error = SignInStartError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignInCodeRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignInStartError(error: error)
         }
@@ -47,7 +51,11 @@ final class SignInStartDelegateDispatcher: DelegateDispatcher<SignInStartDelegat
             telemetryUpdate?(.success(()))
             await onSignInPasswordRequired(newState)
         } else {
-            let error = SignInStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInPasswordRequired"))
+            let error = SignInStartError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignInPasswordRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignInStartError(error: error)
         }
@@ -58,7 +66,7 @@ final class SignInStartDelegateDispatcher: DelegateDispatcher<SignInStartDelegat
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
         } else {
-            let error = SignInStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"))
+            let error = SignInStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignInStartError(error: error)
         }
@@ -72,7 +80,11 @@ final class SignInPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignInP
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
         } else {
-            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"))
+            let error = PasswordRequiredError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignInCompleted"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignInPasswordRequiredError(error: error, newState: nil)
         }
@@ -91,7 +103,7 @@ final class SignInResendCodeDelegateDispatcher: DelegateDispatcher<SignInResendC
             telemetryUpdate?(.success(()))
             await onSignInResendCodeCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = ResendCodeError(message: requiredErrorMessage(for: "onSignInResendCodeCodeRequired"))
+            let error = ResendCodeError(message: requiredErrorMessage(for: "onSignInResendCodeCodeRequired"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignInResendCodeError(error: error, newState: nil)
         }
@@ -105,7 +117,7 @@ final class SignInVerifyCodeDelegateDispatcher: DelegateDispatcher<SignInVerifyC
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
         } else {
-            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"))
+            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignInVerifyCodeError(error: error, newState: nil)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignUpDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignUpDelegateDispatchers.swift
@@ -36,7 +36,11 @@ final class SignUpStartDelegateDispatcher: DelegateDispatcher<SignUpStartDelegat
             telemetryUpdate?(.success(()))
             await onSignUpCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = SignUpStartError(type: .generalError, message: requiredErrorMessage(for: "onSignUpCodeRequired"))
+            let error = SignUpStartError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpCodeRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpStartError(error: error)
         }
@@ -47,7 +51,11 @@ final class SignUpStartDelegateDispatcher: DelegateDispatcher<SignUpStartDelegat
             telemetryUpdate?(.success(()))
             await onSignUpAttributesInvalid(attributeNames)
         } else {
-            let error = SignUpStartError(type: .generalError, message: requiredErrorMessage(for: "onSignUpAttributesInvalid"))
+            let error = SignUpStartError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpAttributesInvalid"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpStartError(error: error)
         }
@@ -61,7 +69,11 @@ final class SignUpVerifyCodeDelegateDispatcher: DelegateDispatcher<SignUpVerifyC
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)
         } else {
-            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignUpAttributesRequired"))
+            let error = VerifyCodeError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpAttributesRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
         }
@@ -72,7 +84,11 @@ final class SignUpVerifyCodeDelegateDispatcher: DelegateDispatcher<SignUpVerifyC
             telemetryUpdate?(.success(()))
             await onSignUpPasswordRequired(newState)
         } else {
-            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignUpPasswordRequired"))
+            let error = VerifyCodeError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpPasswordRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
         }
@@ -83,7 +99,11 @@ final class SignUpVerifyCodeDelegateDispatcher: DelegateDispatcher<SignUpVerifyC
             telemetryUpdate?(.success(()))
             await onSignUpCompleted(newState)
         } else {
-            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignUpCompleted"))
+            let error = VerifyCodeError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpCompleted"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
         }
@@ -102,7 +122,7 @@ final class SignUpResendCodeDelegateDispatcher: DelegateDispatcher<SignUpResendC
             telemetryUpdate?(.success(()))
             await onSignUpResendCodeCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = ResendCodeError(message: requiredErrorMessage(for: "onSignUpResendCodeCodeRequired"))
+            let error = ResendCodeError(message: requiredErrorMessage(for: "onSignUpResendCodeCodeRequired"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpResendCodeError(error: error, newState: nil)
         }
@@ -116,7 +136,11 @@ final class SignUpPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignUpP
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)
         } else {
-            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onSignUpAttributesRequired"))
+            let error = PasswordRequiredError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpAttributesRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpPasswordRequiredError(error: error, newState: nil)
         }
@@ -127,7 +151,11 @@ final class SignUpPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignUpP
             telemetryUpdate?(.success(()))
             await onSignUpCompleted(newState)
         } else {
-            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onSignUpCompleted"))
+            let error = PasswordRequiredError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpCompleted"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpPasswordRequiredError(error: error, newState: nil)
         }
@@ -141,7 +169,7 @@ final class SignUpAttributesRequiredDelegateDispatcher: DelegateDispatcher<SignU
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)
         } else {
-            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpAttributesRequired"))
+            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpAttributesRequired"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpAttributesRequiredError(error: error)
         }
@@ -152,7 +180,7 @@ final class SignUpAttributesRequiredDelegateDispatcher: DelegateDispatcher<SignU
             telemetryUpdate?(.success(()))
             await onSignUpAttributesInvalid(attributeNames, newState)
         } else {
-            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpAttributesInvalid"))
+            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpAttributesInvalid"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpAttributesRequiredError(error: error)
         }
@@ -163,7 +191,7 @@ final class SignUpAttributesRequiredDelegateDispatcher: DelegateDispatcher<SignU
             telemetryUpdate?(.success(()))
             await onSignUpCompleted(newState)
         } else {
-            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpCompleted"))
+            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpCompleted"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpAttributesRequiredError(error: error)
         }

--- a/MSAL/src/native_auth/public/state_machine/error/MSALNativeAuthError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/MSALNativeAuthError.swift
@@ -29,10 +29,18 @@ import Foundation
 public class MSALNativeAuthError: NSObject, LocalizedError {
     /// Describes why an error occurred and provides more information about the error.
     public var errorDescription: String? { message }
+    
+    /// Correlation ID used for the request
+    public let correlationId: UUID
+
+    /// Error codes returned along with the error
+    public let errorCodes: [Int]
 
     private let message: String?
 
-    init(message: String? = nil) {
+    init(message: String? = nil, correlationId: UUID, errorCodes: [Int] = []) {
         self.message = message
+        self.correlationId = correlationId
+        self.errorCodes = errorCodes
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/PasswordRequiredError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/PasswordRequiredError.swift
@@ -35,21 +35,26 @@ public class PasswordRequiredError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = []) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes)
     }
 
     init(signInStartError: SignInStartError) {
+        let errorDescription: String?
+
         switch signInStartError.type {
         case .browserRequired:
             self.type = .browserRequired
+            errorDescription = MSALNativeAuthErrorMessage.browserRequired
         case .invalidCredentials:
             self.type = .invalidPassword
+            errorDescription = MSALNativeAuthErrorMessage.invalidPassword
         default:
             self.type = .generalError
+            errorDescription = signInStartError.errorDescription
         }
-        super.init(message: signInStartError.errorDescription)
+        super.init(message: errorDescription, correlationId: signInStartError.correlationId, errorCodes: signInStartError.errorCodes)
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/error/ResetPasswordStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/ResetPasswordStartError.swift
@@ -37,9 +37,9 @@ public class ResetPasswordStartError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = []) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes)
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/error/RetrieveAccessTokenError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/RetrieveAccessTokenError.swift
@@ -36,9 +36,9 @@ public class RetrieveAccessTokenError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = []) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes)
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/error/SignInStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignInStartError.swift
@@ -37,9 +37,9 @@ public class SignInStartError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = []) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes)
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/error/SignUpStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignUpStartError.swift
@@ -37,9 +37,9 @@ public class SignUpStartError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = []) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes)
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/error/VerifyCodeError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/VerifyCodeError.swift
@@ -35,9 +35,9 @@ public class VerifyCodeError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = []) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes)
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
@@ -36,7 +36,7 @@ extension ResetPasswordCodeRequiredState {
 
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "ResetPassword flow, invalid code")
-            return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
+            return .init(.error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitCode(code: code, username: username, continuationToken: continuationToken, context: context)
@@ -50,7 +50,7 @@ extension ResetPasswordRequiredState {
 
         guard inputValidator.isInputValid(password) else {
             MSALLogger.log(level: .error, context: context, format: "ResetPassword flow, invalid password")
-            return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
+            return .init(.error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitPassword(password: password, username: username, continuationToken: continuationToken, context: context)

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates.swift
@@ -54,6 +54,7 @@ public class ResetPasswordBaseState: MSALNativeAuthBaseState {
             let controllerResponse = await resendCodeInternal()
             let delegateDispatcher = ResetPasswordResendCodeDelegateDispatcher(
                 delegate: delegate,
+                correlationId: correlationId,
                 telemetryUpdate: controllerResponse.telemetryUpdate
             )
 
@@ -80,6 +81,7 @@ public class ResetPasswordBaseState: MSALNativeAuthBaseState {
             let controllerResponse = await submitCodeInternal(code: code)
             let delegateDispatcher = ResetPasswordVerifyCodeDelegateDispatcher(
                 delegate: delegate,
+                correlationId: correlationId,
                 telemetryUpdate: controllerResponse.telemetryUpdate
             )
 
@@ -102,7 +104,11 @@ public class ResetPasswordBaseState: MSALNativeAuthBaseState {
     public func submitPassword(password: String, delegate: ResetPasswordRequiredDelegate) {
         Task {
             let controllerResponse = await submitPasswordInternal(password: password)
-            let delegateDispatcher = ResetPasswordRequiredDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = ResetPasswordRequiredDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .completed(let newState):

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -35,6 +35,7 @@ import Foundation
             let controllerResponse = await signInInternal(scopes: scopes)
             let delegateDispatcher = SignInAfterResetPasswordDelegateDispatcher(
                 delegate: delegate,
+                correlationId: correlationId,
                 telemetryUpdate: controllerResponse.telemetryUpdate
             )
 
@@ -42,7 +43,12 @@ import Foundation
             case .success(let accountResult):
                 await delegateDispatcher.dispatchSignInCompleted(result: accountResult)
             case .failure(let error):
-                await delegate.onSignInAfterResetPasswordError(error: SignInAfterResetPasswordError(message: error.errorDescription))
+                let error = SignInAfterResetPasswordError(
+                    message: error.errorDescription,
+                    correlationId: error.correlationId,
+                    errorCodes: error.errorCodes
+                )
+                await delegate.onSignInAfterResetPasswordError(error: error)
             }
         }
     }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -33,13 +33,19 @@ import Foundation
     public func signIn(scopes: [String]? = nil, delegate: SignInAfterSignUpDelegate) {
         Task {
             let controllerResponse = await signInInternal(scopes: scopes)
-            let delegateDispatcher = SignInAfterSignUpDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = SignInAfterSignUpDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .success(let accountResult):
                 await delegateDispatcher.dispatchSignInCompleted(result: accountResult)
             case .failure(let error):
-                await delegate.onSignInAfterSignUpError(error: SignInAfterSignUpError(message: error.errorDescription))
+                await delegate.onSignInAfterSignUpError(
+                    error: SignInAfterSignUpError(message: error.errorDescription, correlationId: error.correlationId, errorCodes: error.errorCodes)
+                )
             }
         }
     }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
@@ -31,7 +31,7 @@ extension SignInCodeRequiredState {
         MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, code submitted")
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn flow, invalid code")
-            return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
+            return .init(.error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitCode(code, continuationToken: continuationToken, context: context, scopes: scopes)
@@ -53,7 +53,7 @@ extension SignInPasswordRequiredState {
 
         guard inputValidator.isInputValid(password) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn flow, invalid password")
-            return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
+            return .init(.error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitPassword(password, username: username, continuationToken: continuationToken, context: context, scopes: scopes)

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
@@ -60,7 +60,11 @@ import Foundation
     public func resendCode(delegate: SignInResendCodeDelegate) {
         Task {
             let controllerResponse = await resendCodeInternal()
-            let delegateDispatcher = SignInResendCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = SignInResendCodeDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -83,7 +87,11 @@ import Foundation
     public func submitCode(code: String, delegate: SignInVerifyCodeDelegate) {
         Task {
             let controllerResponse = await submitCodeInternal(code: code)
-            let delegateDispatcher = SignInVerifyCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = SignInVerifyCodeDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .completed(let accountResult):
@@ -120,7 +128,11 @@ import Foundation
     public func submitPassword(password: String, delegate: SignInPasswordRequiredDelegate) {
         Task {
             let controllerResponse = await submitPasswordInternal(password: password)
-            let delegateDispatcher = SignInPasswordRequiredDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = SignInPasswordRequiredDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .completed(let accountResult):

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
@@ -36,7 +36,7 @@ extension SignUpCodeRequiredState {
 
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "SignUp flow, invalid code")
-            return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
+            return .init(.error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitCode(code, username: username, continuationToken: continuationToken, context: context)
@@ -50,7 +50,7 @@ extension SignUpPasswordRequiredState {
 
         guard inputValidator.isInputValid(password) else {
             MSALLogger.log(level: .error, context: context, format: "SignUp flow, invalid password")
-            return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
+            return .init(.error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitPassword(password, username: username, continuationToken: continuationToken, context: context)

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
@@ -52,7 +52,12 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     public func resendCode(delegate: SignUpResendCodeDelegate) {
         Task {
             let controllerResponse = await resendCodeInternal()
-            let delegateDispatcher = SignUpResendCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+
+            let delegateDispatcher = SignUpResendCodeDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -75,7 +80,12 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     public func submitCode(code: String, delegate: SignUpVerifyCodeDelegate) {
         Task {
             let controllerResponse = await submitCodeInternal(code: code)
-            let delegateDispatcher = SignUpVerifyCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            
+            let delegateDispatcher = SignUpVerifyCodeDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .completed(let state):
@@ -101,7 +111,12 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     public func submitPassword(password: String, delegate: SignUpPasswordRequiredDelegate) {
         Task {
             let controllerResponse = await submitPasswordInternal(password: password)
-            let delegateDispatcher = SignUpPasswordRequiredDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+
+            let delegateDispatcher = SignUpPasswordRequiredDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .completed(let state):
@@ -127,8 +142,10 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     ) {
         Task {
             let controllerResponse = await submitAttributesInternal(attributes: attributes)
+            
             let delegateDispatcher = SignUpAttributesRequiredDelegateDispatcher(
                 delegate: delegate,
+                correlationId: correlationId,
                 telemetryUpdate: controllerResponse.telemetryUpdate
             )
 

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -41,6 +41,24 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     private var defaultUUID = UUID(uuidString: DEFAULT_TEST_UID)!
     private let defaultScopes = "openid profile offline_access"
 
+    private var signInInitiateApiErrorStub: MSALNativeAuthSignInInitiateResponseError {
+        .init(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+    }
+
+    private var signInChallengeApiErrorStub: MSALNativeAuthSignInChallengeResponseError {
+        .init(
+            error: .expiredToken,
+            errorDescription: nil,
+            errorCodes: nil,
+            errorURI: nil,
+            innerErrors: nil
+        )
+    }
+
+    private var signInTokenApiErrorStub: MSALNativeAuthTokenResponseError {
+        .init(error: .expiredToken, subError: nil, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil)
+    }
+
     override func setUpWithError() throws {
         signInRequestProviderMock = .init()
         tokenRequestProviderMock = .init()
@@ -81,7 +99,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.expectedContext = expectedContext
         signInRequestProviderMock.throwingInitError = ErrorMock.error
 
-        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
 
@@ -100,8 +118,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedScopes = "scope1 scope2 openid profile offline_access"
         let continuationToken = "continuationToken"
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken, correlationId: defaultUUID)
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
@@ -111,7 +129,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
 
-        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "scope2"]))
 
@@ -129,8 +147,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedScopes = "scope1 openid profile offline_access"
         let continuationToken = "continuationToken"
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken, correlationId: defaultUUID)
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
@@ -140,7 +158,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
         tokenRequestProviderMock.throwingTokenError = ErrorMock.error
 
-        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "openid", "profile"]))
 
@@ -157,8 +175,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken, correlationId: defaultUUID)
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -194,8 +212,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken, correlationId: defaultUUID)
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -207,7 +225,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.expectedUsername = expectedUsername
         tokenRequestProviderMock.expectedContext = expectedContext
 
-        let delegateError = SignInStartError(type: .generalError)
+        let delegateError = SignInStartError(type: .generalError, correlationId: defaultUUID)
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
         tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
@@ -229,8 +247,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .error(.invalidToken(message: nil))
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .error(.invalidToken(signInChallengeApiErrorStub))
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -241,7 +259,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.expectedUsername = expectedUsername
         tokenRequestProviderMock.expectedContext = expectedContext
 
-        let delegateError = SignInStartError(type: .generalError)
+        let delegateError = SignInStartError(type: .generalError, correlationId: defaultUUID)
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
         tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
@@ -255,18 +273,18 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenErrorIsReturnedFromValidator_itIsCorrectlyTranslatedToDelegateError() async  {
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .generalError)
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .expiredToken(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .authorizationPending(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .slowDown(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Invalid Client ID"), validatorError: .unauthorizedClient(message: "Invalid Client ID"))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received"), validatorError: .unexpectedError(message: "Unexpected response body received"))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unsupported challenge type"), validatorError: .unsupportedChallengeType(message: "Unsupported challenge type"))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Invalid scope"), validatorError: .invalidScope(message: "Invalid scope"))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .invalidCredentials), validatorError: .invalidPassword(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message"), validatorError: .unexpectedError(message: "Error message"))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .generalError)
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .expiredToken(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .authorizationPending(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .slowDown(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidRequest(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Invalid Client ID", correlationId: defaultUUID), validatorError: .unauthorizedClient(createSignInTokenApiError(message: "Invalid Client ID")))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received", correlationId: defaultUUID), validatorError: .unexpectedError(message: "Unexpected response body received"))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unsupported challenge type", correlationId: defaultUUID), validatorError: .unsupportedChallengeType(createSignInTokenApiError(message: "Unsupported challenge type")))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Invalid scope", correlationId: defaultUUID), validatorError: .invalidScope(createSignInTokenApiError(message: "Invalid scope")))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .userNotFound, correlationId: defaultUUID), validatorError: .userNotFound(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .invalidCredentials, correlationId: defaultUUID), validatorError: .invalidPassword(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message", correlationId: defaultUUID), validatorError: .unexpectedError(message: "Error message"))
     }
     
     func test_whenCredentialsAreRequired_browserRequiredErrorIsReturned() async {
@@ -275,8 +293,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let continuationToken = "continuationToken"
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken, correlationId: defaultUUID)
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -289,9 +307,9 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: .init(type: .browserRequired, message: MSALNativeAuthErrorMessage.unsupportedMFA))
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: .init(type: .browserRequired, message: MSALNativeAuthErrorMessage.unsupportedMFA, correlationId: defaultUUID))
 
-        tokenResponseValidatorMock.tokenValidatedResponse = .error(.strongAuthRequired(message: "MFA currently not supported. Use the browser instead"))
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(.strongAuthRequired(.init(error: .unauthorizedClient, subError: nil, errorDescription: MSALNativeAuthErrorMessage.unsupportedMFA, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil)))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
 
@@ -312,8 +330,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength, correlationId: defaultUUID)
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -346,8 +364,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength, correlationId: defaultUUID)
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -361,7 +379,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         helper.expectedCodeLength = expectedCodeLength
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
-        result.telemetryUpdate?(.failure(.init(message: "error")))
+        result.telemetryUpdate?(.failure(.init(message: "error", correlationId: defaultUUID)))
 
         helper.onSignInCodeRequired(result)
 
@@ -389,8 +407,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedSentTo: sentTo, expectedChannelTargetType: channelTargetType, expectedCodeLength: codeLength)
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength, correlationId: defaultUUID)
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
         result.telemetryUpdate?(.success(()))
@@ -439,7 +457,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         cacheAccessorMock.expectedMSIDTokenResult = nil
 
         let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), continuationToken: continuationToken, correlationId: defaultUUID)
-        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)))
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError, correlationId: defaultUUID)))
 
         wait(for: [expectation], timeout: 1)
 
@@ -454,9 +472,9 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedContext = expectedContext
-        signInRequestProviderMock.throwingInitError = MSALNativeAuthError(message: nil)
+        signInRequestProviderMock.throwingInitError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
 
-        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
 
@@ -467,13 +485,13 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithCodeStartAndInitiateReturnError_properErrorShouldBeReturned() async {
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .browserRequired), validatorError: .redirect)
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .unauthorizedClient(message: nil))
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .unsupportedChallengeType(message: nil))
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received"), validatorError: .unexpectedError(message: "Unexpected response body received"))
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message"), validatorError: .unexpectedError(message: "Error message"))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .browserRequired, correlationId: defaultUUID), validatorError: .redirect)
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .unauthorizedClient(signInInitiateApiErrorStub))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .userNotFound, correlationId: defaultUUID), validatorError: .userNotFound(signInInitiateApiErrorStub))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .unsupportedChallengeType(signInInitiateApiErrorStub))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidRequest(message: nil, correlationId: defaultUUID))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received", correlationId: defaultUUID), validatorError: .unexpectedError(message: "Unexpected response body received"))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message", correlationId: defaultUUID), validatorError: .unexpectedError(message: "Error message"))
     }
     
     func test_whenSignInWithCodeChallengeRequestCreationFail_errorShouldBeReturned() async {
@@ -483,10 +501,10 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError(message: nil)
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: "continuationToken")
-        
-        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: "continuationToken", correlationId: defaultUUID)
+
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
 
@@ -497,15 +515,15 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithCodeChallengeReturnsError_properErrorShouldBeReturned() async {
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .browserRequired), validatorError: .redirect)
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .expiredToken(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidToken(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .unauthorizedClient(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received"), validatorError: .unexpectedError(message: "Unexpected response body received"))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .unsupportedChallengeType(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message"), validatorError: .unexpectedError(message: "Error message"))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .browserRequired, correlationId: defaultUUID), validatorError: .redirect)
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .expiredToken(signInChallengeApiErrorStub))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidToken(signInChallengeApiErrorStub))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidRequest(message: nil, correlationId: defaultUUID))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .unauthorizedClient(signInChallengeApiErrorStub))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received", correlationId: defaultUUID), validatorError: .unexpectedError(message: "Unexpected response body received"))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .userNotFound, correlationId: defaultUUID), validatorError: .userNotFound(signInChallengeApiErrorStub))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .unsupportedChallengeType(signInChallengeApiErrorStub))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message", correlationId: defaultUUID), validatorError: .unexpectedError(message: "Error message"))
     }
     
     func test_whenSignInWithCodePasswordIsRequired_newStateIsPropagatedToUser() async {
@@ -517,9 +535,9 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: expectedCredentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: expectedCredentialToken)
-        
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: expectedCredentialToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: expectedCredentialToken, correlationId: defaultUUID)
+
         let helper = SignInCodeStartWithPasswordRequiredTestsValidatorHelper(expectation: expectation)
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
@@ -541,13 +559,13 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: expectedCredentialToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: expectedCredentialToken)
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: expectedCredentialToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: expectedCredentialToken, correlationId: defaultUUID)
 
         let helper = SignInCodeStartWithPasswordRequiredTestsValidatorHelper(expectation: expectation)
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
-        result.telemetryUpdate?(.failure(.init(message: "error")))
+        result.telemetryUpdate?(.failure(.init(message: "error", correlationId: defaultUUID)))
 
         helper.onSignInPasswordRequired(result.result)
 
@@ -596,7 +614,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: expectedCredentialToken, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
 
-        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID))
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
         tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
         cacheAccessorMock.expectedMSIDTokenResult = nil
@@ -616,10 +634,10 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let exp = expectation(description: "SignInController")
         
-        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil)
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
         signInRequestProviderMock.expectedContext = expectedContext
         
-        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID))
 
         let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, continuationToken: expectedCredentialToken, correlationId: defaultUUID)
         state.submitPassword(password: expectedPassword, delegate: mockDelegate)
@@ -631,20 +649,20 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithCodeSubmitPasswordTokenAPIReturnError_correctErrorShouldBeReturned() async {
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .generalError)
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .expiredToken(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .unauthorizedClient(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidRequest(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "Unexpected response body received"), validatorError: .unexpectedError(message: "Unexpected response body received"))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "User not found"), validatorError: .userNotFound(message: "User not found"))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidOOBCode(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .unsupportedChallengeType(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .browserRequired), validatorError: .strongAuthRequired(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidScope(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .authorizationPending(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .slowDown(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .invalidPassword), validatorError: .invalidPassword(message: "Invalid password"))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "Error message"), validatorError: .unexpectedError(message: "Error message"))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .generalError)
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .expiredToken(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .unauthorizedClient(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidRequest(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "Unexpected response body received", correlationId: defaultUUID), validatorError: .unexpectedError(message: "Unexpected response body received"))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "User does not exist", correlationId: defaultUUID), validatorError: .userNotFound(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidOOBCode(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .unsupportedChallengeType(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .browserRequired, correlationId: defaultUUID), validatorError: .strongAuthRequired(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidScope(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .authorizationPending(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .slowDown(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .invalidPassword, correlationId: defaultUUID), validatorError: .invalidPassword(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "Error message", correlationId: defaultUUID), validatorError: .unexpectedError(message: "Error message"))
     }
     
     func test_signInWithCodeSubmitCodeTokenRequestFailCreation_errorShouldBeReturned() {
@@ -654,10 +672,10 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectation = expectation(description: "SignInController")
 
         signInRequestProviderMock.expectedContext = expectedContext
-        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil)
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
 
         let state = SignInCodeRequiredState(scopes: [], controller: sut, continuationToken: continuationToken, correlationId: defaultUUID)
-        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)))
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError, correlationId: defaultUUID)))
 
         wait(for: [expectation], timeout: 1)
         XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
@@ -666,18 +684,18 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     
     func test_signInWithCodeSubmitCodeReturnError_correctResultShouldReturned() {
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .generalError)
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .expiredToken(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unauthorizedClient(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidRequest(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .expiredToken(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unauthorizedClient(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidRequest(signInTokenApiErrorStub))
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unexpectedError(message: "Unexpected response body received"))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .userNotFound(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .invalidCode, validatorError: .invalidOOBCode(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unsupportedChallengeType(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .browserRequired, validatorError: .strongAuthRequired(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidScope(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .authorizationPending(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .slowDown(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidPassword(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .userNotFound(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .invalidCode, validatorError: .invalidOOBCode(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unsupportedChallengeType(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .browserRequired, validatorError: .strongAuthRequired(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidScope(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .authorizationPending(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .slowDown(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidPassword(signInTokenApiErrorStub))
     }
         
     func test_signInWithCodeResendCode_shouldSendNewCode() async {
@@ -697,7 +715,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation, expectedSentTo: sentTo, expectedChannelTargetType: channelTargetType, expectedCodeLength: codeLength)
 
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength, correlationId: defaultUUID)
 
         let result = await sut.resendCode(continuationToken: continuationToken, context: expectedContext, scopes: [])
         result.telemetryUpdate?(.success(()))
@@ -713,7 +731,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         
         let expectation = expectation(description: "SignInController")
 
-        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError(message: nil)
+        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
 
@@ -737,7 +755,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
 
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken, correlationId: defaultUUID)
 
         let result = await sut.resendCode(continuationToken: continuationToken, context: expectedContext, scopes: [])
 
@@ -759,7 +777,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
 
-        signInResponseValidatorMock.challengeValidatedResponse = .error(.userNotFound(message: nil))
+        signInResponseValidatorMock.challengeValidatedResponse = .error(.userNotFound(signInChallengeApiErrorStub))
 
         let result = await sut.resendCode(continuationToken: continuationToken, context: expectedContext, scopes: [])
 
@@ -804,10 +822,10 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let exp = expectation(description: "SignInController")
         
-        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil)
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
         signInRequestProviderMock.expectedContext = expectedContext
         
-        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: exp, expectedError: SignInAfterSignUpError())
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: exp, expectedError: SignInAfterSignUpError(correlationId: defaultUUID))
 
         let state = SignInAfterSignUpState(controller: sut, username: "", continuationToken: continuationToken, correlationId: defaultUUID)
         state.signIn(delegate: mockDelegate)
@@ -826,9 +844,9 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
 
-        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Invalid Client ID"))
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: MSALNativeAuthErrorMessage.generalError, correlationId: defaultUUID))
 
-        tokenResponseValidatorMock.tokenValidatedResponse = .error(.unauthorizedClient(message: "Invalid Client ID"))
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(.unauthorizedClient(signInTokenApiErrorStub))
 
         let state = SignInAfterSignUpState(controller: sut, username: "", continuationToken: continuationToken, correlationId: defaultUUID)
         state.signIn(delegate: mockDelegate)
@@ -841,7 +859,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     func test_whenSignInWithContinuationTokenHaveTokenNil_shouldReturnAnError() {
         let expectation = expectation(description: "SignInController")
 
-        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Sign In is not available at this point, please use the standalone sign in methods"))
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Sign In is not available at this point, please use the standalone sign in methods", correlationId: defaultUUID))
 
         let state = SignInAfterSignUpState(controller: sut, username: "username", continuationToken: nil, correlationId: defaultUUID)
         state.signIn(delegate: mockDelegate)
@@ -864,7 +882,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, continuationToken: expectedCredentialToken, grantType: MSALNativeAuthGrantType.oobCode, scope: "", password: nil, oobCode: expectedOOBCode, includeChallengeType: true, refreshToken: nil)
-        let mockDelegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedError: VerifyCodeError(type: delegateError))
+        let mockDelegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedError: VerifyCodeError(type: delegateError, correlationId: defaultUUID))
         tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
         
         let state = SignInCodeRequiredState(scopes: [], controller: sut, continuationToken: expectedCredentialToken, correlationId: defaultUUID)
@@ -907,7 +925,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInRequestProviderMock.mockInitiateRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInRequestProviderMock.mockChallengeRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: "continuationToken")
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: "continuationToken", correlationId: defaultUUID)
         signInResponseValidatorMock.challengeValidatedResponse = .error(validatorError)
         
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
@@ -949,9 +967,9 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let continuationToken = "continuationToken"
 
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
-        
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: defaultUUID)
+        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken, correlationId: defaultUUID)
+
         signInRequestProviderMock.mockInitiateRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInRequestProviderMock.mockChallengeRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInRequestProviderMock.expectedUsername = expectedUsername
@@ -992,4 +1010,8 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         XCTAssertNotNil(telemetryEventDict["response_time"])
     }
 
+
+    private func createSignInTokenApiError(message: String) -> MSALNativeAuthTokenResponseError {
+        .init(error: .expiredToken, subError: nil, errorDescription: message, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil)
+    }
 }

--- a/MSAL/test/unit/native_auth/mock/CredentialsDelegateSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/CredentialsDelegateSpies.swift
@@ -52,6 +52,8 @@ open class CredentialsDelegateSpy: CredentialsDelegate {
             XCTAssertTrue(Thread.isMainThread)
             XCTAssertEqual(error.type, expectedError.type)
             XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error.correlationId, expectedError.correlationId)
+            XCTAssertEqual(error.errorCodes, expectedError.errorCodes)
             expectation.fulfill()
             return
         }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
@@ -82,8 +82,20 @@ class MSALNativeAuthSignInResponseValidatorMock: MSALNativeAuthSignInResponseVal
     var expectedChallengeResponse: MSALNativeAuthSignInChallengeResponse?
     var expectedInitiateResponse: MSALNativeAuthSignInInitiateResponse?
     var expectedResponseError: Error?
-    var initiateValidatedResponse: MSALNativeAuthSignInInitiateValidatedResponse = .error(.userNotFound(message: nil))
-    var challengeValidatedResponse: MSALNativeAuthSignInChallengeValidatedResponse = .error(.expiredToken(message: nil))
+    var initiateValidatedResponse: MSALNativeAuthSignInInitiateValidatedResponse = .error(.userNotFound(.init(
+        error: .userNotFound,
+        errorDescription: nil,
+        errorCodes: nil,
+        errorURI: nil,
+        innerErrors: nil))
+    )
+    var challengeValidatedResponse: MSALNativeAuthSignInChallengeValidatedResponse = .error(.expiredToken(.init(
+        error: .expiredToken,
+        errorDescription: nil,
+        errorCodes: nil,
+        errorURI: nil,
+        innerErrors: nil)
+    ))
 
     
     func validate(context: MSAL.MSALNativeAuthRequestContext, result: Result<MSAL.MSALNativeAuthSignInChallengeResponse, Error>) -> MSAL.MSALNativeAuthSignInChallengeValidatedResponse {

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
@@ -46,7 +46,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = parameters.context
         signUpStartPasswordCalled = true
         expectation.fulfill()
-        return .init(.error(.init(type: .generalError)))
+        return .init(.error(.init(type: .generalError, correlationId: parameters.context.correlationId())))
     }
 
     func signUpStart(
@@ -55,7 +55,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = parameters.context
         signUpStartCalled = true
         expectation.fulfill()
-        return .init(.error(.init(type: .generalError)))
+        return .init(.error(.init(type: .generalError, correlationId: parameters.context.correlationId())))
     }
 
     func resendCode(
@@ -66,7 +66,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = context
         resendCodeCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init(), newState: nil))
+        return .init(.error(error: .init(correlationId: context.correlationId()), newState: nil))
     }
 
     func submitCode(
@@ -78,7 +78,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = context
         submitCodeCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init(type: .generalError), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: context.correlationId()), newState: nil))
     }
 
     func submitPassword(
@@ -90,7 +90,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = context
         submitPasswordCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init(type: .generalError), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: context.correlationId()), newState: nil))
     }
 
     func submitAttributes(
@@ -102,6 +102,6 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = context
         submitAttributesCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init()))
+        return .init(.error(error: .init(correlationId: context.correlationId())))
     }
 }

--- a/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
@@ -45,7 +45,7 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         resetPasswordCalled = true
         expectation.fulfill()
 
-        return .init(.error(.init(type: .generalError)))
+        return .init(.error(.init(type: .generalError, correlationId: .init())))
     }
 
     func resendCode(username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
@@ -55,7 +55,7 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         resendCodeCalled = true
         expectation.fulfill()
 
-        return .init(.error(error: .init(), newState: nil))
+        return .init(.error(error: .init(correlationId: .init()), newState: nil))
     }
 
     func submitCode(code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
@@ -65,7 +65,7 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         submitCodeCalled = true
         expectation.fulfill()
 
-        return .init(.error(error: .init(type: .generalError), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: .init()), newState: nil))
     }
 
     func submitPassword(password: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
@@ -75,6 +75,6 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         submitPasswordCalled = true
         expectation.fulfill()
 
-        return .init(.error(error: .init(type: .generalError), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: .init()), newState: nil))
     }
 }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
@@ -33,11 +33,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
     var config: MSALNativeAuthConfiguration! = nil
     
-    let context = MSALNativeAuthRequestContext(
-        correlationId: .init(
-            UUID(uuidString: DEFAULT_TEST_UID)!
-        )
-    )
+    let context = MSALNativeAuthRequestContext(correlationId: UUID(uuidString: DEFAULT_TEST_UID)!)
 
     func test_signInInititate_getsConfiguredSuccessfully() throws {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
@@ -31,11 +31,7 @@ final class MSALNativeAuthRequestableTests: XCTestCase {
     var request: MSALNativeAuthResetPasswordStartRequestParameters! = nil
 
     override func setUpWithError() throws {
-        let context = MSALNativeAuthRequestContext(
-                correlationId: .init(
-                UUID(uuidString: DEFAULT_TEST_UID)!
-            )
-        )
+        let context = MSALNativeAuthRequestContext(correlationId: UUID(uuidString: DEFAULT_TEST_UID)!)
         
         request = MSALNativeAuthResetPasswordStartRequestParameters(context: context, username: DEFAULT_TEST_ID_TOKEN_USERNAME)
     }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseHeadersSerializableTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseHeadersSerializableTests.swift
@@ -1,0 +1,69 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Unit_Test_Private
+
+final class MSALNativeAuthResponseHeadersSerializableTests: XCTestCase {
+
+    private var sut: HeadersSerializableClass!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        sut = HeadersSerializableClass()
+    }
+
+    func test_serializeExpectedHeaders() {
+        let originalHeaders = [
+            "header1": "value1",
+            "header2": "value2",
+        ]
+
+        let httpResponse = HTTPURLResponse(url: URL(string: "http://contoso.com")!, statusCode: 200, httpVersion: nil, headerFields: originalHeaders)
+
+        let headers = sut.serializeHeaders(from: httpResponse)
+
+        XCTAssertEqual(headers?["header1"], "value1")
+        XCTAssertEqual(headers?["header2"], "value2")
+    }
+
+    func test_getCorrelationId() {
+        let originalHeaders = [
+            "client-request-id": "86A64A3C-27DC-426F-AFA0-38F68F583756"
+        ]
+
+        let httpResponse = HTTPURLResponse(url: URL(string: "http://contoso.com")!, statusCode: 200, httpVersion: nil, headerFields: originalHeaders)
+
+        sut.headers = sut.serializeHeaders(from: httpResponse)
+        let correlationId = sut.getHeaderCorrelationId()
+
+        XCTAssertEqual(correlationId, UUID(uuidString: "86A64A3C-27DC-426F-AFA0-38F68F583756"))
+    }
+}
+
+private class HeadersSerializableClass: MSALNativeAuthResponseHeadersSerializable {
+    var headers: [String : String]?
+}

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
@@ -34,28 +34,28 @@ final class MSALNativeAuthResetPasswordChallengeResponseErrorTests: XCTestCase {
 
     func test_toResetPasswordStartPublicError_unauthorizedClient() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unauthorizedClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError()
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResetPasswordStartPublicError_invalidRequest() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError()
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
     }
 
     func test_toResetPasswordStartPublicError_expiredToken() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError()
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unsupportedChallengeType, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError()
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
     }
@@ -64,25 +64,25 @@ final class MSALNativeAuthResetPasswordChallengeResponseErrorTests: XCTestCase {
 
     func test_toResendCodePublicError_unauthorizedClient() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unauthorizedClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError()
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResendCodePublicError_invalidRequest() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError()
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResendCodePublicError_expiredToken() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError()
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResendCodePublicError_unsupportedChallengeType() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unsupportedChallengeType, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError()
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
@@ -34,42 +34,42 @@ final class MSALNativeAuthResetPasswordContinueResponseErrorTests: XCTestCase {
     
     func test_toResetPasswordStartPublicError_invalidRequest() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidRequest, subError: nil, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
     }
     
     func test_toResetPasswordStartPublicError_unauthorizedClient() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .unauthorizedClient, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResetPasswordStartPublicError_invalidGrant() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidGrant, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
     
     func test_toResetPasswordStartPublicError_expiredToken() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .expiredToken, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .verificationRequired, subError: nil, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
     }
     
     func test_toResetPasswordStartPublicError_invalidOOBValue() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidGrant, subError: .invalidOOBValue, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .invalidCode)
         XCTAssertNotNil(error.errorDescription)
     }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
@@ -72,7 +72,7 @@ final class MSALNativeAuthResetPasswordPollCompletionResponseErrorTests: XCTestC
     
     private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthResetPasswordPollCompletionResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toPasswordRequiredPublicError()
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
@@ -68,7 +68,7 @@ final class MSALNativeAuthResetPasswordSubmitResponseErrorTests: XCTestCase {
     
     private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthResetPasswordSubmitResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toPasswordRequiredPublicError()
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
@@ -88,20 +88,20 @@ final class MSALNativeAuthSignUpChallengeResponseErrorTests: XCTestCase {
     
     private func testSignUpChallengeErrorToSignUpStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartError.ErrorType) {
         sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
-        let error = sut.toSignUpStartPublicError()
+        let error = sut.toSignUpStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpChallengeErrorToResendCodePublic(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?) {
         sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
-        let error = sut.toResendCodePublicError()
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpChallengeErrorToPasswordRequired(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
-        let error = sut.toPasswordRequiredPublicError()
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
@@ -220,21 +220,21 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
     
     private func testSignUpContinueErrorToVerifyCode(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: VerifyCodeError.ErrorType) {
         sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpContinueErrorToPasswordRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toPasswordRequiredPublicError()
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpContinueErrorToAttributesRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?) {
         sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toAttributesRequiredPublicError()
+        let error = sut.toAttributesRequiredPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, description)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
@@ -84,7 +84,7 @@ final class MSALNativeAuthSignUpStartResponseErrorTests: XCTestCase {
     
     private func testSignUpStartErrorToSignUpStart(code: MSALNativeAuthSignUpStartOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: SignUpStartError.ErrorType) {
         sut = MSALNativeAuthSignUpStartResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toSignUpStartPublicError()
+        let error = sut.toSignUpStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordStartValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordStartValidatedErrorTypeTests.swift
@@ -28,37 +28,65 @@ import XCTest
 final class MSALNativeAuthResetPasswordStartValidatedErrorTypeTests: XCTestCase {
 
     private typealias sut = MSALNativeAuthResetPasswordStartValidatedErrorType
-    private let testDescription = "testDescription"
+    private var testDescription = "testDescription"
+    private let testErrorCodes = [1, 2, 3]
+    private let testCorrelationId = UUID()
+    private var apiErrorStub: MSALNativeAuthResetPasswordStartResponseError {
+        .init(
+            error: .unauthorizedClient,
+            errorDescription: testDescription,
+            errorCodes: testErrorCodes,
+            errorURI: nil,
+            innerErrors: nil,
+            target: nil
+        )
+    }
 
     // MARK: - to ResetPasswordStartError tests
 
     func test_toResetPasswordStartPublicError_unauthorizedClient() {
-        let error = sut.unauthorizedClient(message: testDescription).toResetPasswordStartPublicError()
+        let error = sut.unauthorizedClient(apiErrorStub).toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
 
     func test_toResetPasswordStartPublicError_invalidRequest() {
-        let error = sut.invalidRequest(message: "General error").toResetPasswordStartPublicError()
+        let error = sut.invalidRequest(apiErrorStub).toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, "General error")
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_toResetPasswordStartPublicError_userDoesNotHavePassword() {
-        let error = sut.userDoesNotHavePassword.toResetPasswordStartPublicError()
+        testDescription = MSALNativeAuthErrorMessage.userDoesNotHavePassword
+        let error = sut.userDoesNotHavePassword(apiErrorStub).toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .userDoesNotHavePassword)
         XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.userDoesNotHavePassword)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
 
     func test_toResetPasswordStartPublicError_userNotFound() {
-        let error = sut.userNotFound(message: testDescription).toResetPasswordStartPublicError()
+        let error = sut.userNotFound(apiErrorStub).toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .userNotFound)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
 
     func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
-        let error = sut.unsupportedChallengeType(message: nil).toResetPasswordStartPublicError()
+        let error = sut.unsupportedChallengeType(apiErrorStub).toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, "General error")
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
@@ -30,81 +30,67 @@ final class MSALNativeAuthSignInInitiateValidatedErrorTypeTests: XCTestCase {
     
     private typealias sut = MSALNativeAuthSignInInitiateValidatedErrorType
     private let testDescription = "testDescription"
-    
+    private let testErrorCodes = [1, 2, 3]
+    private let testCorrelationId = UUID()
+    private var apiErrorStub: MSALNativeAuthSignInInitiateResponseError {
+        .init(
+            error: .invalidRequest,
+            errorDescription: testDescription,
+            errorCodes: testErrorCodes,
+            errorURI: nil,
+            innerErrors: nil
+        )
+    }
+
     // MARK: - convertToSignInStartError tests
     
     func test_convertToSignInStartError_redirect() {
-        let error = sut.redirect.convertToSignInStartError()
+        let error = sut.redirect.convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        
         XCTAssertEqual(error.type, .browserRequired)
         XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.browserRequired)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInStartError_unauthorizedClient() {
-        let error = sut.unauthorizedClient(message: testDescription).convertToSignInStartError()
+        let error = sut.unauthorizedClient(apiErrorStub).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInStartError_invalidRequest() {
-        let error = sut.invalidRequest(message: testDescription).convertToSignInStartError()
+        let error = sut.invalidRequest(message: testDescription, correlationId: testCorrelationId).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInStartError_invalidServerResponse() {
-        let error = sut.unexpectedError(message: "Unexpected response body received").convertToSignInStartError()
+        let error = sut.unexpectedError(message: "Unexpected response body received").convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, "Unexpected response body received")
     }
     
     func test_convertToSignInStartError_userNotFound() {
-        let error = sut.userNotFound(message: testDescription).convertToSignInStartError()
+        let error = sut.userNotFound(apiErrorStub).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .userNotFound)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInStartError_unsupportedChallengeType() {
-        let error = sut.unsupportedChallengeType(message: testDescription).convertToSignInStartError()
+        let error = sut.unsupportedChallengeType(apiErrorStub).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
-    
-    // MARK: - convertToSignInPasswordStartError tests
-    
-    func test_convertToSignInPasswordStartError_redirect() {
-        let error = sut.redirect.convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .browserRequired)
-        XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.browserRequired)
-    }
-    
-    func test_convertToSignInPasswordStartError_unauthorizedClient() {
-        let error = sut.unauthorizedClient(message: testDescription).convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, testDescription)
-    }
-    
-    func test_convertToSignInPasswordStartError_invalidRequest() {
-        let error = sut.invalidRequest(message: testDescription).convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, testDescription)
-    }
-    
-    func test_convertToSignInPasswordStartError_invalidServerResponse() {
-        let error = sut.unexpectedError(message: "Unexpected response body received").convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, "Unexpected response body received")
-    }
-    
-    func test_convertToSignInPasswordStartError_userNotFound() {
-        let error = sut.userNotFound(message: testDescription).convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .userNotFound)
-        XCTAssertEqual(error.errorDescription, testDescription)
-    }
-    
-    func test_convertToSignInPasswordStartError_unsupportedChallengeType() {
-        let error = sut.unsupportedChallengeType(message: testDescription).convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, testDescription)
-    }
-    
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
@@ -57,7 +57,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let continuationToken = "continuationToken"
         let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
         let result = sut.validate(context: context, result: .success(challengeResponse))
-        if case .passwordRequired(continuationToken: continuationToken) = result {} else {
+        if case .passwordRequired(continuationToken: continuationToken, _) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }
@@ -79,7 +79,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let channelType = MSALNativeAuthInternalChannelType.email
         let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
         let result = sut.validate(context: context, result: .success(challengeResponse))
-        if case .codeRequired(continuationToken: continuationToken, sentTo: targetLabel, channelType: .email, codeLength: codeLength) = result {} else {
+        if case .codeRequired(continuationToken: continuationToken, sentTo: targetLabel, channelType: .email, codeLength: codeLength, correlationId: nil) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }
@@ -128,7 +128,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let continuationToken = "continuationToken"
         let initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: continuationToken, challengeType: nil)
         let result = sut.validate(context: context, result: .success(initiateResponse))
-        if case .success(continuationToken: continuationToken) = result {} else {
+        if case .success(continuationToken: continuationToken, correlationId: nil) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
@@ -112,7 +112,7 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
             return XCTFail("Unexpected response")
         }
         
-        if case .unauthorizedClient(message: nil) = innerError {} else {
+        if case .unauthorizedClient(error) = innerError {} else {
             XCTFail("Unexpected Error")
         }
     }
@@ -127,31 +127,31 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
             return XCTFail("Unexpected response")
         }
         
-        if case .unauthorizedClient(message: nil) = innerError {} else {
+        if case .unauthorizedClient(error) = innerError {} else {
             XCTFail("Unexpected Error")
         }
     }
     
 
     func test_invalidGrantTokenResponse_withKnownError_andSeveralUnknownErrorCodes_isProperlyHandled() {
-        let description = "description"
         let unknownErrorCode1 = Int.max
         let unknownErrorCode2 = unknownErrorCode1 - 1
 
         var errorCodes: [Int] = [MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue, unknownErrorCode1, unknownErrorCode2]
-        guard case .userNotFound(message: description) = checkErrorCodes() else {
+
+        guard case .userNotFound(createError(errorCodes)) = checkErrorCodes() else {
             return XCTFail("Unexpected Error")
         }
         errorCodes = [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue, unknownErrorCode1, unknownErrorCode2]
-        guard case .strongAuthRequired(message: description) = checkErrorCodes() else {
+        guard case .strongAuthRequired(createError(errorCodes)) = checkErrorCodes() else {
             return XCTFail("Unexpected Error")
         }
         errorCodes = [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue, unknownErrorCode1, unknownErrorCode2]
-        guard case .strongAuthRequired(message: description) = checkErrorCodes() else {
+        guard case .strongAuthRequired(createError(errorCodes)) = checkErrorCodes() else {
             return XCTFail("Unexpected Error")
         }
         errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidCredentials.rawValue, unknownErrorCode1, unknownErrorCode2]
-        guard case .invalidPassword(message: description) = checkErrorCodes() else {
+        guard case .invalidPassword(createError(errorCodes)) = checkErrorCodes() else {
             return XCTFail("Unexpected Error")
         }
         errorCodes = [MSALNativeAuthESTSApiErrorCodes.userNotHaveAPassword.rawValue, unknownErrorCode1, unknownErrorCode2]
@@ -159,14 +159,16 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
             return XCTFail("Unexpected Error")
         }
         func checkErrorCodes() -> MSALNativeAuthTokenValidatedErrorType? {
-            let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, subError: nil, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, continuationToken: nil)
-
+            let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, subError: nil, errorDescription: nil, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, continuationToken: nil)
             let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
             
             guard case .error(let innerError) = result else {
                 return nil
             }
             return innerError
+        }
+        func createError(_ errorCodes: [Int]) -> MSALNativeAuthTokenResponseError {
+            MSALNativeAuthTokenResponseError(error: .invalidGrant, subError: nil, errorDescription: nil, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, continuationToken: nil)
         }
     }
 
@@ -211,7 +213,7 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
                 return XCTFail("Unexpected response")
             }
             
-            guard case .invalidRequest(message: description) = innerError else {
+            guard case .invalidRequest(error) = innerError else {
                 return XCTFail("Unexpected Error")
             }
         }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
@@ -30,90 +30,143 @@ final class MSALNativeAuthTokenValidatedErrorTypeTests: XCTestCase {
     
     private typealias sut = MSALNativeAuthTokenValidatedErrorType
     private let testDescription = "testDescription"
-    
+    private let testErrorCodes = [1, 2, 3]
+    private let testCorrelationId = UUID()
+    private var apiErrorStub: MSALNativeAuthTokenResponseError {
+        .init(
+            error: .invalidRequest,
+            subError: .attributeValidationFailed,
+            errorDescription: testDescription,
+            errorCodes: testErrorCodes,
+            errorURI: nil,
+            innerErrors: nil, 
+            continuationToken: nil
+        )
+    }
+
     // MARK: - convertToSignInPasswordStartError tests
     
     func test_convertToSignInPasswordStartError_generalError() {
-        let error = sut.generalError.convertToSignInPasswordStartError()
+
+        let error = sut.generalError.convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, "General error")
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_expiredToken() {
-        let error = sut.expiredToken(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.expiredToken(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_expiredRefreshToken() {
-        let error = sut.expiredRefreshToken(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.expiredRefreshToken(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_unauthorizedClient() {
-        let error = sut.unauthorizedClient(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.unauthorizedClient(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_invalidRequest() {
-        let error = sut.invalidRequest(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.invalidRequest(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_invalidServerResponse() {
-        let error = sut.unexpectedError(message: "Unexpected response body received").convertToSignInPasswordStartError()
+        let error = sut.unexpectedError(message: "Unexpected response body received").convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, "Unexpected response body received")
     }
     
     func test_convertToSignInPasswordStartError_userNotFound() {
-        let error = sut.userNotFound(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.userNotFound(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .userNotFound)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_invalidPassword() {
-        let error = sut.invalidPassword(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.invalidPassword(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .invalidCredentials)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_invalidOOBCode() {
-        let error = sut.invalidOOBCode(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.invalidOOBCode(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_unsupportedChallengeType() {
-        let error = sut.unsupportedChallengeType(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.unsupportedChallengeType(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_strongAuthRequired() {
-        let error = sut.strongAuthRequired(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.strongAuthRequired(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .browserRequired)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_invalidScope() {
-        let error = sut.invalidScope(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.invalidScope(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_authorizationPending() {
-        let error = sut.authorizationPending(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.authorizationPending(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_slowDown() {
-        let error = sut.slowDown(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.slowDown(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
 }

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -286,14 +286,14 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
     func testSignInPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
-        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername))
+        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername, correlationId: correlationId))
         sut.signIn(username: "", password: "", delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
     
     func testSignInPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
-        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidCredentials))
+        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidCredentials, correlationId: correlationId))
         sut.signIn(username: "correct", password: "", delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
@@ -315,7 +315,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let exp = expectation(description: "sign-in public interface")
         let exp2 = expectation(description: "expectation Telemetry")
 
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .completed(MSALNativeAuthUserAccountResultStub.result)
@@ -358,7 +358,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let exp = expectation(description: "sign-in public interface")
         let exp2 = expectation(description: "expectation Telemetry")
 
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"), correlationId: correlationId)
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .codeRequired(
@@ -381,7 +381,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
     func testSignIn_delegate_whenInvalidUser_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
-        let delegate = SignInCodeStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername))
+        let delegate = SignInCodeStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername, correlationId: correlationId))
         sut.signIn(username: "", delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
@@ -413,7 +413,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let exp = expectation(description: "sign-in public interface")
         let exp2 = expectation(description: "expectation Telemetry")
 
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"), correlationId: correlationId)
         let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .codeRequired(
@@ -456,7 +456,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let exp = expectation(description: "sign-in public interface")
         let exp2 = expectation(description: "expectation Telemetry")
 
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInPasswordRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInPasswordRequired"), correlationId: correlationId)
         let delegate = SignInCodeStartDelegateSpy(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .passwordRequired(
@@ -556,10 +556,10 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         signUpRequestProviderMock.expectedContinueRequestParameters = expectedSignUpContinueParams(token: "continuationToken 2")
         
         let signUpResponseValidatorMock = MSALNativeAuthSignUpResponseValidatorMock()
-        signUpResponseValidatorMock.mockValidateSignUpStartFunc(.success(continuationToken: "continuationToken"))
-        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "continuationToken 2"))
-        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success("continuationToken"))
-        
+        signUpResponseValidatorMock.mockValidateSignUpStartFunc(.success(continuationToken: "continuationToken", correlationId: correlationId))
+        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "continuationToken 2", correlationId))
+        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success(continuationToken: "continuationToken", correlationId: correlationId))
+
         let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
         
         let expectedUsername = "username"
@@ -658,10 +658,10 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         signUpRequestProviderMock.expectedContinueRequestParameters = expectedSignUpContinueParams(token: "continuationToken 2")
         
         let signUpResponseValidatorMock = MSALNativeAuthSignUpResponseValidatorMock()
-        signUpResponseValidatorMock.mockValidateSignUpStartFunc(.success(continuationToken: "continuationToken"))
-        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "continuationToken 2"))
-        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success("continuationToken"))
-        
+        signUpResponseValidatorMock.mockValidateSignUpStartFunc(.success(continuationToken: "continuationToken", correlationId: correlationId))
+        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "continuationToken 2", correlationId))
+        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success(continuationToken: "continuationToken", correlationId: correlationId))
+
         let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
         
         let expectedUsername = "username"
@@ -759,9 +759,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let expectedChannelTargetType = MSALNativeAuthChannelType.email
         let expectedCodeLength = 4
         let signInResponseValidatorMock = MSALNativeAuthSignInResponseValidatorMock()
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
-        
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: correlationId)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength, correlationId: correlationId)
+
         let expectedScopes = "scope1 scope2 openid profile offline_access"
         
         let tokenResponse = MSIDCIAMTokenResponse()
@@ -849,9 +849,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         delegateCodeStart.expectedCodeLength = expectedCodeLength
         
         let signInResponseValidatorMock = MSALNativeAuthSignInResponseValidatorMock()
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
-        
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken, correlationId: correlationId)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength, correlationId: correlationId)
+
         let expectedScopes = "scope1 scope2 openid profile offline_access"
         
         let tokenResponse = MSIDCIAMTokenResponse()
@@ -940,11 +940,11 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         resetPasswordRequestProviderMock.expectedPollCompletionParameters = expectedResetPasswordPollCompletionParameters(token: "continuationToken 3")
         
         let resetPasswordResponseValidator = MSALNativeAuthResetPasswordResponseValidatorMock()
-        resetPasswordResponseValidator.mockValidateResetPasswordStartFunc(.success(continuationToken: "continuationToken"))
-        resetPasswordResponseValidator.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "continuationToken 2"))
-        resetPasswordResponseValidator.mockValidateResetPasswordContinueFunc(.success(continuationToken: "continuationToken"))
-        resetPasswordResponseValidator.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken 3", pollInterval: 0))
-        resetPasswordResponseValidator.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, continuationToken: "continuationToken"))
+        resetPasswordResponseValidator.mockValidateResetPasswordStartFunc(.success(continuationToken: "continuationToken", correlationId: correlationId))
+        resetPasswordResponseValidator.mockValidateResetPasswordChallengeFunc(.success("sentTo", .email, 4, "continuationToken 2", correlationId))
+        resetPasswordResponseValidator.mockValidateResetPasswordContinueFunc(.success(continuationToken: "continuationToken", correlationId: correlationId))
+        resetPasswordResponseValidator.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken 3", pollInterval: 0, correlationId: correlationId))
+        resetPasswordResponseValidator.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, continuationToken: "continuationToken", correlationId: correlationId))
 
         let expectedUsername = "username"
         let expectedScopes = "scope1 scope2 openid profile offline_access"

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -71,8 +71,9 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
             configuration: MSALNativeAuthConfigStubs.configuration,
             cacheAccessor: MSALNativeAuthCacheAccessorMock()
         )
-        let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .tokenNotFound))
-        sut.getAccessToken(delegate: mockDelegate)
+        let correlationId = UUID()
+        let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .tokenNotFound, correlationId: correlationId, errorCodes: []))
+        sut.getAccessToken(correlationId: correlationId, delegate: mockDelegate)
         wait(for: [expectation], timeout: 1)
     }
 

--- a/MSAL/test/unit/native_auth/public/delegate/DispatchAccessTokenRetrieveCompletedTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/DispatchAccessTokenRetrieveCompletedTests.swift
@@ -30,6 +30,7 @@ final class DispatchAccessTokenRetrieveCompletedTests: XCTestCase {
     private var telemetryExp: XCTestExpectation!
     private var delegateExp: XCTestExpectation!
     private var sut: CredentialsDelegateDispatcher!
+    private let correlationId = UUID()
 
     override func setUp() {
         super.setUp()
@@ -41,7 +42,7 @@ final class DispatchAccessTokenRetrieveCompletedTests: XCTestCase {
         let expectedToken = "token"
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedAccessToken: expectedToken)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,10 +57,10 @@ final class DispatchAccessTokenRetrieveCompletedTests: XCTestCase {
     }
 
     func test_dispatchAccessTokenRetrieveCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = RetrieveAccessTokenError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onAccessTokenRetrieveCompleted"))
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onAccessTokenRetrieveCompleted"), correlationId: correlationId)
         let delegate = CredentialsDelegateOptionalMethodsNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? RetrieveAccessTokenError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/SignInAfterSignUpDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/SignInAfterSignUpDelegateDispatcherTests.swift
@@ -30,6 +30,7 @@ final class SignInAfterSignUpDelegateDispatcherTests: XCTestCase {
     private var telemetryExp: XCTestExpectation!
     private var delegateExp: XCTestExpectation!
     private var sut: SignInAfterSignUpDelegateDispatcher!
+    private let correlationId = UUID()
 
     override func setUp() {
         super.setUp()
@@ -41,7 +42,7 @@ final class SignInAfterSignUpDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInAfterSignUpDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,10 +57,10 @@ final class SignInAfterSignUpDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInAfterSignUpError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = SignInAfterSignUpError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInAfterSignUpDelegateOptionalMethodsNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInAfterSignUpError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordRequiredDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -66,9 +66,9 @@ final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = ResetPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCompleted"))
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordResendCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchResetPasswordResendCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordResendCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -71,9 +71,9 @@ final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchResetPasswordResendCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = ResetPasswordResendCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordResendCodeRequired"))
+        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordResendCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchResetPasswordCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -71,9 +71,9 @@ final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchResetPasswordCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = ResetPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = ResetPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCodeRequired"))
+        let expectedError = ResetPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResetPasswordStartError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordVerifyCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -60,9 +60,9 @@ final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = ResetPasswordVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onPasswordRequired"))
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onPasswordRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/SignInAfterResetPasswordDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/SignInAfterResetPasswordDelegateDispatcherTests.swift
@@ -30,6 +30,7 @@ final class SignInAfterResetPasswordDelegateDispatcherTests: XCTestCase {
     private var telemetryExp: XCTestExpectation!
     private var delegateExp: XCTestExpectation!
     private var sut: SignInAfterResetPasswordDelegateDispatcher!
+    private var correlationId = UUID()
 
     override func setUp() {
         super.setUp()
@@ -41,7 +42,7 @@ final class SignInAfterResetPasswordDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInAfterResetPasswordDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,10 +57,10 @@ final class SignInAfterResetPasswordDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInAfterResetPasswordError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = SignInAfterResetPasswordError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInAfterResetPasswordDelegateOptionalMethodsNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInAfterResetPasswordError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordRequiredDelegateDispatcherTests.swift
@@ -30,6 +30,7 @@ final class SignInPasswordRequiredDelegateDispatcherTests: XCTestCase {
     private var delegateExp: XCTestExpectation!
     private var sut: SignInPasswordRequiredDelegateDispatcher!
     private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
 
     override func setUp() {
         super.setUp()
@@ -41,7 +42,7 @@ final class SignInPasswordRequiredDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInPasswordRequiredDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,11 +57,11 @@ final class SignInPasswordRequiredDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignInCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignInPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -70,11 +70,11 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"), correlationId: correlationId)
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }
@@ -108,7 +108,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInPasswordStartDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -123,11 +123,11 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInResendCodeDelegateDispatcherTests.swift
@@ -47,7 +47,7 @@ final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
 
         let delegate = SignInResendCodeDelegateSpy(expectation: delegateExp, expectedSentTo: expectedSentTo, expectedChannelTargetType: expectedChannelTargetType, expectedCodeLength: expectedCodeLength)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -68,9 +68,9 @@ final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignInResendCodeCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignInResendCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInResendCodeCodeRequired"))
+        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInResendCodeCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInStartDelegateDispatcherTests.swift
@@ -46,7 +46,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
 
         let delegate = SignInCodeStartDelegateSpy(expectation: delegateExp, expectedSentTo: expectedSentTo, expectedChannelTargetType: expectedChannelTargetType, expectedCodeLength: expectedCodeLength)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -69,11 +69,11 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"), correlationId: correlationId)
         let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }
@@ -106,7 +106,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignInPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignInCodeStartDelegateWithPasswordRequiredSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -123,11 +123,11 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInPasswordRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInPasswordRequired"), correlationId: correlationId)
         let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInVerifyCodeDelegateDispatcherTests.swift
@@ -31,6 +31,7 @@ final class SignInVerifyCodeDelegateDispatcherTests: XCTestCase {
     private var delegateExp: XCTestExpectation!
     private var sut: SignInVerifyCodeDelegateDispatcher!
     private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
 
     override func setUp() {
         super.setUp()
@@ -42,7 +43,7 @@ final class SignInVerifyCodeDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInVerifyCodeDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -57,11 +58,11 @@ final class SignInVerifyCodeDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -66,9 +66,9 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpAttributesRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -97,7 +97,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -118,9 +118,9 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpAttributesInvalid_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"))
+        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -146,7 +146,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -164,9 +164,9 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpCompleted_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -66,9 +66,9 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpVerifyCode_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -98,7 +98,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -116,9 +116,9 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpCompleted_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpPasswordCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -71,9 +71,9 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpPasswordCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"))
+        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }
@@ -106,7 +106,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -124,9 +124,9 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpAttributesInvalid_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"))
+        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpResendCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpResendCode_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpResendCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -71,9 +71,9 @@ final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpResendCode_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpResendCodeDelegateMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpResendCodeCodeRequired"))
+        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpResendCodeCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpCodeStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -71,9 +71,9 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"))
+        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }
@@ -106,7 +106,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpCodeStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -124,9 +124,9 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpAttributesInvalid_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"))
+        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -66,9 +66,9 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpVerifyCode_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }
@@ -98,7 +98,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -116,9 +116,9 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpPasswordRequired"))
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpPasswordRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }
@@ -143,7 +143,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -161,9 +161,9 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpCompleted_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/error/AttributesRequiredErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/AttributesRequiredErrorTests.swift
@@ -24,6 +24,7 @@
 
 import XCTest
 @testable import MSAL
+@_implementationOnly import MSAL_Unit_Test_Private
 
 final class AttributesRequiredErrorTests: XCTestCase {
 
@@ -31,12 +32,20 @@ final class AttributesRequiredErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(message: expectedMessage)
+        let uuid = UUID(uuidString: DEFAULT_TEST_UID)!
+
+        sut = .init(message: expectedMessage, correlationId: uuid)
+        
         XCTAssertEqual(sut.errorDescription, expectedMessage)
+        XCTAssertEqual(sut.correlationId, uuid)
     }
 
     func test_defaultErrorDescription() {
-        sut = .init()
+        let uuid = UUID(uuidString: DEFAULT_TEST_UID)!
+
+        sut = .init(correlationId: uuid)
+
         XCTAssertEqual(sut.errorDescription, MSALNativeAuthErrorMessage.generalError)
+        XCTAssertEqual(sut.correlationId, uuid)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/PasswordRequiredErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/PasswordRequiredErrorTests.swift
@@ -35,15 +35,15 @@ final class PasswordRequiredErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [PasswordRequiredError] = [
-            .init(type: .browserRequired),
-            .init(type: .invalidPassword),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .invalidPassword, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedErrorDescriptions = [
@@ -60,13 +60,13 @@ final class PasswordRequiredErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isInvalidPassword)
     }
 
     func test_isInvalidPassword() {
-        sut = .init(type: .invalidPassword)
+        sut = .init(type: .invalidPassword, correlationId: .init())
         XCTAssertTrue(sut.isInvalidPassword)
         XCTAssertFalse(sut.isBrowserRequired)
     }

--- a/MSAL/test/unit/native_auth/public/error/ResendCodeErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/ResendCodeErrorTests.swift
@@ -31,12 +31,12 @@ final class ResendCodeErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(message: expectedMessage)
+        sut = .init(message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
-        sut = .init()
+        sut = .init(correlationId: .init())
         XCTAssertEqual(sut.errorDescription, MSALNativeAuthErrorMessage.generalError)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/ResetPasswordStartErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/ResetPasswordStartErrorTests.swift
@@ -35,17 +35,17 @@ final class ResetPasswordStartErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [ResetPasswordStartError] = [
-            .init(type: .browserRequired),
-            .init(type: .userDoesNotHavePassword),
-            .init(type: .userNotFound),
-            .init(type: .invalidUsername),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .userDoesNotHavePassword, correlationId: .init()),
+            .init(type: .userNotFound, correlationId: .init()),
+            .init(type: .invalidUsername, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedIdentifiers = [
@@ -64,7 +64,7 @@ final class ResetPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserDoesNotHavePassword)
         XCTAssertFalse(sut.isUserNotFound)
@@ -72,7 +72,7 @@ final class ResetPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isUserDoesNotHaveAPassword() {
-        sut = .init(type: .userDoesNotHavePassword)
+        sut = .init(type: .userDoesNotHavePassword, correlationId: .init())
         XCTAssertTrue(sut.isUserDoesNotHavePassword)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserNotFound)
@@ -80,7 +80,7 @@ final class ResetPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isUserNotFound() {
-        sut = .init(type: .userNotFound)
+        sut = .init(type: .userNotFound, correlationId: .init())
         XCTAssertTrue(sut.isUserNotFound)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserDoesNotHavePassword)
@@ -88,7 +88,7 @@ final class ResetPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isInvalidUsername() {
-        sut = .init(type: .invalidUsername)
+        sut = .init(type: .invalidUsername, correlationId: .init())
         XCTAssertTrue(sut.isInvalidUsername)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserDoesNotHavePassword)

--- a/MSAL/test/unit/native_auth/public/error/RetrieveAccessTokenErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/RetrieveAccessTokenErrorTests.swift
@@ -35,16 +35,16 @@ final class RetrieveAccessTokenErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [RetrieveAccessTokenError] = [
-            .init(type: .browserRequired),
-            .init(type: .refreshTokenExpired),
-            .init(type: .tokenNotFound),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .refreshTokenExpired, correlationId: .init()),
+            .init(type: .tokenNotFound, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedIdentifiers = [
@@ -62,21 +62,21 @@ final class RetrieveAccessTokenErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isRefreshTokenExpired)
         XCTAssertFalse(sut.isTokenNotFound)
     }
 
     func test_isRefreshTokenExpired() {
-        sut = .init(type: .refreshTokenExpired)
+        sut = .init(type: .refreshTokenExpired, correlationId: .init())
         XCTAssertTrue(sut.isRefreshTokenExpired)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isTokenNotFound)
     }
 
     func test_isTokenNotFound() {
-        sut = .init(type: .tokenNotFound)
+        sut = .init(type: .tokenNotFound, correlationId: .init())
         XCTAssertTrue(sut.isTokenNotFound)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isRefreshTokenExpired)

--- a/MSAL/test/unit/native_auth/public/error/SignInAfterResetPasswordErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignInAfterResetPasswordErrorTests.swift
@@ -31,12 +31,12 @@ final class SignInAfterResetPasswordErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(message: expectedMessage)
+        sut = .init(message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
-        sut = .init()
+        sut = .init(correlationId: .init())
         XCTAssertEqual(sut.errorDescription, MSALNativeAuthErrorMessage.generalError)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/SignInAfterSignUpErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignInAfterSignUpErrorTests.swift
@@ -31,12 +31,12 @@ final class SignInAfterSignUpErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(message: expectedMessage)
+        sut = .init(message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
-        sut = .init()
+        sut = .init(correlationId: .init())
         XCTAssertEqual(sut.errorDescription, MSALNativeAuthErrorMessage.generalError)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/SignInStartErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignInStartErrorTests.swift
@@ -35,17 +35,17 @@ final class SignInPasswordStartErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [SignInStartError] = [
-            .init(type: .browserRequired),
-            .init(type: .userNotFound),
-            .init(type: .invalidCredentials),
-            .init(type: .invalidUsername),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .userNotFound, correlationId: .init()),
+            .init(type: .invalidCredentials, correlationId: .init()),
+            .init(type: .invalidUsername, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedDescriptions = [
@@ -64,7 +64,7 @@ final class SignInPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserNotFound)
         XCTAssertFalse(sut.isInvalidCredentials)
@@ -72,7 +72,7 @@ final class SignInPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isUserNotFound() {
-        sut = .init(type: .userNotFound)
+        sut = .init(type: .userNotFound, correlationId: .init())
         XCTAssertTrue(sut.isUserNotFound)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isInvalidCredentials)
@@ -80,7 +80,7 @@ final class SignInPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isInvalidPassword() {
-        sut = .init(type: .invalidCredentials)
+        sut = .init(type: .invalidCredentials, correlationId: .init())
         XCTAssertTrue(sut.isInvalidCredentials)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserNotFound)
@@ -88,7 +88,7 @@ final class SignInPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isInvalidUsername() {
-        sut = .init(type: .invalidUsername)
+        sut = .init(type: .invalidUsername, correlationId: .init())
         XCTAssertTrue(sut.isInvalidUsername)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserNotFound)

--- a/MSAL/test/unit/native_auth/public/error/SignUpStartErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignUpStartErrorTests.swift
@@ -35,17 +35,17 @@ final class SignUpStartErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [SignUpStartError] = [
-            .init(type: .browserRequired),
-            .init(type: .userAlreadyExists),
-            .init(type: .invalidUsername),
-            .init(type: .invalidPassword),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .userAlreadyExists, correlationId: .init()),
+            .init(type: .invalidUsername, correlationId: .init()),
+            .init(type: .invalidPassword, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedDescriptions = [
@@ -64,7 +64,7 @@ final class SignUpStartErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserAlreadyExists)
         XCTAssertFalse(sut.isInvalidUsername)
@@ -72,7 +72,7 @@ final class SignUpStartErrorTests: XCTestCase {
     }
 
     func test_isUserAlreadyExists() {
-        sut = .init(type: .userAlreadyExists)
+        sut = .init(type: .userAlreadyExists, correlationId: .init())
         XCTAssertTrue(sut.isUserAlreadyExists)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isInvalidUsername)
@@ -80,7 +80,7 @@ final class SignUpStartErrorTests: XCTestCase {
     }
 
     func test_isInvalidUsername() {
-        sut = .init(type: .invalidUsername)
+        sut = .init(type: .invalidUsername, correlationId: .init())
         XCTAssertTrue(sut.isInvalidUsername)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserAlreadyExists)
@@ -88,7 +88,7 @@ final class SignUpStartErrorTests: XCTestCase {
     }
     
     func test_isInvalidPassword() {
-        sut = .init(type: .invalidPassword)
+        sut = .init(type: .invalidPassword, correlationId: .init())
         XCTAssertTrue(sut.isInvalidPassword)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserAlreadyExists)

--- a/MSAL/test/unit/native_auth/public/error/VerifyCodeErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/VerifyCodeErrorTests.swift
@@ -35,15 +35,15 @@ final class VerifyCodeErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [VerifyCodeError] = [
-            .init(type: .browserRequired),
-            .init(type: .invalidCode),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .invalidCode, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedDescriptions = [
@@ -60,13 +60,13 @@ final class VerifyCodeErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isInvalidCode)
     }
 
     func test_isInvalidCode() {
-        sut = .init(type: .invalidCode)
+        sut = .init(type: .invalidCode, correlationId: .init())
         XCTAssertTrue(sut.isInvalidCode)
         XCTAssertFalse(sut.isBrowserRequired)
     }

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
@@ -44,7 +44,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
     // ResendCode
 
     func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = ResendCodeError(message: "test error")
+        let expectedError = ResendCodeError(message: "test error", correlationId: .init())
         let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: ResetPasswordResendCodeResult = .error(error: expectedError, newState: expectedState)
@@ -112,7 +112,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
     // SubmitCode
 
     func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = VerifyCodeError(type: .invalidCode)
+        let expectedError = VerifyCodeError(type: .invalidCode, correlationId: .init())
         let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: ResetPasswordSubmitCodeResult = .error(error: expectedError, newState: expectedState)

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
@@ -55,7 +55,7 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
         controllerMock = MSALNativeAuthResetPasswordControllerMock()
         let sut = ResetPasswordRequiredState(controller: controllerMock, username: "username", continuationToken: "<token>", correlationId: correlationId)
 
-        let expectedError = PasswordRequiredError(type: .invalidPassword, message: nil)
+        let expectedError = PasswordRequiredError(type: .invalidPassword, message: nil, correlationId: .init())
         let expectedState = ResetPasswordRequiredState(controller: controllerMock, username: "username", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.error(error: expectedError, newState: expectedState))

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
@@ -45,7 +45,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
     func test_resendCode_delegate_withError_shouldReturnSignInResendCodeError() {
         let exp = expectation(description: "sign-in states")
 
-        let expectedError = ResendCodeError(message: "test error")
+        let expectedError = ResendCodeError(message: "test error", correlationId: .init())
         let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignInResendCodeResult = .error(
@@ -111,7 +111,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
 
     func test_submitCode_delegate_withError_shouldReturnSignInVerifyCodeError() {
         let exp = expectation(description: "sign-in states")
-        let expectedError = VerifyCodeError(type: .invalidCode)
+        let expectedError = VerifyCodeError(type: .invalidCode, correlationId: .init())
         let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignInVerifyCodeResult = .error(

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
@@ -41,7 +41,7 @@ final class SignInPasswordRequiredStateTests: XCTestCase {
     // MARK: - Delegates
 
     func test_submitPassword_delegate_withError_shouldReturnError() {
-        let expectedError = PasswordRequiredError(type: .invalidPassword)
+        let expectedError = PasswordRequiredError(type: .invalidPassword, correlationId: .init())
         let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controller, continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignInPasswordRequiredResult = .error(

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
@@ -43,7 +43,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     // MARK: - Delegate
 
     func test_submitPassword_delegate_whenError_shouldReturnAttributesRequiredError() {
-        let expectedError = AttributesRequiredError()
+        let expectedError = AttributesRequiredError(correlationId: correlationId)
 
         let expectedResult: SignUpAttributesRequiredResult = .error(error: expectedError)
         controller.submitAttributesResult = .init(expectedResult)

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
@@ -44,7 +44,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     // ResendCode
 
     func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = ResendCodeError(message: "test error")
+        let expectedError = ResendCodeError(message: "test error", correlationId: .init())
 
         let expectedResult: SignUpResendCodeResult = .error(error: expectedError, newState: nil)
         controller.resendCodeResult = .init(expectedResult)
@@ -110,7 +110,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     // SubmitCode
 
     func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = VerifyCodeError(type: .invalidCode)
+        let expectedError = VerifyCodeError(type: .invalidCode, correlationId: .init())
         let expectedState = SignUpCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpVerifyCodeResult = .error(

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
@@ -43,7 +43,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
     // MARK: - Delegate
 
     func test_submitPassword_delegate_whenError_shouldReturnPasswordRequiredError() {
-        let expectedError = PasswordRequiredError(type: .invalidPassword)
+        let expectedError = PasswordRequiredError(type: .invalidPassword, correlationId: .init())
         let expectedState = SignUpPasswordRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpPasswordRequiredResult = .error(error: expectedError, newState: expectedState)


### PR DESCRIPTION
## Proposed changes

- Read correlationId from the headers of each response (2xx and 4xx).
- Return correlationId and errorCodes in the public errors.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

