### PR TITLE
Read correlationId from server on 2xx and 4xx responses. Add correlationId and errorCodes to public errors.

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1059,6 +1059,7 @@
 		E235613429C9D528000E01CA /* MSALNativeAuthInternalChallengeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E235613329C9D528000E01CA /* MSALNativeAuthInternalChallengeType.swift */; };
 		E23E955F29D4B9F7001DC59C /* MSALNativeAuthSignUpChallengeIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23E955E29D4B9F7001DC59C /* MSALNativeAuthSignUpChallengeIntegrationTests.swift */; };
 		E23E956929D5BD6B001DC59C /* MSALNativeAuthSignUpRequestProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23E956829D5BD6B001DC59C /* MSALNativeAuthSignUpRequestProviderTests.swift */; };
+		E24320752B58428E005290D0 /* MSALNativeAuthResponseCorrelatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24320742B58428E005290D0 /* MSALNativeAuthResponseCorrelatable.swift */; };
 		E243F69429D1976700DAC60F /* MSALNativeAuthSignUpStartResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E243F69329D1976700DAC60F /* MSALNativeAuthSignUpStartResponse.swift */; };
 		E243F69A29D1CC6500DAC60F /* MSALNativeAuthSignUpChallengeRequestParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E243F69929D1CC6500DAC60F /* MSALNativeAuthSignUpChallengeRequestParameters.swift */; };
 		E243F69D29D1D9B400DAC60F /* MSALNativeAuthSignUpChallengeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E243F69C29D1D9B400DAC60F /* MSALNativeAuthSignUpChallengeResponse.swift */; };
@@ -1075,6 +1076,7 @@
 		E25E6E5A2AA7727D0094461E /* MSALNativeAuthCredentialsControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25E6E592AA7727D0094461E /* MSALNativeAuthCredentialsControllerMock.swift */; };
 		E25EA4EC2A4C9B75004C8E40 /* MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26E391A2A4C2BE200063C07 /* MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift */; };
 		E26097C32948FC4D0060DD7C /* MSALNativeAuthLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26097C22948FC4D0060DD7C /* MSALNativeAuthLogging.swift */; };
+		E265943A2B60268400723C1A /* MSALNativeAuthResponseCorrelatableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26594392B60268400723C1A /* MSALNativeAuthResponseCorrelatableTests.swift */; };
 		E26E39242A4C2D7400063C07 /* SignUpDelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26E39232A4C2D7400063C07 /* SignUpDelegateSpies.swift */; };
 		E272C4EC2A4447520013B805 /* MSALNativeAuthSignUpUsernameEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E272C4EA2A4447520013B805 /* MSALNativeAuthSignUpUsernameEndToEndTests.swift */; };
 		E27332C02A153E6500E1B054 /* MSALNativeAuthErrorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27332BF2A153E6500E1B054 /* MSALNativeAuthErrorMessage.swift */; };
@@ -2071,6 +2073,7 @@
 		E235613329C9D528000E01CA /* MSALNativeAuthInternalChallengeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalChallengeType.swift; sourceTree = "<group>"; };
 		E23E955E29D4B9F7001DC59C /* MSALNativeAuthSignUpChallengeIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpChallengeIntegrationTests.swift; sourceTree = "<group>"; };
 		E23E956829D5BD6B001DC59C /* MSALNativeAuthSignUpRequestProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpRequestProviderTests.swift; sourceTree = "<group>"; };
+		E24320742B58428E005290D0 /* MSALNativeAuthResponseCorrelatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResponseCorrelatable.swift; sourceTree = "<group>"; };
 		E243F69329D1976700DAC60F /* MSALNativeAuthSignUpStartResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpStartResponse.swift; sourceTree = "<group>"; };
 		E243F69929D1CC6500DAC60F /* MSALNativeAuthSignUpChallengeRequestParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpChallengeRequestParameters.swift; sourceTree = "<group>"; };
 		E243F69C29D1D9B400DAC60F /* MSALNativeAuthSignUpChallengeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpChallengeResponse.swift; sourceTree = "<group>"; };
@@ -2086,6 +2089,7 @@
 		E25E6E592AA7727D0094461E /* MSALNativeAuthCredentialsControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCredentialsControllerMock.swift; sourceTree = "<group>"; };
 		E26097C22948FC4D0060DD7C /* MSALNativeAuthLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthLogging.swift; sourceTree = "<group>"; };
 		E26097C62948FC720060DD7C /* MSALNativeAuthServerTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthServerTelemetry.swift; sourceTree = "<group>"; };
+		E26594392B60268400723C1A /* MSALNativeAuthResponseCorrelatableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResponseCorrelatableTests.swift; sourceTree = "<group>"; };
 		E26E391A2A4C2BE200063C07 /* MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift; sourceTree = "<group>"; };
 		E26E39232A4C2D7400063C07 /* SignUpDelegateSpies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpDelegateSpies.swift; sourceTree = "<group>"; };
 		E272C4EA2A4447520013B805 /* MSALNativeAuthSignUpUsernameEndToEndTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpUsernameEndToEndTests.swift; sourceTree = "<group>"; };
@@ -2434,6 +2438,7 @@
 				E23E956829D5BD6B001DC59C /* MSALNativeAuthSignUpRequestProviderTests.swift */,
 				DEDD6F0729E83FD20017989F /* MSALNativeAuthRequestConfiguratorTests.swift */,
 				8D61F9A02A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift */,
+				E26594392B60268400723C1A /* MSALNativeAuthResponseCorrelatableTests.swift */,
 			);
 			path = network;
 			sourceTree = "<group>";
@@ -4088,6 +4093,7 @@
 				8D2733132AD8346D00AD67FD /* MSALNativeAuthCustomErrorSerializer.swift */,
 				E2ACA49B2953576C00E98964 /* MSALNativeAuthUrlRequestSerializer.swift */,
 				DE1D8AA729E6B7D900E11D48 /* MSALNativeAuthRequestConfigurator.swift */,
+				E24320742B58428E005290D0 /* MSALNativeAuthResponseCorrelatable.swift */,
 				E2C872C1294CDEAB00C4F580 /* parameters */,
 				DE0FECA92993AD3700B139A8 /* responses */,
 				DEDB29A229DDA992008DA85B /* errors */,
@@ -5674,6 +5680,7 @@
 				96B5E6F42256D197002232F9 /* MSALExtraQueryParameters.m in Sources */,
 				886F516429CCA58900F09471 /* MSALCIAMAuthority.m in Sources */,
 				B223B0C622AE215D00FB8713 /* MSALLegacySharedAccountFactory.m in Sources */,
+				E24320752B58428E005290D0 /* MSALNativeAuthResponseCorrelatable.swift in Sources */,
 				DEE34F72D170B71C00BC302A /* MSALNativeAuthResetPasswordChallengeResponseError.swift in Sources */,
 				E2B8532F2A153651007A4776 /* MSALNativeAuthSignUpStartRequestProviderParameters.swift in Sources */,
 				B26756CC22921C5B000F01D7 /* MSALB2COauth2Provider.m in Sources */,
@@ -5906,6 +5913,7 @@
 				DE94C9E229F19AA200C1EC1F /* MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift in Sources */,
 				E2CE91102B0BA3E80009AEDD /* AttributesRequiredErrorTests.swift in Sources */,
 				E2F5BE8E29893A4100C67EC7 /* MSALNativeAuthEndpointTests.swift in Sources */,
+				E265943A2B60268400723C1A /* MSALNativeAuthResponseCorrelatableTests.swift in Sources */,
 				287F64F0298186EA00ED90BD /* MSALNativeAuthInputValidatorTest.swift in Sources */,
 				8D61F9A12A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift in Sources */,
 				E22427E42B0650CD0006C55E /* SignUpPasswordStartDelegateDispatcherTests.swift in Sources */,

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1123,6 +1123,8 @@
 		E2D3BC4F2A7BE1C4009C4D1F /* MSALNativeAuthUserAccountResult+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D3BC4E2A7BE1C4009C4D1F /* MSALNativeAuthUserAccountResult+Internal.swift */; };
 		E2DC31BC29AFA1E700051CE7 /* MSALNativeAuthPublicClientApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DC31BB29AFA1E700051CE7 /* MSALNativeAuthPublicClientApplication.swift */; };
 		E2DC31C829B0FDB100051CE7 /* MSALNativeAuthAuthorityProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DC31C729B0FDB100051CE7 /* MSALNativeAuthAuthorityProvider.swift */; };
+		E2DDF1AA2B6A9B2100E9FAB7 /* MSALNativeAuthRequestContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DDF1A92B6A9B2100E9FAB7 /* MSALNativeAuthRequestContextTests.swift */; };
+		E2DDF1B32B6A9E1D00E9FAB7 /* MSALNativeAuthCustomErrorSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DDF1B22B6A9E1D00E9FAB7 /* MSALNativeAuthCustomErrorSerializerTests.swift */; };
 		E2EBD6212A1BB4640049467A /* MSALNativeAuthSignUpRequestProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2EBD6202A1BB4640049467A /* MSALNativeAuthSignUpRequestProviderMock.swift */; };
 		E2EBD62A2A1BB7700049467A /* MSALNativeAuthSignUpResponseValidatorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2EBD6292A1BB7700049467A /* MSALNativeAuthSignUpResponseValidatorMock.swift */; };
 		E2EFACFE2A69915100D6C3DE /* SignInResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2EFACFD2A69915100D6C3DE /* SignInResults.swift */; };
@@ -2138,6 +2140,8 @@
 		E2D3BC4E2A7BE1C4009C4D1F /* MSALNativeAuthUserAccountResult+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MSALNativeAuthUserAccountResult+Internal.swift"; sourceTree = "<group>"; };
 		E2DC31BB29AFA1E700051CE7 /* MSALNativeAuthPublicClientApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthPublicClientApplication.swift; sourceTree = "<group>"; };
 		E2DC31C729B0FDB100051CE7 /* MSALNativeAuthAuthorityProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthAuthorityProvider.swift; sourceTree = "<group>"; };
+		E2DDF1A92B6A9B2100E9FAB7 /* MSALNativeAuthRequestContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequestContextTests.swift; sourceTree = "<group>"; };
+		E2DDF1B22B6A9E1D00E9FAB7 /* MSALNativeAuthCustomErrorSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCustomErrorSerializerTests.swift; sourceTree = "<group>"; };
 		E2EBD6202A1BB4640049467A /* MSALNativeAuthSignUpRequestProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpRequestProviderMock.swift; sourceTree = "<group>"; };
 		E2EBD6292A1BB7700049467A /* MSALNativeAuthSignUpResponseValidatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpResponseValidatorMock.swift; sourceTree = "<group>"; };
 		E2EFACFD2A69915100D6C3DE /* SignInResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInResults.swift; sourceTree = "<group>"; };
@@ -2413,6 +2417,7 @@
 				E2C6201F29E0420200F15203 /* sign_in */,
 				DE94C9D629F1898A00C1EC1F /* reset_password */,
 				DE54B5A22A4464D400460B34 /* token */,
+				E2DDF1A92B6A9B2100E9FAB7 /* MSALNativeAuthRequestContextTests.swift */,
 			);
 			path = parameters;
 			sourceTree = "<group>";
@@ -2439,6 +2444,7 @@
 				DEDD6F0729E83FD20017989F /* MSALNativeAuthRequestConfiguratorTests.swift */,
 				8D61F9A02A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift */,
 				E26594392B60268400723C1A /* MSALNativeAuthResponseCorrelatableTests.swift */,
+				E2DDF1B22B6A9E1D00E9FAB7 /* MSALNativeAuthCustomErrorSerializerTests.swift */,
 			);
 			path = network;
 			sourceTree = "<group>";
@@ -5906,6 +5912,7 @@
 				B2725ECC22C0466E009B454A /* MSALLegacySharedADALAccountTests.m in Sources */,
 				DE0347A82A41AD08003CB3B6 /* MSALNativeAuthUserAccountResultStub.swift in Sources */,
 				E2CD2EB32A040012009F8FFA /* SignUpTestsValidatorHelpers.swift in Sources */,
+				E2DDF1AA2B6A9B2100E9FAB7 /* MSALNativeAuthRequestContextTests.swift in Sources */,
 				23F32F0C1FF4789100B2905E /* MSIDTestURLResponse+MSAL.m in Sources */,
 				D61F5BC31E59193500912CB8 /* MSALFakeViewController.m in Sources */,
 				DE5738B62A8E790100D9120D /* MSALNativeAuthTokenValidatedErrorTypeTests.swift in Sources */,
@@ -5939,6 +5946,7 @@
 				DE94C9E829F19E6B00C1EC1F /* MSALNativeAuthResetPasswordPollCompletionRequestParametersTest.swift in Sources */,
 				E22427FD2B0671A10006C55E /* ResetPasswordStartDelegateDispatcherTests.swift in Sources */,
 				DE0D659529C1DCC9005798B1 /* MSALNativeAuthSignInInitiateRequestParametersTest.swift in Sources */,
+				E2DDF1B32B6A9E1D00E9FAB7 /* MSALNativeAuthCustomErrorSerializerTests.swift in Sources */,
 				E2CD2E5129FC087A009F8FFA /* SignUpAttributesRequiredStateTests.swift in Sources */,
 				28DE3FD02A0921E2003148A4 /* SignInTestsValidatorHelpers.swift in Sources */,
 				B2725ECE22C04679009B454A /* MSALLegacySharedMSAAccountTests.m in Sources */,

--- a/MSAL/module.modulemap
+++ b/MSAL/module.modulemap
@@ -90,6 +90,7 @@ module MSAL_Private {
     header "src/MSALAccountId+Internal.h"
     header "IdentityCore/IdentityCore/src/requests/sdk/msal/MSIDDefaultTokenResponseValidator.h"
     header "IdentityCore/IdentityCore/src/network/error_handler/MSIDAADRequestErrorHandler.h"
+    header "IdentityCore/IdentityCore/src/MSIDOAuth2Constants.h"
     export *
 }
 

--- a/MSAL/src/native_auth/MSALNativeAuthInternalError.swift
+++ b/MSAL/src/native_auth/MSALNativeAuthInternalError.swift
@@ -31,7 +31,7 @@ enum MSALNativeAuthInternalError: Error, Equatable {
     case invalidAuthority
     case invalidUrl
     case missingResponseSerializer
-    case responseSerializationError
+    case responseSerializationError(headerCorrelationId: UUID?)
     case invalidResponse
     case invalidRequest
     case generalError

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
@@ -155,11 +155,12 @@ class MSALNativeAuthBaseController {
     ) async -> Result<T, Error> {
         return await withCheckedContinuation { continuation in
             request.send { result, error in
-                if let error = error, let errorWithCorrelationId = error as? MSALNativeAuthResponseCorrelatable {
-                    context.setServerCorrelationId(errorWithCorrelationId.correlationId)
-                    continuation.resume(returning: .failure(error))
-                } else if let error = error {
-                    MSALLogger.log(level: .warning, context: context, format: "Error request - cannot decode error headers. Continuing")
+                if let error = error {
+                    if let errorWithCorrelationId = error as? MSALNativeAuthResponseCorrelatable {
+                        context.setServerCorrelationId(errorWithCorrelationId.correlationId)
+                    } else {
+                        MSALLogger.log(level: .warning, context: context, format: "Error request - cannot decode error headers. Continuing")
+                    }
                     continuation.resume(returning: .failure(error))
                 } else if let response = result as? T {
                     context.setServerCorrelationId(response.correlationId)

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthControllerTelemetryWrapper.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthControllerTelemetryWrapper.swift
@@ -29,10 +29,12 @@ import Foundation
 /// (ex: an optional delegate method not implemented by the external developer).
 struct MSALNativeAuthControllerTelemetryWrapper<R> {
     let result: R
+    let correlationId: UUID
     let telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?
 
-    init(_ result: R, telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)? = nil) {
+    init(_ result: R, correlationId: UUID, telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)? = nil) {
         self.result = result
+        self.correlationId = correlationId
         self.telemetryUpdate = telemetryUpdate
     }
 }

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
@@ -81,7 +81,7 @@ class MSALNativeAuthTokenController: MSALNativeAuthBaseController {
         oobCode: String? = nil,
         grantType: MSALNativeAuthGrantType,
         includeChallengeType: Bool = true,
-        context: MSIDRequestContext) -> MSIDHttpRequest? {
+        context: MSALNativeAuthRequestContext) -> MSIDHttpRequest? {
             do {
                 let params = MSALNativeAuthTokenRequestParameters(
                     context: context,
@@ -103,7 +103,7 @@ class MSALNativeAuthTokenController: MSALNativeAuthBaseController {
     func createRefreshTokenRequest(
         scopes: [String],
         refreshToken: String?,
-        context: MSIDRequestContext) -> MSIDHttpRequest? {
+        context: MSALNativeAuthRequestContext) -> MSIDHttpRequest? {
             guard let refreshToken = refreshToken else {
                 MSALLogger.log(level: .error, context: context, format: "Error creating Refresh Token Request, refresh token is nil!")
                 return nil
@@ -128,7 +128,7 @@ class MSALNativeAuthTokenController: MSALNativeAuthBaseController {
 
     func cacheTokenResponse(
         _ tokenResponse: MSIDTokenResponse,
-        context: MSALNativeAuthRequestContext,
+        context: MSIDRequestContext,
         msidConfiguration: MSIDConfiguration
     ) throws -> MSIDTokenResult {
         let displayableId = tokenResponse.idTokenObj?.username()
@@ -163,7 +163,7 @@ extension MSALNativeAuthTokenController {
 
     private func cacheTokenResponseRetrieveTokenResult(
         _ tokenResponse: MSIDTokenResponse,
-        context: MSALNativeAuthRequestContext,
+        context: MSIDRequestContext,
         msidConfiguration: MSIDConfiguration
     ) -> MSIDTokenResult? {
         do {
@@ -183,7 +183,7 @@ extension MSALNativeAuthTokenController {
         return nil
     }
 
-    private func clearAccount(msidConfiguration: MSIDConfiguration, context: MSALNativeAuthRequestContext) throws {
+    private func clearAccount(msidConfiguration: MSIDConfiguration, context: MSIDRequestContext) throws {
         do {
             let accounts = try cacheAccessor.getAllAccounts(configuration: msidConfiguration)
             if let account = accounts.first {

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -93,7 +93,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
             context: context
         ) else {
             stopTelemetryEvent(telemetryEvent, context: context, error: MSALNativeAuthInternalError.invalidRequest)
-            return .init(.failure(RetrieveAccessTokenError(type: .generalError)))
+            return .init(.failure(RetrieveAccessTokenError(type: .generalError, correlationId: context.correlationId())))
         }
         let config = factory.makeMSIDConfiguration(scopes: scopes)
         let response = await performAndValidateTokenRequest(request, config: config, context: context)
@@ -156,7 +156,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 config: config
             )
         case .error(let errorType):
-            let error = errorType.convertToRetrieveAccessTokenError()
+            let error = errorType.convertToRetrieveAccessTokenError(context: context)
             MSALLogger.log(
                 level: .error,
                 context: context,
@@ -183,7 +183,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 self?.stopTelemetryEvent(telemetryEvent, context: context, delegateDispatcherResult: result)
             })
         } catch {
-            let error = RetrieveAccessTokenError(type: .generalError)
+            let error = RetrieveAccessTokenError(type: .generalError, correlationId: context.correlationId())
             MSALLogger.log(
                 level: .error,
                 context: context,

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -93,7 +93,10 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
             context: context
         ) else {
             stopTelemetryEvent(telemetryEvent, context: context, error: MSALNativeAuthInternalError.invalidRequest)
-            return .init(.failure(RetrieveAccessTokenError(type: .generalError, correlationId: context.correlationId())))
+            return .init(
+                .failure(RetrieveAccessTokenError(type: .generalError, correlationId: context.correlationId())), 
+                correlationId: context.correlationId()
+            )
         }
         let config = factory.makeMSIDConfiguration(scopes: scopes)
         let response = await performAndValidateTokenRequest(request, config: config, context: context)
@@ -162,7 +165,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 context: context,
                 format: "Refresh Token completed with error: \(error.errorDescription ?? "No error description")")
             stopTelemetryEvent(telemetryEvent, context: context, error: error)
-            return .init(.failure(error))
+            return .init(.failure(error), correlationId: context.correlationId())
         }
     }
 
@@ -178,7 +181,10 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 level: .verbose,
                 context: context,
                 format: "Refresh Token completed successfully")
-            return .init(.success(tokenResult.accessToken.accessToken), telemetryUpdate: { [weak self] result in
+            return .init(
+                .success(tokenResult.accessToken.accessToken),
+                correlationId: context.correlationId(),
+                telemetryUpdate: { [weak self] result in
                 telemetryEvent?.setUserInformation(tokenResult.account)
                 self?.stopTelemetryEvent(telemetryEvent, context: context, delegateDispatcherResult: result)
             })
@@ -189,7 +195,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 context: context,
                 format: "Token Result was not created properly error - \(error)")
             stopTelemetryEvent(telemetryEvent, context: context, error: error)
-            return .init(.failure(error))
+            return .init(.failure(error), correlationId: context.correlationId())
         }
     }
 }

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -156,7 +156,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 config: config
             )
         case .error(let errorType):
-            let error = errorType.convertToRetrieveAccessTokenError(context: context)
+            let error = errorType.convertToRetrieveAccessTokenError(correlationId: context.correlationId())
             MSALLogger.log(
                 level: .error,
                 context: context,

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -224,7 +224,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
             })
         case .error(let apiError):
-            let error = apiError.toResetPasswordStartPublicError(context: context)
+            let error = apiError.toResetPasswordStartPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
@@ -280,7 +280,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
             })
         case .error(let apiError):
-            let error = apiError.toResendCodePublicError(context: context)
+            let error = apiError.toResendCodePublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
@@ -349,7 +349,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
             })
         case .error(let apiError):
-            let error = apiError.toVerifyCodePublicError(context: context)
+            let error = apiError.toVerifyCodePublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
@@ -434,7 +434,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 context: context
             )
         case .passwordError(let apiError):
-            let error = apiError.toPasswordRequiredPublicError(context: context)
+            let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             self.stopTelemetryEvent(event, context: context, error: error)
 
             MSALLogger.log(level: .error,
@@ -448,7 +448,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             )
             return .init(.error(error: error, newState: newState))
         case .error(let apiError):
-            let error = apiError.toPasswordRequiredPublicError(context: context)
+            let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             self.stopTelemetryEvent(event, context: context, error: error)
 
             MSALLogger.log(level: .error,
@@ -574,7 +574,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 return .init(.error(error: error, newState: nil))
             }
         case .passwordError(let apiError):
-            let error = apiError.toPasswordRequiredPublicError(context: context)
+            let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             self.stopTelemetryEvent(event, context: context, error: error)
 
             MSALLogger.log(level: .error,
@@ -588,7 +588,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             )
             return .init(.error(error: error, newState: newState))
         case .error(let apiError):
-            let error = apiError.toPasswordRequiredPublicError(context: context)
+            let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             self.stopTelemetryEvent(event, context: context, error: error)
 
             MSALLogger.log(level: .error,

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordControlling.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordControlling.swift
@@ -33,19 +33,23 @@ protocol MSALNativeAuthResetPasswordControlling: AnyObject {
 
     func resetPassword(parameters: MSALNativeAuthResetPasswordStartRequestProviderParameters) async -> ResetPasswordStartControllerResponse
 
-    func resendCode(username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse
+    func resendCode(
+        username: String,
+        continuationToken: String,
+        context: MSALNativeAuthRequestContext
+    ) async -> ResetPasswordResendCodeControllerResponse
 
     func submitCode(
         code: String,
         username: String,
         continuationToken: String,
-        context: MSIDRequestContext
+        context: MSALNativeAuthRequestContext
     ) async -> ResetPasswordSubmitCodeControllerResponse
 
     func submitPassword(
         password: String,
         username: String,
         continuationToken: String,
-        context: MSIDRequestContext
+        context: MSALNativeAuthRequestContext
     ) async -> ResetPasswordSubmitPasswordControllerResponse
 }

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -175,7 +175,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 format: "attribute_validation_failed received from signup/start request for attributes: \(invalidAttributes)"
             )
             let message = String(format: MSALNativeAuthErrorMessage.attributeValidationFailedSignUpStart, invalidAttributes.description)
-            let error = apiError.toSignUpStartPublicError(context: context, message: message)
+            let error = apiError.toSignUpStartPublicError(correlationId: context.correlationId(), message: message)
             return .init(.attributesInvalid(invalidAttributes), telemetryUpdate: { [weak self] result in
                 // The telemetry event always fails because the attribute validation failed
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result, controllerError: error)
@@ -189,7 +189,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             return .init(.error(error))
         case .error(let apiError),
              .unauthorizedClient(let apiError):
-            let error = apiError.toSignUpStartPublicError(context: context)
+            let error = apiError.toSignUpStartPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
@@ -268,7 +268,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 }
             )
         case .error(let apiError):
-            let error = apiError.toSignUpStartPublicError(context: context)
+            let error = apiError.toSignUpStartPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
@@ -328,7 +328,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
             })
         case .error(let apiError):
-            let error = apiError.toResendCodePublicError(context: context)
+            let error = apiError.toResendCodePublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
@@ -500,7 +500,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             })
         case .error(let apiError),
              .attributeValidationFailed(let apiError, _):
-            let error = apiError.toVerifyCodePublicError(context: context)
+            let error = apiError.toVerifyCodePublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
@@ -537,7 +537,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
             })
         case .invalidUserInput(let apiError):
-            let error = apiError.toPasswordRequiredPublicError(context: context)
+            let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(
                 level: .error,
@@ -565,7 +565,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         case .error(let apiError),
              .attributeValidationFailed(let apiError, _),
              .credentialRequired(_, let apiError):
-            let error = apiError.toPasswordRequiredPublicError(context: context)
+            let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,
@@ -602,7 +602,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
             })
         case .attributesRequired(let newContinuationToken, let attributes, let apiError):
-            let error = apiError.toAttributesRequiredPublicError(context: context)
+            let error = apiError.toAttributesRequiredPublicError(correlationId: context.correlationId())
             MSALLogger.log(level: .error,
                            context: context,
                            format: "attributes_required received in signup/continue submitAttributes request: \(attributes)")
@@ -621,7 +621,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             MSALLogger.log(level: .error, context: context, format: message)
 
             let errorMessage = String(format: MSALNativeAuthErrorMessage.attributeValidationFailed, invalidAttributes.description)
-            let error = apiError.toAttributesRequiredPublicError(context: context, message: message)
+            let error = apiError.toAttributesRequiredPublicError(correlationId: context.correlationId(), message: errorMessage)
             let state = SignUpAttributesRequiredState(
                 controller: self,
                 username: username,
@@ -635,7 +635,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         case .error(let apiError),
              .invalidUserInput(let apiError),
              .credentialRequired(_, let apiError):
-            let error = apiError.toAttributesRequiredPublicError(context: context)
+            let error = apiError.toAttributesRequiredPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.log(level: .error,
                            context: context,

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpControlling.swift
@@ -34,26 +34,26 @@ protocol MSALNativeAuthSignUpControlling: AnyObject {
 
     func signUpStart(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) async -> SignUpStartControllerResponse
 
-    func resendCode(username: String, context: MSIDRequestContext, continuationToken: String) async -> SignUpResendCodeControllerResponse
+    func resendCode(username: String, context: MSALNativeAuthRequestContext, continuationToken: String) async -> SignUpResendCodeControllerResponse
 
     func submitCode(
         _ code: String,
         username: String,
         continuationToken: String,
-        context: MSIDRequestContext
+        context: MSALNativeAuthRequestContext
     ) async -> SignUpSubmitCodeControllerResponse
 
     func submitPassword(
         _ password: String,
         username: String,
         continuationToken: String,
-        context: MSIDRequestContext
+        context: MSALNativeAuthRequestContext
     ) async -> SignUpSubmitPasswordControllerResponse
 
     func submitAttributes(
         _ attributes: [String: Any],
         username: String,
         continuationToken: String,
-        context: MSIDRequestContext
+        context: MSALNativeAuthRequestContext
     ) async -> SignUpSubmitAttributesControllerResponse
 }

--- a/MSAL/src/native_auth/network/MSALNativeAuthCustomErrorSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthCustomErrorSerializer.swift
@@ -32,7 +32,7 @@ final class MSALNativeAuthCustomErrorSerializer<T: Decodable & Error & MSALNativ
             var customError = try JSONDecoder().decode(T.self, from: data ?? Data())
             customError.correlationId = T.retrieveCorrelationIdFromHeaders(from: httpResponse)
 
-            // the successfuly constructed "customError" needs to be thrown, 
+            // the successfuly constructed "customError" needs to be thrown,
             // since the previous "try" command just validates the object (error) decoding
             throw customError
         } catch is DecodingError {

--- a/MSAL/src/native_auth/network/MSALNativeAuthCustomErrorSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthCustomErrorSerializer.swift
@@ -26,9 +26,12 @@ import Foundation
 
 @_implementationOnly import MSAL_Private
 
-final class MSALNativeAuthCustomErrorSerializer<T: Decodable & Error>: NSObject, MSIDResponseSerialization {
+// swiftlint:disable:next line_length
+final class MSALNativeAuthCustomErrorSerializer<T: Decodable & Error & MSALNativeAuthResponseCorrelatable>: NSObject, MSIDResponseSerialization {
     func responseObject(for httpResponse: HTTPURLResponse?, data: Data?, context: MSIDRequestContext?) throws -> Any {
-        let customError = try JSONDecoder().decode(T.self, from: data ?? Data())
+        var customError = try JSONDecoder().decode(T.self, from: data ?? Data())
+        customError.correlationId = customError.retrieveCorrelationIdFromHeaders(from: httpResponse)
+
         // the successfuly constructed "customError" needs to be thrown, since the previous "try" command just validates the object (error) decoding
         throw customError
     }

--- a/MSAL/src/native_auth/network/MSALNativeAuthCustomErrorSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthCustomErrorSerializer.swift
@@ -36,7 +36,7 @@ final class MSALNativeAuthCustomErrorSerializer<T: Decodable & Error & MSALNativ
             // since the previous "try" command just validates the object (error) decoding
             throw customError
         } catch is DecodingError {
-            MSALLogger.log(level: .error, context: context, format: "CustomErrorSerializer failed decoding. Key not found")
+            MSALLogger.log(level: .error, context: context, format: "CustomErrorSerializer failed decoding")
             throw MSALNativeAuthInternalError.responseSerializationError(headerCorrelationId: T.retrieveCorrelationIdFromHeaders(from: httpResponse))
         }
     }

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseCorrelatable.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseCorrelatable.swift
@@ -22,14 +22,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+@_implementationOnly import MSAL_Private
 
-protocol MSALNativeAuthResponseError: Error, Decodable, Equatable, MSALNativeAuthResponseCorrelatable {
-    associatedtype ErrorCode: RawRepresentable where ErrorCode.RawValue == String
+protocol MSALNativeAuthResponseCorrelatable {
+    var correlationId: UUID? { get set }
+    func retrieveCorrelationIdFromHeaders(from httpResponse: HTTPURLResponse?) -> UUID?
+}
 
-    var error: ErrorCode? { get }
-    var errorDescription: String? { get }
-    var errorCodes: [Int]? { get }
-    var errorURI: String? { get }
-    var innerErrors: [MSALNativeAuthInnerError]? { get }
+extension MSALNativeAuthResponseCorrelatable {
+
+    func retrieveCorrelationIdFromHeaders(from httpResponse: HTTPURLResponse?) -> UUID? {
+        guard let headers = httpResponse?.allHeaderFields else {
+            return nil
+        }
+
+        if let correlationId = headers[MSID_OAUTH2_CORRELATION_ID_REQUEST_VALUE] as? String {
+            return UUID(uuidString: correlationId)
+        } else {
+            return nil
+        }
+    }
 }

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseCorrelatable.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseCorrelatable.swift
@@ -26,12 +26,11 @@
 
 protocol MSALNativeAuthResponseCorrelatable {
     var correlationId: UUID? { get set }
-    func retrieveCorrelationIdFromHeaders(from httpResponse: HTTPURLResponse?) -> UUID?
 }
 
 extension MSALNativeAuthResponseCorrelatable {
 
-    func retrieveCorrelationIdFromHeaders(from httpResponse: HTTPURLResponse?) -> UUID? {
+    static func retrieveCorrelationIdFromHeaders(from httpResponse: HTTPURLResponse?) -> UUID? {
         guard let headers = httpResponse?.allHeaderFields, let correlationId = headers[MSID_OAUTH2_CORRELATION_ID_REQUEST_VALUE] as? String else {
             return nil
         }

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseCorrelatable.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseCorrelatable.swift
@@ -32,14 +32,10 @@ protocol MSALNativeAuthResponseCorrelatable {
 extension MSALNativeAuthResponseCorrelatable {
 
     func retrieveCorrelationIdFromHeaders(from httpResponse: HTTPURLResponse?) -> UUID? {
-        guard let headers = httpResponse?.allHeaderFields else {
+        guard let headers = httpResponse?.allHeaderFields, let correlationId = headers[MSID_OAUTH2_CORRELATION_ID_REQUEST_VALUE] as? String else {
             return nil
         }
 
-        if let correlationId = headers[MSID_OAUTH2_CORRELATION_ID_REQUEST_VALUE] as? String {
-            return UUID(uuidString: correlationId)
-        } else {
-            return nil
-        }
+        return UUID(uuidString: correlationId)
     }
 }

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseErrorHandler.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseErrorHandler.swift
@@ -26,7 +26,8 @@ import Foundation
 
 @_implementationOnly import MSAL_Private
 
-final class MSALNativeAuthResponseErrorHandler<T: Decodable & Error>: NSObject, MSIDHttpRequestErrorHandling {
+// swiftlint:disable:next line_length
+final class MSALNativeAuthResponseErrorHandler<T: Decodable & Error & MSALNativeAuthResponseCorrelatable>: NSObject, MSIDHttpRequestErrorHandling {
 
     // swiftlint:disable:next function_parameter_count
     func handleError(

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseErrorHandler.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseErrorHandler.swift
@@ -26,7 +26,6 @@ import Foundation
 
 @_implementationOnly import MSAL_Private
 
-// swiftlint:disable:next line_length
 final class MSALNativeAuthResponseErrorHandler<T: Decodable & Error & MSALNativeAuthResponseCorrelatable>: NSObject, MSIDHttpRequestErrorHandling {
 
     // swiftlint:disable:next function_parameter_count

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseSerializer.swift
@@ -24,7 +24,7 @@
 
 @_implementationOnly import MSAL_Private
 
-final class MSALNativeAuthResponseSerializer<T: Decodable>: NSObject, MSIDResponseSerialization {
+final class MSALNativeAuthResponseSerializer<T: Decodable & MSALNativeAuthResponseCorrelatable>: NSObject, MSIDResponseSerialization {
 
     func responseObject(for httpResponse: HTTPURLResponse?, data: Data?, context: MSIDRequestContext?) throws -> Any {
         guard let data = data else {
@@ -34,6 +34,9 @@ final class MSALNativeAuthResponseSerializer<T: Decodable>: NSObject, MSIDRespon
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
 
-        return try decoder.decode(T.self, from: data)
+        var response = try decoder.decode(T.self, from: data)
+        response.correlationId = response.retrieveCorrelationIdFromHeaders(from: httpResponse)
+
+        return response
     }
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@_implementationOnly import MSAL_Private
+import Foundation
 
 struct MSALNativeAuthResetPasswordChallengeResponseError: MSALNativeAuthResponseError {
 
@@ -65,7 +65,7 @@ struct MSALNativeAuthResetPasswordChallengeResponseError: MSALNativeAuthResponse
 
 extension MSALNativeAuthResetPasswordChallengeResponseError {
 
-    func toResetPasswordStartPublicError(context: MSIDRequestContext) -> ResetPasswordStartError {
+    func toResetPasswordStartPublicError(correlationId: UUID) -> ResetPasswordStartError {
         switch error {
         case .invalidRequest,
              .unauthorizedClient,
@@ -75,14 +75,14 @@ extension MSALNativeAuthResetPasswordChallengeResponseError {
             return .init(
                 type: .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
         }
     }
 
-    func toResendCodePublicError(context: MSIDRequestContext) -> ResendCodeError {
+    func toResendCodePublicError(correlationId: UUID) -> ResendCodeError {
         switch error {
         case .unauthorizedClient,
              .unsupportedChallengeType,
@@ -91,7 +91,7 @@ extension MSALNativeAuthResetPasswordChallengeResponseError {
              .none:
             return .init(
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@_implementationOnly import MSAL_Private
+import Foundation
 
 struct MSALNativeAuthResetPasswordContinueResponseError: MSALNativeAuthResponseError {
 
@@ -73,13 +73,13 @@ struct MSALNativeAuthResetPasswordContinueResponseError: MSALNativeAuthResponseE
 
 extension MSALNativeAuthResetPasswordContinueResponseError {
 
-    func toVerifyCodePublicError(context: MSIDRequestContext) -> VerifyCodeError {
+    func toVerifyCodePublicError(correlationId: UUID) -> VerifyCodeError {
         switch error {
         case .invalidGrant:
             return .init(
                 type: subError == .invalidOOBValue ? .invalidCode : .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
@@ -91,7 +91,7 @@ extension MSALNativeAuthResetPasswordContinueResponseError {
             return .init(
                 type: .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+@_implementationOnly import MSAL_Private
 
 struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthResponseError {
 
@@ -33,6 +33,7 @@ struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthRes
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
     let target: String?
+    var correlationId: UUID?
 
     enum CodingKeys: String, CodingKey {
         case error
@@ -42,26 +43,54 @@ struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthRes
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
         case target
+        case correlationId
+    }
+
+    init(
+        error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode? = nil,
+        subError: MSALNativeAuthSubErrorCode? = nil,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil,
+        correlationId: UUID? = nil
+    ) {
+        self.error = error
+        self.subError = subError
+        self.errorDescription = errorDescription
+        self.errorCodes = errorCodes
+        self.errorURI = errorURI
+        self.innerErrors = innerErrors
+        self.target = target
+        self.correlationId = correlationId
     }
 }
 
 extension MSALNativeAuthResetPasswordPollCompletionResponseError {
 
-    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+    func toPasswordRequiredPublicError(context: MSIDRequestContext) -> PasswordRequiredError {
         switch error {
         case .invalidGrant:
-            if let subError, subError.isAnyPasswordError {
-                return .init(type: .invalidPassword, message: errorDescription)
-            } else {
-                return .init(type: .generalError, message: errorDescription)
-            }
+            return .init(
+                type: subError?.isAnyPasswordError == true ? .invalidPassword : .generalError,
+                message: errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         case .unauthorizedClient,
              .expiredToken,
              .invalidRequest,
              .userNotFound,
              .none:
-            return .init(type: .generalError, message: errorDescription)
-            
+            return .init(
+                type: .generalError,
+                message: errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         }
     }
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@_implementationOnly import MSAL_Private
+import Foundation
 
 struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthResponseError {
 
@@ -69,13 +69,13 @@ struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthRes
 
 extension MSALNativeAuthResetPasswordPollCompletionResponseError {
 
-    func toPasswordRequiredPublicError(context: MSIDRequestContext) -> PasswordRequiredError {
+    func toPasswordRequiredPublicError(correlationId: UUID) -> PasswordRequiredError {
         switch error {
         case .invalidGrant:
             return .init(
                 type: subError?.isAnyPasswordError == true ? .invalidPassword : .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
@@ -87,7 +87,7 @@ extension MSALNativeAuthResetPasswordPollCompletionResponseError {
             return .init(
                 type: .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartResponseError.swift
@@ -32,6 +32,7 @@ struct MSALNativeAuthResetPasswordStartResponseError: MSALNativeAuthResponseErro
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
     let target: String?
+    var correlationId: UUID?
 
     enum CodingKeys: String, CodingKey {
         case error
@@ -40,5 +41,24 @@ struct MSALNativeAuthResetPasswordStartResponseError: MSALNativeAuthResponseErro
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
         case target
+        case correlationId
+    }
+
+    init(
+        error: MSALNativeAuthResetPasswordStartOauth2ErrorCode? = nil,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil,
+        correlationId: UUID? = nil
+    ) {
+        self.error = error
+        self.errorDescription = errorDescription
+        self.errorCodes = errorCodes
+        self.errorURI = errorURI
+        self.innerErrors = innerErrors
+        self.target = target
+        self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+@_implementationOnly import MSAL_Private
 
 struct MSALNativeAuthResetPasswordSubmitResponseError: MSALNativeAuthResponseError {
 
@@ -33,6 +33,7 @@ struct MSALNativeAuthResetPasswordSubmitResponseError: MSALNativeAuthResponseErr
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
     let target: String?
+    var correlationId: UUID?
 
     enum CodingKeys: String, CodingKey {
         case error
@@ -42,24 +43,53 @@ struct MSALNativeAuthResetPasswordSubmitResponseError: MSALNativeAuthResponseErr
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
         case target
+        case correlationId
+    }
+
+    init(
+        error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode? = nil,
+        subError: MSALNativeAuthSubErrorCode? = nil,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        target: String? = nil,
+        correlationId: UUID? = nil
+    ) {
+        self.error = error
+        self.subError = subError
+        self.errorDescription = errorDescription
+        self.errorCodes = errorCodes
+        self.errorURI = errorURI
+        self.innerErrors = innerErrors
+        self.target = target
+        self.correlationId = correlationId
     }
 }
 
 extension MSALNativeAuthResetPasswordSubmitResponseError {
 
-    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+    func toPasswordRequiredPublicError(context: MSIDRequestContext) -> PasswordRequiredError {
         switch error {
         case .invalidGrant:
-            if let subError, subError.isAnyPasswordError {
-                return .init(type: .invalidPassword, message: errorDescription)
-            } else {
-                return .init(type: .generalError, message: errorDescription)
-            }
+            return .init(
+                type: subError?.isAnyPasswordError == true ? .invalidPassword : .generalError,
+                message: errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         case .unauthorizedClient,
              .expiredToken,
              .invalidRequest,
              .none:
-            return .init(type: .generalError, message: errorDescription)
+            return .init(
+                type: .generalError,
+                message: errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         }
     }
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@_implementationOnly import MSAL_Private
+import Foundation
 
 struct MSALNativeAuthResetPasswordSubmitResponseError: MSALNativeAuthResponseError {
 
@@ -69,13 +69,13 @@ struct MSALNativeAuthResetPasswordSubmitResponseError: MSALNativeAuthResponseErr
 
 extension MSALNativeAuthResetPasswordSubmitResponseError {
 
-    func toPasswordRequiredPublicError(context: MSIDRequestContext) -> PasswordRequiredError {
+    func toPasswordRequiredPublicError(correlationId: UUID) -> PasswordRequiredError {
         switch error {
         case .invalidGrant:
             return .init(
                 type: subError?.isAnyPasswordError == true ? .invalidPassword : .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
@@ -86,7 +86,7 @@ extension MSALNativeAuthResetPasswordSubmitResponseError {
             return .init(
                 type: .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
@@ -31,6 +31,7 @@ struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
     let errorCodes: [Int]?
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
+    var correlationId: UUID?
 
     enum CodingKeys: String, CodingKey {
         case error
@@ -38,5 +39,22 @@ struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
         case errorCodes = "error_codes"
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
+        case correlationId
+    }
+
+    init(
+        error: MSALNativeAuthSignInChallengeOauth2ErrorCode? = nil,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        correlationId: UUID? = nil
+    ) {
+        self.error = error
+        self.errorDescription = errorDescription
+        self.errorCodes = errorCodes
+        self.errorURI = errorURI
+        self.innerErrors = innerErrors
+        self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateResponseError.swift
@@ -31,6 +31,7 @@ struct MSALNativeAuthSignInInitiateResponseError: MSALNativeAuthResponseError {
     let errorCodes: [Int]?
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
+    var correlationId: UUID?
 
     enum CodingKeys: String, CodingKey {
         case error
@@ -38,5 +39,22 @@ struct MSALNativeAuthSignInInitiateResponseError: MSALNativeAuthResponseError {
         case errorCodes = "error_codes"
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
+        case correlationId
+    }
+
+    init(
+        error: MSALNativeAuthSignInInitiateOauth2ErrorCode? = nil,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        correlationId: UUID? = nil
+    ) {
+        self.error = error
+        self.errorDescription = errorDescription
+        self.errorCodes = errorCodes
+        self.errorURI = errorURI
+        self.innerErrors = innerErrors
+        self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@_implementationOnly import MSAL_Private
+import Foundation
 
 struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
     let error: MSALNativeAuthSignUpChallengeOauth2ErrorCode?
@@ -60,7 +60,7 @@ struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
 
 extension MSALNativeAuthSignUpChallengeResponseError {
 
-    func toSignUpStartPublicError(context: MSIDRequestContext) -> SignUpStartError {
+    func toSignUpStartPublicError(correlationId: UUID) -> SignUpStartError {
         switch error {
         case .unauthorizedClient,
              .unsupportedChallengeType,
@@ -70,14 +70,14 @@ extension MSALNativeAuthSignUpChallengeResponseError {
             return .init(
                 type: .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
         }
     }
 
-    func toResendCodePublicError(context: MSIDRequestContext) -> ResendCodeError {
+    func toResendCodePublicError(correlationId: UUID) -> ResendCodeError {
         switch error {
         case .unauthorizedClient,
              .unsupportedChallengeType,
@@ -86,14 +86,14 @@ extension MSALNativeAuthSignUpChallengeResponseError {
              .none:
             return .init(
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
         }
     }
 
-    func toPasswordRequiredPublicError(context: MSIDRequestContext) -> PasswordRequiredError {
+    func toPasswordRequiredPublicError(correlationId: UUID) -> PasswordRequiredError {
         switch error {
         case .unauthorizedClient,
              .unsupportedChallengeType,
@@ -103,7 +103,7 @@ extension MSALNativeAuthSignUpChallengeResponseError {
             return .init(
                 type: .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+@_implementationOnly import MSAL_Private
 
 struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
     let error: MSALNativeAuthSignUpChallengeOauth2ErrorCode?
@@ -30,6 +30,7 @@ struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
     let errorCodes: [Int]?
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
+    var correlationId: UUID?
 
     enum CodingKeys: String, CodingKey {
         case error
@@ -37,41 +38,75 @@ struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
         case errorCodes = "error_codes"
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
+        case correlationId
+    }
+
+    init(
+        error: MSALNativeAuthSignUpChallengeOauth2ErrorCode? = nil,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        correlationId: UUID? = nil
+    ) {
+        self.error = error
+        self.errorDescription = errorDescription
+        self.errorCodes = errorCodes
+        self.errorURI = errorURI
+        self.innerErrors = innerErrors
+        self.correlationId = correlationId
     }
 }
 
 extension MSALNativeAuthSignUpChallengeResponseError {
 
-    func toSignUpStartPublicError() -> SignUpStartError {
+    func toSignUpStartPublicError(context: MSIDRequestContext) -> SignUpStartError {
         switch error {
         case .unauthorizedClient,
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
              .none:
-            return .init(type: .generalError, message: errorDescription)
+            return .init(
+                type: .generalError,
+                message: errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         }
     }
 
-    func toResendCodePublicError() -> ResendCodeError {
+    func toResendCodePublicError(context: MSIDRequestContext) -> ResendCodeError {
         switch error {
         case .unauthorizedClient,
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
              .none:
-            return .init(message: errorDescription)
+            return .init(
+                message: errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         }
     }
 
-    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+    func toPasswordRequiredPublicError(context: MSIDRequestContext) -> PasswordRequiredError {
         switch error {
         case .unauthorizedClient,
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
              .none:
-            return .init(type: .generalError, message: errorDescription)
+            return .init(
+                type: .generalError,
+                message: errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         }
     }
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@_implementationOnly import MSAL_Private
+import Foundation
 
 struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
     let error: MSALNativeAuthSignUpContinueOauth2ErrorCode?
@@ -80,13 +80,13 @@ struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
 
 extension MSALNativeAuthSignUpContinueResponseError {
 
-    func toVerifyCodePublicError(context: MSIDRequestContext) -> VerifyCodeError {
+    func toVerifyCodePublicError(correlationId: UUID) -> VerifyCodeError {
         switch error {
         case .invalidGrant:
             return .init(
                 type: subError == .invalidOOBValue ? .invalidCode : .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
@@ -101,20 +101,20 @@ extension MSALNativeAuthSignUpContinueResponseError {
             return .init(
                 type: .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
         }
     }
 
-    func toPasswordRequiredPublicError(context: MSIDRequestContext) -> PasswordRequiredError {
+    func toPasswordRequiredPublicError(correlationId: UUID) -> PasswordRequiredError {
         switch error {
         case .invalidGrant:
             return .init(
                 type: subError?.isAnyPasswordError == true ? .invalidPassword : .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
@@ -130,17 +130,17 @@ extension MSALNativeAuthSignUpContinueResponseError {
             return .init(
                 type: .generalError,
                 message: errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
         }
     }
 
-    func toAttributesRequiredPublicError(context: MSIDRequestContext, message: String? = nil) -> AttributesRequiredError {
+    func toAttributesRequiredPublicError(correlationId: UUID, message: String? = nil) -> AttributesRequiredError {
         return AttributesRequiredError(
             message: message ?? errorDescription,
-            correlationId: context.correlationId(),
+            correlationId: correlationId,
             errorCodes: errorCodes ?? [],
             errorUri: errorURI
         )

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+@_implementationOnly import MSAL_Private
 
 struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
     let error: MSALNativeAuthSignUpContinueOauth2ErrorCode?
@@ -35,6 +35,7 @@ struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
     let requiredAttributes: [MSALNativeAuthRequiredAttributeInternal]?
     let unverifiedAttributes: [MSALNativeAuthErrorBasicAttribute]?
     let invalidAttributes: [MSALNativeAuthErrorBasicAttribute]?
+    var correlationId: UUID?
 
     enum CodingKeys: String, CodingKey {
         case error
@@ -47,16 +48,48 @@ struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
         case requiredAttributes = "required_attributes"
         case unverifiedAttributes = "unverified_attributes"
         case invalidAttributes = "invalid_attributes"
+        case correlationId
+    }
+
+    init(
+        error: MSALNativeAuthSignUpContinueOauth2ErrorCode? = nil,
+        subError: MSALNativeAuthSubErrorCode? = nil,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        continuationToken: String? = nil,
+        requiredAttributes: [MSALNativeAuthRequiredAttributeInternal]? = nil,
+        unverifiedAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil,
+        correlationId: UUID? = nil
+    ) {
+        self.error = error
+        self.subError = subError
+        self.errorDescription = errorDescription
+        self.errorCodes = errorCodes
+        self.errorURI = errorURI
+        self.innerErrors = innerErrors
+        self.continuationToken = continuationToken
+        self.requiredAttributes = requiredAttributes
+        self.unverifiedAttributes = unverifiedAttributes
+        self.invalidAttributes = invalidAttributes
+        self.correlationId = correlationId
     }
 }
 
 extension MSALNativeAuthSignUpContinueResponseError {
 
-    func toVerifyCodePublicError() -> VerifyCodeError {
+    func toVerifyCodePublicError(context: MSIDRequestContext) -> VerifyCodeError {
         switch error {
         case .invalidGrant:
-            return subError == .invalidOOBValue ? .init(type: .invalidCode, message: errorDescription)
-                                                : .init(type: .generalError, message: errorDescription)
+            return .init(
+                type: subError == .invalidOOBValue ? .invalidCode : .generalError,
+                message: errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         case .unauthorizedClient,
              .expiredToken,
              .invalidRequest,
@@ -65,18 +98,27 @@ extension MSALNativeAuthSignUpContinueResponseError {
              .verificationRequired,
              .credentialRequired,
              .none:
-            return .init(type: .generalError, message: errorDescription)
+            return .init(
+                type: .generalError,
+                message: errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         }
     }
 
-    func toPasswordRequiredPublicError() -> PasswordRequiredError {
+    func toPasswordRequiredPublicError(context: MSIDRequestContext) -> PasswordRequiredError {
         switch error {
         case .invalidGrant:
-            if let subError, subError.isAnyPasswordError {
-                return .init(type: .invalidPassword, message: errorDescription)
-            } else {
-                return .init(type: .generalError, message: errorDescription)
-            }
+            return .init(
+                type: subError?.isAnyPasswordError == true ? .invalidPassword : .generalError,
+                message: errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
+
         case .unauthorizedClient,
              .expiredToken,
              .invalidRequest,
@@ -85,11 +127,22 @@ extension MSALNativeAuthSignUpContinueResponseError {
              .verificationRequired,
              .credentialRequired,
              .none:
-            return .init(type: .generalError, message: errorDescription)
+            return .init(
+                type: .generalError,
+                message: errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         }
     }
 
-    func toAttributesRequiredPublicError() -> AttributesRequiredError {
-        return AttributesRequiredError(message: errorDescription)
+    func toAttributesRequiredPublicError(context: MSIDRequestContext, message: String? = nil) -> AttributesRequiredError {
+        return AttributesRequiredError(
+            message: message ?? errorDescription,
+            correlationId: context.correlationId(),
+            errorCodes: errorCodes ?? [],
+            errorUri: errorURI
+        )
     }
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+@_implementationOnly import MSAL_Private
 
 struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
 
@@ -35,6 +35,7 @@ struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
     let continuationToken: String?
     let unverifiedAttributes: [MSALNativeAuthErrorBasicAttribute]?
     let invalidAttributes: [MSALNativeAuthErrorBasicAttribute]?
+    var correlationId: UUID?
 
     enum CodingKeys: String, CodingKey {
         case error
@@ -46,28 +47,67 @@ struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
         case continuationToken = "continuation_token"
         case unverifiedAttributes = "unverified_attributes"
         case invalidAttributes = "invalid_attributes"
+        case correlationId
+    }
+
+    init(
+        error: MSALNativeAuthSignUpStartOauth2ErrorCode? = nil,
+        subError: MSALNativeAuthSubErrorCode? = nil,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        continuationToken: String? = nil,
+        unverifiedAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil,
+        invalidAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil,
+        correlationId: UUID? = nil
+    ) {
+        self.error = error
+        self.subError = subError
+        self.errorDescription = errorDescription
+        self.errorCodes = errorCodes
+        self.errorURI = errorURI
+        self.innerErrors = innerErrors
+        self.continuationToken = continuationToken
+        self.unverifiedAttributes = unverifiedAttributes
+        self.invalidAttributes = invalidAttributes
+        self.correlationId = correlationId
     }
 }
 
 extension MSALNativeAuthSignUpStartResponseError {
 
-    func toSignUpStartPublicError() -> SignUpStartError {
+    func toSignUpStartPublicError(context: MSIDRequestContext, message: String? = nil) -> SignUpStartError {
         switch error {
         case .invalidGrant:
-            if let subError, subError.isAnyPasswordError {
-                return .init(type: .invalidPassword, message: errorDescription)
-            } else {
-                return .init(type: .generalError, message: errorDescription)
-            }
+            return .init(
+                type: subError?.isAnyPasswordError == true ? .invalidPassword : .generalError,
+                message: message ?? errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         case .userAlreadyExists:
-            return .init(type: .userAlreadyExists, message: errorDescription)
+            return .init(
+                type: .userAlreadyExists,
+                message: message ?? errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         case .attributesRequired,
              .unauthorizedClient,
              .unsupportedChallengeType,
              .unsupportedAuthMethod,
              .invalidRequest,
              .none:
-            return .init(type: .generalError, message: errorDescription)
+            return .init(
+                type: .generalError,
+                message: message ?? errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: errorCodes ?? [],
+                errorUri: errorURI
+            )
         }
     }
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@_implementationOnly import MSAL_Private
+import Foundation
 
 struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
 
@@ -77,13 +77,13 @@ struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
 
 extension MSALNativeAuthSignUpStartResponseError {
 
-    func toSignUpStartPublicError(context: MSIDRequestContext, message: String? = nil) -> SignUpStartError {
+    func toSignUpStartPublicError(correlationId: UUID, message: String? = nil) -> SignUpStartError {
         switch error {
         case .invalidGrant:
             return .init(
                 type: subError?.isAnyPasswordError == true ? .invalidPassword : .generalError,
                 message: message ?? errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
@@ -91,7 +91,7 @@ extension MSALNativeAuthSignUpStartResponseError {
             return .init(
                 type: .userAlreadyExists,
                 message: message ?? errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )
@@ -104,7 +104,7 @@ extension MSALNativeAuthSignUpStartResponseError {
             return .init(
                 type: .generalError,
                 message: message ?? errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: errorCodes ?? [],
                 errorUri: errorURI
             )

--- a/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
@@ -33,6 +33,7 @@ struct MSALNativeAuthTokenResponseError: MSALNativeAuthResponseError {
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
     let continuationToken: String?
+    var correlationId: UUID?
 
     enum CodingKeys: String, CodingKey {
         case error
@@ -42,5 +43,26 @@ struct MSALNativeAuthTokenResponseError: MSALNativeAuthResponseError {
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
         case continuationToken = "continuation_token"
+        case correlationId
+    }
+
+    init(
+        error: MSALNativeAuthTokenOauth2ErrorCode? = nil,
+        subError: MSALNativeAuthSubErrorCode? = nil,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        continuationToken: String? = nil,
+        correlationId: UUID? = nil
+    ) {
+        self.error = error
+        self.subError = subError
+        self.errorDescription = errorDescription
+        self.errorCodes = errorCodes
+        self.errorURI = errorURI
+        self.innerErrors = innerErrors
+        self.continuationToken = continuationToken
+        self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestContext.swift
+++ b/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestContext.swift
@@ -64,7 +64,8 @@ class MSALNativeAuthRequestContext: MSIDRequestContext {
 
     func setServerCorrelationId(_ serverCorrelationId: UUID?) {
         guard let serverCorrelationId = serverCorrelationId else {
-            MSALLogger.log(level: .info, context: self, format: "correlationId not found in server response")
+            MSALLogger.log(level: .warning, context: self, format: "correlationId not found in server response")
+            _serverCorrelationId = serverCorrelationId
             return
         }
 
@@ -73,10 +74,10 @@ class MSALNativeAuthRequestContext: MSIDRequestContext {
         }
 
         let log = """
-                  Inconsistency between the correlationId sent by the SDK the one received in the response.
+                  Inconsistency between the correlationId sent by the SDK and the one received in the response.
                   Original correlationId: \(_correlationId). Server correlationId \(serverCorrelationId)
                   """
-        MSALLogger.log(level: .info, context: self, format: log)
+        MSALLogger.log(level: .warning, context: self, format: log)
 
         _serverCorrelationId = serverCorrelationId
     }

--- a/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestContext.swift
+++ b/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestContext.swift
@@ -30,8 +30,8 @@ class MSALNativeAuthRequestContext: MSIDRequestContext {
     private let _telemetryRequestId: String
     private var _serverCorrelationId: UUID? // TODO: Setting the server correlation id here is wrong. Needs refactoring.
 
-    init(correlationId: UUID = UUID(), telemetryRequestId: String = MSIDTelemetry.sharedInstance().generateRequestId()) {
-        _correlationId = correlationId
+    init(correlationId: UUID? = nil, telemetryRequestId: String = MSIDTelemetry.sharedInstance().generateRequestId()) {
+        _correlationId = correlationId ?? UUID()
         _telemetryRequestId = telemetryRequestId
     }
 

--- a/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestable.swift
+++ b/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestable.swift
@@ -26,7 +26,7 @@
 
 protocol MSALNativeAuthRequestable {
     var endpoint: MSALNativeAuthEndpoint { get }
-    var context: MSIDRequestContext { get }
+    var context: MSALNativeAuthRequestContext { get }
 
     func makeEndpointUrl(config: MSALNativeAuthConfiguration) throws -> URL
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String]

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParameters.swift
@@ -26,7 +26,7 @@
 
 struct MSALNativeAuthResetPasswordChallengeRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .resetPasswordChallenge
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
     let continuationToken: String
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParameters.swift
@@ -26,7 +26,7 @@
 
 struct MSALNativeAuthResetPasswordContinueRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .resetPasswordContinue
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
     let continuationToken: String
     let grantType: MSALNativeAuthGrantType
     let oobCode: String?

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParameters.swift
@@ -26,7 +26,7 @@
 
 struct MSALNativeAuthResetPasswordPollCompletionRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .resetpasswordPollCompletion
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
     let continuationToken: String
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParameters.swift
@@ -26,7 +26,7 @@
 
 struct MSALNativeAuthResetPasswordStartRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .resetPasswordStart
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
     let username: String
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParameters.swift
@@ -26,7 +26,7 @@
 
 struct MSALNativeAuthResetPasswordSubmitRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .resetPasswordSubmit
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
     let continuationToken: String
     let newPassword: String
 

--- a/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParameters.swift
@@ -26,7 +26,7 @@
 
 struct MSALNativeAuthSignInChallengeRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .signInChallenge
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
     let continuationToken: String
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {

--- a/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParameters.swift
@@ -26,7 +26,7 @@
 
 struct MSALNativeAuthSignInInitiateRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .signInInitiate
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
     let username: String
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParameters.swift
@@ -27,7 +27,7 @@
 struct MSALNativeAuthSignUpChallengeRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .signUpChallenge
     let continuationToken: String
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParameters.swift
@@ -31,7 +31,7 @@ struct MSALNativeAuthSignUpContinueRequestParameters: MSALNativeAuthRequestable 
     let password: String?
     let oobCode: String?
     let attributes: String?
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParameters.swift
@@ -29,7 +29,7 @@ struct MSALNativeAuthSignUpStartRequestParameters: MSALNativeAuthRequestable {
     let username: String
     let password: String?
     let attributes: String?
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey

--- a/MSAL/src/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParameters.swift
@@ -26,7 +26,7 @@
 
 struct MSALNativeAuthTokenRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .token
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
     let username: String?
     let continuationToken: String?
     let grantType: MSALNativeAuthGrantType

--- a/MSAL/src/native_auth/network/reset_password/MSALNativeAuthResetPasswordRequestProvider.swift
+++ b/MSAL/src/native_auth/network/reset_password/MSALNativeAuthResetPasswordRequestProvider.swift
@@ -31,7 +31,7 @@ protocol MSALNativeAuthResetPasswordRequestProviding {
 
     func challenge(
         token: String,
-        context: MSIDRequestContext
+        context: MSALNativeAuthRequestContext
     ) throws -> MSIDHttpRequest
 
     func `continue`(
@@ -83,7 +83,7 @@ final class MSALNativeAuthResetPasswordRequestProvider: MSALNativeAuthResetPassw
 
     // MARK: - Reset Password Challenge
 
-    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+    func challenge(token: String, context: MSALNativeAuthRequestContext) throws -> MSIDHttpRequest {
         let requestParams = MSALNativeAuthResetPasswordChallengeRequestParameters(
             context: context,
             continuationToken: token

--- a/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
+++ b/MSAL/src/native_auth/network/responses/MSALNativeAuthResendCodeRequestResponse.swift
@@ -24,12 +24,9 @@
 
 import Foundation
 
-struct MSALNativeAuthResendCodeRequestResponse: Decodable {
+struct MSALNativeAuthResendCodeRequestResponse: Decodable, MSALNativeAuthResponseCorrelatable {
 
     // MARK: - Variables
     let continuationToken: String
-
-    enum CodingKeys: String, CodingKey {
-        case continuationToken
-    }
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordChallengeResponse.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-struct MSALNativeAuthResetPasswordChallengeResponse: Decodable {
+struct MSALNativeAuthResetPasswordChallengeResponse: Decodable, MSALNativeAuthResponseCorrelatable {
 
     // MARK: - Variables
     let challengeType: MSALNativeAuthInternalChallengeType
@@ -33,4 +33,5 @@ struct MSALNativeAuthResetPasswordChallengeResponse: Decodable {
     let challengeChannel: MSALNativeAuthInternalChannelType?
     let continuationToken: String?
     let codeLength: Int?
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordContinueResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordContinueResponse.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-struct MSALNativeAuthResetPasswordContinueResponse: Decodable {
+struct MSALNativeAuthResetPasswordContinueResponse: Decodable, MSALNativeAuthResponseCorrelatable {
 
     // MARK: - Variables
     let continuationToken: String
     let expiresIn: Int
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordPollCompletionResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordPollCompletionResponse.swift
@@ -24,10 +24,11 @@
 
 import Foundation
 
-struct MSALNativeAuthResetPasswordPollCompletionResponse: Decodable {
+struct MSALNativeAuthResetPasswordPollCompletionResponse: Decodable, MSALNativeAuthResponseCorrelatable {
 
     // MARK: - Variables
     let status: MSALNativeAuthResetPasswordPollCompletionStatus
     let continuationToken: String?
     let expiresIn: Int?
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordStartResponse.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-struct MSALNativeAuthResetPasswordStartResponse: Decodable {
+struct MSALNativeAuthResetPasswordStartResponse: Decodable, MSALNativeAuthResponseCorrelatable {
 
     // MARK: - Variables
     let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType?
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordSubmitResponse.swift
+++ b/MSAL/src/native_auth/network/responses/reset_password/MSALNativeAuthResetPasswordSubmitResponse.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-struct MSALNativeAuthResetPasswordSubmitResponse: Decodable {
+struct MSALNativeAuthResetPasswordSubmitResponse: Decodable, MSALNativeAuthResponseCorrelatable {
 
     // MARK: - Variables
     let continuationToken: String
     let pollInterval: Int
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInChallengeResponse.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-struct MSALNativeAuthSignInChallengeResponse: Decodable {
+struct MSALNativeAuthSignInChallengeResponse: Decodable, MSALNativeAuthResponseCorrelatable {
 
     // MARK: - Variables
     let continuationToken: String?
@@ -34,4 +34,5 @@ struct MSALNativeAuthSignInChallengeResponse: Decodable {
     let challengeChannel: MSALNativeAuthInternalChannelType?
     let codeLength: Int?
     let interval: Int?
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInInitiateResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInInitiateResponse.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-struct MSALNativeAuthSignInInitiateResponse: Decodable {
+struct MSALNativeAuthSignInInitiateResponse: Decodable, MSALNativeAuthResponseCorrelatable {
 
     // MARK: - Variables
     let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType?
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpChallengeResponse.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-struct MSALNativeAuthSignUpChallengeResponse: Decodable {
+struct MSALNativeAuthSignUpChallengeResponse: Decodable, MSALNativeAuthResponseCorrelatable {
     let challengeType: MSALNativeAuthInternalChallengeType?
     let bindingMethod: String?
     let interval: Int?
@@ -32,4 +32,5 @@ struct MSALNativeAuthSignUpChallengeResponse: Decodable {
     let challengeChannel: MSALNativeAuthInternalChannelType?
     let continuationToken: String?
     let codeLength: Int?
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpContinueResponse.swift
@@ -24,7 +24,8 @@
 
 import Foundation
 
-struct MSALNativeAuthSignUpContinueResponse: Decodable {
+struct MSALNativeAuthSignUpContinueResponse: Decodable, MSALNativeAuthResponseCorrelatable {
     let continuationToken: String?
     let expiresIn: Int?
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpStartResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_up/MSALNativeAuthSignUpStartResponse.swift
@@ -24,7 +24,8 @@
 
 import Foundation
 
-struct MSALNativeAuthSignUpStartResponse: Decodable {
+struct MSALNativeAuthSignUpStartResponse: Decodable, MSALNativeAuthResponseCorrelatable {
     let continuationToken: String?
     let challengeType: MSALNativeAuthInternalChallengeType?
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
@@ -90,7 +90,12 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
         case .unsupportedChallengeType:
             return .error(.unsupportedChallengeType(apiError))
         case .none:
-            return .error(.unexpectedError(.init(errorDescription: apiError.errorDescription)))
+            return .error(.unexpectedError(.init(
+                errorDescription: apiError.errorDescription,
+                errorCodes: apiError.errorCodes,
+                errorURI: apiError.errorURI,
+                correlationId: apiError.correlationId
+            )))
         }
     }
 
@@ -185,7 +190,12 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
             MSALLogger.log(level: .error, context: context, format: "verificationRequired is not supported yet")
             return .unexpectedError(nil)
         case .none:
-            return .unexpectedError(.init(errorDescription: apiError.errorDescription))
+            return .unexpectedError(.init(
+                errorDescription: apiError.errorDescription,
+                errorCodes: apiError.errorCodes,
+                errorURI: apiError.errorURI,
+                correlationId: apiError.correlationId
+            ))
         }
     }
 
@@ -227,7 +237,12 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
              .expiredToken:
             return .error(apiError)
         case .none:
-            return .unexpectedError(.init(errorDescription: apiError.errorDescription))
+            return .unexpectedError(.init(
+                errorDescription: apiError.errorDescription,
+                errorCodes: apiError.errorCodes,
+                errorURI: apiError.errorURI,
+                correlationId: apiError.correlationId
+            ))
         }
     }
 
@@ -274,7 +289,12 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
              .expiredToken:
             return .error(apiError)
         case .none:
-            return .unexpectedError(.init(errorDescription: apiError.errorDescription))
+            return .unexpectedError(.init(
+                errorDescription: apiError.errorDescription,
+                errorCodes: apiError.errorCodes,
+                errorURI: apiError.errorURI,
+                correlationId: apiError.correlationId
+            ))
         }
     }
 }

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordValidatedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordValidatedResponses.swift
@@ -22,33 +22,58 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+@_implementationOnly import MSAL_Private
+
 enum MSALNativeAuthResetPasswordStartValidatedResponse: Equatable {
     case success(continuationToken: String)
     case redirect
     case error(MSALNativeAuthResetPasswordStartValidatedErrorType)
-    case unexpectedError(message: String?)
+    case unexpectedError(MSALNativeAuthResetPasswordStartResponseError?)
 }
 
 enum MSALNativeAuthResetPasswordStartValidatedErrorType: Equatable, Error {
-    case invalidRequest(message: String?)
-    case unauthorizedClient(message: String?)
-    case userNotFound(message: String?)
-    case unsupportedChallengeType(message: String?)
-    case userDoesNotHavePassword
-    case unexpectedError(message: String?)
+    case invalidRequest(MSALNativeAuthResetPasswordStartResponseError)
+    case unauthorizedClient(MSALNativeAuthResetPasswordStartResponseError)
+    case userNotFound(MSALNativeAuthResetPasswordStartResponseError)
+    case unsupportedChallengeType(MSALNativeAuthResetPasswordStartResponseError)
+    case userDoesNotHavePassword(MSALNativeAuthResetPasswordStartResponseError)
+    case unexpectedError(MSALNativeAuthResetPasswordStartResponseError?)
 
-    func toResetPasswordStartPublicError() -> ResetPasswordStartError {
+    func toResetPasswordStartPublicError(context: MSIDRequestContext) -> ResetPasswordStartError {
         switch self {
-        case .userNotFound(let message):
-            return .init(type: .userNotFound, message: message)
-        case .unsupportedChallengeType(let message),
-             .invalidRequest(let message),
-             .unauthorizedClient(let message):
-            return .init(type: .generalError, message: message)
-        case .userDoesNotHavePassword:
-            return .init(type: .userDoesNotHavePassword, message: MSALNativeAuthErrorMessage.userDoesNotHavePassword)
-        case .unexpectedError(message: let message):
-            return .init(type: .generalError, message: message)
+        case .userNotFound(let apiError):
+            return .init(
+                type: .userNotFound,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .unsupportedChallengeType(let apiError),
+             .invalidRequest(let apiError),
+             .unauthorizedClient(let apiError):
+            return .init(
+                type: .generalError,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .userDoesNotHavePassword(let apiError):
+            return .init(
+                type: .userDoesNotHavePassword,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .unexpectedError(let apiError):
+            return .init(
+                type: .generalError,
+                message: apiError?.errorDescription,
+                correlationId: context.correlationId(),
+                errorUri: apiError?.errorURI
+            )
         }
     }
 }
@@ -57,26 +82,26 @@ enum MSALNativeAuthResetPasswordChallengeValidatedResponse: Equatable {
     case success(_ sentTo: String, _ channelTargetType: MSALNativeAuthChannelType, _ codeLength: Int, _ resetPasswordChallengeToken: String)
     case redirect
     case error(MSALNativeAuthResetPasswordChallengeResponseError)
-    case unexpectedError(message: String?)
+    case unexpectedError(MSALNativeAuthResetPasswordChallengeResponseError?)
 }
 
 enum MSALNativeAuthResetPasswordContinueValidatedResponse: Equatable {
     case success(continuationToken: String)
-    case invalidOOB
+    case invalidOOB(MSALNativeAuthResetPasswordContinueResponseError)
     case error(MSALNativeAuthResetPasswordContinueResponseError)
-    case unexpectedError(message: String?)
+    case unexpectedError(MSALNativeAuthResetPasswordContinueResponseError?)
 }
 
 enum MSALNativeAuthResetPasswordSubmitValidatedResponse: Equatable {
     case success(continuationToken: String, pollInterval: Int)
     case passwordError(error: MSALNativeAuthResetPasswordSubmitResponseError)
     case error(MSALNativeAuthResetPasswordSubmitResponseError)
-    case unexpectedError(message: String?)
+    case unexpectedError(MSALNativeAuthResetPasswordSubmitResponseError?)
 }
 
 enum MSALNativeAuthResetPasswordPollCompletionValidatedResponse: Equatable {
     case success(status: MSALNativeAuthResetPasswordPollCompletionStatus, continuationToken: String?)
     case passwordError(error: MSALNativeAuthResetPasswordPollCompletionResponseError)
     case error(MSALNativeAuthResetPasswordPollCompletionResponseError)
-    case unexpectedError(message: String?)
+    case unexpectedError(MSALNativeAuthResetPasswordPollCompletionResponseError?)
 }

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -140,7 +140,12 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
             case .unsupportedChallengeType:
                 return .error(.unsupportedChallengeType(error))
             case .none:
-                return .error(.unexpectedError(.init(errorDescription: error.errorDescription)))
+                return .error(.unexpectedError(.init(
+                    errorDescription: error.errorDescription,
+                    errorCodes: error.errorCodes,
+                    errorURI: error.errorURI,
+                    correlationId: error.correlationId
+                )))
             }
     }
 
@@ -155,7 +160,12 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
             case .userNotFound:
                 return .error(.userNotFound(error))
             case .none:
-                return .error(.unexpectedError(.init(errorDescription: error.errorDescription)))
+                return .error(.unexpectedError(.init(
+                    errorDescription: error.errorDescription,
+                    errorCodes: error.errorCodes,
+                    errorURI: error.errorURI,
+                    correlationId: error.correlationId
+                )))
             }
     }
 }

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -26,12 +26,12 @@
 
 protocol MSALNativeAuthSignInResponseValidating {
     func validate(
-        context: MSALNativeAuthRequestContext,
+        context: MSIDRequestContext,
         result: Result<MSALNativeAuthSignInChallengeResponse, Error>
     ) -> MSALNativeAuthSignInChallengeValidatedResponse
 
     func validate(
-        context: MSALNativeAuthRequestContext,
+        context: MSIDRequestContext,
         result: Result<MSALNativeAuthSignInInitiateResponse, Error>
     ) -> MSALNativeAuthSignInInitiateValidatedResponse
 }
@@ -39,7 +39,7 @@ protocol MSALNativeAuthSignInResponseValidating {
 final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseValidating {
 
     func validate(
-        context: MSALNativeAuthRequestContext,
+        context: MSIDRequestContext,
         result: Result<MSALNativeAuthSignInChallengeResponse, Error>
     ) -> MSALNativeAuthSignInChallengeValidatedResponse {
         switch result {
@@ -52,14 +52,14 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                     level: .error,
                     context: context,
                     format: "signin/challenge: Unable to decode error response: \(signInChallengeResponseError)")
-                return .error(.unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody))
+                return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)))
             }
-            return handleFailedSignInChallengeResult(context, error: signInChallengeResponseError)
+            return handleFailedSignInChallengeResult(error: signInChallengeResponseError)
         }
     }
 
     func validate(
-        context: MSALNativeAuthRequestContext,
+        context: MSIDRequestContext,
         result: Result<MSALNativeAuthSignInInitiateResponse, Error>
     ) -> MSALNativeAuthSignInInitiateValidatedResponse {
         switch result {
@@ -71,23 +71,23 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                 return .success(continuationToken: continuationToken)
             }
             MSALLogger.log(level: .error, context: context, format: "signin/initiate: challengeType and continuation token empty")
-            return .error(.unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody))
+            return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)))
         case .failure(let responseError):
             guard let initiateResponseError = responseError as? MSALNativeAuthSignInInitiateResponseError else {
                 MSALLogger.log(
                     level: .error,
                     context: context,
                     format: "signin/initiate: Unable to decode error response: \(responseError)")
-                return .error(.unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody))
+                return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)))
             }
-            return handleFailedSignInInitiateResult(context, error: initiateResponseError)
+            return handleFailedSignInInitiateResult(error: initiateResponseError)
         }
     }
 
     // MARK: private methods
 
     private func handleSuccessfulSignInChallengeResult(
-        _ context: MSALNativeAuthRequestContext,
+        _ context: MSIDRequestContext,
         response: MSALNativeAuthSignInChallengeResponse) -> MSALNativeAuthSignInChallengeValidatedResponse {
         switch response.challengeType {
         case .otp:
@@ -95,7 +95,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                 level: .error,
                 context: context,
                 format: "signin/challenge: Received unexpected challenge type: \(response.challengeType)")
-            return .error(.unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedChallengeType))
+            return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedChallengeType)))
         case .oob:
             guard let continuationToken = response.continuationToken,
                     let targetLabel = response.challengeTargetLabel,
@@ -105,7 +105,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                     level: .error,
                     context: context,
                     format: "signin/challenge: Invalid response with challenge type oob, response: \(response)")
-                return .error(.unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody))
+                return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)))
             }
             return .codeRequired(
                 continuationToken: continuationToken,
@@ -118,7 +118,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                     level: .error,
                     context: context,
                     format: "signin/challenge: Expected continuation token not nil with credential type password")
-                return .error(.unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody))
+                return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)))
             }
             return .passwordRequired(continuationToken: continuationToken)
         case .redirect:
@@ -127,38 +127,35 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
     }
 
     private func handleFailedSignInChallengeResult(
-        _ context: MSALNativeAuthRequestContext,
         error: MSALNativeAuthSignInChallengeResponseError) -> MSALNativeAuthSignInChallengeValidatedResponse {
             switch error.error {
             case .invalidRequest:
-                return .error(.invalidRequest(message: error.errorDescription))
+                return .error(.invalidRequest(error))
             case .unauthorizedClient:
-                return .error(.unauthorizedClient(message: error.errorDescription))
+                return .error(.unauthorizedClient(error))
             case .invalidGrant:
-                return .error(.invalidToken(message: error.errorDescription))
+                return .error(.invalidToken(error))
             case .expiredToken:
-                return .error(.expiredToken(message: error.errorDescription))
+                return .error(.expiredToken(error))
             case .unsupportedChallengeType:
-                return .error(.unsupportedChallengeType(message: error.errorDescription))
+                return .error(.unsupportedChallengeType(error))
             case .none:
-                return .error(.unexpectedError(message: error.errorDescription))
+                return .error(.unexpectedError(.init(errorDescription: error.errorDescription)))
             }
     }
 
-    private func handleFailedSignInInitiateResult(
-        _ context: MSALNativeAuthRequestContext,
-        error: MSALNativeAuthSignInInitiateResponseError) -> MSALNativeAuthSignInInitiateValidatedResponse {
+    private func handleFailedSignInInitiateResult(error: MSALNativeAuthSignInInitiateResponseError) -> MSALNativeAuthSignInInitiateValidatedResponse {
             switch error.error {
             case .invalidRequest:
-                return .error(.invalidRequest(message: error.errorDescription))
+                return .error(.invalidRequest(error))
             case .unauthorizedClient:
-                return .error(.unauthorizedClient(message: error.errorDescription))
+                return .error(.unauthorizedClient(error))
             case .unsupportedChallengeType:
-                return .error(.unsupportedChallengeType(message: error.errorDescription))
+                return .error(.unsupportedChallengeType(error))
             case .userNotFound:
-                return .error(.userNotFound(message: error.errorDescription))
+                return .error(.userNotFound(error))
             case .none:
-                return .error(.unexpectedError(message: error.errorDescription))
+                return .error(.unexpectedError(.init(errorDescription: error.errorDescription)))
             }
     }
 }

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@_implementationOnly import MSAL_Private
+import Foundation
 
 enum MSALNativeAuthSignInChallengeValidatedResponse {
     case codeRequired(continuationToken: String, sentTo: String, channelType: MSALNativeAuthChannelType, codeLength: Int)
@@ -40,15 +40,15 @@ enum MSALNativeAuthSignInChallengeValidatedErrorType: Error {
     case userNotFound(MSALNativeAuthSignInChallengeResponseError)
     case unsupportedChallengeType(MSALNativeAuthSignInChallengeResponseError)
 
-    func convertToSignInStartError(context: MSIDRequestContext) -> SignInStartError {
+    func convertToSignInStartError(correlationId: UUID) -> SignInStartError {
         switch self {
         case .redirect:
-            return .init(type: .browserRequired, correlationId: context.correlationId())
+            return .init(type: .browserRequired, correlationId: correlationId)
         case .unexpectedError(let apiError):
             return .init(
                 type: .generalError,
                 message: apiError?.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError?.errorCodes ?? [],
                 errorUri: apiError?.errorURI
             )
@@ -60,7 +60,7 @@ enum MSALNativeAuthSignInChallengeValidatedErrorType: Error {
             return .init(
                 type: .generalError,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
@@ -68,17 +68,17 @@ enum MSALNativeAuthSignInChallengeValidatedErrorType: Error {
             return .init(
                 type: .userNotFound,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
         }
     }
 
-    func convertToResendCodeError(context: MSIDRequestContext) -> ResendCodeError {
+    func convertToResendCodeError(correlationId: UUID) -> ResendCodeError {
         switch self {
         case .redirect:
-            return .init(correlationId: context.correlationId())
+            return .init(correlationId: correlationId)
         case .invalidRequest(let apiError),
              .expiredToken(let apiError),
              .invalidToken(let apiError),
@@ -87,14 +87,14 @@ enum MSALNativeAuthSignInChallengeValidatedErrorType: Error {
              .unsupportedChallengeType(let apiError):
             return .init(
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
         case .unexpectedError(let apiError):
             return .init(
                 message: apiError?.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError?.errorCodes ?? [],
                 errorUri: apiError?.errorURI
             )

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+@_implementationOnly import MSAL_Private
 
 enum MSALNativeAuthSignInChallengeValidatedResponse {
     case codeRequired(continuationToken: String, sentTo: String, channelType: MSALNativeAuthChannelType, codeLength: Int)
@@ -32,27 +32,72 @@ enum MSALNativeAuthSignInChallengeValidatedResponse {
 
 enum MSALNativeAuthSignInChallengeValidatedErrorType: Error {
     case redirect
-    case expiredToken(message: String?)
-    case invalidToken(message: String?)
-    case unauthorizedClient(message: String?)
-    case invalidRequest(message: String?)
-    case unexpectedError(message: String?)
-    case userNotFound(message: String?)
-    case unsupportedChallengeType(message: String?)
+    case expiredToken(MSALNativeAuthSignInChallengeResponseError)
+    case invalidToken(MSALNativeAuthSignInChallengeResponseError)
+    case unauthorizedClient(MSALNativeAuthSignInChallengeResponseError)
+    case invalidRequest(MSALNativeAuthSignInChallengeResponseError)
+    case unexpectedError(MSALNativeAuthSignInChallengeResponseError?)
+    case userNotFound(MSALNativeAuthSignInChallengeResponseError)
+    case unsupportedChallengeType(MSALNativeAuthSignInChallengeResponseError)
 
-    func convertToSignInStartError() -> SignInStartError {
+    func convertToSignInStartError(context: MSIDRequestContext) -> SignInStartError {
         switch self {
         case .redirect:
-            return .init(type: .browserRequired)
-        case .expiredToken(let message),
-             .invalidToken(let message),
-             .invalidRequest(let message),
-             .unauthorizedClient(let message),
-             .unsupportedChallengeType(let message),
-             .unexpectedError(let message):
-            return .init(type: .generalError, message: message)
-        case .userNotFound(let message):
-            return .init(type: .userNotFound, message: message)
+            return .init(type: .browserRequired, correlationId: context.correlationId())
+        case .unexpectedError(let apiError):
+            return .init(
+                type: .generalError,
+                message: apiError?.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError?.errorCodes ?? [],
+                errorUri: apiError?.errorURI
+            )
+        case .expiredToken(let apiError),
+             .invalidToken(let apiError),
+             .unauthorizedClient(let apiError),
+             .unsupportedChallengeType(let apiError),
+             .invalidRequest(let apiError):
+            return .init(
+                type: .generalError,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .userNotFound(let apiError):
+            return .init(
+                type: .userNotFound,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        }
+    }
+
+    func convertToResendCodeError(context: MSIDRequestContext) -> ResendCodeError {
+        switch self {
+        case .redirect:
+            return .init(correlationId: context.correlationId())
+        case .invalidRequest(let apiError),
+             .expiredToken(let apiError),
+             .invalidToken(let apiError),
+             .unauthorizedClient(let apiError),
+             .userNotFound(let apiError),
+             .unsupportedChallengeType(let apiError):
+            return .init(
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .unexpectedError(let apiError):
+            return .init(
+                message: apiError?.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError?.errorCodes ?? [],
+                errorUri: apiError?.errorURI
+            )
         }
     }
 }

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInInitiateValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInInitiateValidatedResponse.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@_implementationOnly import MSAL_Private
+import Foundation
 
 enum MSALNativeAuthSignInInitiateValidatedResponse {
     case success(continuationToken: String)
@@ -37,15 +37,15 @@ enum MSALNativeAuthSignInInitiateValidatedErrorType: Error {
     case userNotFound(MSALNativeAuthSignInInitiateResponseError)
     case unsupportedChallengeType(MSALNativeAuthSignInInitiateResponseError)
 
-    func convertToSignInStartError(context: MSIDRequestContext) -> SignInStartError {
+    func convertToSignInStartError(correlationId: UUID) -> SignInStartError {
         switch self {
         case .redirect:
-            return .init(type: .browserRequired, correlationId: context.correlationId())
+            return .init(type: .browserRequired, correlationId: correlationId)
         case .userNotFound(let apiError):
             return .init(
                 type: .userNotFound,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
@@ -53,7 +53,7 @@ enum MSALNativeAuthSignInInitiateValidatedErrorType: Error {
             return .init(
                 type: .generalError,
                 message: apiError?.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError?.errorCodes ?? [],
                 errorUri: apiError?.errorURI
             )
@@ -63,7 +63,7 @@ enum MSALNativeAuthSignInInitiateValidatedErrorType: Error {
             return .init(
                 type: .generalError,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInInitiateValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInInitiateValidatedResponse.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+@_implementationOnly import MSAL_Private
 
 enum MSALNativeAuthSignInInitiateValidatedResponse {
     case success(continuationToken: String)
@@ -31,37 +31,42 @@ enum MSALNativeAuthSignInInitiateValidatedResponse {
 
 enum MSALNativeAuthSignInInitiateValidatedErrorType: Error {
     case redirect
-    case unauthorizedClient(message: String?)
-    case invalidRequest(message: String?)
-    case unexpectedError(message: String?)
-    case userNotFound(message: String?)
-    case unsupportedChallengeType(message: String?)
+    case unauthorizedClient(MSALNativeAuthSignInInitiateResponseError)
+    case invalidRequest(MSALNativeAuthSignInInitiateResponseError)
+    case unexpectedError(MSALNativeAuthSignInInitiateResponseError?)
+    case userNotFound(MSALNativeAuthSignInInitiateResponseError)
+    case unsupportedChallengeType(MSALNativeAuthSignInInitiateResponseError)
 
-    func convertToSignInStartError() -> SignInStartError {
+    func convertToSignInStartError(context: MSIDRequestContext) -> SignInStartError {
         switch self {
         case .redirect:
-            return .init(type: .browserRequired)
-        case .userNotFound(let message):
-            return .init(type: .userNotFound, message: message)
-        case .unauthorizedClient(let message),
-             .unsupportedChallengeType(let message),
-             .invalidRequest(let message),
-             .unexpectedError(message: let message):
-            return .init(type: .generalError, message: message)
-        }
-    }
-
-    func convertToSignInPasswordStartError() -> SignInStartError {
-        switch self {
-        case .redirect:
-            return .init(type: .browserRequired)
-        case .userNotFound(let message):
-            return .init(type: .userNotFound, message: message)
-        case .unauthorizedClient(let message),
-             .unsupportedChallengeType(let message),
-             .invalidRequest(let message),
-             .unexpectedError(message: let message):
-            return .init(type: .generalError, message: message)
+            return .init(type: .browserRequired, correlationId: context.correlationId())
+        case .userNotFound(let apiError):
+            return .init(
+                type: .userNotFound,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .unexpectedError(let apiError):
+            return .init(
+                type: .generalError,
+                message: apiError?.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError?.errorCodes ?? [],
+                errorUri: apiError?.errorURI
+            )
+        case .unauthorizedClient(let apiError),
+             .unsupportedChallengeType(let apiError),
+             .invalidRequest(let apiError):
+            return .init(
+                type: .generalError,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
         }
     }
 }

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -62,27 +62,27 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             return .success(continuationToken: continuationToken)
         } else {
             MSALLogger.log(level: .error, context: context, format: "signup/start returned success with unexpected response body")
-            return .unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+            return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
     }
 
     private func handleStartFailed(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpStartValidatedResponse {
         guard let apiError = error as? MSALNativeAuthSignUpStartResponseError else {
             MSALLogger.log(level: .error, context: context, format: "signup/start: Unable to decode error response: \(error)")
-            return .unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+            return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
 
         switch apiError.error {
         case .invalidGrant where apiError.subError == .attributeValidationFailed:
             if let invalidAttributes = apiError.invalidAttributes, !invalidAttributes.isEmpty {
-                return .attributeValidationFailed(invalidAttributes: extractAttributeNames(from: invalidAttributes))
+                return .attributeValidationFailed(error: apiError, invalidAttributes: extractAttributeNames(from: invalidAttributes))
             } else {
                 MSALLogger.log(
                     level: .error,
                     context: context,
                     format: "Missing expected fields in signup/start for attribute_validation_failed error"
                 )
-                return .unexpectedError(message: apiError.errorDescription)
+                return .unexpectedError(.init(errorDescription: apiError.errorDescription))
             }
         case .invalidRequest where isSignUpStartInvalidRequestParameter(
             apiError,
@@ -93,7 +93,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             knownErrorDescription: MSALNativeAuthESTSApiErrorDescriptions.clientIdParameterIsEmptyOrNotValid.rawValue):
             return .unauthorizedClient(apiError)
         case .none:
-            return .unexpectedError(message: apiError.errorDescription)
+            return .unexpectedError(.init(errorDescription: apiError.errorDescription))
         default:
             return .error(apiError)
         }
@@ -119,7 +119,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
     ) -> MSALNativeAuthSignUpChallengeValidatedResponse {
         guard let challengeTypeIssued = response.challengeType else {
             MSALLogger.log(level: .error, context: context, format: "Missing ChallengeType from backend in signup/challenge response")
-            return .unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+            return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
 
         switch challengeTypeIssued {
@@ -133,28 +133,28 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
                 return .codeRequired(sentTo, channelType, codeLength, continuationToken)
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/challenge with challenge_type = oob")
-                return .unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+                return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
             }
         case .password:
             if let continuationToken = response.continuationToken {
                 return .passwordRequired(continuationToken)
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/challenge with challenge_type = password")
-                return .unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+                return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
             }
         case .otp:
             MSALLogger.log(level: .error, context: context, format: "ChallengeType OTP not expected for signup/challenge")
-            return .unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+            return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
     }
 
     private func handleChallengeError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpChallengeValidatedResponse {
         guard let apiError = error as? MSALNativeAuthSignUpChallengeResponseError else {
             MSALLogger.log(level: .error, context: context, format: "signup/challenge: Unable to decode error response: \(error)")
-            return .unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+            return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
         if apiError.error == .none {
-            return .unexpectedError(message: apiError.errorDescription)
+            return .unexpectedError(.init(errorDescription: apiError.errorDescription))
         }
 
         return .error(apiError)
@@ -169,7 +169,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
         switch result {
         case .success(let response):
             // Even if the `continuationToken` is nil, the signUp flow is considered successfully completed
-            return .success(response.continuationToken)
+            return .success(continuationToken: response.continuationToken)
         case .failure(let error):
             return handleContinueError(error, with: context)
         }
@@ -178,7 +178,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
     private func handleContinueError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpContinueValidatedResponse {
         guard let apiError = error as? MSALNativeAuthSignUpContinueResponseError else {
             MSALLogger.log(level: .error, context: context, format: "signup/continue: Unable to decode error response: \(error)")
-            return .unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+            return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
 
         switch apiError.error {
@@ -186,10 +186,10 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             return handleInvalidGrantError(apiError, with: context)
         case .credentialRequired:
             if let continuationToken = apiError.continuationToken {
-                return .credentialRequired(continuationToken: continuationToken)
+                return .credentialRequired(continuationToken: continuationToken, error: apiError)
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/continue for credential_required error")
-                return .unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+                return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
             }
         case .attributesRequired:
             if let continuationToken = apiError.continuationToken,
@@ -197,23 +197,24 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
                 !requiredAttributes.isEmpty {
                 return .attributesRequired(
                     continuationToken: continuationToken,
-                    requiredAttributes: requiredAttributes.map { $0.toRequiredAttributePublic() }
+                    requiredAttributes: requiredAttributes.map { $0.toRequiredAttributePublic() },
+                    error: apiError
                 )
             } else {
                 MSALLogger.log(level: .error, context: context, format: "Missing expected fields in signup/continue for attributes_required error")
-                return .unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+                return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
             }
         // TODO: .verificationRequired is not supported by the API team yet. We treat it as an unexpectedError
         case .verificationRequired:
             MSALLogger.log(level: .error, context: context, format: "verificationRequired is not supported yet")
-            return .unexpectedError(message: nil)
+            return .unexpectedError(nil)
         case .unauthorizedClient,
              .expiredToken,
              .userAlreadyExists,
              .invalidRequest:
             return .error(apiError)
         case .none:
-            return .unexpectedError(message: apiError.errorDescription)
+            return .unexpectedError(.init(errorDescription: apiError.errorDescription))
         }
     }
 
@@ -236,14 +237,14 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             return .invalidUserInput(apiError)
         case .attributeValidationFailed:
             if let invalidAttributes = apiError.invalidAttributes, !invalidAttributes.isEmpty {
-                return .attributeValidationFailed(invalidAttributes: extractAttributeNames(from: invalidAttributes))
+                return .attributeValidationFailed(error: apiError, invalidAttributes: extractAttributeNames(from: invalidAttributes))
             } else {
                 MSALLogger.log(
                     level: .error,
                     context: context,
                     format: "Missing expected fields in signup/continue for attribute_validation_failed error"
                 )
-                return .unexpectedError(message: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+                return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
             }
         }
     }

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -93,7 +93,12 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             knownErrorDescription: MSALNativeAuthESTSApiErrorDescriptions.clientIdParameterIsEmptyOrNotValid.rawValue):
             return .unauthorizedClient(apiError)
         case .none:
-            return .unexpectedError(.init(errorDescription: apiError.errorDescription))
+            return .unexpectedError(.init(
+                errorDescription: apiError.errorDescription,
+                errorCodes: apiError.errorCodes,
+                errorURI: apiError.errorURI,
+                correlationId: apiError.correlationId
+            ))
         default:
             return .error(apiError)
         }
@@ -214,7 +219,12 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
              .invalidRequest:
             return .error(apiError)
         case .none:
-            return .unexpectedError(.init(errorDescription: apiError.errorDescription))
+            return .unexpectedError(.init(
+                errorDescription: apiError.errorDescription,
+                errorCodes: apiError.errorCodes,
+                errorURI: apiError.errorURI,
+                correlationId: apiError.correlationId
+            ))
         }
     }
 

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpValidatedResponses.swift
@@ -24,13 +24,13 @@
 
 enum MSALNativeAuthSignUpStartValidatedResponse: Equatable {
     case success(continuationToken: String)
-    case attributeValidationFailed(invalidAttributes: [String])
+    case attributeValidationFailed(error: MSALNativeAuthSignUpStartResponseError, invalidAttributes: [String])
     case redirect
     case error(MSALNativeAuthSignUpStartResponseError)
     // TODO: Special errors handled separately. Remove after refactor validated error handling
     case invalidUsername(MSALNativeAuthSignUpStartResponseError)
     case unauthorizedClient(MSALNativeAuthSignUpStartResponseError)
-    case unexpectedError(message: String?)
+    case unexpectedError(MSALNativeAuthSignUpStartResponseError?)
 }
 
 enum MSALNativeAuthSignUpChallengeValidatedResponse: Equatable {
@@ -38,16 +38,20 @@ enum MSALNativeAuthSignUpChallengeValidatedResponse: Equatable {
     case passwordRequired(_ signUpChallengeToken: String)
     case redirect
     case error(MSALNativeAuthSignUpChallengeResponseError)
-    case unexpectedError(message: String?)
+    case unexpectedError(MSALNativeAuthSignUpChallengeResponseError?)
 }
 
 enum MSALNativeAuthSignUpContinueValidatedResponse: Equatable {
-    case success(_ continuationToken: String?)
+    case success(continuationToken: String?)
     /// error that represents invalidOOB or invalidPassword, depending on which State the input comes from.
     case invalidUserInput(_ error: MSALNativeAuthSignUpContinueResponseError)
-    case credentialRequired(continuationToken: String)
-    case attributesRequired(continuationToken: String, requiredAttributes: [MSALNativeAuthRequiredAttribute])
-    case attributeValidationFailed(invalidAttributes: [String])
+    case credentialRequired(continuationToken: String, error: MSALNativeAuthSignUpContinueResponseError)
+    case attributesRequired(
+        continuationToken: String,
+        requiredAttributes: [MSALNativeAuthRequiredAttribute],
+        error: MSALNativeAuthSignUpContinueResponseError
+    )
+    case attributeValidationFailed(error: MSALNativeAuthSignUpContinueResponseError, invalidAttributes: [String])
     case error(MSALNativeAuthSignUpContinueResponseError)
-    case unexpectedError(message: String?)
+    case unexpectedError(MSALNativeAuthSignUpContinueResponseError?)
 }

--- a/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
@@ -31,98 +31,189 @@ enum MSALNativeAuthTokenValidatedResponse {
 
 enum MSALNativeAuthTokenValidatedErrorType: Error {
     case generalError
-    case expiredToken(message: String?)
-    case expiredRefreshToken(message: String?)
-    case unauthorizedClient(message: String?)
-    case invalidRequest(message: String?)
-    case unexpectedError(message: String?)
-    case userNotFound(message: String?)
-    case invalidPassword(message: String?)
-    case invalidOOBCode(message: String?)
-    case unsupportedChallengeType(message: String?)
-    case strongAuthRequired(message: String?)
-    case invalidScope(message: String?)
-    case authorizationPending(message: String?)
-    case slowDown(message: String?)
+    case expiredToken(MSALNativeAuthTokenResponseError)
+    case expiredRefreshToken(MSALNativeAuthTokenResponseError)
+    case unauthorizedClient(MSALNativeAuthTokenResponseError)
+    case invalidRequest(MSALNativeAuthTokenResponseError)
+    case unexpectedError(MSALNativeAuthTokenResponseError?)
+    case userNotFound(MSALNativeAuthTokenResponseError)
+    case invalidPassword(MSALNativeAuthTokenResponseError)
+    case invalidOOBCode(MSALNativeAuthTokenResponseError)
+    case unsupportedChallengeType(MSALNativeAuthTokenResponseError)
+    case strongAuthRequired(MSALNativeAuthTokenResponseError)
+    case invalidScope(MSALNativeAuthTokenResponseError)
+    case authorizationPending(MSALNativeAuthTokenResponseError)
+    case slowDown(MSALNativeAuthTokenResponseError)
 
-    func convertToSignInPasswordStartError() -> SignInStartError {
+    // swiftlint:disable:next function_body_length
+    func convertToSignInPasswordStartError(context: MSIDRequestContext) -> SignInStartError {
         switch self {
-        case .expiredToken(let message),
-             .authorizationPending(let message),
-             .slowDown(let message),
-             .invalidRequest(let message),
-             .invalidOOBCode(let message),
-             .unauthorizedClient(let message),
-             .unsupportedChallengeType(let message),
-             .invalidScope(let message):
-            return SignInStartError(type: .generalError, message: message)
+        case .expiredToken(let apiError),
+             .authorizationPending(let apiError),
+             .slowDown(let apiError),
+             .invalidOOBCode(let apiError),
+             .unauthorizedClient(let apiError),
+             .unsupportedChallengeType(let apiError),
+             .invalidScope(let apiError),
+             .invalidRequest(let apiError):
+            return SignInStartError(
+                type: .generalError,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
         case .generalError:
-            return SignInStartError(type: .generalError)
-        case .userNotFound(let message):
-            return SignInStartError(type: .userNotFound, message: message)
-        case .invalidPassword(let message):
-            return SignInStartError(type: .invalidCredentials, message: message)
-        case .strongAuthRequired(let message):
-            return SignInStartError(type: .browserRequired, message: message)
-        case .expiredRefreshToken(let message):
+            return SignInStartError(type: .generalError, correlationId: context.correlationId())
+        case .unexpectedError(let apiError):
+            return SignInStartError(
+                type: .generalError,
+                message: apiError?.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError?.errorCodes ?? [],
+                errorUri: apiError?.errorURI
+            )
+        case .userNotFound(let apiError):
+            return SignInStartError(
+                type: .userNotFound,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .invalidPassword(let apiError):
+            return SignInStartError(
+                type: .invalidCredentials,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .strongAuthRequired(let apiError):
+            return SignInStartError(
+                type: .browserRequired,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .expiredRefreshToken(let apiError):
             MSALLogger.log(level: .error, context: nil, format: "Error not treated - \(self))")
-            return SignInStartError(type: .generalError, message: message)
-        case .unexpectedError(message: let message):
-            return SignInStartError(type: .generalError, message: message)
+            return SignInStartError(
+                type: .generalError,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
         }
     }
 
-    func convertToRetrieveAccessTokenError() -> RetrieveAccessTokenError {
+    func convertToRetrieveAccessTokenError(context: MSIDRequestContext) -> RetrieveAccessTokenError {
         switch self {
-        case .expiredToken(let message),
-             .authorizationPending(let message),
-             .slowDown(let message),
-             .invalidRequest(let message),
-             .unauthorizedClient(let message),
-             .unsupportedChallengeType(let message),
-             .invalidScope(let message):
-            return RetrieveAccessTokenError(type: .generalError, message: message)
+        case .expiredToken(let apiError),
+             .authorizationPending(let apiError),
+             .slowDown(let apiError),
+             .unauthorizedClient(let apiError),
+             .unsupportedChallengeType(let apiError),
+             .invalidScope(let apiError),
+             .invalidRequest(let apiError):
+            return RetrieveAccessTokenError(
+                type: .generalError,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
         case .generalError:
-            return RetrieveAccessTokenError(type: .generalError)
-        case .expiredRefreshToken:
-            return RetrieveAccessTokenError(type: .refreshTokenExpired)
-        case .strongAuthRequired(let message):
-            return RetrieveAccessTokenError(type: .browserRequired, message: message)
-        case .userNotFound(let message),
-             .invalidPassword(let message),
-             .invalidOOBCode(let message):
+            return RetrieveAccessTokenError(type: .generalError, correlationId: context.correlationId())
+        case .unexpectedError(let apiError):
+            return RetrieveAccessTokenError(
+                type: .generalError,
+                message: apiError?.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError?.errorCodes ?? [],
+                errorUri: apiError?.errorURI
+            )
+        case .expiredRefreshToken(let apiError):
+            return RetrieveAccessTokenError(
+                type: .refreshTokenExpired,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .strongAuthRequired(let apiError):
+            return RetrieveAccessTokenError(
+                type: .browserRequired,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .userNotFound(let apiError),
+             .invalidPassword(let apiError),
+             .invalidOOBCode(let apiError):
             MSALLogger.log(level: .error, context: nil, format: "Error not treated - \(self))")
-            return RetrieveAccessTokenError(type: .generalError, message: message)
-        case .unexpectedError(message: let message):
-            return RetrieveAccessTokenError(type: .generalError, message: message)
+            return RetrieveAccessTokenError(
+                type: .generalError,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
         }
     }
 
-    func convertToVerifyCodeError() -> VerifyCodeError {
+    func convertToVerifyCodeError(context: MSIDRequestContext) -> VerifyCodeError {
         switch self {
-        case .invalidOOBCode(let message):
-            return VerifyCodeError(type: .invalidCode, message: message)
-        case .strongAuthRequired(let message):
-            return VerifyCodeError(type: .browserRequired, message: message)
-        case .expiredToken(let message),
-             .authorizationPending(let message),
-             .slowDown(let message),
-             .invalidRequest(let message),
-             .unauthorizedClient(let message),
-             .unsupportedChallengeType(let message),
-             .invalidScope(let message),
-             .expiredRefreshToken(let message),
-             .userNotFound(let message),
-             .invalidPassword(let message):
-            return VerifyCodeError(type: .generalError, message: message)
+        case .invalidOOBCode(let apiError):
+            return VerifyCodeError(
+                type: .invalidCode,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .strongAuthRequired(let apiError):
+            return VerifyCodeError(
+                type: .browserRequired,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
+        case .expiredToken(let apiError),
+             .authorizationPending(let apiError),
+             .slowDown(let apiError),
+             .unauthorizedClient(let apiError),
+             .unsupportedChallengeType(let apiError),
+             .invalidScope(let apiError),
+             .expiredRefreshToken(let apiError),
+             .userNotFound(let apiError),
+             .invalidPassword(let apiError),
+             .invalidRequest(let apiError):
+            return VerifyCodeError(
+                type: .generalError,
+                message: apiError.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
+            )
         case .generalError:
-            return VerifyCodeError(type: .generalError)
-        case .unexpectedError(message: let message):
-            return VerifyCodeError(type: .generalError, message: message)
+            return VerifyCodeError(type: .generalError, correlationId: context.correlationId())
+        case .unexpectedError(let apiError):
+            return VerifyCodeError(
+                type: .generalError,
+                message: apiError?.errorDescription,
+                correlationId: context.correlationId(),
+                errorCodes: apiError?.errorCodes ?? [],
+                errorUri: apiError?.errorURI
+            )
         }
     }
 
-    func convertToPasswordRequiredError() -> PasswordRequiredError {
-        return PasswordRequiredError(signInStartError: convertToSignInPasswordStartError())
+    func convertToPasswordRequiredError(context: MSIDRequestContext) -> PasswordRequiredError {
+        return PasswordRequiredError(signInStartError: convertToSignInPasswordStartError(context: context))
     }
 }

--- a/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
@@ -30,7 +30,7 @@ enum MSALNativeAuthTokenValidatedResponse {
 }
 
 enum MSALNativeAuthTokenValidatedErrorType: Error {
-    case generalError
+    case generalError(MSALNativeAuthTokenResponseError?)
     case expiredToken(MSALNativeAuthTokenResponseError)
     case expiredRefreshToken(MSALNativeAuthTokenResponseError)
     case unauthorizedClient(MSALNativeAuthTokenResponseError)
@@ -46,7 +46,7 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
     case slowDown(MSALNativeAuthTokenResponseError)
 
     // swiftlint:disable:next function_body_length
-    func convertToSignInPasswordStartError(context: MSIDRequestContext) -> SignInStartError {
+    func convertToSignInPasswordStartError(correlationId: UUID) -> SignInStartError {
         switch self {
         case .expiredToken(let apiError),
              .authorizationPending(let apiError),
@@ -59,17 +59,16 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
             return SignInStartError(
                 type: .generalError,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
-        case .generalError:
-            return SignInStartError(type: .generalError, correlationId: context.correlationId())
-        case .unexpectedError(let apiError):
+        case .unexpectedError(let apiError),
+             .generalError(let apiError):
             return SignInStartError(
                 type: .generalError,
                 message: apiError?.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError?.errorCodes ?? [],
                 errorUri: apiError?.errorURI
             )
@@ -77,7 +76,7 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
             return SignInStartError(
                 type: .userNotFound,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
@@ -85,7 +84,7 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
             return SignInStartError(
                 type: .invalidCredentials,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
@@ -93,7 +92,7 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
             return SignInStartError(
                 type: .browserRequired,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
@@ -102,14 +101,14 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
             return SignInStartError(
                 type: .generalError,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
         }
     }
 
-    func convertToRetrieveAccessTokenError(context: MSIDRequestContext) -> RetrieveAccessTokenError {
+    func convertToRetrieveAccessTokenError(correlationId: UUID) -> RetrieveAccessTokenError {
         switch self {
         case .expiredToken(let apiError),
              .authorizationPending(let apiError),
@@ -121,17 +120,17 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
             return RetrieveAccessTokenError(
                 type: .generalError,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
         case .generalError:
-            return RetrieveAccessTokenError(type: .generalError, correlationId: context.correlationId())
+            return RetrieveAccessTokenError(type: .generalError, correlationId: correlationId)
         case .unexpectedError(let apiError):
             return RetrieveAccessTokenError(
                 type: .generalError,
                 message: apiError?.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError?.errorCodes ?? [],
                 errorUri: apiError?.errorURI
             )
@@ -139,7 +138,7 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
             return RetrieveAccessTokenError(
                 type: .refreshTokenExpired,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
@@ -147,7 +146,7 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
             return RetrieveAccessTokenError(
                 type: .browserRequired,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
@@ -158,20 +157,20 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
             return RetrieveAccessTokenError(
                 type: .generalError,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
         }
     }
 
-    func convertToVerifyCodeError(context: MSIDRequestContext) -> VerifyCodeError {
+    func convertToVerifyCodeError(correlationId: UUID) -> VerifyCodeError {
         switch self {
         case .invalidOOBCode(let apiError):
             return VerifyCodeError(
                 type: .invalidCode,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
@@ -179,7 +178,7 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
             return VerifyCodeError(
                 type: .browserRequired,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
@@ -196,24 +195,24 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
             return VerifyCodeError(
                 type: .generalError,
                 message: apiError.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
         case .generalError:
-            return VerifyCodeError(type: .generalError, correlationId: context.correlationId())
+            return VerifyCodeError(type: .generalError, correlationId: correlationId)
         case .unexpectedError(let apiError):
             return VerifyCodeError(
                 type: .generalError,
                 message: apiError?.errorDescription,
-                correlationId: context.correlationId(),
+                correlationId: correlationId,
                 errorCodes: apiError?.errorCodes ?? [],
                 errorUri: apiError?.errorURI
             )
         }
     }
 
-    func convertToPasswordRequiredError(context: MSIDRequestContext) -> PasswordRequiredError {
-        return PasswordRequiredError(signInStartError: convertToSignInPasswordStartError(context: context))
+    func convertToPasswordRequiredError(correlationId: UUID) -> PasswordRequiredError {
+        return PasswordRequiredError(signInStartError: convertToSignInPasswordStartError(correlationId: correlationId))
     }
 }

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpContinueRequestProviderParams.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpContinueRequestProviderParams.swift
@@ -30,7 +30,7 @@ struct MSALNativeAuthSignUpContinueRequestProviderParams {
     let password: String?
     let oobCode: String?
     let attributes: [String: Any]?
-    let context: MSIDRequestContext
+    let context: MSALNativeAuthRequestContext
 
     init(
         grantType: MSALNativeAuthGrantType,
@@ -38,7 +38,7 @@ struct MSALNativeAuthSignUpContinueRequestProviderParams {
         password: String? = nil,
         oobCode: String? = nil,
         attributes: [String: Any]? = nil,
-        context: MSIDRequestContext
+        context: MSALNativeAuthRequestContext
     ) {
         self.grantType = grantType
         self.continuationToken = continuationToken

--- a/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_up/MSALNativeAuthSignUpRequestProvider.swift
@@ -26,7 +26,7 @@
 
 protocol MSALNativeAuthSignUpRequestProviding {
     func start(parameters: MSALNativeAuthSignUpStartRequestProviderParameters) throws -> MSIDHttpRequest
-    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest
+    func challenge(token: String, context: MSALNativeAuthRequestContext) throws -> MSIDHttpRequest
     func `continue`(parameters: MSALNativeAuthSignUpContinueRequestProviderParams) throws -> MSIDHttpRequest
 }
 
@@ -57,7 +57,7 @@ final class MSALNativeAuthSignUpRequestProvider: MSALNativeAuthSignUpRequestProv
         return request
     }
 
-    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+    func challenge(token: String, context: MSALNativeAuthRequestContext) throws -> MSIDHttpRequest {
         let params = MSALNativeAuthSignUpChallengeRequestParameters(
             continuationToken: token,
             context: context

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -30,18 +30,20 @@ extension MSALNativeAuthPublicClientApplication {
         username: String,
         password: String?,
         attributes: [String: Any]?,
-        correlationId: UUID
+        correlationId: UUID?
     ) async -> MSALNativeAuthSignUpControlling.SignUpStartControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        let correlationId = context.correlationId()
+
         guard inputValidator.isInputValid(username) else {
-            return .init(.error(SignUpStartError(type: .invalidUsername, correlationId: correlationId)))
+            return .init(.error(SignUpStartError(type: .invalidUsername, correlationId: correlationId)), correlationId: correlationId)
         }
 
         if let password = password, !inputValidator.isInputValid(password) {
-            return .init(.error(SignUpStartError(type: .invalidPassword, correlationId: correlationId)))
+            return .init(.error(SignUpStartError(type: .invalidPassword, correlationId: correlationId)), correlationId: correlationId)
         }
 
         let controller = controllerFactory.makeSignUpController(cacheAccessor: cacheAccessor)
-        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         let parameters = MSALNativeAuthSignUpStartRequestProviderParameters(
             username: username,
@@ -56,14 +58,17 @@ extension MSALNativeAuthPublicClientApplication {
         username: String,
         password: String?,
         scopes: [String]?,
-        correlationId: UUID
+        correlationId: UUID?
     ) async -> MSALNativeAuthSignInControlling.SignInControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        let correlationId = context.correlationId()
+
         guard inputValidator.isInputValid(username) else {
-            return .init(.error(SignInStartError(type: .invalidUsername, correlationId: correlationId)))
+            return .init(.error(SignInStartError(type: .invalidUsername, correlationId: correlationId)), correlationId: correlationId)
         }
 
         if let password = password, !inputValidator.isInputValid(password) {
-            return .init(.error(SignInStartError(type: .invalidCredentials, correlationId: correlationId)))
+            return .init(.error(SignInStartError(type: .invalidCredentials, correlationId: correlationId)), correlationId: correlationId)
         }
 
         let controller = controllerFactory.makeSignInController(cacheAccessor: cacheAccessor)
@@ -71,7 +76,7 @@ extension MSALNativeAuthPublicClientApplication {
         let params = MSALNativeAuthSignInParameters(
             username: username,
             password: password,
-            context: MSALNativeAuthRequestContext(correlationId: correlationId),
+            context: context,
             scopes: scopes
         )
         return await controller.signIn(params: params)
@@ -79,14 +84,16 @@ extension MSALNativeAuthPublicClientApplication {
 
     func resetPasswordInternal(
         username: String,
-        correlationId: UUID
+        correlationId: UUID?
     ) async -> MSALNativeAuthResetPasswordControlling.ResetPasswordStartControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        let correlationId = context.correlationId()
+        
         guard inputValidator.isInputValid(username) else {
-            return .init(.error(ResetPasswordStartError(type: .invalidUsername, correlationId: correlationId)))
+            return .init(.error(ResetPasswordStartError(type: .invalidUsername, correlationId: correlationId)), correlationId: correlationId)
         }
 
         let controller = controllerFactory.makeResetPasswordController(cacheAccessor: cacheAccessor)
-        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 
         return await controller.resetPassword(
             parameters: .init(

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -30,14 +30,14 @@ extension MSALNativeAuthPublicClientApplication {
         username: String,
         password: String?,
         attributes: [String: Any]?,
-        correlationId: UUID?
+        correlationId: UUID
     ) async -> MSALNativeAuthSignUpControlling.SignUpStartControllerResponse {
         guard inputValidator.isInputValid(username) else {
-            return .init(.error(SignUpStartError(type: .invalidUsername)))
+            return .init(.error(SignUpStartError(type: .invalidUsername, correlationId: correlationId)))
         }
 
         if let password = password, !inputValidator.isInputValid(password) {
-            return .init(.error(SignUpStartError(type: .invalidPassword)))
+            return .init(.error(SignUpStartError(type: .invalidPassword, correlationId: correlationId)))
         }
 
         let controller = controllerFactory.makeSignUpController(cacheAccessor: cacheAccessor)
@@ -56,14 +56,14 @@ extension MSALNativeAuthPublicClientApplication {
         username: String,
         password: String?,
         scopes: [String]?,
-        correlationId: UUID?
+        correlationId: UUID
     ) async -> MSALNativeAuthSignInControlling.SignInControllerResponse {
         guard inputValidator.isInputValid(username) else {
-            return .init(.error(SignInStartError(type: .invalidUsername)))
+            return .init(.error(SignInStartError(type: .invalidUsername, correlationId: correlationId)))
         }
 
         if let password = password, !inputValidator.isInputValid(password) {
-            return .init(.error(SignInStartError(type: .invalidCredentials)))
+            return .init(.error(SignInStartError(type: .invalidCredentials, correlationId: correlationId)))
         }
 
         let controller = controllerFactory.makeSignInController(cacheAccessor: cacheAccessor)
@@ -79,10 +79,10 @@ extension MSALNativeAuthPublicClientApplication {
 
     func resetPasswordInternal(
         username: String,
-        correlationId: UUID?
+        correlationId: UUID
     ) async -> MSALNativeAuthResetPasswordControlling.ResetPasswordStartControllerResponse {
         guard inputValidator.isInputValid(username) else {
-            return .init(.error(ResetPasswordStartError(type: .invalidUsername)))
+            return .init(.error(ResetPasswordStartError(type: .invalidUsername, correlationId: correlationId)))
         }
 
         let controller = controllerFactory.makeResetPasswordController(cacheAccessor: cacheAccessor)

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -165,13 +165,20 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: SignUpStartDelegate
     ) {
         Task {
+            let correlationId = correlationId ?? .init()
+
             let controllerResponse = await signUpInternal(
                 username: username,
                 password: password,
                 attributes: attributes,
                 correlationId: correlationId
             )
-            let delegateDispatcher = SignUpStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+
+            let delegateDispatcher = SignUpStartDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -204,6 +211,8 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: SignInStartDelegate
     ) {
         Task {
+            let correlationId = correlationId ?? .init()
+
             let controllerResponse = await signInInternal(
                 username: username,
                 password: password,
@@ -211,7 +220,11 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                 correlationId: correlationId
             )
 
-            let delegateDispatcher = SignInStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = SignInStartDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -242,8 +255,15 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: ResetPasswordStartDelegate
     ) {
         Task {
+            let correlationId = correlationId ?? .init()
+
             let controllerResponse = await resetPasswordInternal(username: username, correlationId: correlationId)
-            let delegateDispatcher = ResetPasswordStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+
+            let delegateDispatcher = ResetPasswordStartDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -263,6 +283,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
     /// - Parameter correlationId: Optional. UUID to correlate this request with the server for debugging.
     /// - Returns: An object representing the account information if present in the local cache.
     public func getNativeAuthUserAccount(correlationId: UUID? = nil) -> MSALNativeAuthUserAccountResult? {
+        let correlationId = correlationId ?? .init()
         let controller = controllerFactory.makeCredentialsController(cacheAccessor: cacheAccessor)
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -30,7 +30,7 @@ import Foundation
 /// to the initialiser method.
 ///
 /// For example:
- 
+
 /// <pre>
 ///     do {
 ///         nativeAuth = try MSALNativeAuthPublicClientApplication(
@@ -165,8 +165,6 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: SignUpStartDelegate
     ) {
         Task {
-            let correlationId = correlationId ?? .init()
-
             let controllerResponse = await signUpInternal(
                 username: username,
                 password: password,
@@ -174,11 +172,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                 correlationId: correlationId
             )
 
-            let delegateDispatcher = SignUpStartDelegateDispatcher(
-                delegate: delegate,
-                correlationId: correlationId,
-                telemetryUpdate: controllerResponse.telemetryUpdate
-            )
+            let delegateDispatcher = SignUpStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -186,10 +180,11 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                     newState: newState,
                     sentTo: sentTo,
                     channelTargetType: channelTargetType,
-                    codeLength: codeLength
+                    codeLength: codeLength,
+                    correlationId: controllerResponse.correlationId
                 )
             case .attributesInvalid(let attributes):
-                await delegateDispatcher.dispatchSignUpAttributesInvalid(attributeNames: attributes)
+                await delegateDispatcher.dispatchSignUpAttributesInvalid(attributeNames: attributes, correlationId: controllerResponse.correlationId)
             case .error(let error):
                 await delegate.onSignUpStartError(error: error)
             }
@@ -211,8 +206,6 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: SignInStartDelegate
     ) {
         Task {
-            let correlationId = correlationId ?? .init()
-
             let controllerResponse = await signInInternal(
                 username: username,
                 password: password,
@@ -220,11 +213,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                 correlationId: correlationId
             )
 
-            let delegateDispatcher = SignInStartDelegateDispatcher(
-                delegate: delegate,
-                correlationId: correlationId,
-                telemetryUpdate: controllerResponse.telemetryUpdate
-            )
+            let delegateDispatcher = SignInStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -232,12 +221,13 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                     newState: newState,
                     sentTo: sentTo,
                     channelTargetType: channelTargetType,
-                    codeLength: codeLength
+                    codeLength: codeLength,
+                    correlationId: controllerResponse.correlationId
                 )
             case .passwordRequired(let newState):
-                await delegateDispatcher.dispatchSignInPasswordRequired(newState: newState)
+                await delegateDispatcher.dispatchSignInPasswordRequired(newState: newState, correlationId: controllerResponse.correlationId)
             case .completed(let result):
-                await delegateDispatcher.dispatchSignInCompleted(result: result)
+                await delegateDispatcher.dispatchSignInCompleted(result: result, correlationId: controllerResponse.correlationId)
             case .error(let error):
                 await delegate.onSignInStartError(error: error)
             }
@@ -255,15 +245,9 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: ResetPasswordStartDelegate
     ) {
         Task {
-            let correlationId = correlationId ?? .init()
-
             let controllerResponse = await resetPasswordInternal(username: username, correlationId: correlationId)
 
-            let delegateDispatcher = ResetPasswordStartDelegateDispatcher(
-                delegate: delegate,
-                correlationId: correlationId,
-                telemetryUpdate: controllerResponse.telemetryUpdate
-            )
+            let delegateDispatcher = ResetPasswordStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -271,7 +255,8 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                     newState: newState,
                     sentTo: sentTo,
                     channelTargetType: channelTargetType,
-                    codeLength: codeLength
+                    codeLength: codeLength,
+                    correlationId: controllerResponse.correlationId
                 )
             case .error(let error):
                 await delegate.onResetPasswordStartError(error: error)
@@ -283,7 +268,6 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
     /// - Parameter correlationId: Optional. UUID to correlate this request with the server for debugging.
     /// - Returns: An object representing the account information if present in the local cache.
     public func getNativeAuthUserAccount(correlationId: UUID? = nil) -> MSALNativeAuthUserAccountResult? {
-        let correlationId = correlationId ?? .init()
         let controller = controllerFactory.makeCredentialsController(cacheAccessor: cacheAccessor)
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
 

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -28,10 +28,11 @@ extension MSALNativeAuthUserAccountResult {
 
     func getAccessTokenInternal(
         forceRefresh: Bool,
-        correlationId: UUID,
+        correlationId: UUID?,
         cacheAccessor: MSALNativeAuthCacheInterface
     ) async -> MSALNativeAuthCredentialsControlling.RefreshTokenCredentialControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        let correlationId = context.correlationId()
 
         if let accessToken = self.authTokens.accessToken {
             if forceRefresh || accessToken.isExpired() {
@@ -39,11 +40,11 @@ extension MSALNativeAuthUserAccountResult {
                 let credentialsController = controllerFactory.makeCredentialsController(cacheAccessor: cacheAccessor)
                 return await credentialsController.refreshToken(context: context, authTokens: authTokens)
             } else {
-                return .init(.success(accessToken.accessToken))
+                return .init(.success(accessToken.accessToken), correlationId: correlationId)
             }
         } else {
             MSALLogger.log(level: .error, context: context, format: "Retrieve Access Token: Existing token not found")
-            return .init(.failure(RetrieveAccessTokenError(type: .tokenNotFound, correlationId: correlationId)))
+            return .init(.failure(RetrieveAccessTokenError(type: .tokenNotFound, correlationId: correlationId)), correlationId: correlationId)
         }
     }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -28,7 +28,7 @@ extension MSALNativeAuthUserAccountResult {
 
     func getAccessTokenInternal(
         forceRefresh: Bool,
-        correlationId: UUID?,
+        correlationId: UUID,
         cacheAccessor: MSALNativeAuthCacheInterface
     ) async -> MSALNativeAuthCredentialsControlling.RefreshTokenCredentialControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
@@ -43,7 +43,7 @@ extension MSALNativeAuthUserAccountResult {
             }
         } else {
             MSALLogger.log(level: .error, context: context, format: "Retrieve Access Token: Existing token not found")
-            return .init(.failure(RetrieveAccessTokenError(type: .tokenNotFound)))
+            return .init(.failure(RetrieveAccessTokenError(type: .tokenNotFound, correlationId: correlationId)))
         }
     }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -87,23 +87,20 @@ import Foundation
     ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
     @objc public func getAccessToken(forceRefresh: Bool = false, correlationId: UUID? = nil, delegate: CredentialsDelegate) {
         Task {
-            let correlationId = correlationId ?? .init()
-
             let controllerResponse = await getAccessTokenInternal(
                 forceRefresh: forceRefresh,
                 correlationId: correlationId,
                 cacheAccessor: cacheAccessor
             )
-            
-            let delegateDispatcher = CredentialsDelegateDispatcher(
-                delegate: delegate,
-                correlationId: correlationId,
-                telemetryUpdate: controllerResponse.telemetryUpdate
-            )
+
+            let delegateDispatcher = CredentialsDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .success(let accessToken):
-                await delegateDispatcher.dispatchAccessTokenRetrieveCompleted(accessToken: accessToken)
+                await delegateDispatcher.dispatchAccessTokenRetrieveCompleted(
+                    accessToken: accessToken,
+                    correlationId: controllerResponse.correlationId
+                )
             case .failure(let error):
                 await delegate.onAccessTokenRetrieveError(error: error)
             }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -87,12 +87,19 @@ import Foundation
     ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
     @objc public func getAccessToken(forceRefresh: Bool = false, correlationId: UUID? = nil, delegate: CredentialsDelegate) {
         Task {
+            let correlationId = correlationId ?? .init()
+
             let controllerResponse = await getAccessTokenInternal(
                 forceRefresh: forceRefresh,
                 correlationId: correlationId,
                 cacheAccessor: cacheAccessor
             )
-            let delegateDispatcher = CredentialsDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            
+            let delegateDispatcher = CredentialsDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .success(let accessToken):

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
@@ -26,7 +26,7 @@ import Foundation
 
 final class CredentialsDelegateDispatcher: DelegateDispatcher<CredentialsDelegate> {
 
-    func dispatchAccessTokenRetrieveCompleted(accessToken: String) async {
+    func dispatchAccessTokenRetrieveCompleted(accessToken: String, correlationId: UUID) async {
         if let onAccessTokenRetrieveCompleted = delegate.onAccessTokenRetrieveCompleted {
             telemetryUpdate?(.success(()))
             await onAccessTokenRetrieveCompleted(accessToken)

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
@@ -31,7 +31,11 @@ final class CredentialsDelegateDispatcher: DelegateDispatcher<CredentialsDelegat
             telemetryUpdate?(.success(()))
             await onAccessTokenRetrieveCompleted(accessToken)
         } else {
-            let error = RetrieveAccessTokenError(type: .generalError, message: requiredErrorMessage(for: "onAccessTokenRetrieveCompleted"))
+            let error = RetrieveAccessTokenError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onAccessTokenRetrieveCompleted"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onAccessTokenRetrieveError(error: error)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/DelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/DelegateDispatcher.swift
@@ -26,10 +26,12 @@ import Foundation
 
 class DelegateDispatcher<T> {
     let delegate: T
+    let correlationId: UUID
     let telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?
 
-    init(delegate: T, telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?) {
+    init(delegate: T, correlationId: UUID, telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?) {
         self.delegate = delegate
+        self.correlationId = correlationId
         self.telemetryUpdate = telemetryUpdate
     }
 

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/DelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/DelegateDispatcher.swift
@@ -26,12 +26,10 @@ import Foundation
 
 class DelegateDispatcher<T> {
     let delegate: T
-    let correlationId: UUID
     let telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?
 
-    init(delegate: T, correlationId: UUID, telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?) {
+    init(delegate: T, telemetryUpdate: ((Result<Void, MSALNativeAuthError>) -> Void)?) {
         self.delegate = delegate
-        self.correlationId = correlationId
         self.telemetryUpdate = telemetryUpdate
     }
 

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/ResetPasswordDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/ResetPasswordDelegateDispatchers.swift
@@ -30,7 +30,8 @@ final class ResetPasswordStartDelegateDispatcher: DelegateDispatcher<ResetPasswo
         newState: ResetPasswordCodeRequiredState,
         sentTo: String,
         channelTargetType: MSALNativeAuthChannelType,
-        codeLength: Int
+        codeLength: Int,
+        correlationId: UUID
     ) async {
         if let onResetPasswordCodeRequired = delegate.onResetPasswordCodeRequired {
             telemetryUpdate?(.success(()))
@@ -49,7 +50,7 @@ final class ResetPasswordStartDelegateDispatcher: DelegateDispatcher<ResetPasswo
 
 final class ResetPasswordVerifyCodeDelegateDispatcher: DelegateDispatcher<ResetPasswordVerifyCodeDelegate> {
 
-    func dispatchPasswordRequired(newState: ResetPasswordRequiredState) async {
+    func dispatchPasswordRequired(newState: ResetPasswordRequiredState, correlationId: UUID) async {
         if let onPasswordRequired = delegate.onPasswordRequired {
             telemetryUpdate?(.success(()))
             await onPasswordRequired(newState)
@@ -67,7 +68,8 @@ final class ResetPasswordResendCodeDelegateDispatcher: DelegateDispatcher<ResetP
         newState: ResetPasswordCodeRequiredState,
         sentTo: String,
         channelTargetType: MSALNativeAuthChannelType,
-        codeLength: Int
+        codeLength: Int,
+        correlationId: UUID
     ) async {
         if let onResetPasswordResendCodeRequired = delegate.onResetPasswordResendCodeRequired {
             telemetryUpdate?(.success(()))
@@ -82,7 +84,7 @@ final class ResetPasswordResendCodeDelegateDispatcher: DelegateDispatcher<ResetP
 
 final class ResetPasswordRequiredDelegateDispatcher: DelegateDispatcher<ResetPasswordRequiredDelegate> {
 
-    func dispatchResetPasswordCompleted(newState: SignInAfterResetPasswordState) async {
+    func dispatchResetPasswordCompleted(newState: SignInAfterResetPasswordState, correlationId: UUID) async {
         if let onResetPasswordCompleted = delegate.onResetPasswordCompleted {
             telemetryUpdate?(.success(()))
             await onResetPasswordCompleted(newState)

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/ResetPasswordDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/ResetPasswordDelegateDispatchers.swift
@@ -36,7 +36,11 @@ final class ResetPasswordStartDelegateDispatcher: DelegateDispatcher<ResetPasswo
             telemetryUpdate?(.success(()))
             await onResetPasswordCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = ResetPasswordStartError(type: .generalError, message: requiredErrorMessage(for: "onResetPasswordCodeRequired"))
+            let error = ResetPasswordStartError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onResetPasswordCodeRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onResetPasswordStartError(error: error)
         }
@@ -50,7 +54,7 @@ final class ResetPasswordVerifyCodeDelegateDispatcher: DelegateDispatcher<ResetP
             telemetryUpdate?(.success(()))
             await onPasswordRequired(newState)
         } else {
-            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onPasswordRequired"))
+            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onPasswordRequired"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onResetPasswordVerifyCodeError(error: error, newState: nil)
         }
@@ -69,7 +73,7 @@ final class ResetPasswordResendCodeDelegateDispatcher: DelegateDispatcher<ResetP
             telemetryUpdate?(.success(()))
             await onResetPasswordResendCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = ResendCodeError(message: requiredErrorMessage(for: "onResetPasswordResendCodeRequired"))
+            let error = ResendCodeError(message: requiredErrorMessage(for: "onResetPasswordResendCodeRequired"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onResetPasswordResendCodeError(error: error, newState: nil)
         }
@@ -83,7 +87,11 @@ final class ResetPasswordRequiredDelegateDispatcher: DelegateDispatcher<ResetPas
             telemetryUpdate?(.success(()))
             await onResetPasswordCompleted(newState)
         } else {
-            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onResetPasswordCompleted"))
+            let error = PasswordRequiredError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onResetPasswordCompleted"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onResetPasswordRequiredError(error: error, newState: nil)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterResetPasswordDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterResetPasswordDelegateDispatcher.swift
@@ -31,7 +31,7 @@ final class SignInAfterResetPasswordDelegateDispatcher: DelegateDispatcher<SignI
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
         } else {
-            let error = SignInAfterResetPasswordError(message: requiredErrorMessage(for: "onSignInCompleted"))
+            let error = SignInAfterResetPasswordError(message: requiredErrorMessage(for: "onSignInCompleted"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignInAfterResetPasswordError(error: error)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterResetPasswordDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterResetPasswordDelegateDispatcher.swift
@@ -26,7 +26,7 @@ import Foundation
 
 final class SignInAfterResetPasswordDelegateDispatcher: DelegateDispatcher<SignInAfterResetPasswordDelegate> {
 
-    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult) async {
+    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult, correlationId: UUID) async {
         if let onSignInCompleted = delegate.onSignInCompleted {
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterSignUpDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterSignUpDelegateDispatcher.swift
@@ -31,7 +31,7 @@ final class SignInAfterSignUpDelegateDispatcher: DelegateDispatcher<SignInAfterS
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
         } else {
-            let error = SignInAfterSignUpError(message: requiredErrorMessage(for: "onSignInCompleted"))
+            let error = SignInAfterSignUpError(message: requiredErrorMessage(for: "onSignInCompleted"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignInAfterSignUpError(error: error)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterSignUpDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterSignUpDelegateDispatcher.swift
@@ -26,7 +26,7 @@ import Foundation
 
 final class SignInAfterSignUpDelegateDispatcher: DelegateDispatcher<SignInAfterSignUpDelegate> {
 
-    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult) async {
+    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult, correlationId: UUID) async {
         if let onSignInCompleted = delegate.onSignInCompleted {
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInDelegateDispatchers.swift
@@ -30,7 +30,8 @@ final class SignInStartDelegateDispatcher: DelegateDispatcher<SignInStartDelegat
         newState: SignInCodeRequiredState,
         sentTo: String,
         channelTargetType: MSALNativeAuthChannelType,
-        codeLength: Int
+        codeLength: Int,
+        correlationId: UUID
     ) async {
         if let onSignInCodeRequired = delegate.onSignInCodeRequired {
             telemetryUpdate?(.success(()))
@@ -46,7 +47,7 @@ final class SignInStartDelegateDispatcher: DelegateDispatcher<SignInStartDelegat
         }
     }
 
-    func dispatchSignInPasswordRequired(newState: SignInPasswordRequiredState) async {
+    func dispatchSignInPasswordRequired(newState: SignInPasswordRequiredState, correlationId: UUID) async {
         if let onSignInPasswordRequired = delegate.onSignInPasswordRequired {
             telemetryUpdate?(.success(()))
             await onSignInPasswordRequired(newState)
@@ -61,7 +62,7 @@ final class SignInStartDelegateDispatcher: DelegateDispatcher<SignInStartDelegat
         }
     }
 
-    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult) async {
+    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult, correlationId: UUID) async {
         if let onSignInCompleted = delegate.onSignInCompleted {
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
@@ -75,7 +76,7 @@ final class SignInStartDelegateDispatcher: DelegateDispatcher<SignInStartDelegat
 
 final class SignInPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignInPasswordRequiredDelegate> {
 
-    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult) async {
+    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult, correlationId: UUID) async {
         if let onSignInCompleted = delegate.onSignInCompleted {
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
@@ -97,7 +98,8 @@ final class SignInResendCodeDelegateDispatcher: DelegateDispatcher<SignInResendC
         newState: SignInCodeRequiredState,
         sentTo: String,
         channelTargetType: MSALNativeAuthChannelType,
-        codeLength: Int
+        codeLength: Int,
+        correlationId: UUID
     ) async {
         if let onSignInResendCodeCodeRequired = delegate.onSignInResendCodeCodeRequired {
             telemetryUpdate?(.success(()))
@@ -112,7 +114,7 @@ final class SignInResendCodeDelegateDispatcher: DelegateDispatcher<SignInResendC
 
 final class SignInVerifyCodeDelegateDispatcher: DelegateDispatcher<SignInVerifyCodeDelegate> {
 
-    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult) async {
+    func dispatchSignInCompleted(result: MSALNativeAuthUserAccountResult, correlationId: UUID) async {
         if let onSignInCompleted = delegate.onSignInCompleted {
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInDelegateDispatchers.swift
@@ -36,7 +36,11 @@ final class SignInStartDelegateDispatcher: DelegateDispatcher<SignInStartDelegat
             telemetryUpdate?(.success(()))
             await onSignInCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = SignInStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInCodeRequired"))
+            let error = SignInStartError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignInCodeRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignInStartError(error: error)
         }
@@ -47,7 +51,11 @@ final class SignInStartDelegateDispatcher: DelegateDispatcher<SignInStartDelegat
             telemetryUpdate?(.success(()))
             await onSignInPasswordRequired(newState)
         } else {
-            let error = SignInStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInPasswordRequired"))
+            let error = SignInStartError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignInPasswordRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignInStartError(error: error)
         }
@@ -58,7 +66,7 @@ final class SignInStartDelegateDispatcher: DelegateDispatcher<SignInStartDelegat
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
         } else {
-            let error = SignInStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"))
+            let error = SignInStartError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignInStartError(error: error)
         }
@@ -72,7 +80,11 @@ final class SignInPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignInP
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
         } else {
-            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"))
+            let error = PasswordRequiredError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignInCompleted"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignInPasswordRequiredError(error: error, newState: nil)
         }
@@ -91,7 +103,7 @@ final class SignInResendCodeDelegateDispatcher: DelegateDispatcher<SignInResendC
             telemetryUpdate?(.success(()))
             await onSignInResendCodeCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = ResendCodeError(message: requiredErrorMessage(for: "onSignInResendCodeCodeRequired"))
+            let error = ResendCodeError(message: requiredErrorMessage(for: "onSignInResendCodeCodeRequired"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignInResendCodeError(error: error, newState: nil)
         }
@@ -105,7 +117,7 @@ final class SignInVerifyCodeDelegateDispatcher: DelegateDispatcher<SignInVerifyC
             telemetryUpdate?(.success(()))
             await onSignInCompleted(result)
         } else {
-            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"))
+            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignInCompleted"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignInVerifyCodeError(error: error, newState: nil)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignUpDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignUpDelegateDispatchers.swift
@@ -36,7 +36,11 @@ final class SignUpStartDelegateDispatcher: DelegateDispatcher<SignUpStartDelegat
             telemetryUpdate?(.success(()))
             await onSignUpCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = SignUpStartError(type: .generalError, message: requiredErrorMessage(for: "onSignUpCodeRequired"))
+            let error = SignUpStartError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpCodeRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpStartError(error: error)
         }
@@ -47,7 +51,11 @@ final class SignUpStartDelegateDispatcher: DelegateDispatcher<SignUpStartDelegat
             telemetryUpdate?(.success(()))
             await onSignUpAttributesInvalid(attributeNames)
         } else {
-            let error = SignUpStartError(type: .generalError, message: requiredErrorMessage(for: "onSignUpAttributesInvalid"))
+            let error = SignUpStartError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpAttributesInvalid"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpStartError(error: error)
         }
@@ -61,7 +69,11 @@ final class SignUpVerifyCodeDelegateDispatcher: DelegateDispatcher<SignUpVerifyC
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)
         } else {
-            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignUpAttributesRequired"))
+            let error = VerifyCodeError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpAttributesRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
         }
@@ -72,7 +84,11 @@ final class SignUpVerifyCodeDelegateDispatcher: DelegateDispatcher<SignUpVerifyC
             telemetryUpdate?(.success(()))
             await onSignUpPasswordRequired(newState)
         } else {
-            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignUpPasswordRequired"))
+            let error = VerifyCodeError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpPasswordRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
         }
@@ -83,7 +99,11 @@ final class SignUpVerifyCodeDelegateDispatcher: DelegateDispatcher<SignUpVerifyC
             telemetryUpdate?(.success(()))
             await onSignUpCompleted(newState)
         } else {
-            let error = VerifyCodeError(type: .generalError, message: requiredErrorMessage(for: "onSignUpCompleted"))
+            let error = VerifyCodeError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpCompleted"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpVerifyCodeError(error: error, newState: nil)
         }
@@ -102,7 +122,7 @@ final class SignUpResendCodeDelegateDispatcher: DelegateDispatcher<SignUpResendC
             telemetryUpdate?(.success(()))
             await onSignUpResendCodeCodeRequired(newState, sentTo, channelTargetType, codeLength)
         } else {
-            let error = ResendCodeError(message: requiredErrorMessage(for: "onSignUpResendCodeCodeRequired"))
+            let error = ResendCodeError(message: requiredErrorMessage(for: "onSignUpResendCodeCodeRequired"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpResendCodeError(error: error, newState: nil)
         }
@@ -116,7 +136,11 @@ final class SignUpPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignUpP
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)
         } else {
-            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onSignUpAttributesRequired"))
+            let error = PasswordRequiredError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpAttributesRequired"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpPasswordRequiredError(error: error, newState: nil)
         }
@@ -127,7 +151,11 @@ final class SignUpPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignUpP
             telemetryUpdate?(.success(()))
             await onSignUpCompleted(newState)
         } else {
-            let error = PasswordRequiredError(type: .generalError, message: requiredErrorMessage(for: "onSignUpCompleted"))
+            let error = PasswordRequiredError(
+                type: .generalError,
+                message: requiredErrorMessage(for: "onSignUpCompleted"),
+                correlationId: correlationId
+            )
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpPasswordRequiredError(error: error, newState: nil)
         }
@@ -141,7 +169,7 @@ final class SignUpAttributesRequiredDelegateDispatcher: DelegateDispatcher<SignU
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)
         } else {
-            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpAttributesRequired"))
+            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpAttributesRequired"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpAttributesRequiredError(error: error)
         }
@@ -152,7 +180,7 @@ final class SignUpAttributesRequiredDelegateDispatcher: DelegateDispatcher<SignU
             telemetryUpdate?(.success(()))
             await onSignUpAttributesInvalid(attributeNames, newState)
         } else {
-            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpAttributesInvalid"))
+            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpAttributesInvalid"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpAttributesRequiredError(error: error)
         }
@@ -163,7 +191,7 @@ final class SignUpAttributesRequiredDelegateDispatcher: DelegateDispatcher<SignU
             telemetryUpdate?(.success(()))
             await onSignUpCompleted(newState)
         } else {
-            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpCompleted"))
+            let error = AttributesRequiredError(message: requiredErrorMessage(for: "onSignUpCompleted"), correlationId: correlationId)
             telemetryUpdate?(.failure(error))
             await delegate.onSignUpAttributesRequiredError(error: error)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignUpDelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignUpDelegateDispatchers.swift
@@ -30,7 +30,8 @@ final class SignUpStartDelegateDispatcher: DelegateDispatcher<SignUpStartDelegat
         newState: SignUpCodeRequiredState,
         sentTo: String,
         channelTargetType: MSALNativeAuthChannelType,
-        codeLength: Int
+        codeLength: Int,
+        correlationId: UUID
     ) async {
         if let onSignUpCodeRequired = delegate.onSignUpCodeRequired {
             telemetryUpdate?(.success(()))
@@ -46,7 +47,7 @@ final class SignUpStartDelegateDispatcher: DelegateDispatcher<SignUpStartDelegat
         }
     }
 
-    func dispatchSignUpAttributesInvalid(attributeNames: [String]) async {
+    func dispatchSignUpAttributesInvalid(attributeNames: [String], correlationId: UUID) async {
         if let onSignUpAttributesInvalid = delegate.onSignUpAttributesInvalid {
             telemetryUpdate?(.success(()))
             await onSignUpAttributesInvalid(attributeNames)
@@ -64,7 +65,11 @@ final class SignUpStartDelegateDispatcher: DelegateDispatcher<SignUpStartDelegat
 
 final class SignUpVerifyCodeDelegateDispatcher: DelegateDispatcher<SignUpVerifyCodeDelegate> {
 
-    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState) async {
+    func dispatchSignUpAttributesRequired(
+        attributes: [MSALNativeAuthRequiredAttribute],
+        newState: SignUpAttributesRequiredState,
+        correlationId: UUID
+    ) async {
         if let onSignUpAttributesRequired = delegate.onSignUpAttributesRequired {
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)
@@ -79,7 +84,7 @@ final class SignUpVerifyCodeDelegateDispatcher: DelegateDispatcher<SignUpVerifyC
         }
     }
 
-    func dispatchSignUpPasswordRequired(newState: SignUpPasswordRequiredState) async {
+    func dispatchSignUpPasswordRequired(newState: SignUpPasswordRequiredState, correlationId: UUID) async {
         if let onSignUpPasswordRequired = delegate.onSignUpPasswordRequired {
             telemetryUpdate?(.success(()))
             await onSignUpPasswordRequired(newState)
@@ -94,7 +99,7 @@ final class SignUpVerifyCodeDelegateDispatcher: DelegateDispatcher<SignUpVerifyC
         }
     }
 
-    func dispatchSignUpCompleted(newState: SignInAfterSignUpState) async {
+    func dispatchSignUpCompleted(newState: SignInAfterSignUpState, correlationId: UUID) async {
         if let onSignUpCompleted = delegate.onSignUpCompleted {
             telemetryUpdate?(.success(()))
             await onSignUpCompleted(newState)
@@ -116,7 +121,8 @@ final class SignUpResendCodeDelegateDispatcher: DelegateDispatcher<SignUpResendC
         newState: SignUpCodeRequiredState,
         sentTo: String,
         channelTargetType: MSALNativeAuthChannelType,
-        codeLength: Int
+        codeLength: Int,
+        correlationId: UUID
     ) async {
         if let onSignUpResendCodeCodeRequired = delegate.onSignUpResendCodeCodeRequired {
             telemetryUpdate?(.success(()))
@@ -131,7 +137,11 @@ final class SignUpResendCodeDelegateDispatcher: DelegateDispatcher<SignUpResendC
 
 final class SignUpPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignUpPasswordRequiredDelegate> {
 
-    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState) async {
+    func dispatchSignUpAttributesRequired(
+        attributes: [MSALNativeAuthRequiredAttribute],
+        newState: SignUpAttributesRequiredState,
+        correlationId: UUID
+    ) async {
         if let onSignUpAttributesRequired = delegate.onSignUpAttributesRequired {
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)
@@ -146,7 +156,7 @@ final class SignUpPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignUpP
         }
     }
 
-    func dispatchSignUpCompleted(newState: SignInAfterSignUpState) async {
+    func dispatchSignUpCompleted(newState: SignInAfterSignUpState, correlationId: UUID) async {
         if let onSignUpCompleted = delegate.onSignUpCompleted {
             telemetryUpdate?(.success(()))
             await onSignUpCompleted(newState)
@@ -164,7 +174,11 @@ final class SignUpPasswordRequiredDelegateDispatcher: DelegateDispatcher<SignUpP
 
 final class SignUpAttributesRequiredDelegateDispatcher: DelegateDispatcher<SignUpAttributesRequiredDelegate> {
 
-    func dispatchSignUpAttributesRequired(attributes: [MSALNativeAuthRequiredAttribute], newState: SignUpAttributesRequiredState) async {
+    func dispatchSignUpAttributesRequired(
+        attributes: [MSALNativeAuthRequiredAttribute],
+        newState: SignUpAttributesRequiredState,
+        correlationId: UUID
+    ) async {
         if let onSignUpAttributesRequired = delegate.onSignUpAttributesRequired {
             telemetryUpdate?(.success(()))
             await onSignUpAttributesRequired(attributes, newState)
@@ -175,7 +189,7 @@ final class SignUpAttributesRequiredDelegateDispatcher: DelegateDispatcher<SignU
         }
     }
 
-    func dispatchSignUpAttributesInvalid(attributeNames: [String], newState: SignUpAttributesRequiredState) async {
+    func dispatchSignUpAttributesInvalid(attributeNames: [String], newState: SignUpAttributesRequiredState, correlationId: UUID) async {
         if let onSignUpAttributesInvalid = delegate.onSignUpAttributesInvalid {
             telemetryUpdate?(.success(()))
             await onSignUpAttributesInvalid(attributeNames, newState)
@@ -186,7 +200,7 @@ final class SignUpAttributesRequiredDelegateDispatcher: DelegateDispatcher<SignU
         }
     }
 
-    func dispatchSignUpCompleted(newState: SignInAfterSignUpState) async {
+    func dispatchSignUpCompleted(newState: SignInAfterSignUpState, correlationId: UUID) async {
         if let onSignUpCompleted = delegate.onSignUpCompleted {
             telemetryUpdate?(.success(()))
             await onSignUpCompleted(newState)

--- a/MSAL/src/native_auth/public/state_machine/error/MSALNativeAuthError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/MSALNativeAuthError.swift
@@ -30,9 +30,21 @@ public class MSALNativeAuthError: NSObject, LocalizedError {
     /// Describes why an error occurred and provides more information about the error.
     public var errorDescription: String? { message }
 
+    /// Correlation ID used for the request
+    public let correlationId: UUID
+
+    /// Error codes returned along with the error
+    public let errorCodes: [Int]
+
+    /// Error uri that can be followed to get more information about the error returned by the server
+    public let errorUri: String?
+
     private let message: String?
 
-    init(message: String? = nil) {
+    init(message: String? = nil, correlationId: UUID, errorCodes: [Int] = [], errorUri: String? = nil) {
         self.message = message
+        self.correlationId = correlationId
+        self.errorCodes = errorCodes
+        self.errorUri = errorUri
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/PasswordRequiredError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/PasswordRequiredError.swift
@@ -35,21 +35,31 @@ public class PasswordRequiredError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = [], errorUri: String? = nil) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes, errorUri: errorUri)
     }
 
     init(signInStartError: SignInStartError) {
+        let errorDescription: String?
+
         switch signInStartError.type {
         case .browserRequired:
             self.type = .browserRequired
+            errorDescription = MSALNativeAuthErrorMessage.browserRequired
         case .invalidCredentials:
             self.type = .invalidPassword
+            errorDescription = MSALNativeAuthErrorMessage.invalidPassword
         default:
             self.type = .generalError
+            errorDescription = signInStartError.errorDescription
         }
-        super.init(message: signInStartError.errorDescription)
+        super.init(
+            message: errorDescription,
+            correlationId: signInStartError.correlationId,
+            errorCodes: signInStartError.errorCodes,
+            errorUri: signInStartError.errorUri
+        )
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/error/ResetPasswordStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/ResetPasswordStartError.swift
@@ -37,9 +37,9 @@ public class ResetPasswordStartError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = [], errorUri: String? = nil) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes, errorUri: errorUri)
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/error/RetrieveAccessTokenError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/RetrieveAccessTokenError.swift
@@ -36,9 +36,9 @@ public class RetrieveAccessTokenError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = [], errorUri: String? = nil) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes, errorUri: errorUri)
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/error/SignInStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignInStartError.swift
@@ -37,9 +37,9 @@ public class SignInStartError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = [], errorUri: String? = nil) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes, errorUri: errorUri)
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/error/SignUpStartError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/SignUpStartError.swift
@@ -37,9 +37,9 @@ public class SignUpStartError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = [], errorUri: String? = nil) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes, errorUri: errorUri)
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/error/VerifyCodeError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/VerifyCodeError.swift
@@ -35,9 +35,9 @@ public class VerifyCodeError: MSALNativeAuthError {
 
     let type: ErrorType
 
-    init(type: ErrorType, message: String? = nil) {
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = [], errorUri: String? = nil) {
         self.type = type
-        super.init(message: message)
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes, errorUri: errorUri)
     }
 
     /// Describes why an error occurred and provides more information about the error.

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
@@ -36,7 +36,10 @@ extension ResetPasswordCodeRequiredState {
 
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "ResetPassword flow, invalid code")
-            return .init(.error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self))
+            return .init(
+                .error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self), 
+                correlationId: correlationId
+            )
         }
 
         return await controller.submitCode(code: code, username: username, continuationToken: continuationToken, context: context)
@@ -50,7 +53,10 @@ extension ResetPasswordRequiredState {
 
         guard inputValidator.isInputValid(password) else {
             MSALLogger.log(level: .error, context: context, format: "ResetPassword flow, invalid password")
-            return .init(.error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self))
+            return .init(
+                .error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self), 
+                correlationId: correlationId
+            )
         }
 
         return await controller.submitPassword(password: password, username: username, continuationToken: continuationToken, context: context)

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates+Internal.swift
@@ -36,7 +36,7 @@ extension ResetPasswordCodeRequiredState {
 
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "ResetPassword flow, invalid code")
-            return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
+            return .init(.error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitCode(code: code, username: username, continuationToken: continuationToken, context: context)
@@ -50,7 +50,7 @@ extension ResetPasswordRequiredState {
 
         guard inputValidator.isInputValid(password) else {
             MSALLogger.log(level: .error, context: context, format: "ResetPassword flow, invalid password")
-            return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
+            return .init(.error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitPassword(password: password, username: username, continuationToken: continuationToken, context: context)

--- a/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/ResetPasswordStates.swift
@@ -54,6 +54,7 @@ public class ResetPasswordBaseState: MSALNativeAuthBaseState {
             let controllerResponse = await resendCodeInternal()
             let delegateDispatcher = ResetPasswordResendCodeDelegateDispatcher(
                 delegate: delegate,
+                correlationId: correlationId,
                 telemetryUpdate: controllerResponse.telemetryUpdate
             )
 
@@ -80,6 +81,7 @@ public class ResetPasswordBaseState: MSALNativeAuthBaseState {
             let controllerResponse = await submitCodeInternal(code: code)
             let delegateDispatcher = ResetPasswordVerifyCodeDelegateDispatcher(
                 delegate: delegate,
+                correlationId: correlationId,
                 telemetryUpdate: controllerResponse.telemetryUpdate
             )
 
@@ -102,7 +104,11 @@ public class ResetPasswordBaseState: MSALNativeAuthBaseState {
     public func submitPassword(password: String, delegate: ResetPasswordRequiredDelegate) {
         Task {
             let controllerResponse = await submitPasswordInternal(password: password)
-            let delegateDispatcher = ResetPasswordRequiredDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = ResetPasswordRequiredDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .completed(let newState):

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -35,13 +35,12 @@ import Foundation
             let controllerResponse = await signInInternal(scopes: scopes)
             let delegateDispatcher = SignInAfterResetPasswordDelegateDispatcher(
                 delegate: delegate,
-                correlationId: correlationId,
                 telemetryUpdate: controllerResponse.telemetryUpdate
             )
 
             switch controllerResponse.result {
             case .success(let accountResult):
-                await delegateDispatcher.dispatchSignInCompleted(result: accountResult)
+                await delegateDispatcher.dispatchSignInCompleted(result: accountResult, correlationId: controllerResponse.correlationId)
             case .failure(let error):
                 let error = SignInAfterResetPasswordError(
                     message: error.errorDescription,

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -35,6 +35,7 @@ import Foundation
             let controllerResponse = await signInInternal(scopes: scopes)
             let delegateDispatcher = SignInAfterResetPasswordDelegateDispatcher(
                 delegate: delegate,
+                correlationId: correlationId,
                 telemetryUpdate: controllerResponse.telemetryUpdate
             )
 
@@ -42,7 +43,12 @@ import Foundation
             case .success(let accountResult):
                 await delegateDispatcher.dispatchSignInCompleted(result: accountResult)
             case .failure(let error):
-                await delegate.onSignInAfterResetPasswordError(error: SignInAfterResetPasswordError(message: error.errorDescription))
+                let error = SignInAfterResetPasswordError(
+                    message: error.errorDescription,
+                    correlationId: error.correlationId,
+                    errorCodes: error.errorCodes
+                )
+                await delegate.onSignInAfterResetPasswordError(error: error)
             }
         }
     }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -33,13 +33,19 @@ import Foundation
     public func signIn(scopes: [String]? = nil, delegate: SignInAfterSignUpDelegate) {
         Task {
             let controllerResponse = await signInInternal(scopes: scopes)
-            let delegateDispatcher = SignInAfterSignUpDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = SignInAfterSignUpDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .success(let accountResult):
                 await delegateDispatcher.dispatchSignInCompleted(result: accountResult)
             case .failure(let error):
-                await delegate.onSignInAfterSignUpError(error: SignInAfterSignUpError(message: error.errorDescription))
+                await delegate.onSignInAfterSignUpError(
+                    error: SignInAfterSignUpError(message: error.errorDescription, correlationId: error.correlationId, errorCodes: error.errorCodes)
+                )
             }
         }
     }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -33,15 +33,11 @@ import Foundation
     public func signIn(scopes: [String]? = nil, delegate: SignInAfterSignUpDelegate) {
         Task {
             let controllerResponse = await signInInternal(scopes: scopes)
-            let delegateDispatcher = SignInAfterSignUpDelegateDispatcher(
-                delegate: delegate,
-                correlationId: correlationId,
-                telemetryUpdate: controllerResponse.telemetryUpdate
-            )
+            let delegateDispatcher = SignInAfterSignUpDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .success(let accountResult):
-                await delegateDispatcher.dispatchSignInCompleted(result: accountResult)
+                await delegateDispatcher.dispatchSignInCompleted(result: accountResult, correlationId: controllerResponse.correlationId)
             case .failure(let error):
                 await delegate.onSignInAfterSignUpError(
                     error: SignInAfterSignUpError(message: error.errorDescription, correlationId: error.correlationId, errorCodes: error.errorCodes)

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
@@ -31,7 +31,7 @@ extension SignInCodeRequiredState {
         MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, code submitted")
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn flow, invalid code")
-            return .init(.error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self))
+            return .init(.error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self), correlationId: context.correlationId())
         }
 
         return await controller.submitCode(code, continuationToken: continuationToken, context: context, scopes: scopes)
@@ -53,7 +53,10 @@ extension SignInPasswordRequiredState {
 
         guard inputValidator.isInputValid(password) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn flow, invalid password")
-            return .init(.error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self))
+            return .init(
+                .error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self),
+                correlationId: context.correlationId()
+            )
         }
 
         return await controller.submitPassword(password, username: username, continuationToken: continuationToken, context: context, scopes: scopes)

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
@@ -31,7 +31,7 @@ extension SignInCodeRequiredState {
         MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, code submitted")
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn flow, invalid code")
-            return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
+            return .init(.error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitCode(code, continuationToken: continuationToken, context: context, scopes: scopes)
@@ -53,7 +53,7 @@ extension SignInPasswordRequiredState {
 
         guard inputValidator.isInputValid(password) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn flow, invalid password")
-            return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
+            return .init(.error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitPassword(password, username: username, continuationToken: continuationToken, context: context, scopes: scopes)

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
@@ -60,7 +60,11 @@ import Foundation
     public func resendCode(delegate: SignInResendCodeDelegate) {
         Task {
             let controllerResponse = await resendCodeInternal()
-            let delegateDispatcher = SignInResendCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = SignInResendCodeDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -83,7 +87,11 @@ import Foundation
     public func submitCode(code: String, delegate: SignInVerifyCodeDelegate) {
         Task {
             let controllerResponse = await submitCodeInternal(code: code)
-            let delegateDispatcher = SignInVerifyCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = SignInVerifyCodeDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .completed(let accountResult):
@@ -120,7 +128,11 @@ import Foundation
     public func submitPassword(password: String, delegate: SignInPasswordRequiredDelegate) {
         Task {
             let controllerResponse = await submitPasswordInternal(password: password)
-            let delegateDispatcher = SignInPasswordRequiredDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            let delegateDispatcher = SignInPasswordRequiredDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .completed(let accountResult):

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates.swift
@@ -60,11 +60,7 @@ import Foundation
     public func resendCode(delegate: SignInResendCodeDelegate) {
         Task {
             let controllerResponse = await resendCodeInternal()
-            let delegateDispatcher = SignInResendCodeDelegateDispatcher(
-                delegate: delegate,
-                correlationId: correlationId,
-                telemetryUpdate: controllerResponse.telemetryUpdate
-            )
+            let delegateDispatcher = SignInResendCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -72,7 +68,8 @@ import Foundation
                     newState: newState,
                     sentTo: sentTo,
                     channelTargetType: channelTargetType,
-                    codeLength: codeLength
+                    codeLength: codeLength,
+                    correlationId: controllerResponse.correlationId
                 )
             case .error(let error, let newState):
                 await delegate.onSignInResendCodeError(error: error, newState: newState)
@@ -87,15 +84,11 @@ import Foundation
     public func submitCode(code: String, delegate: SignInVerifyCodeDelegate) {
         Task {
             let controllerResponse = await submitCodeInternal(code: code)
-            let delegateDispatcher = SignInVerifyCodeDelegateDispatcher(
-                delegate: delegate,
-                correlationId: correlationId,
-                telemetryUpdate: controllerResponse.telemetryUpdate
-            )
+            let delegateDispatcher = SignInVerifyCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .completed(let accountResult):
-                await delegateDispatcher.dispatchSignInCompleted(result: accountResult)
+                await delegateDispatcher.dispatchSignInCompleted(result: accountResult, correlationId: controllerResponse.correlationId)
             case .error(let error, let newState):
                 await delegate.onSignInVerifyCodeError(error: error, newState: newState)
             }
@@ -128,15 +121,11 @@ import Foundation
     public func submitPassword(password: String, delegate: SignInPasswordRequiredDelegate) {
         Task {
             let controllerResponse = await submitPasswordInternal(password: password)
-            let delegateDispatcher = SignInPasswordRequiredDelegateDispatcher(
-                delegate: delegate,
-                correlationId: correlationId,
-                telemetryUpdate: controllerResponse.telemetryUpdate
-            )
+            let delegateDispatcher = SignInPasswordRequiredDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .completed(let accountResult):
-                await delegateDispatcher.dispatchSignInCompleted(result: accountResult)
+                await delegateDispatcher.dispatchSignInCompleted(result: accountResult, correlationId: controllerResponse.correlationId)
             case .error(let error, let newState):
                 await delegate.onSignInPasswordRequiredError(error: error, newState: newState)
             }

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
@@ -36,7 +36,10 @@ extension SignUpCodeRequiredState {
 
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "SignUp flow, invalid code")
-            return .init(.error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self))
+            return .init(
+                .error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self),
+                correlationId: correlationId
+            )
         }
 
         return await controller.submitCode(code, username: username, continuationToken: continuationToken, context: context)
@@ -50,7 +53,10 @@ extension SignUpPasswordRequiredState {
 
         guard inputValidator.isInputValid(password) else {
             MSALLogger.log(level: .error, context: context, format: "SignUp flow, invalid password")
-            return .init(.error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self))
+            return .init(
+                .error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self),
+                correlationId: correlationId
+            )
         }
 
         return await controller.submitPassword(password, username: username, continuationToken: continuationToken, context: context)

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates+Internal.swift
@@ -36,7 +36,7 @@ extension SignUpCodeRequiredState {
 
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "SignUp flow, invalid code")
-            return .init(.error(error: VerifyCodeError(type: .invalidCode), newState: self))
+            return .init(.error(error: VerifyCodeError(type: .invalidCode, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitCode(code, username: username, continuationToken: continuationToken, context: context)
@@ -50,7 +50,7 @@ extension SignUpPasswordRequiredState {
 
         guard inputValidator.isInputValid(password) else {
             MSALLogger.log(level: .error, context: context, format: "SignUp flow, invalid password")
-            return .init(.error(error: PasswordRequiredError(type: .invalidPassword), newState: self))
+            return .init(.error(error: PasswordRequiredError(type: .invalidPassword, correlationId: correlationId), newState: self))
         }
 
         return await controller.submitPassword(password, username: username, continuationToken: continuationToken, context: context)

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
@@ -53,11 +53,7 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
         Task {
             let controllerResponse = await resendCodeInternal()
 
-            let delegateDispatcher = SignUpResendCodeDelegateDispatcher(
-                delegate: delegate,
-                correlationId: correlationId,
-                telemetryUpdate: controllerResponse.telemetryUpdate
-            )
+            let delegateDispatcher = SignUpResendCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -65,7 +61,8 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
                     newState: newState,
                     sentTo: sentTo,
                     channelTargetType: channelTargetType,
-                    codeLength: codeLength
+                    codeLength: codeLength,
+                    correlationId: controllerResponse.correlationId
                 )
             case .error(let error, let newState):
                 await delegate.onSignUpResendCodeError(error: error, newState: newState)
@@ -81,19 +78,19 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
         Task {
             let controllerResponse = await submitCodeInternal(code: code)
             
-            let delegateDispatcher = SignUpVerifyCodeDelegateDispatcher(
-                delegate: delegate,
-                correlationId: correlationId,
-                telemetryUpdate: controllerResponse.telemetryUpdate
-            )
+            let delegateDispatcher = SignUpVerifyCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .completed(let state):
-                await delegateDispatcher.dispatchSignUpCompleted(newState: state)
+                await delegateDispatcher.dispatchSignUpCompleted(newState: state, correlationId: controllerResponse.correlationId)
             case .passwordRequired(let state):
-                await delegateDispatcher.dispatchSignUpPasswordRequired(newState: state)
+                await delegateDispatcher.dispatchSignUpPasswordRequired(newState: state, correlationId: controllerResponse.correlationId)
             case .attributesRequired(let attributes, let state):
-                await delegateDispatcher.dispatchSignUpAttributesRequired(attributes: attributes, newState: state)
+                await delegateDispatcher.dispatchSignUpAttributesRequired(
+                    attributes: attributes,
+                    newState: state,
+                    correlationId: controllerResponse.correlationId
+                )
             case .error(let error, let state):
                 await delegate.onSignUpVerifyCodeError(error: error, newState: state)
             }
@@ -112,17 +109,17 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
         Task {
             let controllerResponse = await submitPasswordInternal(password: password)
 
-            let delegateDispatcher = SignUpPasswordRequiredDelegateDispatcher(
-                delegate: delegate,
-                correlationId: correlationId,
-                telemetryUpdate: controllerResponse.telemetryUpdate
-            )
+            let delegateDispatcher = SignUpPasswordRequiredDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
             case .completed(let state):
-                await delegateDispatcher.dispatchSignUpCompleted(newState: state)
+                await delegateDispatcher.dispatchSignUpCompleted(newState: state, correlationId: controllerResponse.correlationId)
             case .attributesRequired(let attributes, let state):
-                await delegateDispatcher.dispatchSignUpAttributesRequired(attributes: attributes, newState: state)
+                await delegateDispatcher.dispatchSignUpAttributesRequired(
+                    attributes: attributes,
+                    newState: state,
+                    correlationId: controllerResponse.correlationId
+                )
             case .error(let error, let state):
                 await delegate.onSignUpPasswordRequiredError(error: error, newState: state)
             }
@@ -145,19 +142,26 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
             
             let delegateDispatcher = SignUpAttributesRequiredDelegateDispatcher(
                 delegate: delegate,
-                correlationId: correlationId,
                 telemetryUpdate: controllerResponse.telemetryUpdate
             )
 
             switch controllerResponse.result {
             case .completed(let state):
-                await delegateDispatcher.dispatchSignUpCompleted(newState: state)
+                await delegateDispatcher.dispatchSignUpCompleted(newState: state, correlationId: controllerResponse.correlationId)
             case .error(let error):
                 await delegate.onSignUpAttributesRequiredError(error: error)
             case .attributesRequired(let attributes, let state):
-                await delegateDispatcher.dispatchSignUpAttributesRequired(attributes: attributes, newState: state)
+                await delegateDispatcher.dispatchSignUpAttributesRequired(
+                    attributes: attributes,
+                    newState: state,
+                    correlationId: controllerResponse.correlationId
+                )
             case .attributesInvalid(let attributes, let state):
-                await delegateDispatcher.dispatchSignUpAttributesInvalid(attributeNames: attributes, newState: state)
+                await delegateDispatcher.dispatchSignUpAttributesInvalid(
+                    attributeNames: attributes,
+                    newState: state,
+                    correlationId: controllerResponse.correlationId
+                )
             }
         }
     }

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
@@ -52,7 +52,12 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     public func resendCode(delegate: SignUpResendCodeDelegate) {
         Task {
             let controllerResponse = await resendCodeInternal()
-            let delegateDispatcher = SignUpResendCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+
+            let delegateDispatcher = SignUpResendCodeDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .codeRequired(let newState, let sentTo, let channelTargetType, let codeLength):
@@ -75,7 +80,12 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     public func submitCode(code: String, delegate: SignUpVerifyCodeDelegate) {
         Task {
             let controllerResponse = await submitCodeInternal(code: code)
-            let delegateDispatcher = SignUpVerifyCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+            
+            let delegateDispatcher = SignUpVerifyCodeDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .completed(let state):
@@ -101,7 +111,12 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     public func submitPassword(password: String, delegate: SignUpPasswordRequiredDelegate) {
         Task {
             let controllerResponse = await submitPasswordInternal(password: password)
-            let delegateDispatcher = SignUpPasswordRequiredDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
+
+            let delegateDispatcher = SignUpPasswordRequiredDelegateDispatcher(
+                delegate: delegate,
+                correlationId: correlationId,
+                telemetryUpdate: controllerResponse.telemetryUpdate
+            )
 
             switch controllerResponse.result {
             case .completed(let state):
@@ -127,8 +142,10 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     ) {
         Task {
             let controllerResponse = await submitAttributesInternal(attributes: attributes)
+            
             let delegateDispatcher = SignUpAttributesRequiredDelegateDispatcher(
                 delegate: delegate,
+                correlationId: correlationId,
                 telemetryUpdate: controllerResponse.telemetryUpdate
             )
 

--- a/MSAL/test/integration/native_auth/common/MSALNativeAuthIntegrationBaseTests.swift
+++ b/MSAL/test/integration/native_auth/common/MSALNativeAuthIntegrationBaseTests.swift
@@ -76,7 +76,7 @@ class MSALNativeAuthIntegrationBaseTests: XCTestCase {
         try await mockResponse(response, endpoint: endpoint)
         let response: Error = try await perform_uncheckedTestFail()
 
-        XCTAssertEqual(response.error.rawValue, expectedError.error.rawValue)
+        XCTAssertEqual(response.error?.rawValue, expectedError.error?.rawValue)
 
         // TODO: Fix these checks
         if expectedError.errorDescription != nil {

--- a/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpContinueIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_up/MSALNativeAuthSignUpContinueIntegrationTests.swift
@@ -29,7 +29,7 @@ import XCTest
 final class MSALNativeAuthSignUpContinueIntegrationTests: MSALNativeAuthIntegrationBaseTests {
 
     private var provider: MSALNativeAuthSignUpRequestProvider!
-    private var context: MSIDRequestContext!
+    private var context: MSALNativeAuthRequestContext!
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/MSAL/test/integration/native_auth/requests/token/MSALNativeAuthTokenIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/token/MSALNativeAuthTokenIntegrationTests.swift
@@ -170,7 +170,7 @@ class MSALNativeAuthTokenIntegrationTests: MSALNativeAuthIntegrationBaseTests {
 
         let expectedError = createError(.slowDown)
 
-        XCTAssertEqual(result.error.rawValue, expectedError.error.rawValue)
+        XCTAssertEqual(result.error?.rawValue, expectedError.error?.rawValue)
     }
 
     private func createError(_ code: MSALNativeAuthTokenOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, errorCodes: [MSALNativeAuthESTSApiErrorCodes]? = nil) -> Error {

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthBaseControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthBaseControllerTests.swift
@@ -266,3 +266,17 @@ final class MSALNativeAuthBaseControllerTests: MSALNativeAuthTestCase {
         }
     }
 }
+
+extension String: MSALNativeAuthResponseCorrelatable {
+    public var correlationId: UUID? {
+        get { nil }
+        set {}
+    }
+}
+
+extension Array<String>: MSALNativeAuthResponseCorrelatable {
+    public var correlationId: UUID? {
+        get { nil }
+        set {}
+    }
+}

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
@@ -167,7 +167,7 @@ final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
     }
 
     func test_whenErrorIsReturnedFromValidator_itIsCorrectlyTranslatedToDelegateError() async  {
-        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, correlationId: defaultUUID), validatorError: .generalError)
+        await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, correlationId: defaultUUID), validatorError: .generalError(apiErrorStub))
         await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, correlationId: defaultUUID), validatorError: .expiredToken(apiErrorStub))
         await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, correlationId: defaultUUID), validatorError: .authorizationPending(apiErrorStub))
         await checkPublicErrorWithValidatorError(publicError: RetrieveAccessTokenError(type: .generalError, correlationId: defaultUUID), validatorError: .slowDown(apiErrorStub))

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
@@ -882,7 +882,7 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
 
         let exp2 = expectation(description: "SignInAfterResetPassword expectation")
         signInControllerMock.expectation = exp2
-        signInControllerMock.continuationTokenResult = .init(.failure(SignInAfterResetPasswordError(correlationId: correlationId)))
+        signInControllerMock.continuationTokenResult = .init(.failure(SignInAfterResetPasswordError(correlationId: correlationId)), correlationId: correlationId)
 
         helper.signInAfterResetPasswordState?.signIn(delegate: SignInAfterResetPasswordDelegateStub())
         await fulfillment(of: [exp2], timeout: 1)

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -41,6 +41,24 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     private var defaultUUID = UUID(uuidString: DEFAULT_TEST_UID)!
     private let defaultScopes = "openid profile offline_access"
 
+    private var signInInitiateApiErrorStub: MSALNativeAuthSignInInitiateResponseError {
+        .init(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+    }
+
+    private var signInChallengeApiErrorStub: MSALNativeAuthSignInChallengeResponseError {
+        .init(
+            error: .expiredToken,
+            errorDescription: nil,
+            errorCodes: nil,
+            errorURI: nil,
+            innerErrors: nil
+        )
+    }
+
+    private var signInTokenApiErrorStub: MSALNativeAuthTokenResponseError {
+        .init(error: .expiredToken, subError: nil, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil)
+    }
+
     override func setUpWithError() throws {
         signInRequestProviderMock = .init()
         tokenRequestProviderMock = .init()
@@ -81,7 +99,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.expectedContext = expectedContext
         signInRequestProviderMock.throwingInitError = ErrorMock.error
 
-        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
 
@@ -111,7 +129,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
 
-        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "scope2"]))
 
@@ -140,7 +158,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
         tokenRequestProviderMock.throwingTokenError = ErrorMock.error
 
-        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "openid", "profile"]))
 
@@ -207,7 +225,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.expectedUsername = expectedUsername
         tokenRequestProviderMock.expectedContext = expectedContext
 
-        let delegateError = SignInStartError(type: .generalError)
+        let delegateError = SignInStartError(type: .generalError, correlationId: defaultUUID)
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
         tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
@@ -230,7 +248,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectation = expectation(description: "SignInController")
 
         signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .error(.invalidToken(message: nil))
+        signInResponseValidatorMock.challengeValidatedResponse = .error(.invalidToken(signInChallengeApiErrorStub))
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -241,7 +259,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.expectedUsername = expectedUsername
         tokenRequestProviderMock.expectedContext = expectedContext
 
-        let delegateError = SignInStartError(type: .generalError)
+        let delegateError = SignInStartError(type: .generalError, correlationId: defaultUUID)
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
         tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
@@ -255,18 +273,18 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenErrorIsReturnedFromValidator_itIsCorrectlyTranslatedToDelegateError() async  {
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .generalError)
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .expiredToken(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .authorizationPending(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .slowDown(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Invalid Client ID"), validatorError: .unauthorizedClient(message: "Invalid Client ID"))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received"), validatorError: .unexpectedError(message: "Unexpected response body received"))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unsupported challenge type"), validatorError: .unsupportedChallengeType(message: "Unsupported challenge type"))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Invalid scope"), validatorError: .invalidScope(message: "Invalid scope"))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .invalidCredentials), validatorError: .invalidPassword(message: nil))
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message"), validatorError: .unexpectedError(message: "Error message"))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .generalError)
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .expiredToken(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .authorizationPending(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .slowDown(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidRequest(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Invalid Client ID", correlationId: defaultUUID), validatorError: .unauthorizedClient(createSignInTokenApiError(message: "Invalid Client ID")))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received", correlationId: defaultUUID), validatorError: .unexpectedError(.init(errorDescription: "Unexpected response body received")))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unsupported challenge type", correlationId: defaultUUID), validatorError: .unsupportedChallengeType(createSignInTokenApiError(message: "Unsupported challenge type")))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Invalid scope", correlationId: defaultUUID), validatorError: .invalidScope(createSignInTokenApiError(message: "Invalid scope")))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .userNotFound, correlationId: defaultUUID), validatorError: .userNotFound(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .invalidCredentials, correlationId: defaultUUID), validatorError: .invalidPassword(signInTokenApiErrorStub))
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message", correlationId: defaultUUID), validatorError: .unexpectedError(.init(errorDescription: "Error message")))
     }
     
     func test_whenCredentialsAreRequired_browserRequiredErrorIsReturned() async {
@@ -289,9 +307,9 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let expectation = expectation(description: "SignInController")
 
-        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: .init(type: .browserRequired, message: MSALNativeAuthErrorMessage.unsupportedMFA))
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: .init(type: .browserRequired, message: MSALNativeAuthErrorMessage.unsupportedMFA, correlationId: defaultUUID))
 
-        tokenResponseValidatorMock.tokenValidatedResponse = .error(.strongAuthRequired(message: "MFA currently not supported. Use the browser instead"))
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(.strongAuthRequired(.init(error: .unauthorizedClient, subError: nil, errorDescription: MSALNativeAuthErrorMessage.unsupportedMFA, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil)))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
 
@@ -361,7 +379,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         helper.expectedCodeLength = expectedCodeLength
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
-        result.telemetryUpdate?(.failure(.init(message: "error")))
+        result.telemetryUpdate?(.failure(.init(message: "error", correlationId: defaultUUID)))
 
         helper.onSignInCodeRequired(result)
 
@@ -439,7 +457,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         cacheAccessorMock.expectedMSIDTokenResult = nil
 
         let state = SignInCodeRequiredState(scopes: ["openid","profile","offline_access"], controller: sut, inputValidator: MSALNativeAuthInputValidator(), continuationToken: continuationToken, correlationId: defaultUUID)
-        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)))
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError, correlationId: defaultUUID)))
 
         wait(for: [expectation], timeout: 1)
 
@@ -454,9 +472,9 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInRequestProviderMock.expectedUsername = expectedUsername
         signInRequestProviderMock.expectedContext = expectedContext
-        signInRequestProviderMock.throwingInitError = MSALNativeAuthError(message: nil)
+        signInRequestProviderMock.throwingInitError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
 
-        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
 
@@ -467,13 +485,13 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithCodeStartAndInitiateReturnError_properErrorShouldBeReturned() async {
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .browserRequired), validatorError: .redirect)
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .unauthorizedClient(message: nil))
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .unsupportedChallengeType(message: nil))
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received"), validatorError: .unexpectedError(message: "Unexpected response body received"))
-        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message"), validatorError: .unexpectedError(message: "Error message"))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .browserRequired, correlationId: defaultUUID), validatorError: .redirect)
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .unauthorizedClient(signInInitiateApiErrorStub))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .userNotFound, correlationId: defaultUUID), validatorError: .userNotFound(signInInitiateApiErrorStub))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .unsupportedChallengeType(signInInitiateApiErrorStub))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidRequest(createSignInInitiateApiError(correlationId: defaultUUID)))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received", correlationId: defaultUUID), validatorError: .unexpectedError(.init(errorDescription: "Unexpected response body received")))
+        await checkCodeStartDelegateErrorWithInitiateValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message", correlationId: defaultUUID), validatorError: .unexpectedError(.init(errorDescription: "Error message")))
     }
     
     func test_whenSignInWithCodeChallengeRequestCreationFail_errorShouldBeReturned() async {
@@ -483,10 +501,10 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError(message: nil)
+        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
         signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: "continuationToken")
-        
-        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError))
+
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
 
@@ -497,15 +515,15 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithCodeChallengeReturnsError_properErrorShouldBeReturned() async {
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .browserRequired), validatorError: .redirect)
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .expiredToken(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidToken(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError), validatorError: .invalidRequest(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .unauthorizedClient(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received"), validatorError: .unexpectedError(message: "Unexpected response body received"))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .userNotFound), validatorError: .userNotFound(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: nil), validatorError: .unsupportedChallengeType(message: nil))
-        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message"), validatorError: .unexpectedError(message: "Error message"))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .browserRequired, correlationId: defaultUUID), validatorError: .redirect)
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .expiredToken(signInChallengeApiErrorStub))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidToken(signInChallengeApiErrorStub))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidRequest(createSignInChallengeApiError(correlationId: defaultUUID)))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .unauthorizedClient(signInChallengeApiErrorStub))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: "Unexpected response body received", correlationId: defaultUUID), validatorError: .unexpectedError(.init(errorDescription: "Unexpected response body received")))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .userNotFound, correlationId: defaultUUID), validatorError: .userNotFound(signInChallengeApiErrorStub))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .unsupportedChallengeType(signInChallengeApiErrorStub))
+        await checkCodeStartDelegateErrorWithChallengeValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message", correlationId: defaultUUID), validatorError: .unexpectedError(.init(errorDescription: "Error message")))
     }
     
     func test_whenSignInWithCodePasswordIsRequired_newStateIsPropagatedToUser() async {
@@ -547,7 +565,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let helper = SignInCodeStartWithPasswordRequiredTestsValidatorHelper(expectation: expectation)
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
-        result.telemetryUpdate?(.failure(.init(message: "error")))
+        result.telemetryUpdate?(.failure(.init(message: "error", correlationId: defaultUUID)))
 
         helper.onSignInPasswordRequired(result.result)
 
@@ -596,7 +614,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: expectedCredentialToken, grantType: MSALNativeAuthGrantType.password, scope: "", password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
 
-        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID))
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
         tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
         cacheAccessorMock.expectedMSIDTokenResult = nil
@@ -616,10 +634,10 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let exp = expectation(description: "SignInController")
         
-        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil)
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
         signInRequestProviderMock.expectedContext = expectedContext
         
-        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError))
+        let mockDelegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID))
 
         let state = SignInPasswordRequiredState(scopes: [], username: expectedUsername, controller: sut, continuationToken: expectedCredentialToken, correlationId: defaultUUID)
         state.submitPassword(password: expectedPassword, delegate: mockDelegate)
@@ -631,20 +649,20 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithCodeSubmitPasswordTokenAPIReturnError_correctErrorShouldBeReturned() async {
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .generalError)
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .expiredToken(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .unauthorizedClient(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidRequest(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "Unexpected response body received"), validatorError: .unexpectedError(message: "Unexpected response body received"))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "User not found"), validatorError: .userNotFound(message: "User not found"))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidOOBCode(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .unsupportedChallengeType(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .browserRequired), validatorError: .strongAuthRequired(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .invalidScope(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .authorizationPending(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError), validatorError: .slowDown(message: nil))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .invalidPassword), validatorError: .invalidPassword(message: "Invalid password"))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "Error message"), validatorError: .unexpectedError(message: "Error message"))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .generalError)
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .expiredToken(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .unauthorizedClient(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidRequest(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "Unexpected response body received", correlationId: defaultUUID), validatorError: .unexpectedError(.init(errorDescription: "Unexpected response body received")))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "User does not exist", correlationId: defaultUUID), validatorError: .userNotFound(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidOOBCode(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .unsupportedChallengeType(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .browserRequired, correlationId: defaultUUID), validatorError: .strongAuthRequired(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidScope(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .authorizationPending(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .slowDown(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .invalidPassword, correlationId: defaultUUID), validatorError: .invalidPassword(signInTokenApiErrorStub))
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "Error message", correlationId: defaultUUID), validatorError: .unexpectedError(.init(errorDescription: "Error message")))
     }
     
     func test_signInWithCodeSubmitCodeTokenRequestFailCreation_errorShouldBeReturned() {
@@ -654,10 +672,10 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let expectation = expectation(description: "SignInController")
 
         signInRequestProviderMock.expectedContext = expectedContext
-        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil)
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
 
         let state = SignInCodeRequiredState(scopes: [], controller: sut, continuationToken: continuationToken, correlationId: defaultUUID)
-        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError)))
+        state.submitCode(code: "code", delegate: SignInVerifyCodeDelegateSpy(expectation: expectation, expectedError: VerifyCodeError(type: .generalError, correlationId: defaultUUID)))
 
         wait(for: [expectation], timeout: 1)
         XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
@@ -666,18 +684,18 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     
     func test_signInWithCodeSubmitCodeReturnError_correctResultShouldReturned() {
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .generalError)
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .expiredToken(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unauthorizedClient(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidRequest(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unexpectedError(message: "Unexpected response body received"))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .userNotFound(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .invalidCode, validatorError: .invalidOOBCode(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unsupportedChallengeType(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .browserRequired, validatorError: .strongAuthRequired(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidScope(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .authorizationPending(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .slowDown(message: nil))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidPassword(message: nil))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .expiredToken(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unauthorizedClient(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidRequest(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unexpectedError(.init(errorDescription: "Unexpected response body received")))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .userNotFound(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .invalidCode, validatorError: .invalidOOBCode(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unsupportedChallengeType(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .browserRequired, validatorError: .strongAuthRequired(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidScope(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .authorizationPending(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .slowDown(signInTokenApiErrorStub))
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidPassword(signInTokenApiErrorStub))
     }
         
     func test_signInWithCodeResendCode_shouldSendNewCode() async {
@@ -713,7 +731,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         
         let expectation = expectation(description: "SignInController")
 
-        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError(message: nil)
+        signInRequestProviderMock.throwingChallengeError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
 
@@ -759,7 +777,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation)
 
-        signInResponseValidatorMock.challengeValidatedResponse = .error(.userNotFound(message: nil))
+        signInResponseValidatorMock.challengeValidatedResponse = .error(.userNotFound(signInChallengeApiErrorStub))
 
         let result = await sut.resendCode(continuationToken: continuationToken, context: expectedContext, scopes: [])
 
@@ -804,10 +822,10 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let exp = expectation(description: "SignInController")
         
-        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil)
+        tokenRequestProviderMock.throwingTokenError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
         signInRequestProviderMock.expectedContext = expectedContext
         
-        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: exp, expectedError: SignInAfterSignUpError())
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: exp, expectedError: SignInAfterSignUpError(correlationId: defaultUUID))
 
         let state = SignInAfterSignUpState(controller: sut, username: "", continuationToken: continuationToken, correlationId: defaultUUID)
         state.signIn(delegate: mockDelegate)
@@ -826,9 +844,9 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
 
-        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Invalid Client ID"))
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: MSALNativeAuthErrorMessage.generalError, correlationId: defaultUUID))
 
-        tokenResponseValidatorMock.tokenValidatedResponse = .error(.unauthorizedClient(message: "Invalid Client ID"))
+        tokenResponseValidatorMock.tokenValidatedResponse = .error(.unauthorizedClient(signInTokenApiErrorStub))
 
         let state = SignInAfterSignUpState(controller: sut, username: "", continuationToken: continuationToken, correlationId: defaultUUID)
         state.signIn(delegate: mockDelegate)
@@ -841,7 +859,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     func test_whenSignInWithContinuationTokenHaveTokenNil_shouldReturnAnError() {
         let expectation = expectation(description: "SignInController")
 
-        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Sign In is not available at this point, please use the standalone sign in methods"))
+        let mockDelegate = SignInAfterSignUpDelegateSpy(expectation: expectation, expectedError: SignInAfterSignUpError(message: "Sign In is not available at this point, please use the standalone sign in methods", correlationId: defaultUUID))
 
         let state = SignInAfterSignUpState(controller: sut, username: "username", continuationToken: nil, correlationId: defaultUUID)
         state.signIn(delegate: mockDelegate)
@@ -864,7 +882,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         tokenRequestProviderMock.expectedContext = expectedContext
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: nil, continuationToken: expectedCredentialToken, grantType: MSALNativeAuthGrantType.oobCode, scope: "", password: nil, oobCode: expectedOOBCode, includeChallengeType: true, refreshToken: nil)
-        let mockDelegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedError: VerifyCodeError(type: delegateError))
+        let mockDelegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedError: VerifyCodeError(type: delegateError, correlationId: defaultUUID))
         tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
         
         let state = SignInCodeRequiredState(scopes: [], controller: sut, continuationToken: expectedCredentialToken, correlationId: defaultUUID)
@@ -951,7 +969,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
         signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
-        
+
         signInRequestProviderMock.mockInitiateRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInRequestProviderMock.mockChallengeRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInRequestProviderMock.expectedUsername = expectedUsername
@@ -992,4 +1010,20 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         XCTAssertNotNil(telemetryEventDict["response_time"])
     }
 
+
+    private func createSignInTokenApiError(message: String) -> MSALNativeAuthTokenResponseError {
+        .init(error: .expiredToken, subError: nil, errorDescription: message, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil)
+    }
+
+    private func createSignInInitiateApiError(correlationId: UUID) -> MSALNativeAuthSignInInitiateResponseError {
+        var error = MSALNativeAuthSignInInitiateResponseError()
+        error.correlationId = correlationId
+        return error
+    }
+
+    private func createSignInChallengeApiError(correlationId: UUID) -> MSALNativeAuthSignInChallengeResponseError {
+        var error = MSALNativeAuthSignInChallengeResponseError()
+        error.correlationId = correlationId
+        return error
+    }
 }

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -273,7 +273,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenErrorIsReturnedFromValidator_itIsCorrectlyTranslatedToDelegateError() async  {
-        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .generalError)
+        await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .generalError(signInTokenApiErrorStub))
         await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .expiredToken(signInTokenApiErrorStub))
         await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .authorizationPending(signInTokenApiErrorStub))
         await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, correlationId: defaultUUID), validatorError: .slowDown(signInTokenApiErrorStub))
@@ -649,7 +649,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_whenSignInWithCodeSubmitPasswordTokenAPIReturnError_correctErrorShouldBeReturned() async {
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .generalError)
+        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .generalError(signInTokenApiErrorStub))
         await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .expiredToken(signInTokenApiErrorStub))
         await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .unauthorizedClient(signInTokenApiErrorStub))
         await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidRequest(signInTokenApiErrorStub))
@@ -683,7 +683,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
     }
     
     func test_signInWithCodeSubmitCodeReturnError_correctResultShouldReturned() {
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .generalError)
+        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .generalError(signInTokenApiErrorStub))
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .expiredToken(signInTokenApiErrorStub))
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unauthorizedClient(signInTokenApiErrorStub))
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidRequest(signInTokenApiErrorStub))

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
@@ -1842,7 +1842,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
 
         let exp2 = expectation(description: "SignInAfterSignUp expectation")
         signInControllerMock.expectation = exp2
-        signInControllerMock.continuationTokenResult = .init(.init(.failure(SignInAfterSignUpError(correlationId: correlationId))))
+        signInControllerMock.continuationTokenResult = .init(.init(.failure(SignInAfterSignUpError(correlationId: correlationId)), correlationId: correlationId))
         helper.signInAfterSignUpState?.signIn(delegate: SignInAfterSignUpDelegateStub())
         await fulfillment(of: [exp2], timeout: 1)
 

--- a/MSAL/test/unit/native_auth/mock/CredentialsDelegateSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/CredentialsDelegateSpies.swift
@@ -52,6 +52,8 @@ open class CredentialsDelegateSpy: CredentialsDelegate {
             XCTAssertTrue(Thread.isMainThread)
             XCTAssertEqual(error.type, expectedError.type)
             XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error.correlationId, expectedError.correlationId)
+            XCTAssertEqual(error.errorCodes, expectedError.errorCodes)
             expectation.fulfill()
             return
         }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
@@ -136,7 +136,7 @@ class MSALNativeAuthTokenResponseValidatorMock: MSALNativeAuthTokenResponseValid
     var expectedConfiguration: MSIDConfiguration?
     var expectedTokenResponse: MSIDCIAMTokenResponse?
     var expectedResponseError: Error?
-    var tokenValidatedResponse: MSALNativeAuthTokenValidatedResponse = .error(.generalError)
+    var tokenValidatedResponse: MSALNativeAuthTokenValidatedResponse = .error(.generalError(.init()))
 
     func validate(context: MSIDRequestContext, msidConfiguration: MSIDConfiguration, result: Result<MSIDCIAMTokenResponse, Error>) -> MSAL.MSALNativeAuthTokenValidatedResponse {
         checkConfAndContext(context, config: msidConfiguration)

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
@@ -47,7 +47,7 @@ struct MSALNativeAuthNetworkStubs {
     }
 }
 
-class MSALNativeAuthRequestContextMock: MSIDRequestContext {
+class MSALNativeAuthRequestContextMock: MSALNativeAuthRequestContext {
 
     let mockCorrelationId: UUID
     var mockTelemetryRequestId = ""
@@ -58,19 +58,19 @@ class MSALNativeAuthRequestContextMock: MSIDRequestContext {
         self.mockCorrelationId = correlationId
     }
 
-    func correlationId() -> UUID {
+    override func correlationId() -> UUID {
         return mockCorrelationId
     }
 
-    func logComponent() -> String {
+    override func logComponent() -> String {
         return mockLogComponent
     }
 
-    func telemetryRequestId() -> String {
+    override func telemetryRequestId() -> String {
         return mockTelemetryRequestId
     }
 
-    func appRequestMetadata() -> [AnyHashable: Any] {
+    override func appRequestMetadata() -> [AnyHashable: Any] {
         return mockAppRequestMetadata
     }
 }
@@ -82,11 +82,15 @@ class MSALNativeAuthSignInResponseValidatorMock: MSALNativeAuthSignInResponseVal
     var expectedChallengeResponse: MSALNativeAuthSignInChallengeResponse?
     var expectedInitiateResponse: MSALNativeAuthSignInInitiateResponse?
     var expectedResponseError: Error?
-    var initiateValidatedResponse: MSALNativeAuthSignInInitiateValidatedResponse = .error(.userNotFound(message: nil))
-    var challengeValidatedResponse: MSALNativeAuthSignInChallengeValidatedResponse = .error(.expiredToken(message: nil))
+    var initiateValidatedResponse: MSALNativeAuthSignInInitiateValidatedResponse = .error(.userNotFound(.init(
+        error: .userNotFound))
+    )
+    var challengeValidatedResponse: MSALNativeAuthSignInChallengeValidatedResponse = .error(.expiredToken(.init(
+        error: .expiredToken)
+    ))
 
     
-    func validate(context: MSAL.MSALNativeAuthRequestContext, result: Result<MSAL.MSALNativeAuthSignInChallengeResponse, Error>) -> MSAL.MSALNativeAuthSignInChallengeValidatedResponse {
+    func validate(context: MSIDRequestContext, result: Result<MSAL.MSALNativeAuthSignInChallengeResponse, Error>) -> MSAL.MSALNativeAuthSignInChallengeValidatedResponse {
         checkConfAndContext(context)
         if case .success(let successChallengeResponse) = result, let expectedChallengeResponse = expectedChallengeResponse {
             XCTAssertEqual(successChallengeResponse.challengeType, expectedChallengeResponse.challengeType)
@@ -102,7 +106,7 @@ class MSALNativeAuthSignInResponseValidatorMock: MSALNativeAuthSignInResponseVal
         return challengeValidatedResponse
     }
     
-    func validate(context: MSAL.MSALNativeAuthRequestContext, result: Result<MSAL.MSALNativeAuthSignInInitiateResponse, Error>) -> MSAL.MSALNativeAuthSignInInitiateValidatedResponse {
+    func validate(context: MSIDRequestContext, result: Result<MSAL.MSALNativeAuthSignInInitiateResponse, Error>) -> MSAL.MSALNativeAuthSignInInitiateValidatedResponse {
         checkConfAndContext(context)
         if case .success(let successInitiateResponse) = result, let expectedInitiateResponse = expectedInitiateResponse {
             XCTAssertEqual(successInitiateResponse.challengeType, expectedInitiateResponse.challengeType)
@@ -115,7 +119,7 @@ class MSALNativeAuthSignInResponseValidatorMock: MSALNativeAuthSignInResponseVal
         return initiateValidatedResponse
     }
     
-    private func checkConfAndContext(_ context: MSAL.MSALNativeAuthRequestContext, config: MSIDConfiguration? = nil) {
+    private func checkConfAndContext(_ context: MSIDRequestContext, config: MSIDConfiguration? = nil) {
         if let expectedRequestContext = expectedRequestContext {
             XCTAssertEqual(expectedRequestContext.correlationId(), context.correlationId())
             XCTAssertEqual(expectedRequestContext.telemetryRequestId(), context.telemetryRequestId())
@@ -134,7 +138,7 @@ class MSALNativeAuthTokenResponseValidatorMock: MSALNativeAuthTokenResponseValid
     var expectedResponseError: Error?
     var tokenValidatedResponse: MSALNativeAuthTokenValidatedResponse = .error(.generalError)
 
-    func validate(context: MSAL.MSALNativeAuthRequestContext, msidConfiguration: MSIDConfiguration, result: Result<MSIDCIAMTokenResponse, Error>) -> MSAL.MSALNativeAuthTokenValidatedResponse {
+    func validate(context: MSIDRequestContext, msidConfiguration: MSIDConfiguration, result: Result<MSIDCIAMTokenResponse, Error>) -> MSAL.MSALNativeAuthTokenValidatedResponse {
         checkConfAndContext(context, config: msidConfiguration)
         if case .success(let successTokenResponse) = result, let expectedTokenResponse = expectedTokenResponse {
             XCTAssertEqual(successTokenResponse.accessToken, expectedTokenResponse.accessToken)
@@ -153,7 +157,7 @@ class MSALNativeAuthTokenResponseValidatorMock: MSALNativeAuthTokenResponseValid
         true
     }
 
-    private func checkConfAndContext(_ context: MSAL.MSALNativeAuthRequestContext, config: MSIDConfiguration? = nil) {
+    private func checkConfAndContext(_ context: MSIDRequestContext, config: MSIDConfiguration? = nil) {
         if let expectedRequestContext = expectedRequestContext {
             XCTAssertEqual(expectedRequestContext.correlationId(), context.correlationId())
             XCTAssertEqual(expectedRequestContext.telemetryRequestId(), context.telemetryRequestId())

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthResetPasswordControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthResetPasswordControllerMock.swift
@@ -37,15 +37,15 @@ class MSALNativeAuthResetPasswordControllerMock: MSALNativeAuthResetPasswordCont
         return resetPasswordResponse
     }
 
-    func resendCode(username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
+    func resendCode(username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> ResetPasswordResendCodeControllerResponse {
         return resendCodeResponse
     }
 
-    func submitCode(code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
+    func submitCode(code: String, username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
         return submitCodeResponse
     }
 
-    func submitPassword(password: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
+    func submitPassword(password: String, username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
         return submitPasswordResponse
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerMock.swift
@@ -40,19 +40,19 @@ class MSALNativeAuthSignUpControllerMock: MSALNativeAuthSignUpControlling {
         return startResult
     }
 
-    func resendCode(username: String, context: MSIDRequestContext, continuationToken: String) async -> SignUpResendCodeControllerResponse {
+    func resendCode(username: String, context: MSALNativeAuthRequestContext, continuationToken: String) async -> SignUpResendCodeControllerResponse {
         return resendCodeResult
     }
 
-    func submitCode(_ code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
+    func submitCode(_ code: String, username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
         return submitCodeResult
     }
 
-    func submitPassword(_ password: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
+    func submitPassword(_ password: String, username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
         return submitPasswordResult
     }
 
-    func submitAttributes(_ attributes: [String : Any], username: String, continuationToken: String, context: MSIDRequestContext) async -> SignUpSubmitAttributesControllerResponse {
+    func submitAttributes(_ attributes: [String : Any], username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> SignUpSubmitAttributesControllerResponse {
         return submitAttributesResult
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
@@ -46,7 +46,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = parameters.context
         signUpStartPasswordCalled = true
         expectation.fulfill()
-        return .init(.error(.init(type: .generalError, correlationId: parameters.context.correlationId())))
+        return .init(.error(.init(type: .generalError, correlationId: parameters.context.correlationId())), correlationId: parameters.context.correlationId())
     }
 
     func signUpStart(
@@ -55,7 +55,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = parameters.context
         signUpStartCalled = true
         expectation.fulfill()
-        return .init(.error(.init(type: .generalError, correlationId: parameters.context.correlationId())))
+        return .init(.error(.init(type: .generalError, correlationId: parameters.context.correlationId())), correlationId: parameters.context.correlationId())
     }
 
     func resendCode(
@@ -66,7 +66,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = context
         resendCodeCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init(correlationId: context.correlationId()), newState: nil))
+        return .init(.error(error: .init(correlationId: context.correlationId()), newState: nil), correlationId: context.correlationId())
     }
 
     func submitCode(
@@ -78,7 +78,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = context
         submitCodeCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init(type: .generalError, correlationId: context.correlationId()), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: context.correlationId()), newState: nil), correlationId: context.correlationId())
     }
 
     func submitPassword(
@@ -90,7 +90,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = context
         submitPasswordCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init(type: .generalError, correlationId: context.correlationId()), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: context.correlationId()), newState: nil), correlationId: context.correlationId())
     }
 
     func submitAttributes(
@@ -102,6 +102,6 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = context
         submitAttributesCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init(correlationId: context.correlationId())))
+        return .init(.error(error: .init(correlationId: context.correlationId())), correlationId: context.correlationId())
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpControllerSpy.swift
@@ -46,7 +46,7 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = parameters.context
         signUpStartPasswordCalled = true
         expectation.fulfill()
-        return .init(.error(.init(type: .generalError)))
+        return .init(.error(.init(type: .generalError, correlationId: parameters.context.correlationId())))
     }
 
     func signUpStart(
@@ -55,53 +55,53 @@ class MSALNativeAuthSignUpControllerSpy: MSALNativeAuthSignUpControlling {
         self.context = parameters.context
         signUpStartCalled = true
         expectation.fulfill()
-        return .init(.error(.init(type: .generalError)))
+        return .init(.error(.init(type: .generalError, correlationId: parameters.context.correlationId())))
     }
 
     func resendCode(
         username: String,
-        context: MSIDRequestContext,
+        context: MSALNativeAuthRequestContext,
         continuationToken: String
     ) async -> SignUpResendCodeControllerResponse {
         self.context = context
         resendCodeCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init(), newState: nil))
+        return .init(.error(error: .init(correlationId: context.correlationId()), newState: nil))
     }
 
     func submitCode(
         _ code: String,
         username: String,
         continuationToken: String,
-        context: MSIDRequestContext
+        context: MSALNativeAuthRequestContext
     ) async -> MSALNativeAuthSignUpControlling.SignUpSubmitCodeControllerResponse {
         self.context = context
         submitCodeCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init(type: .generalError), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: context.correlationId()), newState: nil))
     }
 
     func submitPassword(
         _ password: String,
         username: String,
         continuationToken: String,
-        context: MSIDRequestContext
+        context: MSALNativeAuthRequestContext
     ) async -> MSALNativeAuthSignUpControlling.SignUpSubmitPasswordControllerResponse {
         self.context = context
         submitPasswordCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init(type: .generalError), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: context.correlationId()), newState: nil))
     }
 
     func submitAttributes(
         _ attributes: [String: Any],
         username: String,
         continuationToken: String,
-        context: MSIDRequestContext
+        context: MSALNativeAuthRequestContext
     ) async -> SignUpSubmitAttributesControllerResponse {
         self.context = context
         submitAttributesCalled = true
         expectation.fulfill()
-        return .init(.error(error: .init()))
+        return .init(.error(error: .init(correlationId: context.correlationId())))
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignUpRequestProviderMock.swift
@@ -71,7 +71,7 @@ class MSALNativeAuthSignUpRequestProviderMock: MSALNativeAuthSignUpRequestProvid
         self.throwErrorChallenge = throwError
     }
 
-    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+    func challenge(token: String, context: MSALNativeAuthRequestContext) throws -> MSIDHttpRequest {
         challengeCalled = true
         checkChallengeParameters(token: token, context: context)
 

--- a/MSAL/test/unit/native_auth/mock/SignInDelegatesSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/SignInDelegatesSpies.swift
@@ -43,8 +43,7 @@ open class SignInPasswordStartDelegateSpy: SignInStartDelegate {
     public func onSignInStartError(error: MSAL.SignInStartError) {
         if let expectedError = expectedError {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertEqual(error.type, expectedError.type)
-            XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
+            checkErrors(error: error, expectedError: expectedError)
             expectation.fulfill()
             return
         }
@@ -90,8 +89,7 @@ class SignInPasswordRequiredDelegateSpy: SignInPasswordRequiredDelegate {
 
     func onSignInPasswordRequiredError(error: MSAL.PasswordRequiredError, newState: MSAL.SignInPasswordRequiredState?) {
         XCTAssertTrue(Thread.isMainThread)
-        XCTAssertEqual(error.type, expectedError?.type)
-        XCTAssertEqual(error.errorDescription, expectedError?.errorDescription)
+        checkErrors(error: error, expectedError: expectedError)
         newPasswordRequiredState = newState
         expectation.fulfill()
     }
@@ -318,7 +316,7 @@ open class SignInAfterSignUpDelegateSpy: SignInAfterSignUpDelegate {
     }
 
     public func onSignInAfterSignUpError(error: MSAL.SignInAfterSignUpError) {
-        XCTAssertEqual(error.errorDescription, expectedError?.errorDescription)
+        checkErrors(error: error, expectedError: expectedError)
         XCTAssertTrue(Thread.isMainThread)
         expectation.fulfill()
     }
@@ -350,7 +348,7 @@ class SignInAfterResetPasswordDelegateSpy: SignInAfterResetPasswordDelegate {
     }
 
     func onSignInAfterResetPasswordError(error: SignInAfterResetPasswordError) {
-        XCTAssertEqual(error.errorDescription, expectedError?.errorDescription)
+        checkErrors(error: error, expectedError: expectedError)
         XCTAssertTrue(Thread.isMainThread)
         expectation.fulfill()
     }
@@ -380,7 +378,7 @@ final class SignInAfterSignUpDelegateOptionalMethodsNotImplemented: SignInAfterS
     }
 
     public func onSignInAfterSignUpError(error: MSAL.SignInAfterSignUpError) {
-        XCTAssertEqual(error.errorDescription, expectedError?.errorDescription)
+        checkErrors(error: error, expectedError: expectedError)
         XCTAssertTrue(Thread.isMainThread)
         expectation.fulfill()
     }
@@ -400,8 +398,7 @@ final class SignInPasswordStartDelegateOptionalMethodNotImplemented: SignInStart
     func onSignInStartError(error: MSAL.SignInStartError) {
         if let expectedError = expectedError {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertEqual(error.type, expectedError.type)
-            XCTAssertEqual(error.errorDescription, expectedError.errorDescription)
+            checkErrors(error: error, expectedError: expectedError)
             expectation.fulfill()
             return
         }
@@ -421,9 +418,38 @@ final class SignInCodeStartDelegateOptionalMethodNotImplemented: SignInStartDele
     }
 
     public func onSignInStartError(error: SignInStartError) {
-        XCTAssertEqual(error.type, expectedError?.type)
-        XCTAssertEqual(error.localizedDescription, expectedError?.localizedDescription)
+        checkErrors(error: error, expectedError: expectedError)
         XCTAssertTrue(Thread.isMainThread)
         expectation.fulfill()
     }
+}
+
+fileprivate func checkErrors(error: SignInStartError, expectedError: SignInStartError?) {
+    XCTAssertEqual(error.type, expectedError?.type)
+    XCTAssertEqual(error.errorDescription, expectedError?.errorDescription)
+    XCTAssertEqual(error.errorCodes, expectedError?.errorCodes)
+    XCTAssertEqual(error.errorUri, expectedError?.errorUri)
+    XCTAssertEqual(error.correlationId, expectedError?.correlationId)
+}
+
+fileprivate func checkErrors(error: PasswordRequiredError, expectedError: PasswordRequiredError?) {
+    XCTAssertEqual(error.type, expectedError?.type)
+    XCTAssertEqual(error.errorDescription, expectedError?.errorDescription)
+    XCTAssertEqual(error.errorCodes, expectedError?.errorCodes)
+    XCTAssertEqual(error.errorUri, expectedError?.errorUri)
+    XCTAssertEqual(error.correlationId, expectedError?.correlationId)
+}
+
+fileprivate func checkErrors(error: SignInAfterSignUpError, expectedError: SignInAfterSignUpError?) {
+    XCTAssertEqual(error.errorDescription, expectedError?.errorDescription)
+    XCTAssertEqual(error.errorCodes, expectedError?.errorCodes)
+    XCTAssertEqual(error.errorUri, expectedError?.errorUri)
+    XCTAssertEqual(error.correlationId, expectedError?.correlationId)
+}
+
+fileprivate func checkErrors(error: SignInAfterResetPasswordError, expectedError: SignInAfterResetPasswordError?) {
+    XCTAssertEqual(error.errorDescription, expectedError?.errorDescription)
+    XCTAssertEqual(error.errorCodes, expectedError?.errorCodes)
+    XCTAssertEqual(error.errorUri, expectedError?.errorUri)
+    XCTAssertEqual(error.correlationId, expectedError?.correlationId)
 }

--- a/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
@@ -45,36 +45,36 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         resetPasswordCalled = true
         expectation.fulfill()
 
-        return .init(.error(.init(type: .generalError)))
+        return .init(.error(.init(type: .generalError, correlationId: .init())))
     }
 
-    func resendCode(username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordResendCodeControllerResponse {
+    func resendCode(username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> ResetPasswordResendCodeControllerResponse {
         self.continuationToken = continuationToken
         self.username = username
         self.context = context
         resendCodeCalled = true
         expectation.fulfill()
 
-        return .init(.error(error: .init(), newState: nil))
+        return .init(.error(error: .init(correlationId: .init()), newState: nil))
     }
 
-    func submitCode(code: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
+    func submitCode(code: String, username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
         self.continuationToken = continuationToken
         self.username = username
         self.context = context
         submitCodeCalled = true
         expectation.fulfill()
 
-        return .init(.error(error: .init(type: .generalError), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: .init()), newState: nil))
     }
 
-    func submitPassword(password: String, username: String, continuationToken: String, context: MSIDRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
+    func submitPassword(password: String, username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
         self.continuationToken = continuationToken
         self.username = username
         self.context = context
         submitPasswordCalled = true
         expectation.fulfill()
 
-        return .init(.error(error: .init(type: .generalError), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: .init()), newState: nil))
     }
 }

--- a/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
+++ b/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordControllerSpy.swift
@@ -45,7 +45,7 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         resetPasswordCalled = true
         expectation.fulfill()
 
-        return .init(.error(.init(type: .generalError, correlationId: .init())))
+        return .init(.error(.init(type: .generalError, correlationId: .init())), correlationId: parameters.context.correlationId())
     }
 
     func resendCode(username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> ResetPasswordResendCodeControllerResponse {
@@ -55,7 +55,7 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         resendCodeCalled = true
         expectation.fulfill()
 
-        return .init(.error(error: .init(correlationId: .init()), newState: nil))
+        return .init(.error(error: .init(correlationId: .init()), newState: nil), correlationId: context.correlationId())
     }
 
     func submitCode(code: String, username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> ResetPasswordSubmitCodeControllerResponse {
@@ -65,7 +65,7 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         submitCodeCalled = true
         expectation.fulfill()
 
-        return .init(.error(error: .init(type: .generalError, correlationId: .init()), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: .init()), newState: nil), correlationId: context.correlationId())
     }
 
     func submitPassword(password: String, username: String, continuationToken: String, context: MSALNativeAuthRequestContext) async -> ResetPasswordSubmitPasswordControllerResponse {
@@ -75,6 +75,6 @@ class MSALNativeAuthResetPasswordControllerSpy: MSALNativeAuthResetPasswordContr
         submitPasswordCalled = true
         expectation.fulfill()
 
-        return .init(.error(error: .init(type: .generalError, correlationId: .init()), newState: nil))
+        return .init(.error(error: .init(type: .generalError, correlationId: .init()), newState: nil), correlationId: context.correlationId())
     }
 }

--- a/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordRequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/reset_password/MSALNativeAuthResetPasswordRequestProviderMock.swift
@@ -69,7 +69,7 @@ class MSALNativeAuthResetPasswordRequestProviderMock: MSALNativeAuthResetPasswor
         throwErrorChallenge = throwError
     }
 
-    func challenge(token: String, context: MSIDRequestContext) throws -> MSIDHttpRequest {
+    func challenge(token: String, context: MSALNativeAuthRequestContext) throws -> MSIDHttpRequest {
         challengeCalled = true
         checkParameters(token: token, context: context)
 

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
@@ -33,11 +33,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
     var config: MSALNativeAuthConfiguration! = nil
     
-    let context = MSALNativeAuthRequestContext(
-        correlationId: .init(
-            UUID(uuidString: DEFAULT_TEST_UID)!
-        )
-    )
+    let context = MSALNativeAuthRequestContext(correlationId: UUID(uuidString: DEFAULT_TEST_UID)!)
 
     func test_signInInititate_getsConfiguredSuccessfully() throws {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password]))

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
@@ -31,11 +31,7 @@ final class MSALNativeAuthRequestableTests: XCTestCase {
     var request: MSALNativeAuthResetPasswordStartRequestParameters! = nil
 
     override func setUpWithError() throws {
-        let context = MSALNativeAuthRequestContext(
-                correlationId: .init(
-                UUID(uuidString: DEFAULT_TEST_UID)!
-            )
-        )
+        let context = MSALNativeAuthRequestContext(correlationId: UUID(uuidString: DEFAULT_TEST_UID)!)
         
         request = MSALNativeAuthResetPasswordStartRequestParameters(context: context, username: DEFAULT_TEST_ID_TOKEN_USERNAME)
     }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseCorrelatableTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseCorrelatableTests.swift
@@ -22,14 +22,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 
-protocol MSALNativeAuthResponseError: Error, Decodable, Equatable, MSALNativeAuthResponseCorrelatable {
-    associatedtype ErrorCode: RawRepresentable where ErrorCode.RawValue == String
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Unit_Test_Private
 
-    var error: ErrorCode? { get }
-    var errorDescription: String? { get }
-    var errorCodes: [Int]? { get }
-    var errorURI: String? { get }
-    var innerErrors: [MSALNativeAuthInnerError]? { get }
+final class MSALNativeAuthResponseCorrelatableTests: XCTestCase {
+
+    private var sut: ResponseCorrelatableClass!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        sut = ResponseCorrelatableClass()
+    }
+
+    func test_serializeExpectedCorrelationId() {
+        let originalHeaders = [
+            "client-request-id": "9958D9BC-D9D1-43E4-B5CA-5A7B0C3F28B0",
+            "header2": "value2",
+        ]
+
+        let httpResponse = HTTPURLResponse(url: URL(string: "http://contoso.com")!, statusCode: 200, httpVersion: nil, headerFields: originalHeaders)
+
+        let correlationIdString = sut.retrieveCorrelationIdFromHeaders(from: httpResponse)
+
+        XCTAssertEqual(correlationIdString, UUID(uuidString: "9958D9BC-D9D1-43E4-B5CA-5A7B0C3F28B0"))
+    }
+}
+
+private class ResponseCorrelatableClass: MSALNativeAuthResponseCorrelatable {
+    var correlationId: UUID?
 }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseCorrelatableTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseCorrelatableTests.swift
@@ -44,7 +44,7 @@ final class MSALNativeAuthResponseCorrelatableTests: XCTestCase {
 
         let httpResponse = HTTPURLResponse(url: URL(string: "http://contoso.com")!, statusCode: 200, httpVersion: nil, headerFields: originalHeaders)
 
-        let correlationIdString = sut.retrieveCorrelationIdFromHeaders(from: httpResponse)
+        let correlationIdString = ResponseCorrelatableClass.retrieveCorrelationIdFromHeaders(from: httpResponse)
 
         XCTAssertEqual(correlationIdString, UUID(uuidString: "9958D9BC-D9D1-43E4-B5CA-5A7B0C3F28B0"))
     }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseSerializerTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthResponseSerializerTests.swift
@@ -67,9 +67,37 @@ final class MSALNativeAuthResponseSerializerTests: XCTestCase {
         """
         XCTAssertThrowsError(try serializer.responseObject(for: nil, data: wrongResponseString.data(using: .utf8) , context: nil))
     }
+
+    func testSerialize_headersCorrelationId() throws {
+        let originalHeaders = [
+            "client-request-id": "9958D9BC-D9D1-43E4-B5CA-5A7B0C3F28B0",
+            "header2": "value2"
+        ]
+        let responseString = """
+        {
+          "token_type": "Bearer",
+          "scope": "scope",
+          "expires_in": 4141,
+          "extended_expires_in": 4141,
+          "access_token": "access",
+          "refresh_token": "refresh",
+          "id_token": "id"
+        }
+        """
+
+        let httpResponse = HTTPURLResponse(url: URL(string: "https://contoso.com")!, statusCode: 200, httpVersion: nil, headerFields: originalHeaders)
+
+        let serializer = MSALNativeAuthResponseSerializer<ResponseStub>()
+
+        let result = try serializer.responseObject(for: httpResponse, data: responseString.data(using: .utf8), context: nil)
+
+        let resultCorrelationId = (result as? MSALNativeAuthResponseCorrelatable)?.correlationId
+
+        XCTAssertEqual(resultCorrelationId?.uuidString, "9958D9BC-D9D1-43E4-B5CA-5A7B0C3F28B0")
+    }
 }
 
-private struct ResponseStub: Decodable {
+private struct ResponseStub: Decodable, MSALNativeAuthResponseCorrelatable {
     let tokenType: String
     let scope: String
     let expiresIn: Int
@@ -77,4 +105,5 @@ private struct ResponseStub: Decodable {
     let accessToken: String
     let refreshToken: String
     let idToken: String
+    var correlationId: UUID?
 }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
@@ -31,11 +31,11 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
 
     private var sut: MSALNativeAuthSignUpRequestProvider!
     private var telemetryProvider: MSALNativeAuthTelemetryProvider!
-    private var context: MSIDRequestContext!
+    private var context: MSALNativeAuthRequestContextMock!
 
     override func setUpWithError() throws {
         telemetryProvider = MSALNativeAuthTelemetryProvider()
-        context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        context = MSALNativeAuthRequestContextMock(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
 
         sut = .init(requestConfigurator: MSALNativeAuthRequestConfigurator(config: MSALNativeAuthConfigStubs.configuration),
                     telemetryProvider: telemetryProvider)

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
@@ -34,28 +34,28 @@ final class MSALNativeAuthResetPasswordChallengeResponseErrorTests: XCTestCase {
 
     func test_toResetPasswordStartPublicError_unauthorizedClient() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unauthorizedClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError()
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResetPasswordStartPublicError_invalidRequest() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError()
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
     }
 
     func test_toResetPasswordStartPublicError_expiredToken() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError()
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unsupportedChallengeType, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError()
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
     }
@@ -64,25 +64,25 @@ final class MSALNativeAuthResetPasswordChallengeResponseErrorTests: XCTestCase {
 
     func test_toResendCodePublicError_unauthorizedClient() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unauthorizedClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError()
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResendCodePublicError_invalidRequest() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError()
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResendCodePublicError_expiredToken() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError()
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResendCodePublicError_unsupportedChallengeType() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unsupportedChallengeType, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError()
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
@@ -29,69 +29,113 @@ final class MSALNativeAuthResetPasswordChallengeResponseErrorTests: XCTestCase {
 
     private var sut: MSALNativeAuthResetPasswordChallengeResponseError!
     private let testDescription = "testDescription"
+    private let testErrorCodes = [1, 2, 3]
     private let correlationId = UUID()
+    private let testErrorUri = "test error uri"
+
+    private func createApiChallengeError(type: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode) -> MSALNativeAuthResetPasswordChallengeResponseError {
+        .init(
+            error: type,
+            errorDescription: testDescription,
+            errorCodes: testErrorCodes,
+            errorURI: testErrorUri,
+            correlationId: correlationId
+        )
+    }
+
+    private func createApiResendCodeError(type: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode) -> MSALNativeAuthResetPasswordChallengeResponseError {
+        .init(
+            error: type,
+            errorDescription: testDescription,
+            errorCodes: testErrorCodes,
+            errorURI: testErrorUri,
+            correlationId: correlationId
+        )
+    }
 
     // MARK: - to ResetPasswordStartError tests
 
     func test_toResetPasswordStartPublicError_unauthorizedClient() {
-        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unauthorizedClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiChallengeError(type: .unauthorizedClient)
+        let error = sut.toResetPasswordStartPublicError(correlationId: correlationId)
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 
     func test_toResetPasswordStartPublicError_invalidRequest() {
-        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiChallengeError(type: .invalidRequest)
+        let error = sut.toResetPasswordStartPublicError(correlationId: correlationId)
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
         XCTAssertEqual(error.correlationId, correlationId)
     }
 
     func test_toResetPasswordStartPublicError_expiredToken() {
-        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiChallengeError(type: .expiredToken)
+        let error = sut.toResetPasswordStartPublicError(correlationId: correlationId)
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 
     func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
-        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unsupportedChallengeType, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiChallengeError(type: .unsupportedChallengeType)
+        let error = sut.toResetPasswordStartPublicError(correlationId: correlationId)
+        
         XCTAssertEqual(error.type, .generalError)
-        XCTAssertNotNil(error.errorDescription)
+        XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 
     // MARK: - to ResendCodePublicError tests
 
     func test_toResendCodePublicError_unauthorizedClient() {
-        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unauthorizedClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiResendCodeError(type: .unauthorizedClient)
+        let error = sut.toResendCodePublicError(correlationId: correlationId)
+        
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 
     func test_toResendCodePublicError_invalidRequest() {
-        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiResendCodeError(type: .invalidRequest)
+        let error = sut.toResendCodePublicError(correlationId: correlationId)
+
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 
     func test_toResendCodePublicError_expiredToken() {
-        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiResendCodeError(type: .expiredToken)
+        let error = sut.toResendCodePublicError(correlationId: correlationId)
+        
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 
     func test_toResendCodePublicError_unsupportedChallengeType() {
-        sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unsupportedChallengeType, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiResendCodeError(type: .unsupportedChallengeType)
+        let error = sut.toResendCodePublicError(correlationId: correlationId)
+        
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
@@ -29,60 +29,69 @@ final class MSALNativeAuthResetPasswordChallengeResponseErrorTests: XCTestCase {
 
     private var sut: MSALNativeAuthResetPasswordChallengeResponseError!
     private let testDescription = "testDescription"
+    private let correlationId = UUID()
 
     // MARK: - to ResetPasswordStartError tests
 
     func test_toResetPasswordStartPublicError_unauthorizedClient() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unauthorizedClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 
     func test_toResetPasswordStartPublicError_invalidRequest() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 
     func test_toResetPasswordStartPublicError_expiredToken() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 
     func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unsupportedChallengeType, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 
     // MARK: - to ResendCodePublicError tests
 
     func test_toResendCodePublicError_unauthorizedClient() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unauthorizedClient, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 
     func test_toResendCodePublicError_invalidRequest() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .invalidRequest, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 
     func test_toResendCodePublicError_expiredToken() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 
     func test_toResendCodePublicError_unsupportedChallengeType() {
         sut = MSALNativeAuthResetPasswordChallengeResponseError(error: .unsupportedChallengeType, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
@@ -29,55 +29,86 @@ final class MSALNativeAuthResetPasswordContinueResponseErrorTests: XCTestCase {
 
     private var sut: MSALNativeAuthResetPasswordContinueResponseError!
     private let testDescription = "testDescription"
+    private let testErrorCodes = [1, 2, 3]
     private let correlationId = UUID()
+    private let testErrorUri = "test error uri"
+
+    private func createApiError(type: MSALNativeAuthResetPasswordContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil) -> MSALNativeAuthResetPasswordContinueResponseError {
+        .init(
+            error: type,
+            subError: subError,
+            errorDescription: testDescription,
+            errorCodes: testErrorCodes,
+            errorURI: testErrorUri,
+            correlationId: correlationId
+        )
+    }
 
     // MARK: - to toVerifyCodePublicError tests
     
     func test_toResetPasswordStartPublicError_invalidRequest() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidRequest, subError: nil, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiError(type: .invalidRequest)
+        let error = sut.toVerifyCodePublicError(correlationId: correlationId)
+
         XCTAssertEqual(error.type, .generalError)
-        XCTAssertNotNil(error.errorDescription)
+        XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_toResetPasswordStartPublicError_unauthorizedClient() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .unauthorizedClient, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiError(type: .unauthorizedClient)
+        let error = sut.toVerifyCodePublicError(correlationId: correlationId)
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 
     func test_toResetPasswordStartPublicError_invalidGrant() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidGrant, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiError(type: .invalidGrant)
+        let error = sut.toVerifyCodePublicError(correlationId: correlationId)
+        
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_toResetPasswordStartPublicError_expiredToken() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .expiredToken, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiError(type: .expiredToken)
+        let error = sut.toVerifyCodePublicError(correlationId: correlationId)
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 
     func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .verificationRequired, subError: nil, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiError(type: .verificationRequired)
+        let error = sut.toVerifyCodePublicError(correlationId: correlationId)
+        
         XCTAssertEqual(error.type, .generalError)
-        XCTAssertNotNil(error.errorDescription)
+        XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_toResetPasswordStartPublicError_invalidOOBValue() {
-        sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidGrant, subError: .invalidOOBValue, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+        sut = createApiError(type: .invalidGrant, subError: .invalidOOBValue)
+        let error = sut.toVerifyCodePublicError(correlationId: correlationId)
+
         XCTAssertEqual(error.type, .invalidCode)
-        XCTAssertNotNil(error.errorDescription)
+        XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
@@ -34,42 +34,42 @@ final class MSALNativeAuthResetPasswordContinueResponseErrorTests: XCTestCase {
     
     func test_toResetPasswordStartPublicError_invalidRequest() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidRequest, subError: nil, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
     }
     
     func test_toResetPasswordStartPublicError_unauthorizedClient() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .unauthorizedClient, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResetPasswordStartPublicError_invalidGrant() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidGrant, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
     
     func test_toResetPasswordStartPublicError_expiredToken() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .expiredToken, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
 
     func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .verificationRequired, subError: nil, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
     }
     
     func test_toResetPasswordStartPublicError_invalidOOBValue() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidGrant, subError: .invalidOOBValue, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, .invalidCode)
         XCTAssertNotNil(error.errorDescription)
     }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
@@ -29,48 +29,55 @@ final class MSALNativeAuthResetPasswordContinueResponseErrorTests: XCTestCase {
 
     private var sut: MSALNativeAuthResetPasswordContinueResponseError!
     private let testDescription = "testDescription"
+    private let correlationId = UUID()
 
     // MARK: - to toVerifyCodePublicError tests
     
     func test_toResetPasswordStartPublicError_invalidRequest() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidRequest, subError: nil, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
     
     func test_toResetPasswordStartPublicError_unauthorizedClient() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .unauthorizedClient, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 
     func test_toResetPasswordStartPublicError_invalidGrant() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidGrant, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
     
     func test_toResetPasswordStartPublicError_expiredToken() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .expiredToken, subError: nil, errorDescription: testDescription, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 
     func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .verificationRequired, subError: nil, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, .generalError)
         XCTAssertNotNil(error.errorDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
     
     func test_toResetPasswordStartPublicError_invalidOOBValue() {
         sut = MSALNativeAuthResetPasswordContinueResponseError(error: .invalidGrant, subError: .invalidOOBValue, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil, continuationToken: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, .invalidCode)
         XCTAssertNotNil(error.errorDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
@@ -71,9 +71,11 @@ final class MSALNativeAuthResetPasswordPollCompletionResponseErrorTests: XCTestC
     // MARK: private methods
     
     private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
+        let correlationId = UUID()
         sut = MSALNativeAuthResetPasswordPollCompletionResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
@@ -29,53 +29,59 @@ final class MSALNativeAuthResetPasswordPollCompletionResponseErrorTests: XCTestC
 
     private var sut: MSALNativeAuthResetPasswordPollCompletionResponseError!
     private let testDescription = "testDescription"
+    private let testErrorCodes = [1, 2, 3]
+    private let testCorrelationId = UUID()
+    private let testErrorUri = "test error uri"
 
     // MARK: - toPasswordRequiredPublicError tests
     
     func test_toPasswordRequiredPublicError_invalidRequest() {
-        testPasswordRequiredError(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+        testPasswordRequiredError(code: .invalidRequest, expectedErrorType: .generalError)
     }
 
     func test_toPasswordRequiredPublicError_unauthorizedClient() {
-        testPasswordRequiredError(code: .unauthorizedClient, description: "General error", expectedErrorType: .generalError)
+        testPasswordRequiredError(code: .unauthorizedClient, expectedErrorType: .generalError)
     }
 
     func test_toPasswordRequiredPublicError_expiredToken() {
-        testPasswordRequiredError(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+        testPasswordRequiredError(code: .expiredToken, expectedErrorType: .generalError)
     }
 
     func test_toPasswordRequiredPublicError_passwordTooWeak() {
-        testPasswordRequiredError(code: .invalidGrant, subError: .passwordTooWeak, description: testDescription, expectedErrorType: .invalidPassword)
+        testPasswordRequiredError(code: .invalidGrant, subError: .passwordTooWeak, expectedErrorType: .invalidPassword)
     }
 
     func test_toPasswordRequiredPublicError_passwordTooShort() {
-        testPasswordRequiredError(code: .invalidGrant,subError: .passwordTooShort, description: testDescription, expectedErrorType: .invalidPassword)
+        testPasswordRequiredError(code: .invalidGrant,subError: .passwordTooShort, expectedErrorType: .invalidPassword)
     }
 
     func test_toPasswordRequiredPublicError_passwordTooLong() {
-        testPasswordRequiredError(code: .invalidGrant, subError: .passwordTooLong, description: "General error", expectedErrorType: .invalidPassword)
+        testPasswordRequiredError(code: .invalidGrant, subError: .passwordTooLong, expectedErrorType: .invalidPassword)
     }
 
     func test_toPasswordRequiredPublicError_passwordRecentlyUsed() {
-        testPasswordRequiredError(code: .invalidGrant, subError: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .invalidPassword)
+        testPasswordRequiredError(code: .invalidGrant, subError: .passwordRecentlyUsed, expectedErrorType: .invalidPassword)
     }
 
     func test_toPasswordRequiredPublicError_passwordBanned() {
-        testPasswordRequiredError(code: .invalidGrant, subError: .passwordBanned, description: testDescription, expectedErrorType: .invalidPassword)
+        testPasswordRequiredError(code: .invalidGrant, subError: .passwordBanned, expectedErrorType: .invalidPassword)
     }
     
     func test_toPasswordRequiredPublicError_userNotFound() {
-        testPasswordRequiredError(code: .userNotFound, description: testDescription, expectedErrorType: .generalError)
+        testPasswordRequiredError(code: .userNotFound, expectedErrorType: .generalError)
     }
     
     // MARK: private methods
     
-    private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
-        let correlationId = UUID()
-        sut = MSALNativeAuthResetPasswordPollCompletionResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+    private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, expectedErrorType: PasswordRequiredError.ErrorType) {
+
+        sut = MSALNativeAuthResetPasswordPollCompletionResponseError(error: code, subError: subError, errorDescription: testDescription, errorCodes: testErrorCodes, errorURI: testErrorUri, correlationId: testCorrelationId)
+        let error = sut.toPasswordRequiredPublicError(correlationId: testCorrelationId)
+
         XCTAssertEqual(error.type, expectedErrorType)
-        XCTAssertEqual(error.errorDescription, description)
-        XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
@@ -72,7 +72,7 @@ final class MSALNativeAuthResetPasswordPollCompletionResponseErrorTests: XCTestC
     
     private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthResetPasswordPollCompletionResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toPasswordRequiredPublicError()
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
@@ -29,49 +29,53 @@ final class MSALNativeAuthResetPasswordSubmitResponseErrorTests: XCTestCase {
 
     private var sut: MSALNativeAuthResetPasswordSubmitResponseError!
     private let testDescription = "testDescription"
+    private let testErrorCodes = [1, 2, 3]
+    private let testCorrelationId = UUID()
+    private let testErrorUri = "test error uri"
 
     // MARK: - toPasswordRequiredPublicError tests
 
     func test_toPasswordRequiredPublicError_invalidRequest() {
-        testPasswordRequiredError(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+        testPasswordRequiredError(code: .invalidRequest, expectedErrorType: .generalError)
     }
 
     func test_toPasswordRequiredPublicError_unauthorizedClient() {
-        testPasswordRequiredError(code: .unauthorizedClient, description: "General error", expectedErrorType: .generalError)
+        testPasswordRequiredError(code: .unauthorizedClient, expectedErrorType: .generalError)
     }
 
     func test_toPasswordRequiredPublicError_expiredToken() {
-        testPasswordRequiredError(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+        testPasswordRequiredError(code: .expiredToken, expectedErrorType: .generalError)
     }
 
     func test_toPasswordRequiredPublicError_passwordTooWeak() {
-        testPasswordRequiredError(code: .invalidGrant, subError: .passwordTooWeak, description: testDescription, expectedErrorType: .invalidPassword)
+        testPasswordRequiredError(code: .invalidGrant, subError: .passwordTooWeak, expectedErrorType: .invalidPassword)
     }
 
     func test_toPasswordRequiredPublicError_passwordTooShort() {
-        testPasswordRequiredError(code: .invalidGrant, subError: .passwordTooShort, description: testDescription, expectedErrorType: .invalidPassword)
+        testPasswordRequiredError(code: .invalidGrant, subError: .passwordTooShort, expectedErrorType: .invalidPassword)
     }
 
     func test_toPasswordRequiredPublicError_passwordTooLong() {
-        testPasswordRequiredError(code: .invalidGrant, subError: .passwordTooLong, description: "General error", expectedErrorType: .invalidPassword)
+        testPasswordRequiredError(code: .invalidGrant, subError: .passwordTooLong, expectedErrorType: .invalidPassword)
     }
 
     func test_toPasswordRequiredPublicError_passwordRecentlyUsed() {
-        testPasswordRequiredError(code: .invalidGrant, subError: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .invalidPassword)
+        testPasswordRequiredError(code: .invalidGrant, subError: .passwordRecentlyUsed, expectedErrorType: .invalidPassword)
     }
 
     func test_toPasswordRequiredPublicError_passwordBanned() {
-        testPasswordRequiredError(code: .invalidGrant, subError: .passwordBanned, description: testDescription, expectedErrorType: .invalidPassword)
+        testPasswordRequiredError(code: .invalidGrant, subError: .passwordBanned, expectedErrorType: .invalidPassword)
     }
     
     // MARK: private methods
     
-    private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
-        let correlationId = UUID()
-        sut = MSALNativeAuthResetPasswordSubmitResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+    private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, expectedErrorType: PasswordRequiredError.ErrorType) {
+        sut = MSALNativeAuthResetPasswordSubmitResponseError(error: code, subError: subError, errorDescription: testDescription, errorCodes: testErrorCodes, errorURI: testErrorUri, correlationId: testCorrelationId)
+        let error = sut.toPasswordRequiredPublicError(correlationId: testCorrelationId)
         XCTAssertEqual(error.type, expectedErrorType)
-        XCTAssertEqual(error.errorDescription, description)
-        XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
@@ -68,7 +68,7 @@ final class MSALNativeAuthResetPasswordSubmitResponseErrorTests: XCTestCase {
     
     private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthResetPasswordSubmitResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toPasswordRequiredPublicError()
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
@@ -67,9 +67,11 @@ final class MSALNativeAuthResetPasswordSubmitResponseErrorTests: XCTestCase {
     // MARK: private methods
     
     private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
+        let correlationId = UUID()
         sut = MSALNativeAuthResetPasswordSubmitResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, target: nil)
-        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
@@ -88,20 +88,20 @@ final class MSALNativeAuthSignUpChallengeResponseErrorTests: XCTestCase {
     
     private func testSignUpChallengeErrorToSignUpStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartError.ErrorType) {
         sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
-        let error = sut.toSignUpStartPublicError()
+        let error = sut.toSignUpStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpChallengeErrorToResendCodePublic(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?) {
         sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
-        let error = sut.toResendCodePublicError()
+        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpChallengeErrorToPasswordRequired(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
-        let error = sut.toPasswordRequiredPublicError()
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
@@ -29,83 +29,97 @@ final class MSALNativeAuthSignUpChallengeResponseErrorTests: XCTestCase {
 
     private var sut: MSALNativeAuthSignUpChallengeResponseError!
     private let testDescription = "testDescription"
+    private let testErrorCodes = [1, 2, 3]
+    private let testCorrelationId = UUID()
+    private let testErrorUri = "test error uri"
 
     // MARK: - to SignUpCodeStartError tests
 
     func test_toSignUpCodeStartPublicError_unauthorizedClient() {
-        testSignUpChallengeErrorToSignUpStart(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+        testSignUpChallengeErrorToSignUpStart(code: .unauthorizedClient, expectedErrorType: .generalError)
     }
 
     func test_toSignUpCodeStartPublicError_unsupportedChallengeType() {
-        testSignUpChallengeErrorToSignUpStart(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+        testSignUpChallengeErrorToSignUpStart(code: .unsupportedChallengeType, expectedErrorType: .generalError)
     }
 
     func test_toSignUpCodeStartPublicError_expiredToken() {
-        testSignUpChallengeErrorToSignUpStart(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+        testSignUpChallengeErrorToSignUpStart(code: .expiredToken, expectedErrorType: .generalError)
     }
 
     func test_toSignUpCodeStartPublicError_invalidRequest() {
-        testSignUpChallengeErrorToSignUpStart(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+        testSignUpChallengeErrorToSignUpStart(code: .invalidRequest, expectedErrorType: .generalError)
     }
 
     // MARK: - to ResendCodeError tests
 
     func test_toResendCodePublicError_unauthorizedClient() {
-        testSignUpChallengeErrorToResendCodePublic(code: .unauthorizedClient, description: testDescription)
+        testSignUpChallengeErrorToResendCodePublic(code: .unauthorizedClient)
     }
 
     func test_toResendCodePublicError_unsupportedChallengeType() {
-        testSignUpChallengeErrorToResendCodePublic(code: .unsupportedChallengeType, description: "General error")
+        testSignUpChallengeErrorToResendCodePublic(code: .unsupportedChallengeType)
     }
 
     func test_toResendCodePublicError_expiredToken() {
-        testSignUpChallengeErrorToResendCodePublic(code: .expiredToken, description: testDescription)
+        testSignUpChallengeErrorToResendCodePublic(code: .expiredToken)
     }
 
     func test_toResendCodePublicError_invalidRequest() {
-        testSignUpChallengeErrorToResendCodePublic(code: .invalidRequest, description: testDescription)
+        testSignUpChallengeErrorToResendCodePublic(code: .invalidRequest)
     }
 
     // MARK: - to PasswordRequiredError tests
 
     func test_toPasswordRequiredPublicError_unauthorizedClient() {
-        testSignUpChallengeErrorToPasswordRequired(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+        testSignUpChallengeErrorToPasswordRequired(code: .unauthorizedClient, expectedErrorType: .generalError)
     }
 
     func test_toPasswordRequiredPublicError_unsupportedChallengeType() {
-        testSignUpChallengeErrorToPasswordRequired(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+        testSignUpChallengeErrorToPasswordRequired(code: .unsupportedChallengeType, expectedErrorType: .generalError)
     }
 
     func test_toPasswordRequiredPublicError_expiredToken() {
-        testSignUpChallengeErrorToPasswordRequired(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+        testSignUpChallengeErrorToPasswordRequired(code: .expiredToken, expectedErrorType: .generalError)
     }
 
     func test_toPasswordRequiredPublicError_invalidRequest() {
-        testSignUpChallengeErrorToPasswordRequired(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+        testSignUpChallengeErrorToPasswordRequired(code: .invalidRequest, expectedErrorType: .generalError)
     }
         
     // MARK: private methods
     
-    private func testSignUpChallengeErrorToSignUpStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: SignUpStartError.ErrorType) {
-        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
-        let error = sut.toSignUpStartPublicError(context: MSALNativeAuthRequestContextMock())
+    private func testSignUpChallengeErrorToSignUpStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, expectedErrorType: SignUpStartError.ErrorType) {
+        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: testDescription, errorCodes: testErrorCodes, errorURI: testErrorUri, innerErrors: nil)
+
+        let error = sut.toSignUpStartPublicError(correlationId: testCorrelationId)
         XCTAssertEqual(error.type, expectedErrorType)
-        XCTAssertEqual(error.errorDescription, description)
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
-    private func testSignUpChallengeErrorToResendCodePublic(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?) {
-        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
-        let error = sut.toResendCodePublicError(context: MSALNativeAuthRequestContextMock())
-        XCTAssertEqual(error.errorDescription, description)
+    private func testSignUpChallengeErrorToResendCodePublic(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode) {
+        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: testDescription, errorCodes: testErrorCodes, errorURI: testErrorUri, innerErrors: nil)
+
+        let error = sut.toResendCodePublicError(correlationId: testCorrelationId)
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
-    private func testSignUpChallengeErrorToPasswordRequired(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
-        let correlationId = UUID()
-        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
-        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+    private func testSignUpChallengeErrorToPasswordRequired(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, expectedErrorType: PasswordRequiredError.ErrorType) {
+
+        sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: testDescription, errorCodes: testErrorCodes, errorURI: testErrorUri, innerErrors: nil)
+
+        let error = sut.toPasswordRequiredPublicError(correlationId: testCorrelationId)
         XCTAssertEqual(error.type, expectedErrorType)
-        XCTAssertEqual(error.errorDescription, description)
-        XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
 }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
@@ -100,10 +100,12 @@ final class MSALNativeAuthSignUpChallengeResponseErrorTests: XCTestCase {
     }
     
     private func testSignUpChallengeErrorToPasswordRequired(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
+        let correlationId = UUID()
         sut = MSALNativeAuthSignUpChallengeResponseError(error: code, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil)
-        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
     
 }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
@@ -219,22 +219,28 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
     // MARK: private methods
     
     private func testSignUpContinueErrorToVerifyCode(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: VerifyCodeError.ErrorType) {
+        let correlationId = UUID()
         sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.correlationId, correlationId)
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpContinueErrorToPasswordRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
+        let correlationId = UUID()
         sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, expectedErrorType)
+        XCTAssertEqual(error.correlationId, correlationId)
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpContinueErrorToAttributesRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?) {
+        let correlationId = UUID()
         sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toAttributesRequiredPublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toAttributesRequiredPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.errorDescription, description)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
@@ -29,218 +29,228 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
     
     private var sut: MSALNativeAuthSignUpContinueResponseError!
     private let testDescription = "testDescription"
-    
+    private let testErrorCodes = [1, 2, 3]
+    private let testCorrelationId = UUID()
+    private let testErrorUri = "test error uri"
+
     // MARK: - to toVerifyCodePublicError tests
     
     func test_toVerifyCodePublicError_invalidRequest() {
-        testSignUpContinueErrorToVerifyCode(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .invalidRequest, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_unauthorizedClient() {
-        testSignUpContinueErrorToVerifyCode(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .unauthorizedClient, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_invalidGrant() {
-        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_expiredToken() {
-        testSignUpContinueErrorToVerifyCode(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .expiredToken, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_passwordTooWeak() {
-        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .passwordTooWeak, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .passwordTooWeak, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_passwordTooShort() {
-        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .passwordTooShort, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .passwordTooShort, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_passwordTooLong() {
-        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .passwordTooLong, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .passwordTooLong, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_passwordRecentlyUsed() {
-        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .passwordRecentlyUsed, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_passwordBanned() {
-        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .passwordBanned, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .passwordBanned, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_userAlreadyExists() {
-        testSignUpContinueErrorToVerifyCode(code: .userAlreadyExists, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .userAlreadyExists, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_attributesRequired() {
-        testSignUpContinueErrorToVerifyCode(code: .attributesRequired, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .attributesRequired, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_verificationRequired() {
-        testSignUpContinueErrorToVerifyCode(code: .verificationRequired, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .verificationRequired, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_attributeValidationFailed() {
-        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .attributeValidationFailed, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .attributeValidationFailed, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_credentialRequired() {
-        testSignUpContinueErrorToVerifyCode(code: .credentialRequired, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToVerifyCode(code: .credentialRequired, expectedErrorType: .generalError)
     }
     
     func test_toVerifyCodePublicError_invalidOOBValue() {
-        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .invalidOOBValue, description: testDescription, expectedErrorType: .invalidCode)
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .invalidOOBValue, expectedErrorType: .invalidCode)
     }
     
     // MARK: - toPasswordRequiredPublicError tests
     
     func test_toPasswordRequiredPublicError_invalidRequest() {
-        testSignUpContinueErrorToPasswordRequired(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToPasswordRequired(code: .invalidRequest, expectedErrorType: .generalError)
     }
     
     func test_toPasswordRequiredPublicError_unauthorizedClient() {
-        testSignUpContinueErrorToPasswordRequired(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToPasswordRequired(code: .unauthorizedClient, expectedErrorType: .generalError)
     }
     
     func test_toPasswordRequiredPublicError_invalidGrant() {
-        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, expectedErrorType: .generalError)
     }
     
     func test_toPasswordRequiredPublicError_expiredToken() {
-        testSignUpContinueErrorToPasswordRequired(code: .expiredToken, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToPasswordRequired(code: .expiredToken, expectedErrorType: .generalError)
     }
     
     func test_toPasswordRequiredPublicError_passwordTooWeak() {
-        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .passwordTooWeak, description: testDescription, expectedErrorType: .invalidPassword)
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .passwordTooWeak, expectedErrorType: .invalidPassword)
     }
     
     func test_toPasswordRequiredPublicError_passwordTooShort() {
-        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .passwordTooShort, description: testDescription, expectedErrorType: .invalidPassword)
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .passwordTooShort, expectedErrorType: .invalidPassword)
     }
     
     func test_toPasswordRequiredPublicError_passwordTooLong() {
-        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .passwordTooLong, description: testDescription, expectedErrorType: .invalidPassword)
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .passwordTooLong, expectedErrorType: .invalidPassword)
     }
     
     func test_toPasswordRequiredPublicError_passwordRecentlyUsed() {
-        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .invalidPassword)
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .passwordRecentlyUsed, expectedErrorType: .invalidPassword)
     }
     
     func test_toPasswordRequiredPublicError_passwordBanned() {
-        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .passwordBanned, description: testDescription, expectedErrorType: .invalidPassword)
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .passwordBanned, expectedErrorType: .invalidPassword)
     }
     
     func test_toPasswordRequiredPublicError_userAlreadyExists() {
-        testSignUpContinueErrorToPasswordRequired(code: .userAlreadyExists, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToPasswordRequired(code: .userAlreadyExists, expectedErrorType: .generalError)
     }
     
     func test_toPasswordRequiredPublicError_attributesRequired() {
-        testSignUpContinueErrorToPasswordRequired(code: .attributesRequired, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToPasswordRequired(code: .attributesRequired, expectedErrorType: .generalError)
     }
     
     func test_toPasswordRequiredPublicError_verificationRequired() {
-        testSignUpContinueErrorToPasswordRequired(code: .verificationRequired, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToPasswordRequired(code: .verificationRequired, expectedErrorType: .generalError)
     }
     
     func test_toPasswordRequiredPublicError_attributeValidationFailed() {
-        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .attributeValidationFailed, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .attributeValidationFailed, expectedErrorType: .generalError)
     }
     
     func test_toPasswordRequiredPublicError_credentialRequired() {
-        testSignUpContinueErrorToPasswordRequired(code: .credentialRequired, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToPasswordRequired(code: .credentialRequired, expectedErrorType: .generalError)
     }
     
     func test_toPasswordRequiredPublicError_invalidOOBValue() {
-        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .invalidOOBValue, description: testDescription, expectedErrorType: .generalError)
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .invalidOOBValue, expectedErrorType: .generalError)
     }
     
     // MARK: - toAttributesRequiredPublicError tests
     
     func test_toAttributesRequiredPublicError_invalidRequest() {
-        testSignUpContinueErrorToAttributesRequired(code: .invalidRequest, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .invalidRequest)
     }
     
     func test_toAttributesRequiredPublicError_unauthorizedClien() {
-        testSignUpContinueErrorToAttributesRequired(code: .unauthorizedClient, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .unauthorizedClient)
     }
     
     func test_toAttributesRequiredPublicError_invalidGrant() {
-        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant)
     }
     
     func test_toAttributesRequiredPublicError_expiredToken() {
-        testSignUpContinueErrorToAttributesRequired(code: .expiredToken, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .expiredToken)
     }
     
     func test_toAttributesRequiredPublicError_passwordTooWeak() {
-        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .passwordTooWeak, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .passwordTooWeak)
     }
     
     func test_toAttributesRequiredPublicError_passwordTooShort() {
-        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .passwordTooShort, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .passwordTooShort)
     }
     
     func test_toAttributesRequiredPublicError_passwordTooLong() {
-        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .passwordTooLong, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .passwordTooLong)
     }
     
     func test_toAttributesRequiredPublicError_passwordRecentlyUsed() {
-        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .passwordRecentlyUsed, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .passwordRecentlyUsed)
     }
     
     func test_toAttributesRequiredPublicError_passwordBanned() {
-        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .passwordBanned, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .passwordBanned)
     }
     
     func test_toAttributesRequiredPublicError_userAlreadyExists() {
-        testSignUpContinueErrorToAttributesRequired(code: .userAlreadyExists, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .userAlreadyExists)
     }
     
     func test_toAttributesRequiredPublicError_attributesRequired() {
-        testSignUpContinueErrorToAttributesRequired(code: .attributesRequired, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .attributesRequired)
     }
     
     func test_toAttributesRequiredPublicError_verificationRequired() {
-        testSignUpContinueErrorToAttributesRequired(code: .verificationRequired, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .verificationRequired)
     }
     
     func test_toAttributesRequiredPublicError_attributeValidationFailed() {
-        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .attributeValidationFailed, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .attributeValidationFailed)
     }
     
     func test_toAttributesRequiredPublicError_credentialRequired() {
-        testSignUpContinueErrorToAttributesRequired(code: .credentialRequired, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .credentialRequired)
     }
     
     func test_toAttributesRequiredPublicError_invalidOOBValue() {
-        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .invalidOOBValue, description: testDescription)
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .invalidOOBValue)
     }
     
     // MARK: private methods
     
-    private func testSignUpContinueErrorToVerifyCode(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: VerifyCodeError.ErrorType) {
-        let correlationId = UUID()
-        sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+    private func testSignUpContinueErrorToVerifyCode(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, expectedErrorType: VerifyCodeError.ErrorType) {
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: testDescription, errorCodes: testErrorCodes, errorURI: testErrorUri, correlationId: testCorrelationId)
+        
+        let error = sut.toVerifyCodePublicError(correlationId: testCorrelationId)
         XCTAssertEqual(error.type, expectedErrorType)
-        XCTAssertEqual(error.correlationId, correlationId)
-        XCTAssertEqual(error.errorDescription, description)
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
-    private func testSignUpContinueErrorToPasswordRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
-        let correlationId = UUID()
-        sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+    private func testSignUpContinueErrorToPasswordRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, expectedErrorType: PasswordRequiredError.ErrorType) {
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: testDescription, errorCodes: testErrorCodes, errorURI: testErrorUri, correlationId: testCorrelationId)
+
+        let error = sut.toPasswordRequiredPublicError(correlationId: testCorrelationId)
         XCTAssertEqual(error.type, expectedErrorType)
-        XCTAssertEqual(error.correlationId, correlationId)
-        XCTAssertEqual(error.errorDescription, description)
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
+
     }
     
-    private func testSignUpContinueErrorToAttributesRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?) {
-        let correlationId = UUID()
-        sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toAttributesRequiredPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
-        XCTAssertEqual(error.errorDescription, description)
-        XCTAssertEqual(error.correlationId, correlationId)
+    private func testSignUpContinueErrorToAttributesRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil) {
+        sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: testDescription, errorCodes: testErrorCodes, errorURI: testErrorUri, correlationId: testCorrelationId)
+        let error = sut.toAttributesRequiredPublicError(correlationId: testCorrelationId)
+
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
@@ -220,21 +220,21 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
     
     private func testSignUpContinueErrorToVerifyCode(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: VerifyCodeError.ErrorType) {
         sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toVerifyCodePublicError()
+        let error = sut.toVerifyCodePublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpContinueErrorToPasswordRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: PasswordRequiredError.ErrorType) {
         sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toPasswordRequiredPublicError()
+        let error = sut.toPasswordRequiredPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }
     
     private func testSignUpContinueErrorToAttributesRequired(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?) {
         sut = MSALNativeAuthSignUpContinueResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, requiredAttributes: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toAttributesRequiredPublicError()
+        let error = sut.toAttributesRequiredPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.errorDescription, description)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
@@ -84,7 +84,7 @@ final class MSALNativeAuthSignUpStartResponseErrorTests: XCTestCase {
     
     private func testSignUpStartErrorToSignUpStart(code: MSALNativeAuthSignUpStartOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: SignUpStartError.ErrorType) {
         sut = MSALNativeAuthSignUpStartResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toSignUpStartPublicError()
+        let error = sut.toSignUpStartPublicError(context: MSALNativeAuthRequestContextMock())
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
     }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
@@ -29,65 +29,70 @@ final class MSALNativeAuthSignUpStartResponseErrorTests: XCTestCase {
 
     private var sut: MSALNativeAuthSignUpStartResponseError!
     private let testDescription = "testDescription"
+    private let testErrorCodes = [1, 2, 3]
+    private let testCorrelationId = UUID()
+    private let testErrorUri = "test error uri"
 
     // MARK: - to toSignUpStartPublicError tests
 
     func test_toSignUpStartPublicError_invalidRequest() {
-        testSignUpStartErrorToSignUpStart(code: .invalidRequest, description: testDescription, expectedErrorType: .generalError)
+        testSignUpStartErrorToSignUpStart(code: .invalidRequest, expectedErrorType: .generalError)
     }
     
     func test_toSignUpStartPublicError_unauthorizedClient() {
-        testSignUpStartErrorToSignUpStart(code: .unauthorizedClient, description: testDescription, expectedErrorType: .generalError)
+        testSignUpStartErrorToSignUpStart(code: .unauthorizedClient, expectedErrorType: .generalError)
     }
 
     func test_toSignUpStartPublicError_unsupportedChallengeType() {
-        testSignUpStartErrorToSignUpStart(code: .unsupportedChallengeType, description: "General error", expectedErrorType: .generalError)
+        testSignUpStartErrorToSignUpStart(code: .unsupportedChallengeType, expectedErrorType: .generalError)
     }
     
     func test_toSignUpStartPublicError_passwordTooWeak() {
-        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .passwordTooWeak, description: testDescription, expectedErrorType: .invalidPassword)
+        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .passwordTooWeak, expectedErrorType: .invalidPassword)
     }
     
     func test_toSignUpStartPublicError_passwordTooShort() {
-        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .passwordTooShort, description: testDescription, expectedErrorType: .invalidPassword)
+        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .passwordTooShort, expectedErrorType: .invalidPassword)
     }
     
     func test_toSignUpStartPublicError_passwordTooLong() {
-        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .passwordTooLong, description: testDescription, expectedErrorType: .invalidPassword)
+        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .passwordTooLong, expectedErrorType: .invalidPassword)
     }
     
     func test_toSignUpStartPublicError_passwordRecentlyUsed() {
-        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .passwordRecentlyUsed, description: testDescription, expectedErrorType: .invalidPassword)
+        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .passwordRecentlyUsed, expectedErrorType: .invalidPassword)
     }
     
     func test_toSignUpStartPublicError_passwordBanned() {
-        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .passwordBanned, description: testDescription, expectedErrorType: .invalidPassword)
+        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .passwordBanned, expectedErrorType: .invalidPassword)
     }
     
     func test_toSignUpStartPublicError_userAlreadyExists() {
-        testSignUpStartErrorToSignUpStart(code: .userAlreadyExists, description: testDescription, expectedErrorType: .userAlreadyExists)
+        testSignUpStartErrorToSignUpStart(code: .userAlreadyExists, expectedErrorType: .userAlreadyExists)
     }
     
     func test_toSignUpStartPublicError_attributesRequired() {
-        testSignUpStartErrorToSignUpStart(code: .attributesRequired, description: testDescription, expectedErrorType: .generalError)
+        testSignUpStartErrorToSignUpStart(code: .attributesRequired, expectedErrorType: .generalError)
     }
     
     func test_toSignUpStartPublicError_unsupportedAuthMethod() {
-        testSignUpStartErrorToSignUpStart(code: .unsupportedAuthMethod, description: testDescription, expectedErrorType: .generalError)
+        testSignUpStartErrorToSignUpStart(code: .unsupportedAuthMethod, expectedErrorType: .generalError)
     }
     
     func test_toSignUpStartPublicError_attributeValidationFailed() {
-        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .attributeValidationFailed, description: testDescription, expectedErrorType: .generalError)
+        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .attributeValidationFailed, expectedErrorType: .generalError)
     }
 
     // MARK: private methods
     
-    private func testSignUpStartErrorToSignUpStart(code: MSALNativeAuthSignUpStartOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: SignUpStartError.ErrorType) {
-        let correlationId = UUID()
-        sut = MSALNativeAuthSignUpStartResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toSignUpStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
+    private func testSignUpStartErrorToSignUpStart(code: MSALNativeAuthSignUpStartOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, expectedErrorType: SignUpStartError.ErrorType) {
+        sut = MSALNativeAuthSignUpStartResponseError(error: code, subError: subError, errorDescription: testDescription, errorCodes: testErrorCodes, errorURI: testErrorUri, correlationId: testCorrelationId)
+        let error = sut.toSignUpStartPublicError(correlationId: testCorrelationId)
+        
         XCTAssertEqual(error.type, expectedErrorType)
-        XCTAssertEqual(error.errorDescription, description)
-        XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 }

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
@@ -83,9 +83,11 @@ final class MSALNativeAuthSignUpStartResponseErrorTests: XCTestCase {
     // MARK: private methods
     
     private func testSignUpStartErrorToSignUpStart(code: MSALNativeAuthSignUpStartOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, description: String?, expectedErrorType: SignUpStartError.ErrorType) {
+        let correlationId = UUID()
         sut = MSALNativeAuthSignUpStartResponseError(error: code, subError: subError, errorDescription: description, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil, unverifiedAttributes: nil, invalidAttributes: nil)
-        let error = sut.toSignUpStartPublicError(context: MSALNativeAuthRequestContextMock())
+        let error = sut.toSignUpStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: correlationId))
         XCTAssertEqual(error.type, expectedErrorType)
         XCTAssertEqual(error.errorDescription, description)
+        XCTAssertEqual(error.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/network/parameters/MSALNativeAuthRequestContextTests.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/MSALNativeAuthRequestContextTests.swift
@@ -22,16 +22,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
+import XCTest
+@testable import MSAL
 
-@_implementationOnly import MSAL_Private
+final class MSALNativeAuthRequestContextTests: XCTestCase {
 
-final class MSALNativeAuthCustomErrorSerializer<T: Decodable & Error & MSALNativeAuthResponseCorrelatable>: NSObject, MSIDResponseSerialization {
-    func responseObject(for httpResponse: HTTPURLResponse?, data: Data?, context: MSIDRequestContext?) throws -> Any {
-        var customError = try JSONDecoder().decode(T.self, from: data ?? Data())
-        customError.correlationId = customError.retrieveCorrelationIdFromHeaders(from: httpResponse)
+    func test_setServerCorrelationId() {
+        let requestCorrelationId = UUID()
+        let sut = MSALNativeAuthRequestContext(correlationId: requestCorrelationId)
 
-        // the successfuly constructed "customError" needs to be thrown, since the previous "try" command just validates the object (error) decoding
-        throw customError
+        XCTAssertEqual(sut.correlationId(), requestCorrelationId)
+
+        let serverCorrelationId = UUID()
+        sut.setServerCorrelationId(serverCorrelationId)
+        XCTAssertEqual(sut.correlationId(), serverCorrelationId)
     }
 }

--- a/MSAL/test/unit/native_auth/network/parameters/MSALNativeAuthRequestContextTests.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/MSALNativeAuthRequestContextTests.swift
@@ -37,4 +37,19 @@ final class MSALNativeAuthRequestContextTests: XCTestCase {
         sut.setServerCorrelationId(serverCorrelationId)
         XCTAssertEqual(sut.correlationId(), serverCorrelationId)
     }
+
+    func test_setServerCorrelationIdNil_worksAsExpected() {
+        let requestCorrelationId = UUID()
+        let sut = MSALNativeAuthRequestContext(correlationId: requestCorrelationId)
+
+        XCTAssertEqual(sut.correlationId(), requestCorrelationId)
+
+        let serverCorrelationId1 = UUID()
+        sut.setServerCorrelationId(serverCorrelationId1)
+        XCTAssertEqual(sut.correlationId(), serverCorrelationId1)
+
+        let serverCorrelationId2: UUID? = nil
+        sut.setServerCorrelationId(serverCorrelationId2)
+        XCTAssertEqual(sut.correlationId(), requestCorrelationId)
+    }
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
@@ -84,7 +84,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .error(.unexpectedError(message: "API error message")))
+        XCTAssertEqual(result, .error(.unexpectedError(.init(errorDescription: "API error message"))))
     }
 
     func test_whenResetPasswordStartErrorResponseUserNotFound_itReturnsRelatedError() {
@@ -196,7 +196,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         )
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenResetPasswordChallengeSuccessResponseHasInvalidChallengeChannel_itReturnsUnexpectedError() {
@@ -210,7 +210,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         )
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: nil))
+        XCTAssertEqual(result, .unexpectedError(.init()))
     }
 
     func test_whenResetPasswordChallengeErrorResponseIsNotExpected_itReturnsUnexpectedError() {
@@ -221,7 +221,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "API error message"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "API error message")))
     }
 
     func test_whenResetPasswordChallengeErrorResponseIsExpected_itReturnsError() {
@@ -260,19 +260,23 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "API error message"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "API error message")))
     }
 
     func test_whenResetPasswordContinueErrorResponseIs_invalidOOBValue_itReturnsExpectedError() {
+        let apiError = MSALNativeAuthResetPasswordContinueResponseError(
+            error: .invalidGrant,
+            subError: .invalidOOBValue
+        )
         let result = buildContinueErrorResponse(expectedError: .invalidGrant, expectedSubError: .invalidOOBValue)
 
-        XCTAssertEqual(result, .invalidOOB)
+        XCTAssertEqual(result, .invalidOOB(apiError))
     }
 
     func test_whenResetPasswordContinueErrorResponseIs_verificationRequired_itReturnsUnexpectedError() {
         let result = buildContinueErrorResponse(expectedError: .verificationRequired)
 
-        XCTAssertEqual(result, .unexpectedError(message: nil))
+        XCTAssertEqual(result, .unexpectedError(nil))
     }
 
     func test_whenResetPasswordContinueErrorResponseIs_unauthorizedClient_itReturnsExpectedError() {
@@ -430,7 +434,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "API error message"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "API error message")))
     }
 
     // MARK: - Poll Completion Response
@@ -544,7 +548,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "API error message"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "API error message")))
     }
 
     // MARK: - Helper methods

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordStartValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordStartValidatedErrorTypeTests.swift
@@ -31,11 +31,14 @@ final class MSALNativeAuthResetPasswordStartValidatedErrorTypeTests: XCTestCase 
     private var testDescription = "testDescription"
     private let testErrorCodes = [1, 2, 3]
     private let testCorrelationId = UUID()
+    private let testErrorUri = "test error uri"
     private var apiErrorStub: MSALNativeAuthResetPasswordStartResponseError {
         .init(
             error: .unauthorizedClient,
             errorDescription: testDescription,
-            errorCodes: testErrorCodes
+            errorCodes: testErrorCodes,
+            errorURI: testErrorUri,
+            correlationId: testCorrelationId
         )
     }
 

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordStartValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordStartValidatedErrorTypeTests.swift
@@ -28,37 +28,62 @@ import XCTest
 final class MSALNativeAuthResetPasswordStartValidatedErrorTypeTests: XCTestCase {
 
     private typealias sut = MSALNativeAuthResetPasswordStartValidatedErrorType
-    private let testDescription = "testDescription"
+    private var testDescription = "testDescription"
+    private let testErrorCodes = [1, 2, 3]
+    private let testCorrelationId = UUID()
+    private var apiErrorStub: MSALNativeAuthResetPasswordStartResponseError {
+        .init(
+            error: .unauthorizedClient,
+            errorDescription: testDescription,
+            errorCodes: testErrorCodes
+        )
+    }
 
     // MARK: - to ResetPasswordStartError tests
 
     func test_toResetPasswordStartPublicError_unauthorizedClient() {
-        let error = sut.unauthorizedClient(message: testDescription).toResetPasswordStartPublicError()
+        let error = sut.unauthorizedClient(apiErrorStub).toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
 
     func test_toResetPasswordStartPublicError_invalidRequest() {
-        let error = sut.invalidRequest(message: "General error").toResetPasswordStartPublicError()
+        let error = sut.invalidRequest(apiErrorStub).toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, "General error")
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_toResetPasswordStartPublicError_userDoesNotHavePassword() {
-        let error = sut.userDoesNotHavePassword.toResetPasswordStartPublicError()
+        testDescription = MSALNativeAuthErrorMessage.userDoesNotHavePassword
+        let error = sut.userDoesNotHavePassword(apiErrorStub).toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .userDoesNotHavePassword)
         XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.userDoesNotHavePassword)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
 
     func test_toResetPasswordStartPublicError_userNotFound() {
-        let error = sut.userNotFound(message: testDescription).toResetPasswordStartPublicError()
+        let error = sut.userNotFound(apiErrorStub).toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .userNotFound)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
 
     func test_toResetPasswordStartPublicError_unsupportedChallengeType() {
-        let error = sut.unsupportedChallengeType(message: nil).toResetPasswordStartPublicError()
+        let error = sut.unsupportedChallengeType(apiErrorStub).toResetPasswordStartPublicError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, "General error")
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
@@ -32,18 +32,21 @@ final class MSALNativeAuthSignInInitiateValidatedErrorTypeTests: XCTestCase {
     private let testDescription = "testDescription"
     private let testErrorCodes = [1, 2, 3]
     private let testCorrelationId = UUID()
+    private let testErrorUri = "test error uri"
     private var apiErrorStub: MSALNativeAuthSignInInitiateResponseError {
         .init(
             error: .invalidRequest,
             errorDescription: testDescription,
-            errorCodes: testErrorCodes
+            errorCodes: testErrorCodes,
+            errorURI: testErrorUri,
+            correlationId: testCorrelationId
         )
     }
 
     // MARK: - convertToSignInStartError tests
     
     func test_convertToSignInStartError_redirect() {
-        let error = sut.redirect.convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.redirect.convertToSignInStartError(correlationId: testCorrelationId)
         
         XCTAssertEqual(error.type, .browserRequired)
         XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.browserRequired)
@@ -51,45 +54,52 @@ final class MSALNativeAuthSignInInitiateValidatedErrorTypeTests: XCTestCase {
     }
     
     func test_convertToSignInStartError_unauthorizedClient() {
-        let error = sut.unauthorizedClient(apiErrorStub).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.unauthorizedClient(apiErrorStub).convertToSignInStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInStartError_invalidRequest() {
-        let error = sut.invalidRequest(.init(errorDescription: testDescription)).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.invalidRequest(apiErrorStub).convertToSignInStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInStartError_invalidServerResponse() {
-        let error = sut.unexpectedError(.init(errorDescription: "Unexpected response body received")).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.unexpectedError(apiErrorStub).convertToSignInStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, "Unexpected response body received")
+        XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInStartError_userNotFound() {
-        let error = sut.userNotFound(apiErrorStub).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.userNotFound(apiErrorStub).convertToSignInStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .userNotFound)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInStartError_unsupportedChallengeType() {
-        let error = sut.unsupportedChallengeType(apiErrorStub).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.unsupportedChallengeType(apiErrorStub).convertToSignInStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
@@ -30,81 +30,64 @@ final class MSALNativeAuthSignInInitiateValidatedErrorTypeTests: XCTestCase {
     
     private typealias sut = MSALNativeAuthSignInInitiateValidatedErrorType
     private let testDescription = "testDescription"
-    
+    private let testErrorCodes = [1, 2, 3]
+    private let testCorrelationId = UUID()
+    private var apiErrorStub: MSALNativeAuthSignInInitiateResponseError {
+        .init(
+            error: .invalidRequest,
+            errorDescription: testDescription,
+            errorCodes: testErrorCodes
+        )
+    }
+
     // MARK: - convertToSignInStartError tests
     
     func test_convertToSignInStartError_redirect() {
-        let error = sut.redirect.convertToSignInStartError()
+        let error = sut.redirect.convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        
         XCTAssertEqual(error.type, .browserRequired)
         XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.browserRequired)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInStartError_unauthorizedClient() {
-        let error = sut.unauthorizedClient(message: testDescription).convertToSignInStartError()
+        let error = sut.unauthorizedClient(apiErrorStub).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInStartError_invalidRequest() {
-        let error = sut.invalidRequest(message: testDescription).convertToSignInStartError()
+        let error = sut.invalidRequest(.init(errorDescription: testDescription)).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
     }
     
     func test_convertToSignInStartError_invalidServerResponse() {
-        let error = sut.unexpectedError(message: "Unexpected response body received").convertToSignInStartError()
+        let error = sut.unexpectedError(.init(errorDescription: "Unexpected response body received")).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, "Unexpected response body received")
     }
     
     func test_convertToSignInStartError_userNotFound() {
-        let error = sut.userNotFound(message: testDescription).convertToSignInStartError()
+        let error = sut.userNotFound(apiErrorStub).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .userNotFound)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInStartError_unsupportedChallengeType() {
-        let error = sut.unsupportedChallengeType(message: testDescription).convertToSignInStartError()
+        let error = sut.unsupportedChallengeType(apiErrorStub).convertToSignInStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
-    
-    // MARK: - convertToSignInPasswordStartError tests
-    
-    func test_convertToSignInPasswordStartError_redirect() {
-        let error = sut.redirect.convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .browserRequired)
-        XCTAssertEqual(error.errorDescription, MSALNativeAuthErrorMessage.browserRequired)
-    }
-    
-    func test_convertToSignInPasswordStartError_unauthorizedClient() {
-        let error = sut.unauthorizedClient(message: testDescription).convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, testDescription)
-    }
-    
-    func test_convertToSignInPasswordStartError_invalidRequest() {
-        let error = sut.invalidRequest(message: testDescription).convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, testDescription)
-    }
-    
-    func test_convertToSignInPasswordStartError_invalidServerResponse() {
-        let error = sut.unexpectedError(message: "Unexpected response body received").convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, "Unexpected response body received")
-    }
-    
-    func test_convertToSignInPasswordStartError_userNotFound() {
-        let error = sut.userNotFound(message: testDescription).convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .userNotFound)
-        XCTAssertEqual(error.errorDescription, testDescription)
-    }
-    
-    func test_convertToSignInPasswordStartError_unsupportedChallengeType() {
-        let error = sut.unsupportedChallengeType(message: testDescription).convertToSignInPasswordStartError()
-        XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, testDescription)
-    }
-    
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInInitiateValidatedErrorTypeTests.swift
@@ -64,6 +64,7 @@ final class MSALNativeAuthSignInInitiateValidatedErrorTypeTests: XCTestCase {
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInStartError_invalidServerResponse() {
@@ -71,6 +72,7 @@ final class MSALNativeAuthSignInInitiateValidatedErrorTypeTests: XCTestCase {
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, "Unexpected response body received")
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInStartError_userNotFound() {

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
@@ -66,7 +66,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: nil, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
         let result = sut.validate(context: context, result: .success(challengeResponse))
-        if case .error(.unexpectedError(message: "Unexpected response body received")) = result {} else {
+        if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }
@@ -92,22 +92,22 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let channelType = MSALNativeAuthInternalChannelType.email
         let missingCredentialToken = MSALNativeAuthSignInChallengeResponse(continuationToken: nil, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
         var result = sut.validate(context: context, result: .success(missingCredentialToken))
-        if case .error(.unexpectedError(message: "Unexpected response body received")) = result {} else {
+        if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
         let missingTargetLabel = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: channelType, codeLength: codeLength, interval: nil)
         result = sut.validate(context: context, result: .success(missingTargetLabel))
-        if case .error(.unexpectedError(message: "Unexpected response body received")) = result {} else {
+        if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
         let missingChannelType = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: nil, codeLength: codeLength, interval: nil)
         result = sut.validate(context: context, result: .success(missingChannelType))
-        if case .error(.unexpectedError(message: "Unexpected response body received")) = result {} else {
+        if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
         let missingCodeLength = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: nil, interval: nil)
         result = sut.validate(context: context, result: .success(missingCodeLength))
-        if case .error(.unexpectedError(message: "Unexpected response body received")) = result {} else {
+        if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }
@@ -116,7 +116,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: "something", challengeType: .otp, bindingMethod: nil, challengeTargetLabel: "some", challengeChannel: .email, codeLength: 2, interval: nil)
         let result = sut.validate(context: context, result: .success(challengeResponse))
-        if case .error(.unexpectedError(message: "Unexpected challenge type")) = result {} else {
+        if case .error(.unexpectedError(.init(errorDescription: "Unexpected challenge type"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }
@@ -137,7 +137,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: nil)
         let result = sut.validate(context: context, result: .success(initiateResponse))
-        if case .error(.unexpectedError(message: "Unexpected response body received")) = result {} else {
+        if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }
@@ -155,17 +155,17 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         var initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .oob)
         var result = sut.validate(context: context, result: .success(initiateResponse))
-        if case .error(.unexpectedError(message: "Unexpected response body received")) = result {} else {
+        if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
         initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .otp)
         result = sut.validate(context: context, result: .success(initiateResponse))
-        if case .error(.unexpectedError(message: "Unexpected response body received")) = result {} else {
+        if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
         initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .password)
         result = sut.validate(context: context, result: .success(initiateResponse))
-        if case .error(.unexpectedError(message: "Unexpected response body received")) = result {} else {
+        if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
@@ -55,7 +55,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         )
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpStartErrorResponseIsNotExpected_it_returns_unexpectedError() {
@@ -66,7 +66,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "API error message"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "API error message")))
     }
 
     func test_whenSignUpStart_succeedsWithContinuationToken_it_returns_success() {
@@ -91,7 +91,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
 
         let result = sut.validate(response, with: context)
 
-        guard case .attributeValidationFailed(let invalidAttributes) = result else {
+        guard case .attributeValidationFailed(let error, let invalidAttributes) = result else {
             return XCTFail("Unexpected response")
         }
 
@@ -107,7 +107,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: nil))
+        XCTAssertEqual(result, .unexpectedError(.init()))
     }
 
     func test_whenSignUpStart_attributeValidationFailed_but_invalidAttributesIsNil_it_returns_attributeValidationFailed() {
@@ -119,7 +119,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: nil))
+        XCTAssertEqual(result, .unexpectedError(.init()))
     }
 
     func test_whenSignUpStartErrorResponseIsExpected_it_returns_error() {
@@ -225,7 +225,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         )
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpChallengeSuccessResponseContainsRedirect_it_returns_redirect() {
@@ -298,7 +298,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         )
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndOTP_it_returns_unexpectedError() {
@@ -313,7 +313,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         )
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpChallengeSuccessResponseOmitsSomeAttributes_it_returns_unexpectedError() {
@@ -328,7 +328,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         )
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpChallengeErrorResponseIsNotExpected_it_returns_unexpectedError() {
@@ -339,7 +339,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "API error message"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "API error message")))
     }
 
     func test_whenSignUpChallengeErrorResponseIsExpected_it_returns_error() {
@@ -364,7 +364,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         )
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .success("<continuationToken>"))
+        XCTAssertEqual(result, .success(continuationToken: "<continuationToken>"))
     }
 
     func test_whenSignUpStartSuccessResponseButDoesNotContainContinuationToken_it_returns_successWithNoContinuationToken() throws {
@@ -373,7 +373,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         )
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .success(nil))
+        XCTAssertEqual(result, .success(continuationToken: nil))
     }
 
     func test_whenSignUpContinueErrorResponseIsNotExpected_it_returns_unexpectedError() {
@@ -384,7 +384,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(message: "API error message"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "API error message")))
     }
 
     func test_whenSignUpContinueErrorResponseIs_invalidOOBValue_it_returns_expectedError() {
@@ -474,7 +474,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_it_returns_expectedError() {
         let result = buildContinueErrorResponse(expectedError: .invalidGrant, expectedSubError: .attributeValidationFailed, invalidAttributes: [MSALNativeAuthErrorBasicAttribute(name: "email")])
 
-        guard case .attributeValidationFailed(let invalidAttributes) = result else {
+        guard case .attributeValidationFailed(_, let invalidAttributes) = result else {
             return XCTFail("Unexpected response")
         }
 
@@ -495,19 +495,19 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_invalidAttributesIsNil_it_returns_unexpectedError() {
         let result = buildContinueErrorResponse(expectedError: .invalidGrant, expectedSubError: .attributeValidationFailed, invalidAttributes: nil)
 
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpContinueErrorResponseIs_attributeValidationFailed_but_invalidAttributesIsEmpty_it_returns_unexpectedError() {
         let result = buildContinueErrorResponse(expectedError: .invalidGrant, expectedSubError: .attributeValidationFailed, invalidAttributes: [])
 
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpContinueErrorResponseIs_credentialRequired_it_returns_expectedError() {
         let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedContinuationToken: "continuation-token")
 
-        guard case .credentialRequired(let continuationToken) = result else {
+        guard case .credentialRequired(let continuationToken, _) = result else {
             return XCTFail("Unexpected response")
         }
 
@@ -516,13 +516,13 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
 
     func test_whenSignUpContinueErrorResponseIs_credentialRequired_but_continuationToken_isNil_it_returns_unexpectedError() {
         let result = buildContinueErrorResponse(expectedError: .credentialRequired, expectedContinuationToken: nil)
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpContinueErrorResponseIs_attributesRequired_it_returns_expectedError() {
         let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedContinuationToken: "continuation-token", requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
 
-        guard case .attributesRequired(let continuationToken, let requiredAttributes) = result else {
+        guard case .attributesRequired(let continuationToken, let requiredAttributes, _) = result else {
             return XCTFail("Unexpected response")
         }
 
@@ -535,24 +535,24 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_continuationToken_IsNil_it_returns_expectedError() {
         let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedContinuationToken: nil, requiredAttributes: [.init(name: "email", type: "", required: true), .init(name: "city", type: "", required: false)])
 
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_requiredAttributesIsNil_it_returns_expectedError() {
         let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedContinuationToken: "continuation-token", requiredAttributes: nil)
 
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpContinueErrorResponseIs_attributesRequired_but_requiredAttributes_IsEmpty_it_returns_expectedError() {
         let result = buildContinueErrorResponse(expectedError: .attributesRequired, expectedContinuationToken: "continuation-token", requiredAttributes: [])
 
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpContinueErrorResponseIs_verificationRequired_it_returns_unexpectedError() {
         let result = buildContinueErrorResponse(expectedError: .attributesRequired)
-        XCTAssertEqual(result, .unexpectedError(message: "Unexpected response body received"))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
     }
 
     func test_whenSignUpContinueErrorResponseIs_unauthorizedClient_it_returns_expectedError() {

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
@@ -32,12 +32,15 @@ final class MSALNativeAuthTokenValidatedErrorTypeTests: XCTestCase {
     private let testDescription = "testDescription"
     private let testErrorCodes = [1, 2, 3]
     private let testCorrelationId = UUID()
+    private let testErrorUri = "test error uri"
     private var apiErrorStub: MSALNativeAuthTokenResponseError {
         .init(
             error: .invalidRequest,
             subError: .attributeValidationFailed,
             errorDescription: testDescription,
-            errorCodes: testErrorCodes
+            errorCodes: testErrorCodes,
+            errorURI: testErrorUri,
+            correlationId: testCorrelationId
         )
     }
 
@@ -45,125 +48,142 @@ final class MSALNativeAuthTokenValidatedErrorTypeTests: XCTestCase {
     
     func test_convertToSignInPasswordStartError_generalError() {
 
-        let error = sut.generalError.convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.generalError(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, "General error")
+        XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_expiredToken() {
-        let error = sut.expiredToken(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.expiredToken(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_expiredRefreshToken() {
-        let error = sut.expiredRefreshToken(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.expiredRefreshToken(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_unauthorizedClient() {
-        let error = sut.unauthorizedClient(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.unauthorizedClient(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_invalidRequest() {
-        let error = sut.invalidRequest(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.invalidRequest(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_invalidServerResponse() {
-        let error = sut.unexpectedError(.init(errorDescription: "Unexpected response body received")).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.unexpectedError(.init(apiErrorStub)).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
-        XCTAssertEqual(error.errorDescription, "Unexpected response body received")
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_userNotFound() {
-        let error = sut.userNotFound(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.userNotFound(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .userNotFound)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_invalidPassword() {
-        let error = sut.invalidPassword(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.invalidPassword(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .invalidCredentials)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_invalidOOBCode() {
-        let error = sut.invalidOOBCode(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.invalidOOBCode(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_unsupportedChallengeType() {
-        let error = sut.unsupportedChallengeType(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.unsupportedChallengeType(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_strongAuthRequired() {
-        let error = sut.strongAuthRequired(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.strongAuthRequired(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .browserRequired)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_invalidScope() {
-        let error = sut.invalidScope(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.invalidScope(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_authorizationPending() {
-        let error = sut.authorizationPending(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.authorizationPending(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
     func test_convertToSignInPasswordStartError_slowDown() {
-        let error = sut.slowDown(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+        let error = sut.slowDown(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.correlationId, testCorrelationId)
+        XCTAssertEqual(error.errorUri, testErrorUri)
     }
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
@@ -30,90 +30,140 @@ final class MSALNativeAuthTokenValidatedErrorTypeTests: XCTestCase {
     
     private typealias sut = MSALNativeAuthTokenValidatedErrorType
     private let testDescription = "testDescription"
-    
+    private let testErrorCodes = [1, 2, 3]
+    private let testCorrelationId = UUID()
+    private var apiErrorStub: MSALNativeAuthTokenResponseError {
+        .init(
+            error: .invalidRequest,
+            subError: .attributeValidationFailed,
+            errorDescription: testDescription,
+            errorCodes: testErrorCodes
+        )
+    }
+
     // MARK: - convertToSignInPasswordStartError tests
     
     func test_convertToSignInPasswordStartError_generalError() {
-        let error = sut.generalError.convertToSignInPasswordStartError()
+
+        let error = sut.generalError.convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, "General error")
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_expiredToken() {
-        let error = sut.expiredToken(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.expiredToken(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_expiredRefreshToken() {
-        let error = sut.expiredRefreshToken(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.expiredRefreshToken(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_unauthorizedClient() {
-        let error = sut.unauthorizedClient(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.unauthorizedClient(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_invalidRequest() {
-        let error = sut.invalidRequest(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.invalidRequest(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_invalidServerResponse() {
-        let error = sut.unexpectedError(message: "Unexpected response body received").convertToSignInPasswordStartError()
+        let error = sut.unexpectedError(.init(errorDescription: "Unexpected response body received")).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, "Unexpected response body received")
     }
     
     func test_convertToSignInPasswordStartError_userNotFound() {
-        let error = sut.userNotFound(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.userNotFound(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .userNotFound)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_invalidPassword() {
-        let error = sut.invalidPassword(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.invalidPassword(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .invalidCredentials)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_invalidOOBCode() {
-        let error = sut.invalidOOBCode(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.invalidOOBCode(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_unsupportedChallengeType() {
-        let error = sut.unsupportedChallengeType(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.unsupportedChallengeType(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_strongAuthRequired() {
-        let error = sut.strongAuthRequired(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.strongAuthRequired(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .browserRequired)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_invalidScope() {
-        let error = sut.invalidScope(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.invalidScope(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_authorizationPending() {
-        let error = sut.authorizationPending(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.authorizationPending(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
     
     func test_convertToSignInPasswordStartError_slowDown() {
-        let error = sut.slowDown(message: testDescription).convertToSignInPasswordStartError()
+        let error = sut.slowDown(apiErrorStub).convertToSignInPasswordStartError(context: MSALNativeAuthRequestContextMock(correlationId: testCorrelationId))
+
         XCTAssertEqual(error.type, .generalError)
         XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.correlationId, testCorrelationId)
     }
 }

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -286,14 +286,14 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
     func testSignInPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
-        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername))
+        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername, correlationId: correlationId))
         sut.signIn(username: "", password: "", delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
     
     func testSignInPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
-        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidCredentials))
+        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidCredentials, correlationId: correlationId))
         sut.signIn(username: "correct", password: "", delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
@@ -315,7 +315,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let exp = expectation(description: "sign-in public interface")
         let exp2 = expectation(description: "expectation Telemetry")
 
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .completed(MSALNativeAuthUserAccountResultStub.result)
@@ -358,7 +358,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let exp = expectation(description: "sign-in public interface")
         let exp2 = expectation(description: "expectation Telemetry")
 
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"), correlationId: correlationId)
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .codeRequired(
@@ -381,7 +381,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
     func testSignIn_delegate_whenInvalidUser_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
-        let delegate = SignInCodeStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername))
+        let delegate = SignInCodeStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername, correlationId: correlationId))
         sut.signIn(username: "", delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
@@ -413,7 +413,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let exp = expectation(description: "sign-in public interface")
         let exp2 = expectation(description: "expectation Telemetry")
 
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"), correlationId: correlationId)
         let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .codeRequired(
@@ -456,7 +456,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let exp = expectation(description: "sign-in public interface")
         let exp2 = expectation(description: "expectation Telemetry")
 
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInPasswordRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInPasswordRequired"), correlationId: correlationId)
         let delegate = SignInCodeStartDelegateSpy(expectation: exp, expectedError: expectedError)
 
         let expectedResult: SignInStartResult = .passwordRequired(
@@ -558,8 +558,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let signUpResponseValidatorMock = MSALNativeAuthSignUpResponseValidatorMock()
         signUpResponseValidatorMock.mockValidateSignUpStartFunc(.success(continuationToken: "continuationToken"))
         signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "continuationToken 2"))
-        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success("continuationToken"))
-        
+        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success(continuationToken: "continuationToken"))
+
         let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
         
         let expectedUsername = "username"
@@ -660,8 +660,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let signUpResponseValidatorMock = MSALNativeAuthSignUpResponseValidatorMock()
         signUpResponseValidatorMock.mockValidateSignUpStartFunc(.success(continuationToken: "continuationToken"))
         signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", .email, 4, "continuationToken 2"))
-        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success("continuationToken"))
-        
+        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success(continuationToken: "continuationToken"))
+
         let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
         
         let expectedUsername = "username"

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -105,7 +105,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -128,7 +128,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
         
@@ -141,6 +141,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             delegate.error?.errorDescription,
             String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired")
         )
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func testSignUpPassword_delegate_whenSendAttributes_shouldReturnAttributesInvalid() {
@@ -150,7 +151,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let expectedInvalidAttributes = ["attribute"]
 
         let expectedResult: SignUpStartResult = .attributesInvalid(expectedInvalidAttributes)
-        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -168,7 +169,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let expectedInvalidAttributes = ["attribute"]
 
         let expectedResult: SignUpStartResult = .attributesInvalid(expectedInvalidAttributes)
-        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -181,6 +182,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             delegate.error?.errorDescription, 
             String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid")
         )
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     // Sign Up with code
@@ -204,7 +206,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -227,7 +229,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -240,6 +242,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             delegate.error?.errorDescription,
             String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired")
         )
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func testSignUp_delegate_whenSendAttributes_shouldReturnAttributesInvalid() {
@@ -249,7 +252,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let expectedInvalidAttributes = ["attribute"]
 
         let expectedResult: SignUpStartResult = .attributesInvalid(expectedInvalidAttributes)
-        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -267,7 +270,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let expectedInvalidAttributes = ["attribute"]
 
         let expectedResult: SignUpStartResult = .attributesInvalid(expectedInvalidAttributes)
-        controllerFactoryMock.signUpController.startResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -280,6 +283,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             delegate.error?.errorDescription,
             String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid")
         )
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     // Sign in with password
@@ -287,14 +291,14 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     func testSignInPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
         let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername, correlationId: correlationId))
-        sut.signIn(username: "", password: "", delegate: delegate)
+        sut.signIn(username: "", password: "", correlationId: correlationId, delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
     
     func testSignInPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
         let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidCredentials, correlationId: correlationId))
-        sut.signIn(username: "correct", password: "", delegate: delegate)
+        sut.signIn(username: "correct", password: "", correlationId: correlationId, delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
 
@@ -303,7 +307,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let exp2 = expectation(description: "expectation Telemetry")
         let delegate = SignInPasswordStartDelegateSpy(expectation: exp1, expectedUserAccountResult: MSALNativeAuthUserAccountResultStub.result)
 
-        controllerFactoryMock.signInController.signInStartResult = .init(.init(.completed(MSALNativeAuthUserAccountResultStub.result), telemetryUpdate: { _ in
+        controllerFactoryMock.signInController.signInStartResult = .init(.init(.completed(MSALNativeAuthUserAccountResultStub.result), correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         }))
         sut.signIn(username: "correct", password: "correct", delegate: delegate)
@@ -320,7 +324,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         let expectedResult: SignInStartResult = .completed(MSALNativeAuthUserAccountResultStub.result)
 
-        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -345,7 +349,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             codeLength: 1
         )
         
-        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -368,7 +372,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             codeLength: 1
         )
 
-        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -401,7 +405,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             codeLength: 1
         )
 
-        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
         sut.signIn(username: "correct", delegate: delegate)
@@ -423,7 +427,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             codeLength: 1
         )
 
-        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -441,7 +445,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
         let expectedResult: SignInStartResult = .passwordRequired(newState: expectedState)
 
-        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -463,7 +467,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             newState: SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, continuationToken: "", correlationId: correlationId)
         )
 
-        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -494,7 +498,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             codeLength: 1
         )
 
-        controllerFactoryMock.resetPasswordController.resetPasswordResponse = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.resetPasswordController.resetPasswordResponse = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
         sut.resetPassword(username: "correct", delegate: delegate)
@@ -519,7 +523,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controllerFactoryMock.resetPasswordController.resetPasswordResponse = .init(expectedResult, telemetryUpdate: { _ in
+        controllerFactoryMock.resetPasswordController.resetPasswordResponse = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -71,8 +71,9 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
             configuration: MSALNativeAuthConfigStubs.configuration,
             cacheAccessor: MSALNativeAuthCacheAccessorMock()
         )
-        let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .tokenNotFound))
-        sut.getAccessToken(delegate: mockDelegate)
+        let correlationId = UUID()
+        let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .tokenNotFound, correlationId: correlationId, errorCodes: []))
+        sut.getAccessToken(correlationId: correlationId, delegate: mockDelegate)
         wait(for: [expectation], timeout: 1)
     }
 

--- a/MSAL/test/unit/native_auth/public/delegate/DispatchAccessTokenRetrieveCompletedTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/DispatchAccessTokenRetrieveCompletedTests.swift
@@ -42,14 +42,14 @@ final class DispatchAccessTokenRetrieveCompletedTests: XCTestCase {
         let expectedToken = "token"
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedAccessToken: expectedToken)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
             self.telemetryExp.fulfill()
         })
 
-        await sut.dispatchAccessTokenRetrieveCompleted(accessToken: expectedToken)
+        await sut.dispatchAccessTokenRetrieveCompleted(accessToken: expectedToken, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -60,7 +60,7 @@ final class DispatchAccessTokenRetrieveCompletedTests: XCTestCase {
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onAccessTokenRetrieveCompleted"), correlationId: correlationId)
         let delegate = CredentialsDelegateOptionalMethodsNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? RetrieveAccessTokenError else {
                 return XCTFail("wrong result")
             }
@@ -69,7 +69,7 @@ final class DispatchAccessTokenRetrieveCompletedTests: XCTestCase {
             self.telemetryExp.fulfill()
         })
 
-        await sut.dispatchAccessTokenRetrieveCompleted(accessToken: "token")
+        await sut.dispatchAccessTokenRetrieveCompleted(accessToken: "token", correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.expectedError)
@@ -77,6 +77,7 @@ final class DispatchAccessTokenRetrieveCompletedTests: XCTestCase {
         func checkError(_ error: RetrieveAccessTokenError?) {
             XCTAssertEqual(error?.type, .generalError)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/DispatchAccessTokenRetrieveCompletedTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/DispatchAccessTokenRetrieveCompletedTests.swift
@@ -30,6 +30,7 @@ final class DispatchAccessTokenRetrieveCompletedTests: XCTestCase {
     private var telemetryExp: XCTestExpectation!
     private var delegateExp: XCTestExpectation!
     private var sut: CredentialsDelegateDispatcher!
+    private let correlationId = UUID()
 
     override func setUp() {
         super.setUp()
@@ -41,7 +42,7 @@ final class DispatchAccessTokenRetrieveCompletedTests: XCTestCase {
         let expectedToken = "token"
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedAccessToken: expectedToken)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,10 +57,10 @@ final class DispatchAccessTokenRetrieveCompletedTests: XCTestCase {
     }
 
     func test_dispatchAccessTokenRetrieveCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = RetrieveAccessTokenError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onAccessTokenRetrieveCompleted"))
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onAccessTokenRetrieveCompleted"), correlationId: correlationId)
         let delegate = CredentialsDelegateOptionalMethodsNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? RetrieveAccessTokenError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/SignInAfterSignUpDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/SignInAfterSignUpDelegateDispatcherTests.swift
@@ -42,14 +42,14 @@ final class SignInAfterSignUpDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInAfterSignUpDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
             self.telemetryExp.fulfill()
         })
 
-        await sut.dispatchSignInCompleted(result: expectedResult)
+        await sut.dispatchSignInCompleted(result: expectedResult, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -60,7 +60,7 @@ final class SignInAfterSignUpDelegateDispatcherTests: XCTestCase {
         let expectedError = SignInAfterSignUpError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInAfterSignUpDelegateOptionalMethodsNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInAfterSignUpError else {
                 return XCTFail("wrong result")
             }
@@ -71,13 +71,14 @@ final class SignInAfterSignUpDelegateDispatcherTests: XCTestCase {
 
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
 
-        await sut.dispatchSignInCompleted(result: expectedResult)
+        await sut.dispatchSignInCompleted(result: expectedResult, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.expectedError)
 
         func checkError(_ error: SignInAfterSignUpError?) {
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/SignInAfterSignUpDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/SignInAfterSignUpDelegateDispatcherTests.swift
@@ -30,6 +30,7 @@ final class SignInAfterSignUpDelegateDispatcherTests: XCTestCase {
     private var telemetryExp: XCTestExpectation!
     private var delegateExp: XCTestExpectation!
     private var sut: SignInAfterSignUpDelegateDispatcher!
+    private let correlationId = UUID()
 
     override func setUp() {
         super.setUp()
@@ -41,7 +42,7 @@ final class SignInAfterSignUpDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInAfterSignUpDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,10 +57,10 @@ final class SignInAfterSignUpDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInAfterSignUpError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = SignInAfterSignUpError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInAfterSignUpDelegateOptionalMethodsNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInAfterSignUpError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordRequiredDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,7 +56,7 @@ final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
             correlationId: correlationId
         )
 
-        await sut.dispatchResetPasswordCompleted(newState: expectedState)
+        await sut.dispatchResetPasswordCompleted(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -68,7 +68,7 @@ final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
         let delegate = ResetPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -84,7 +84,7 @@ final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
             correlationId: correlationId
         )
 
-        await sut.dispatchResetPasswordCompleted(newState: expectedState)
+        await sut.dispatchResetPasswordCompleted(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
@@ -92,6 +92,7 @@ final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: PasswordRequiredError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordRequiredDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -66,9 +66,9 @@ final class ResetPasswordRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = ResetPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCompleted"))
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordResendCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchResetPasswordResendCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordResendCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -58,7 +58,8 @@ final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -73,7 +74,7 @@ final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
         let delegate = ResetPasswordResendCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordResendCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
                 return XCTFail("wrong result")
             }
@@ -91,7 +92,8 @@ final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -99,6 +101,7 @@ final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
 
         func checkError(_ error: ResendCodeError?) {
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordResendCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchResetPasswordResendCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordResendCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -71,9 +71,9 @@ final class ResetPasswordResendCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchResetPasswordResendCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = ResetPasswordResendCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordResendCodeRequired"))
+        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordResendCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchResetPasswordCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -71,9 +71,9 @@ final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchResetPasswordCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = ResetPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = ResetPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCodeRequired"))
+        let expectedError = ResetPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResetPasswordStartError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchResetPasswordCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -58,7 +58,8 @@ final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -73,7 +74,7 @@ final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
         let delegate = ResetPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = ResetPasswordStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResetPasswordStartError else {
                 return XCTFail("wrong result")
             }
@@ -91,7 +92,8 @@ final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -100,6 +102,7 @@ final class ResetPasswordStartDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: ResetPasswordStartError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordVerifyCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -51,7 +51,7 @@ final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
 
         let expectedState = ResetPasswordRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "username", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchPasswordRequired(newState: expectedState)
+        await sut.dispatchPasswordRequired(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -62,7 +62,7 @@ final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
         let delegate = ResetPasswordVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onPasswordRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }
@@ -73,7 +73,7 @@ final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
 
         let expectedState = ResetPasswordRequiredState(controller: controllerFactoryMock.resetPasswordController, username: "username", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchPasswordRequired(newState: expectedState)
+        await sut.dispatchPasswordRequired(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
@@ -81,6 +81,7 @@ final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: VerifyCodeError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/ResetPasswordVerifyCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = ResetPasswordVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -60,9 +60,9 @@ final class ResetPasswordVerifyCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = ResetPasswordVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onPasswordRequired"))
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onPasswordRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/SignInAfterResetPasswordDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/SignInAfterResetPasswordDelegateDispatcherTests.swift
@@ -42,14 +42,14 @@ final class SignInAfterResetPasswordDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInAfterResetPasswordDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
             self.telemetryExp.fulfill()
         })
 
-        await sut.dispatchSignInCompleted(result: expectedResult)
+        await sut.dispatchSignInCompleted(result: expectedResult, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -60,7 +60,7 @@ final class SignInAfterResetPasswordDelegateDispatcherTests: XCTestCase {
         let expectedError = SignInAfterResetPasswordError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInAfterResetPasswordDelegateOptionalMethodsNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInAfterResetPasswordError else {
                 return XCTFail("wrong result")
             }
@@ -71,12 +71,13 @@ final class SignInAfterResetPasswordDelegateDispatcherTests: XCTestCase {
 
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
 
-        await sut.dispatchSignInCompleted(result: expectedResult)
+        await sut.dispatchSignInCompleted(result: expectedResult, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
         func checkError(_ error: SignInAfterResetPasswordError?) {
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/reset_password/SignInAfterResetPasswordDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/reset_password/SignInAfterResetPasswordDelegateDispatcherTests.swift
@@ -30,6 +30,7 @@ final class SignInAfterResetPasswordDelegateDispatcherTests: XCTestCase {
     private var telemetryExp: XCTestExpectation!
     private var delegateExp: XCTestExpectation!
     private var sut: SignInAfterResetPasswordDelegateDispatcher!
+    private var correlationId = UUID()
 
     override func setUp() {
         super.setUp()
@@ -41,7 +42,7 @@ final class SignInAfterResetPasswordDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInAfterResetPasswordDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,10 +57,10 @@ final class SignInAfterResetPasswordDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInAfterResetPasswordError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = SignInAfterResetPasswordError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInAfterResetPasswordDelegateOptionalMethodsNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInAfterResetPasswordError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordRequiredDelegateDispatcherTests.swift
@@ -30,6 +30,7 @@ final class SignInPasswordRequiredDelegateDispatcherTests: XCTestCase {
     private var delegateExp: XCTestExpectation!
     private var sut: SignInPasswordRequiredDelegateDispatcher!
     private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
 
     override func setUp() {
         super.setUp()
@@ -41,7 +42,7 @@ final class SignInPasswordRequiredDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInPasswordRequiredDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,11 +57,11 @@ final class SignInPasswordRequiredDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordRequiredDelegateDispatcherTests.swift
@@ -42,14 +42,14 @@ final class SignInPasswordRequiredDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInPasswordRequiredDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
             self.telemetryExp.fulfill()
         })
 
-        await sut.dispatchSignInCompleted(result: expectedResult)
+        await sut.dispatchSignInCompleted(result: expectedResult, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -61,7 +61,7 @@ final class SignInPasswordRequiredDelegateDispatcherTests: XCTestCase {
         let delegate = SignInPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
 
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -72,7 +72,7 @@ final class SignInPasswordRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
 
-        await sut.dispatchSignInCompleted(result: expectedResult)
+        await sut.dispatchSignInCompleted(result: expectedResult, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.delegateError)
@@ -80,6 +80,7 @@ final class SignInPasswordRequiredDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: PasswordRequiredError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignInCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignInPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -70,11 +70,11 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"), correlationId: correlationId)
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }
@@ -108,7 +108,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInPasswordStartDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -123,11 +123,11 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInPasswordStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignInCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignInPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -58,7 +58,8 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -74,7 +75,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }
@@ -92,7 +93,8 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -101,6 +103,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: SignInStartError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 
@@ -108,14 +111,14 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInPasswordStartDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
             self.telemetryExp.fulfill()
         })
 
-        await sut.dispatchSignInCompleted(result: expectedResult)
+        await sut.dispatchSignInCompleted(result: expectedResult, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -127,7 +130,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
         let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }
@@ -138,7 +141,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
 
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
 
-        await sut.dispatchSignInCompleted(result: expectedResult)
+        await sut.dispatchSignInCompleted(result: expectedResult, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.expectedError)
@@ -146,6 +149,7 @@ final class SignInPasswordStartDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: SignInStartError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInResendCodeDelegateDispatcherTests.swift
@@ -47,7 +47,7 @@ final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
 
         let delegate = SignInResendCodeDelegateSpy(expectation: delegateExp, expectedSentTo: expectedSentTo, expectedChannelTargetType: expectedChannelTargetType, expectedCodeLength: expectedCodeLength)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -58,7 +58,8 @@ final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -70,7 +71,7 @@ final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
         let delegate = SignInResendCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInResendCodeCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
                 return XCTFail("wrong result")
             }
@@ -88,7 +89,8 @@ final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -96,6 +98,7 @@ final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
 
         func checkError(_ error: ResendCodeError?) {
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInResendCodeDelegateDispatcherTests.swift
@@ -47,7 +47,7 @@ final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
 
         let delegate = SignInResendCodeDelegateSpy(expectation: delegateExp, expectedSentTo: expectedSentTo, expectedChannelTargetType: expectedChannelTargetType, expectedCodeLength: expectedCodeLength)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -68,9 +68,9 @@ final class SignInResendCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignInResendCodeCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignInResendCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInResendCodeCodeRequired"))
+        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInResendCodeCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInStartDelegateDispatcherTests.swift
@@ -46,7 +46,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
 
         let delegate = SignInCodeStartDelegateSpy(expectation: delegateExp, expectedSentTo: expectedSentTo, expectedChannelTargetType: expectedChannelTargetType, expectedCodeLength: expectedCodeLength)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -57,7 +57,8 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -73,7 +74,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
         let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }
@@ -91,7 +92,8 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -100,13 +102,14 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: SignInStartError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 
     func test_dispatchSignInPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignInCodeStartDelegateWithPasswordRequiredSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -115,7 +118,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignInPasswordRequiredState(scopes: [], username: "username", controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignInPasswordRequired(newState: expectedState)
+        await sut.dispatchSignInPasswordRequired(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -127,7 +130,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
         let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }
@@ -138,7 +141,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignInPasswordRequiredState(scopes: [], username: "username", controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignInPasswordRequired(newState: expectedState)
+        await sut.dispatchSignInPasswordRequired(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.expectedError)
@@ -146,6 +149,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: SignInStartError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInStartDelegateDispatcherTests.swift
@@ -46,7 +46,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
 
         let delegate = SignInCodeStartDelegateSpy(expectation: delegateExp, expectedSentTo: expectedSentTo, expectedChannelTargetType: expectedChannelTargetType, expectedCodeLength: expectedCodeLength)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -69,11 +69,11 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"), correlationId: correlationId)
         let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }
@@ -106,7 +106,7 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignInPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignInCodeStartDelegateWithPasswordRequiredSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -123,11 +123,11 @@ final class SignInStartDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInPasswordRequired"))
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInPasswordRequired"), correlationId: correlationId)
         let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: delegateExp, expectedError: expectedError)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignInStartError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInVerifyCodeDelegateDispatcherTests.swift
@@ -31,6 +31,7 @@ final class SignInVerifyCodeDelegateDispatcherTests: XCTestCase {
     private var delegateExp: XCTestExpectation!
     private var sut: SignInVerifyCodeDelegateDispatcher!
     private let controllerFactoryMock = MSALNativeAuthControllerFactoryMock()
+    private let correlationId = UUID()
 
     override func setUp() {
         super.setUp()
@@ -42,7 +43,7 @@ final class SignInVerifyCodeDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInVerifyCodeDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -57,11 +58,11 @@ final class SignInVerifyCodeDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSignInCompleted_whenDelegateOptionalMethodsNotImplemented() async {
-        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
         let delegate = SignInVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
 
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_in/SignInVerifyCodeDelegateDispatcherTests.swift
@@ -43,14 +43,14 @@ final class SignInVerifyCodeDelegateDispatcherTests: XCTestCase {
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
         let delegate = SignInVerifyCodeDelegateSpy(expectation: delegateExp, expectedUserAccountResult: expectedResult)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
             self.telemetryExp.fulfill()
         })
 
-        await sut.dispatchSignInCompleted(result: expectedResult)
+        await sut.dispatchSignInCompleted(result: expectedResult, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -62,7 +62,7 @@ final class SignInVerifyCodeDelegateDispatcherTests: XCTestCase {
         let delegate = SignInVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
 
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }
@@ -73,7 +73,7 @@ final class SignInVerifyCodeDelegateDispatcherTests: XCTestCase {
 
         let expectedResult = MSALNativeAuthUserAccountResultStub.result
 
-        await sut.dispatchSignInCompleted(result: expectedResult)
+        await sut.dispatchSignInCompleted(result: expectedResult, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.expectedError)
@@ -81,6 +81,7 @@ final class SignInVerifyCodeDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: VerifyCodeError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,7 +56,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -68,7 +68,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -84,20 +84,21 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
 
         func checkError(_ error: AttributesRequiredError?) {
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 
     func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -108,7 +109,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, newState: expectedState)
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -120,7 +121,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -133,20 +134,21 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, newState: expectedState)
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
 
         func checkError(_ error: AttributesRequiredError?) {
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 
     func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -155,7 +157,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpCompleted(newState: expectedState)
+        await sut.dispatchSignUpCompleted(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -166,7 +168,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -177,13 +179,14 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpCompleted(newState: expectedState)
+        await sut.dispatchSignUpCompleted(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
 
         func checkError(_ error: AttributesRequiredError?) {
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpAttributesRequiredDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -66,9 +66,9 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpAttributesRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -97,7 +97,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -118,9 +118,9 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpAttributesInvalid_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"))
+        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -146,7 +146,7 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -164,9 +164,9 @@ final class SignUpAttributesRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpCompleted_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpAttributesRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+        let expectedError = AttributesRequiredError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? AttributesRequiredError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,7 +56,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -68,7 +68,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -84,7 +84,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
@@ -92,13 +92,14 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: PasswordRequiredError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 
     func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -107,7 +108,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpCompleted(newState: expectedState)
+        await sut.dispatchSignUpCompleted(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -118,7 +119,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -129,7 +130,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpCompleted(newState: expectedState)
+        await sut.dispatchSignUpCompleted(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
@@ -137,6 +138,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: PasswordRequiredError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordRequiredDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -66,9 +66,9 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpVerifyCode_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }
@@ -98,7 +98,7 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordRequiredDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -116,9 +116,9 @@ final class SignUpPasswordRequiredDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpCompleted_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpPasswordRequiredDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+        let expectedError = PasswordRequiredError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? PasswordRequiredError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpPasswordCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -58,7 +58,8 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -73,7 +74,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }
@@ -91,7 +92,8 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -100,13 +102,14 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: SignUpStartError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 
     func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -115,7 +118,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
 
         let expectedAttributeNames = ["attribute1", "attribute2"]
 
-        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames)
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -126,7 +129,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }
@@ -137,7 +140,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
 
         let expectedAttributeNames = ["attribute1", "attribute2"]
 
-        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames)
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
@@ -145,6 +148,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: SignUpStartError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpPasswordStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpPasswordCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -71,9 +71,9 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpPasswordCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"))
+        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }
@@ -106,7 +106,7 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpPasswordStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -124,9 +124,9 @@ final class SignUpPasswordStartDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpAttributesInvalid_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"))
+        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpResendCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpResendCode_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpResendCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -71,9 +71,9 @@ final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpResendCode_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpResendCodeDelegateMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpResendCodeCodeRequired"))
+        let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpResendCodeCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpResendCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpResendCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpResendCode_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpResendCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -58,7 +58,8 @@ final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -73,7 +74,7 @@ final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpResendCodeDelegateMethodsNotImplemented(expectation: delegateExp)
         let expectedError = ResendCodeError(message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpResendCodeCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? ResendCodeError else {
                 return XCTFail("wrong result")
             }
@@ -91,7 +92,8 @@ final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -99,6 +101,7 @@ final class SignUpResendCodeDelegateDispatcherTests: XCTestCase {
 
         func checkError(_ error: ResendCodeError?) {
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpCodeStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -71,9 +71,9 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpCodeRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"))
+        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }
@@ -106,7 +106,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpCodeStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -124,9 +124,9 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpAttributesInvalid_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"))
+        let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpStartDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpStartDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpCodeRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpCodeStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -58,7 +58,8 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -73,7 +74,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }
@@ -91,7 +92,8 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
             newState: expectedState,
             sentTo: expectedSentTo,
             channelTargetType: expectedChannelTargetType,
-            codeLength: expectedCodeLength
+            codeLength: expectedCodeLength,
+            correlationId: correlationId
         )
 
         await fulfillment(of: [telemetryExp, delegateExp])
@@ -100,13 +102,14 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: SignUpStartError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 
     func test_dispatchSignUpAttributesInvalid_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpCodeStartDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -115,7 +118,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
 
         let expectedAttributeNames = ["attribute1", "attribute2"]
 
-        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames)
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -126,7 +129,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = SignUpStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? SignUpStartError else {
                 return XCTFail("wrong result")
             }
@@ -137,7 +140,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
 
         let expectedAttributeNames = ["attribute1", "attribute2"]
 
-        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames)
+        await sut.dispatchSignUpAttributesInvalid(attributeNames: expectedAttributeNames, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
@@ -145,6 +148,7 @@ final class SignUpStartDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: SignUpStartError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -66,9 +66,9 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpVerifyCode_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }
@@ -98,7 +98,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -116,9 +116,9 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpPasswordRequired_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpPasswordRequired"))
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpPasswordRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }
@@ -143,7 +143,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -161,9 +161,9 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
     func test_dispatchSignUpCompleted_whenDelegateOptionalMethodsNotImplemented() async {
         let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
-        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+        let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }

--- a/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/sign_up/SignUpVerifyCodeDelegateDispatcherTests.swift
@@ -42,7 +42,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
     func test_dispatchSignUpAttributesRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -56,7 +56,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -68,7 +68,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }
@@ -84,7 +84,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignUpAttributesRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState)
+        await sut.dispatchSignUpAttributesRequired(attributes: expectedAttributes, newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
@@ -92,13 +92,14 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: VerifyCodeError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 
     func test_dispatchSignUpPasswordRequired_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -107,7 +108,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignUpPasswordRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpPasswordRequired(newState: expectedState)
+        await sut.dispatchSignUpPasswordRequired(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -118,7 +119,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpPasswordRequired"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }
@@ -129,7 +130,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignUpPasswordRequiredState(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpPasswordRequired(newState: expectedState)
+        await sut.dispatchSignUpPasswordRequired(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
@@ -137,13 +138,14 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: VerifyCodeError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 
     func test_dispatchSignUpCompleted_whenDelegateMethodsAreImplemented() async {
         let delegate = SignUpVerifyCodeDelegateSpy(expectation: delegateExp)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case .success = result else {
                 return XCTFail("wrong result")
             }
@@ -152,7 +154,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpCompleted(newState: expectedState)
+        await sut.dispatchSignUpCompleted(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
 
@@ -163,7 +165,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
         let delegate = SignUpVerifyCodeDelegateOptionalMethodsNotImplemented(expectation: delegateExp)
         let expectedError = VerifyCodeError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"), correlationId: correlationId)
 
-        sut = .init(delegate: delegate, correlationId: correlationId, telemetryUpdate: { result in
+        sut = .init(delegate: delegate, telemetryUpdate: { result in
             guard case let .failure(error) = result, let customError = error as? VerifyCodeError else {
                 return XCTFail("wrong result")
             }
@@ -174,7 +176,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
 
         let expectedState = SignInAfterSignUpState(controller: controllerFactoryMock.signInController, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
-        await sut.dispatchSignUpCompleted(newState: expectedState)
+        await sut.dispatchSignUpCompleted(newState: expectedState, correlationId: correlationId)
 
         await fulfillment(of: [telemetryExp, delegateExp])
         checkError(delegate.error)
@@ -182,6 +184,7 @@ final class SignUpVerifyCodeDelegateDispatcherTests: XCTestCase {
         func checkError(_ error: VerifyCodeError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
+            XCTAssertEqual(error?.correlationId, expectedError.correlationId)
         }
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/AttributesRequiredErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/AttributesRequiredErrorTests.swift
@@ -24,6 +24,7 @@
 
 import XCTest
 @testable import MSAL
+@_implementationOnly import MSAL_Unit_Test_Private
 
 final class AttributesRequiredErrorTests: XCTestCase {
 
@@ -31,12 +32,20 @@ final class AttributesRequiredErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(message: expectedMessage)
+        let uuid = UUID(uuidString: DEFAULT_TEST_UID)!
+
+        sut = .init(message: expectedMessage, correlationId: uuid)
+        
         XCTAssertEqual(sut.errorDescription, expectedMessage)
+        XCTAssertEqual(sut.correlationId, uuid)
     }
 
     func test_defaultErrorDescription() {
-        sut = .init()
+        let uuid = UUID(uuidString: DEFAULT_TEST_UID)!
+
+        sut = .init(correlationId: uuid)
+
         XCTAssertEqual(sut.errorDescription, MSALNativeAuthErrorMessage.generalError)
+        XCTAssertEqual(sut.correlationId, uuid)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/PasswordRequiredErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/PasswordRequiredErrorTests.swift
@@ -35,15 +35,15 @@ final class PasswordRequiredErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [PasswordRequiredError] = [
-            .init(type: .browserRequired),
-            .init(type: .invalidPassword),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .invalidPassword, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedErrorDescriptions = [
@@ -60,13 +60,13 @@ final class PasswordRequiredErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isInvalidPassword)
     }
 
     func test_isInvalidPassword() {
-        sut = .init(type: .invalidPassword)
+        sut = .init(type: .invalidPassword, correlationId: .init())
         XCTAssertTrue(sut.isInvalidPassword)
         XCTAssertFalse(sut.isBrowserRequired)
     }

--- a/MSAL/test/unit/native_auth/public/error/ResendCodeErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/ResendCodeErrorTests.swift
@@ -31,12 +31,12 @@ final class ResendCodeErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(message: expectedMessage)
+        sut = .init(message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
-        sut = .init()
+        sut = .init(correlationId: .init())
         XCTAssertEqual(sut.errorDescription, MSALNativeAuthErrorMessage.generalError)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/ResetPasswordStartErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/ResetPasswordStartErrorTests.swift
@@ -35,17 +35,17 @@ final class ResetPasswordStartErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [ResetPasswordStartError] = [
-            .init(type: .browserRequired),
-            .init(type: .userDoesNotHavePassword),
-            .init(type: .userNotFound),
-            .init(type: .invalidUsername),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .userDoesNotHavePassword, correlationId: .init()),
+            .init(type: .userNotFound, correlationId: .init()),
+            .init(type: .invalidUsername, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedIdentifiers = [
@@ -64,7 +64,7 @@ final class ResetPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserDoesNotHavePassword)
         XCTAssertFalse(sut.isUserNotFound)
@@ -72,7 +72,7 @@ final class ResetPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isUserDoesNotHaveAPassword() {
-        sut = .init(type: .userDoesNotHavePassword)
+        sut = .init(type: .userDoesNotHavePassword, correlationId: .init())
         XCTAssertTrue(sut.isUserDoesNotHavePassword)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserNotFound)
@@ -80,7 +80,7 @@ final class ResetPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isUserNotFound() {
-        sut = .init(type: .userNotFound)
+        sut = .init(type: .userNotFound, correlationId: .init())
         XCTAssertTrue(sut.isUserNotFound)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserDoesNotHavePassword)
@@ -88,7 +88,7 @@ final class ResetPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isInvalidUsername() {
-        sut = .init(type: .invalidUsername)
+        sut = .init(type: .invalidUsername, correlationId: .init())
         XCTAssertTrue(sut.isInvalidUsername)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserDoesNotHavePassword)

--- a/MSAL/test/unit/native_auth/public/error/RetrieveAccessTokenErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/RetrieveAccessTokenErrorTests.swift
@@ -35,16 +35,16 @@ final class RetrieveAccessTokenErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [RetrieveAccessTokenError] = [
-            .init(type: .browserRequired),
-            .init(type: .refreshTokenExpired),
-            .init(type: .tokenNotFound),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .refreshTokenExpired, correlationId: .init()),
+            .init(type: .tokenNotFound, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedIdentifiers = [
@@ -62,21 +62,21 @@ final class RetrieveAccessTokenErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isRefreshTokenExpired)
         XCTAssertFalse(sut.isTokenNotFound)
     }
 
     func test_isRefreshTokenExpired() {
-        sut = .init(type: .refreshTokenExpired)
+        sut = .init(type: .refreshTokenExpired, correlationId: .init())
         XCTAssertTrue(sut.isRefreshTokenExpired)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isTokenNotFound)
     }
 
     func test_isTokenNotFound() {
-        sut = .init(type: .tokenNotFound)
+        sut = .init(type: .tokenNotFound, correlationId: .init())
         XCTAssertTrue(sut.isTokenNotFound)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isRefreshTokenExpired)

--- a/MSAL/test/unit/native_auth/public/error/SignInAfterResetPasswordErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignInAfterResetPasswordErrorTests.swift
@@ -31,12 +31,12 @@ final class SignInAfterResetPasswordErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(message: expectedMessage)
+        sut = .init(message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
-        sut = .init()
+        sut = .init(correlationId: .init())
         XCTAssertEqual(sut.errorDescription, MSALNativeAuthErrorMessage.generalError)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/SignInAfterSignUpErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignInAfterSignUpErrorTests.swift
@@ -31,12 +31,12 @@ final class SignInAfterSignUpErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(message: expectedMessage)
+        sut = .init(message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
-        sut = .init()
+        sut = .init(correlationId: .init())
         XCTAssertEqual(sut.errorDescription, MSALNativeAuthErrorMessage.generalError)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/SignInStartErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignInStartErrorTests.swift
@@ -35,17 +35,17 @@ final class SignInPasswordStartErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [SignInStartError] = [
-            .init(type: .browserRequired),
-            .init(type: .userNotFound),
-            .init(type: .invalidCredentials),
-            .init(type: .invalidUsername),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .userNotFound, correlationId: .init()),
+            .init(type: .invalidCredentials, correlationId: .init()),
+            .init(type: .invalidUsername, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedDescriptions = [
@@ -64,7 +64,7 @@ final class SignInPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserNotFound)
         XCTAssertFalse(sut.isInvalidCredentials)
@@ -72,7 +72,7 @@ final class SignInPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isUserNotFound() {
-        sut = .init(type: .userNotFound)
+        sut = .init(type: .userNotFound, correlationId: .init())
         XCTAssertTrue(sut.isUserNotFound)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isInvalidCredentials)
@@ -80,7 +80,7 @@ final class SignInPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isInvalidPassword() {
-        sut = .init(type: .invalidCredentials)
+        sut = .init(type: .invalidCredentials, correlationId: .init())
         XCTAssertTrue(sut.isInvalidCredentials)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserNotFound)
@@ -88,7 +88,7 @@ final class SignInPasswordStartErrorTests: XCTestCase {
     }
 
     func test_isInvalidUsername() {
-        sut = .init(type: .invalidUsername)
+        sut = .init(type: .invalidUsername, correlationId: .init())
         XCTAssertTrue(sut.isInvalidUsername)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserNotFound)

--- a/MSAL/test/unit/native_auth/public/error/SignUpStartErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/SignUpStartErrorTests.swift
@@ -35,17 +35,17 @@ final class SignUpStartErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [SignUpStartError] = [
-            .init(type: .browserRequired),
-            .init(type: .userAlreadyExists),
-            .init(type: .invalidUsername),
-            .init(type: .invalidPassword),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .userAlreadyExists, correlationId: .init()),
+            .init(type: .invalidUsername, correlationId: .init()),
+            .init(type: .invalidPassword, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedDescriptions = [
@@ -64,7 +64,7 @@ final class SignUpStartErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserAlreadyExists)
         XCTAssertFalse(sut.isInvalidUsername)
@@ -72,7 +72,7 @@ final class SignUpStartErrorTests: XCTestCase {
     }
 
     func test_isUserAlreadyExists() {
-        sut = .init(type: .userAlreadyExists)
+        sut = .init(type: .userAlreadyExists, correlationId: .init())
         XCTAssertTrue(sut.isUserAlreadyExists)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isInvalidUsername)
@@ -80,7 +80,7 @@ final class SignUpStartErrorTests: XCTestCase {
     }
 
     func test_isInvalidUsername() {
-        sut = .init(type: .invalidUsername)
+        sut = .init(type: .invalidUsername, correlationId: .init())
         XCTAssertTrue(sut.isInvalidUsername)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserAlreadyExists)
@@ -88,7 +88,7 @@ final class SignUpStartErrorTests: XCTestCase {
     }
     
     func test_isInvalidPassword() {
-        sut = .init(type: .invalidPassword)
+        sut = .init(type: .invalidPassword, correlationId: .init())
         XCTAssertTrue(sut.isInvalidPassword)
         XCTAssertFalse(sut.isBrowserRequired)
         XCTAssertFalse(sut.isUserAlreadyExists)

--- a/MSAL/test/unit/native_auth/public/error/VerifyCodeErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/VerifyCodeErrorTests.swift
@@ -35,15 +35,15 @@ final class VerifyCodeErrorTests: XCTestCase {
 
     func test_customErrorDescription() {
         let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage)
+        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
         XCTAssertEqual(sut.errorDescription, expectedMessage)
     }
 
     func test_defaultErrorDescription() {
         let sut: [VerifyCodeError] = [
-            .init(type: .browserRequired),
-            .init(type: .invalidCode),
-            .init(type: .generalError)
+            .init(type: .browserRequired, correlationId: .init()),
+            .init(type: .invalidCode, correlationId: .init()),
+            .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedDescriptions = [
@@ -60,13 +60,13 @@ final class VerifyCodeErrorTests: XCTestCase {
     }
 
     func test_isBrowserRequired() {
-        sut = .init(type: .browserRequired)
+        sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isInvalidCode)
     }
 
     func test_isInvalidCode() {
-        sut = .init(type: .invalidCode)
+        sut = .init(type: .invalidCode, correlationId: .init())
         XCTAssertTrue(sut.isInvalidCode)
         XCTAssertFalse(sut.isBrowserRequired)
     }

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
@@ -44,11 +44,11 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
     // ResendCode
 
     func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = ResendCodeError(message: "test error", correlationId: .init())
+        let expectedError = ResendCodeError(message: "test error", correlationId: correlationId)
         let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: ResetPasswordResendCodeResult = .error(error: expectedError, newState: expectedState)
-        controller.resendCodeResponse = .init(expectedResult)
+        controller.resendCodeResponse = .init(expectedResult, correlationId: correlationId)
 
         let exp = expectation(description: "reset password states")
         let delegate = ResetPasswordResendCodeDelegateSpy(expectation: exp)
@@ -57,6 +57,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
         wait(for: [exp])
 
         XCTAssertEqual(delegate.error, expectedError)
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
         XCTAssertEqual(delegate.newState, expectedState)
     }
 
@@ -71,7 +72,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controller.resendCodeResponse = .init(expectedResult, telemetryUpdate: { _ in
+        controller.resendCodeResponse = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -97,7 +98,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controller.resendCodeResponse = .init(expectedResult, telemetryUpdate: { _ in
+        controller.resendCodeResponse = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -107,16 +108,17 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
         wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordResendCodeRequired"))
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     // SubmitCode
 
     func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = VerifyCodeError(type: .invalidCode, correlationId: .init())
+        let expectedError = VerifyCodeError(type: .invalidCode, correlationId: correlationId)
         let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: ResetPasswordSubmitCodeResult = .error(error: expectedError, newState: expectedState)
-        controller.submitCodeResponse = .init(expectedResult)
+        controller.submitCodeResponse = .init(expectedResult, correlationId: correlationId)
 
         let exp = expectation(description: "reset password states")
         let delegate = ResetPasswordVerifyCodeDelegateSpy(expectation: exp)
@@ -126,6 +128,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
 
         XCTAssertEqual(delegate.error, expectedError)
         XCTAssertEqual(delegate.newCodeRequiredState, expectedState)
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func test_submitCode_delegate_success_shouldReturnPasswordRequired() {
@@ -134,7 +137,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
         let expectedState = ResetPasswordRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: ResetPasswordSubmitCodeResult = .passwordRequired(newState: expectedState)
-        controller.submitCodeResponse = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitCodeResponse = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -152,7 +155,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
         let expectedState = ResetPasswordRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: ResetPasswordSubmitCodeResult = .passwordRequired(newState: expectedState)
-        controller.submitCodeResponse = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitCodeResponse = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -163,5 +166,6 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
 
         XCTAssertEqual(delegate.error?.type, .generalError)
         XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onPasswordRequired"))
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordCodeSentStateTests.swift
@@ -44,7 +44,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
     // ResendCode
 
     func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = ResendCodeError(message: "test error")
+        let expectedError = ResendCodeError(message: "test error", correlationId: .init())
         let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: ResetPasswordResendCodeResult = .error(error: expectedError, newState: expectedState)
@@ -112,7 +112,7 @@ final class ResetPasswordCodeRequiredStateTests: XCTestCase {
     // SubmitCode
 
     func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = VerifyCodeError(type: .invalidCode)
+        let expectedError = VerifyCodeError(type: .invalidCode, correlationId: .init())
         let expectedState = ResetPasswordCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: ResetPasswordSubmitCodeResult = .error(error: expectedError, newState: expectedState)

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
@@ -55,10 +55,10 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
         controllerMock = MSALNativeAuthResetPasswordControllerMock()
         let sut = ResetPasswordRequiredState(controller: controllerMock, username: "username", continuationToken: "<token>", correlationId: correlationId)
 
-        let expectedError = PasswordRequiredError(type: .invalidPassword, message: nil, correlationId: .init())
+        let expectedError = PasswordRequiredError(type: .invalidPassword, message: nil, correlationId: correlationId)
         let expectedState = ResetPasswordRequiredState(controller: controllerMock, username: "username", continuationToken: "continuationToken", correlationId: correlationId)
 
-        let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.error(error: expectedError, newState: expectedState))
+        let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.error(error: expectedError, newState: expectedState), correlationId: correlationId)
         controllerMock.submitPasswordResponse = expectedResult
 
         let exp = expectation(description: "reset password states")
@@ -68,6 +68,7 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
         wait(for: [exp])
 
         XCTAssertEqual(delegate.error?.type, expectedError.type)
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
         XCTAssertEqual(delegate.newPasswordRequiredState, expectedState)
     }
 
@@ -78,7 +79,7 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
         let sut = ResetPasswordRequiredState(controller: controllerMock, username: "", continuationToken: "<token>", correlationId: correlationId)
         let expectedState = SignInAfterResetPasswordState(controller: controllerFactoryMock.signInController, username: "", continuationToken: nil, correlationId: correlationId)
 
-        let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.completed(expectedState), telemetryUpdate: { _ in
+        let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.completed(expectedState), correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
         controllerMock.submitPasswordResponse = expectedResult
@@ -99,7 +100,7 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
         let sut = ResetPasswordRequiredState(controller: controllerMock, username: "", continuationToken: "<token>", correlationId: correlationId)
         let state = SignInAfterResetPasswordState(controller: controllerFactoryMock.signInController, username: "", continuationToken: nil, correlationId: correlationId)
 
-        let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.completed(state), telemetryUpdate: { _ in
+        let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.completed(state), correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
         controllerMock.submitPasswordResponse = expectedResult
@@ -110,6 +111,7 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
         wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
         XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCompleted"))
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/reset_password/ResetPasswordRequiredStateTests.swift
@@ -55,7 +55,7 @@ final class ResetPasswordRequiredStateTests: XCTestCase {
         controllerMock = MSALNativeAuthResetPasswordControllerMock()
         let sut = ResetPasswordRequiredState(controller: controllerMock, username: "username", continuationToken: "<token>", correlationId: correlationId)
 
-        let expectedError = PasswordRequiredError(type: .invalidPassword, message: nil)
+        let expectedError = PasswordRequiredError(type: .invalidPassword, message: nil, correlationId: .init())
         let expectedState = ResetPasswordRequiredState(controller: controllerMock, username: "username", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: MSALNativeAuthResetPasswordControlling.ResetPasswordSubmitPasswordControllerResponse = .init(.error(error: expectedError, newState: expectedState))

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
@@ -45,7 +45,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
     func test_resendCode_delegate_withError_shouldReturnSignInResendCodeError() {
         let exp = expectation(description: "sign-in states")
 
-        let expectedError = ResendCodeError(message: "test error")
+        let expectedError = ResendCodeError(message: "test error", correlationId: .init())
         let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignInResendCodeResult = .error(
@@ -111,7 +111,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
 
     func test_submitCode_delegate_withError_shouldReturnSignInVerifyCodeError() {
         let exp = expectation(description: "sign-in states")
-        let expectedError = VerifyCodeError(type: .invalidCode)
+        let expectedError = VerifyCodeError(type: .invalidCode, correlationId: .init())
         let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignInVerifyCodeResult = .error(

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInCodeRequiredStateTests.swift
@@ -45,14 +45,14 @@ final class SignInCodeRequiredStateTests: XCTestCase {
     func test_resendCode_delegate_withError_shouldReturnSignInResendCodeError() {
         let exp = expectation(description: "sign-in states")
 
-        let expectedError = ResendCodeError(message: "test error", correlationId: .init())
+        let expectedError = ResendCodeError(message: "test error", correlationId: correlationId)
         let expectedState = SignInCodeRequiredState(scopes: [], controller: controller, continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignInResendCodeResult = .error(
             error: expectedError,
             newState: expectedState
         )
-        controller.resendCodeResult = .init(expectedResult)
+        controller.resendCodeResult = .init(expectedResult, correlationId: correlationId)
 
         let delegate = SignInResendCodeDelegateSpy(expectation: exp)
 
@@ -61,6 +61,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
 
         XCTAssertEqual(delegate.newSignInResendCodeError, expectedError)
         XCTAssertEqual(delegate.newSignInCodeRequiredState?.continuationToken, expectedState.continuationToken)
+        XCTAssertEqual(delegate.newSignInResendCodeError?.correlationId, correlationId)
     }
 
     func test_resendCode_delegate_success_shouldReturnSignInResendCodeCodeRequired() {
@@ -74,7 +75,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controller.resendCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.resendCodeResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -96,7 +97,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controller.resendCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.resendCodeResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -105,6 +106,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
         sut.resendCode(delegate: delegate)
         wait(for: [exp, exp2])
         XCTAssertEqual(delegate.newSignInResendCodeError?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInResendCodeCodeRequired"))
+        XCTAssertEqual(delegate.newSignInResendCodeError?.correlationId, correlationId)
     }
 
     // SubmitCode
@@ -118,7 +120,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
             error: expectedError,
             newState: expectedState
         )
-        controller.submitCodeResult = .init(expectedResult)
+        controller.submitCodeResult = .init(expectedResult, correlationId: correlationId)
 
         let delegate = SignInVerifyCodeDelegateSpy(expectation: exp, expectedError: expectedError)
         delegate.expectedNewState = expectedState
@@ -133,7 +135,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
         let expectedAccountResult = MSALNativeAuthUserAccountResultStub.result
 
         let expectedResult: SignInVerifyCodeResult = .completed(expectedAccountResult)
-        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitCodeResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -149,7 +151,7 @@ final class SignInCodeRequiredStateTests: XCTestCase {
         let expectedAccountResult = MSALNativeAuthUserAccountResultStub.result
 
         let expectedResult: SignInVerifyCodeResult = .completed(expectedAccountResult)
-        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitCodeResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -159,5 +161,6 @@ final class SignInCodeRequiredStateTests: XCTestCase {
         wait(for: [exp, exp2])
         XCTAssertEqual(delegate.expectedError?.type, .generalError)
         XCTAssertEqual(delegate.expectedError?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        XCTAssertEqual(delegate.expectedError?.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
@@ -48,7 +48,7 @@ final class SignInPasswordRequiredStateTests: XCTestCase {
             error: expectedError,
             newState: expectedState
         )
-        controller.submitPasswordResult = .init(expectedResult)
+        controller.submitPasswordResult = .init(expectedResult, correlationId: correlationId)
 
         let exp = expectation(description: "sign-in states")
         let delegate = SignInPasswordRequiredDelegateSpy(expectation: exp, expectedError: expectedError)
@@ -65,7 +65,7 @@ final class SignInPasswordRequiredStateTests: XCTestCase {
         let expectedAccountResult = MSALNativeAuthUserAccountResultStub.result
 
         let expectedResult: SignInPasswordRequiredResult = .completed(expectedAccountResult)
-        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitPasswordResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -81,7 +81,7 @@ final class SignInPasswordRequiredStateTests: XCTestCase {
         let expectedAccountResult = MSALNativeAuthUserAccountResultStub.result
 
         let expectedResult: SignInPasswordRequiredResult = .completed(expectedAccountResult)
-        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitPasswordResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -92,5 +92,6 @@ final class SignInPasswordRequiredStateTests: XCTestCase {
 
         XCTAssertNil(delegate.newPasswordRequiredState)
         XCTAssertEqual(delegate.delegateError?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"))
+        XCTAssertEqual(delegate.delegateError?.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInPasswordRequiredStateTests.swift
@@ -41,7 +41,7 @@ final class SignInPasswordRequiredStateTests: XCTestCase {
     // MARK: - Delegates
 
     func test_submitPassword_delegate_withError_shouldReturnError() {
-        let expectedError = PasswordRequiredError(type: .invalidPassword)
+        let expectedError = PasswordRequiredError(type: .invalidPassword, correlationId: .init())
         let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controller, continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignInPasswordRequiredResult = .error(

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
@@ -43,7 +43,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
     // MARK: - Delegate
 
     func test_submitPassword_delegate_whenError_shouldReturnAttributesRequiredError() {
-        let expectedError = AttributesRequiredError()
+        let expectedError = AttributesRequiredError(correlationId: correlationId)
 
         let expectedResult: SignUpAttributesRequiredResult = .error(error: expectedError)
         controller.submitAttributesResult = .init(expectedResult)

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpAttributesRequiredStateTests.swift
@@ -46,7 +46,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         let expectedError = AttributesRequiredError(correlationId: correlationId)
 
         let expectedResult: SignUpAttributesRequiredResult = .error(error: expectedError)
-        controller.submitAttributesResult = .init(expectedResult)
+        controller.submitAttributesResult = .init(expectedResult, correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let delegate = SignUpAttributesRequiredDelegateSpy(expectation: exp)
@@ -55,6 +55,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         wait(for: [exp])
 
         XCTAssertEqual(delegate.error, expectedError)
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func test_submitPassword_delegate_whenSuccess_shouldReturnCompleted() {
@@ -63,7 +64,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: SignUpAttributesRequiredResult = .completed(expectedState)
-        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitAttributesResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -81,7 +82,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         let expectedState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", continuationToken: "continuationToken", correlationId: UUID())
 
         let expectedResult: SignUpAttributesRequiredResult = .completed(expectedState)
-        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitAttributesResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -91,6 +92,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func test_submitPassword_delegate_whenAttributesRequired_shouldReturnAttributesRequired() {
@@ -102,7 +104,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         ]
 
         let expectedResult: SignUpAttributesRequiredResult = .attributesRequired(attributes: expectedAttributes, state: expectedState)
-        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitAttributesResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -124,7 +126,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         ]
 
         let expectedResult: SignUpAttributesRequiredResult = .attributesRequired(attributes: expectedAttributes, state: expectedState)
-        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitAttributesResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -134,6 +136,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func test_submitPassword_delegate_whenAttributesAreInvalid_shouldReturnAttributesInvalid() {
@@ -143,7 +146,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         let expectedAttributes = ["anAttribute"]
 
         let expectedResult: SignUpAttributesRequiredResult = .attributesInvalid(attributes: expectedAttributes, newState: expectedState)
-        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitAttributesResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -163,7 +166,7 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         let expectedAttributes = ["anAttribute"]
 
         let expectedResult: SignUpAttributesRequiredResult = .attributesInvalid(attributes: expectedAttributes, newState: expectedState)
-        controller.submitAttributesResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitAttributesResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -173,5 +176,6 @@ final class SignUpAttributesRequiredStateTests: XCTestCase {
         wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid"))
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
@@ -44,10 +44,10 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     // ResendCode
 
     func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = ResendCodeError(message: "test error", correlationId: .init())
+        let expectedError = ResendCodeError(message: "test error", correlationId: correlationId)
 
         let expectedResult: SignUpResendCodeResult = .error(error: expectedError, newState: nil)
-        controller.resendCodeResult = .init(expectedResult)
+        controller.resendCodeResult = .init(expectedResult, correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let delegate = SignUpResendCodeDelegateSpy(expectation: exp)
@@ -56,6 +56,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         wait(for: [exp])
 
         XCTAssertEqual(delegate.error, expectedError)
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func test_resendCode_delegate_success_shouldReturnCodeRequired() {
@@ -69,7 +70,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controller.resendCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.resendCodeResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -95,7 +96,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
             channelTargetType: .email,
             codeLength: 1
         )
-        controller.resendCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.resendCodeResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -105,19 +106,20 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         wait(for: [exp, exp2])
 
         XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpResendCodeCodeRequired"))
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     // SubmitCode
 
     func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = VerifyCodeError(type: .invalidCode, correlationId: .init())
+        let expectedError = VerifyCodeError(type: .invalidCode, correlationId: correlationId)
         let expectedState = SignUpCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpVerifyCodeResult = .error(
             error: expectedError,
             newState: expectedState
         )
-        controller.submitCodeResult = .init(expectedResult)
+        controller.submitCodeResult = .init(expectedResult, correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let delegate = SignUpVerifyCodeDelegateSpy(expectation: exp)
@@ -127,6 +129,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
 
         XCTAssertEqual(delegate.error, expectedError)
         XCTAssertEqual(delegate.newCodeRequiredState?.continuationToken, expectedState.continuationToken)
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func test_submitCode_delegate_whenPasswordRequired_AndUserHasImplementedOptionalDelegate_shouldReturnPasswordRequired() {
@@ -136,7 +139,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         let exp2 = expectation(description: "exp telemetry is called")
 
         let expectedResult: SignUpVerifyCodeResult = .passwordRequired(expectedPasswordRequiredState)
-        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitCodeResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -153,7 +156,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         let exp2 = expectation(description: "exp telemetry is called")
 
         let expectedResult: SignUpVerifyCodeResult = .passwordRequired(.init(controller: controller, username: "", continuationToken: "", correlationId: correlationId))
-        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitCodeResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -167,6 +170,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
             delegate.error?.errorDescription,
             String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpPasswordRequired")
         )
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func test_submitCode_delegate_whenAttributesRequired_AndUserHasImplementedOptionalDelegate_shouldReturnAttributesRequired() {
@@ -176,7 +180,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         let exp2 = expectation(description: "exp telemetry is called")
 
         let expectedResult: SignUpVerifyCodeResult = .attributesRequired(attributes: [], newState: expectedAttributesRequiredState)
-        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitCodeResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -193,7 +197,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         let exp2 = expectation(description: "exp telemetry is called")
 
         let expectedResult: SignUpVerifyCodeResult = .attributesRequired(attributes: [], newState: .init(controller: controller, username: "", continuationToken: "", correlationId: correlationId))
-        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitCodeResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -207,6 +211,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
             delegate.error?.errorDescription,
             String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired")
         )
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func test_submitCode_delegate_whenSuccess_shouldReturnAccountResult() {
@@ -215,7 +220,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: SignUpVerifyCodeResult = .completed(expectedSignInAfterSignUpState)
-        controller.submitCodeResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitCodeResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -232,7 +237,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
         let exp2 = expectation(description: "telemetry expectation")
         let expectedSignInAfterSignUpState = SignInAfterSignUpState(controller: MSALNativeAuthSignInControllerMock(), username: "", continuationToken: "continuationToken", correlationId: correlationId)
         let result: SignUpVerifyCodeResult = .completed(expectedSignInAfterSignUpState)
-        controller.submitCodeResult = .init(result, telemetryUpdate: { _ in
+        controller.submitCodeResult = .init(result, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -246,5 +251,6 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
             delegate.error?.errorDescription,
             String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted")
         )
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpCodeSentStateTests.swift
@@ -44,7 +44,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     // ResendCode
 
     func test_resendCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = ResendCodeError(message: "test error")
+        let expectedError = ResendCodeError(message: "test error", correlationId: .init())
 
         let expectedResult: SignUpResendCodeResult = .error(error: expectedError, newState: nil)
         controller.resendCodeResult = .init(expectedResult)
@@ -110,7 +110,7 @@ final class SignUpCodeRequiredStateTests: XCTestCase {
     // SubmitCode
 
     func test_submitCode_delegate_whenError_shouldReturnCorrectError() {
-        let expectedError = VerifyCodeError(type: .invalidCode)
+        let expectedError = VerifyCodeError(type: .invalidCode, correlationId: .init())
         let expectedState = SignUpCodeRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpVerifyCodeResult = .error(

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
@@ -43,11 +43,11 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
     // MARK: - Delegate
 
     func test_submitPassword_delegate_whenError_shouldReturnPasswordRequiredError() {
-        let expectedError = PasswordRequiredError(type: .invalidPassword, correlationId: .init())
+        let expectedError = PasswordRequiredError(type: .invalidPassword, correlationId: correlationId)
         let expectedState = SignUpPasswordRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpPasswordRequiredResult = .error(error: expectedError, newState: expectedState)
-        controller.submitPasswordResult = .init(expectedResult)
+        controller.submitPasswordResult = .init(expectedResult, correlationId: correlationId)
 
         let exp = expectation(description: "sign-up states")
         let delegate = SignUpPasswordRequiredDelegateSpy(expectation: exp)
@@ -57,6 +57,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
 
         XCTAssertEqual(delegate.error, expectedError)
         XCTAssertEqual(delegate.newPasswordRequiredState?.continuationToken, expectedState.continuationToken)
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func test_submitCode_delegate_whenAttributesRequired_AndUserHasImplementedOptionalDelegate_shouldReturnAttributesRequired() {
@@ -66,7 +67,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
         let exp2 = expectation(description: "exp telemetry is called")
 
         let expectedResult: SignUpPasswordRequiredResult = .attributesRequired(attributes: [], newState: expectedAttributesRequiredState)
-        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitPasswordResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -85,7 +86,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
         let exp2 = expectation(description: "exp telemetry is called")
 
         let expectedResult: SignUpPasswordRequiredResult = .attributesRequired(attributes: [], newState: expectedAttributesRequiredState)
-        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitPasswordResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -96,6 +97,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
 
         XCTAssertEqual(delegate.error?.type, .generalError)
         XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesRequired"))
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
     func test_submitCode_delegate_whenSuccess_shouldReturnSignUpCompleted() {
@@ -105,7 +107,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
         let exp2 = expectation(description: "telemetry expectation")
 
         let expectedResult: SignUpPasswordRequiredResult = .completed(expectedSignInAfterSignUpState)
-        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitPasswordResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -124,7 +126,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
         let exp2 = expectation(description: "telemetry expectation")
 
         let expectedResult: SignUpPasswordRequiredResult = .completed(expectedSignInAfterSignUpState)
-        controller.submitPasswordResult = .init(expectedResult, telemetryUpdate: { _ in
+        controller.submitPasswordResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
 
@@ -135,5 +137,6 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
 
         XCTAssertEqual(delegate.error?.type, .generalError)
         XCTAssertEqual(delegate.error?.errorDescription, String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCompleted"))
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 }

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_up/SignUpPasswordRequiredStateTests.swift
@@ -43,7 +43,7 @@ final class SignUpPasswordRequiredStateTests: XCTestCase {
     // MARK: - Delegate
 
     func test_submitPassword_delegate_whenError_shouldReturnPasswordRequiredError() {
-        let expectedError = PasswordRequiredError(type: .invalidPassword)
+        let expectedError = PasswordRequiredError(type: .invalidPassword, correlationId: .init())
         let expectedState = SignUpPasswordRequiredState(controller: controller, username: "", continuationToken: "continuationToken 2", correlationId: correlationId)
 
         let expectedResult: SignUpPasswordRequiredResult = .error(error: expectedError, newState: expectedState)


### PR DESCRIPTION
## Proposed changes

- Read correlationId from the headers of every 2xx and 4xx response.
- Add correlationId and errorCodes to the public errors in sign-up, sign-in, reset-password and credentials-token flows.

Note: The MSAL-ObjC-CIAM team has been added because I've made a made an addition to the `MSAL/module.modulemap` file, but the rest of the changes don't affect MSAL objc.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

