### PR TITLE
Mark MSAL-ObjC-CIAM team as owner of the modulemap file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,8 @@
 # @AzureAD/AppleIdentityTeam and @AzureAD/MSAL-ObjC-CIAM will be the co-owners of the MSAL.project file
 /MSAL/MSAL.xcodeproj/project.pbxproj @AzureAD/AppleIdentityTeam @AzureAD/MSAL-ObjC-CIAM
 # @AzureAD/MSAL-ObjC-CIAM owns any files in the */native_auth
-# directories and any of its subdirectories.
+# directories, subdirectories and the module.modulemap file.
+/MSAL/module.modulemap @AzureAD/MSAL-ObjC-CIAM
 /MSAL/src/native_auth/ @AzureAD/MSAL-ObjC-CIAM
 /MSAL/test/unit/native_auth/ @AzureAD/MSAL-ObjC-CIAM
 /MSAL/test/integration/native_auth/ @AzureAD/MSAL-ObjC-CIAM


### PR DESCRIPTION
## Proposed changes

The private modulemap file is used by the MSAL CIAM team to specifies the Objective-C files that needs to be used by Swift code. more information about it can be found here: https://clang.llvm.org/docs/Modules.html#private-module-map-files

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
