### PR TITLE
Fix unknown cases in Oauth2ErrorCode and SubErrorCode enums

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1143,6 +1143,8 @@
 		E2F626AD2A78119900C4A303 /* ResetPasswordStates+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F626AC2A78119900C4A303 /* ResetPasswordStates+Internal.swift */; };
 		E2F626B02A78130700C4A303 /* SignInAfterPreviousFlowBaseState+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F626AF2A78130700C4A303 /* SignInAfterPreviousFlowBaseState+Internal.swift */; };
 		E2F626B32A781CE300C4A303 /* SignInDelegatesSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F626B22A781CE300C4A303 /* SignInDelegatesSpies.swift */; };
+		E2F890052B755355001FBC7C /* MSALNativeAuthUnknownCaseProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F890042B755355001FBC7C /* MSALNativeAuthUnknownCaseProtocol.swift */; };
+		E2F8900E2B75546A001FBC7C /* MSALNativeAuthUnknownCaseProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F8900D2B75546A001FBC7C /* MSALNativeAuthUnknownCaseProtocolTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2161,6 +2163,8 @@
 		E2F626AC2A78119900C4A303 /* ResetPasswordStates+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResetPasswordStates+Internal.swift"; sourceTree = "<group>"; };
 		E2F626AF2A78130700C4A303 /* SignInAfterPreviousFlowBaseState+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SignInAfterPreviousFlowBaseState+Internal.swift"; sourceTree = "<group>"; };
 		E2F626B22A781CE300C4A303 /* SignInDelegatesSpies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInDelegatesSpies.swift; sourceTree = "<group>"; };
+		E2F890042B755355001FBC7C /* MSALNativeAuthUnknownCaseProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthUnknownCaseProtocol.swift; sourceTree = "<group>"; };
+		E2F8900D2B75546A001FBC7C /* MSALNativeAuthUnknownCaseProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthUnknownCaseProtocolTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2445,6 +2449,7 @@
 				8D61F9A02A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift */,
 				E26594392B60268400723C1A /* MSALNativeAuthResponseCorrelatableTests.swift */,
 				E2DDF1B22B6A9E1D00E9FAB7 /* MSALNativeAuthCustomErrorSerializerTests.swift */,
+				E2F8900D2B75546A001FBC7C /* MSALNativeAuthUnknownCaseProtocolTests.swift */,
 			);
 			path = network;
 			sourceTree = "<group>";
@@ -4097,6 +4102,7 @@
 				287F650B2982F4AD00ED90BD /* MSALNativeAuthResponseSerializer.swift */,
 				DE0D65B829D1AE02005798B1 /* MSALNativeAuthResponseErrorHandler.swift */,
 				8D2733132AD8346D00AD67FD /* MSALNativeAuthCustomErrorSerializer.swift */,
+				E2F890042B755355001FBC7C /* MSALNativeAuthUnknownCaseProtocol.swift */,
 				E2ACA49B2953576C00E98964 /* MSALNativeAuthUrlRequestSerializer.swift */,
 				DE1D8AA729E6B7D900E11D48 /* MSALNativeAuthRequestConfigurator.swift */,
 				E24320742B58428E005290D0 /* MSALNativeAuthResponseCorrelatable.swift */,
@@ -5747,6 +5753,7 @@
 				E205D62E29B783FF003887BC /* MSALNativeAuthConfiguration.swift in Sources */,
 				D61BD2B21EBD09F90007E484 /* MSALAccount.m in Sources */,
 				DE0D65B629CC6BBA005798B1 /* MSALNativeAuthSignInChallengeResponse.swift in Sources */,
+				E2F890052B755355001FBC7C /* MSALNativeAuthUnknownCaseProtocol.swift in Sources */,
 				E2EFAD092A69A34300D6C3DE /* CodeRequiredGenericResult.swift in Sources */,
 				E2EFAD0C2A69B45100D6C3DE /* SignUpResults.swift in Sources */,
 				DE0D65AC29CC6A5A005798B1 /* MSALNativeAuthSignInInitiateResponse.swift in Sources */,
@@ -5993,6 +6000,7 @@
 				E22428072B0676970006C55E /* DispatchAccessTokenRetrieveCompletedTests.swift in Sources */,
 				A0274CBE24B432B100BD198D /* MSALAuthSchemeTests.m in Sources */,
 				E22427F22B0668910006C55E /* SignInPasswordStartDelegateDispatcherTests.swift in Sources */,
+				E2F8900E2B75546A001FBC7C /* MSALNativeAuthUnknownCaseProtocolTests.swift in Sources */,
 				E2025D202B2B8EEA00E32871 /* MSALNativeAuthSubErrorCodeTests.swift in Sources */,
 				B286BA00238A08F6007833AD /* MSALB2CPolicyTests.m in Sources */,
 				E22428012B0673290006C55E /* ResetPasswordResendCodeDelegateDispatcherTests.swift in Sources */,

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -334,7 +334,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                     sentTo: sentTo,
                     channelTargetType: channelType,
                     codeLength: codeLength
-                ), 
+                ),
                 correlationId: context.correlationId(),
                 telemetryUpdate: { [weak self] result in
                     self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
@@ -398,7 +398,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         telemetryInfo: TelemetryInfo
     ) async -> MSALNativeAuthSignInInitiateValidatedResponse {
         guard let request = createInitiateRequest(username: username, context: telemetryInfo.context) else {
-            let error = MSALNativeAuthSignInInitiateValidatedErrorType.invalidRequest(.init())
+            let errorDescription = "SignIn Initiate: Cannot create Initiate request object"
+            MSALLogger.log(level: .error, context: telemetryInfo.context, format: errorDescription)
+            let error = MSALNativeAuthSignInInitiateValidatedErrorType.invalidRequest(.init(errorDescription: errorDescription))
             stopTelemetryEvent(telemetryInfo, error: error)
             return .error(error)
         }
@@ -582,8 +584,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         context: MSALNativeAuthRequestContext
     ) async -> MSALNativeAuthSignInChallengeValidatedResponse {
         guard let challengeRequest = createChallengeRequest(continuationToken: continuationToken, context: context) else {
-            MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: Cannot create Challenge request object")
-            return .error(.invalidRequest(.init()))
+            let errorDescription = "SignIn ResendCode: Cannot create Challenge request object"
+            MSALLogger.log(level: .error, context: context, format: errorDescription)
+            return .error(.invalidRequest(.init(errorDescription: errorDescription)))
         }
         let challengeResponse: Result<MSALNativeAuthSignInChallengeResponse, Error> = await performRequest(challengeRequest, context: context)
         return signInResponseValidator.validate(context: context, result: challengeResponse)

--- a/MSAL/src/native_auth/network/MSALNativeAuthUnknownCaseProtocol.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthUnknownCaseProtocol.swift
@@ -24,23 +24,23 @@
 
 import Foundation
 
-/// Conform any decodable enum to this protocol to add an `unknownCase`, that will be returned when the backend introduces
+/// Conform any decodable enum to this protocol to add an `unknown` case, that will be returned when the backend introduces
 /// a new case that is not registered in the SDK
 
 protocol MSALNativeAuthUnknownCaseProtocol: RawRepresentable, CaseIterable where RawValue: Decodable & Equatable {
-    static var unknownCase: Self { get }
+    static var unknown: Self { get }
 }
 
 extension MSALNativeAuthUnknownCaseProtocol {
     init(rawValue: RawValue) {
         let value = Self.allCases.first { $0.rawValue == rawValue }
-        self = value ?? Self.unknownCase
+        self = value ?? Self.unknown
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let rawValue = try container.decode(RawValue.self)
         let value = Self(rawValue: rawValue)
-        self = value ?? Self.unknownCase
+        self = value ?? Self.unknown
     }
 }

--- a/MSAL/src/native_auth/network/MSALNativeAuthUnknownCaseProtocol.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthUnknownCaseProtocol.swift
@@ -24,10 +24,23 @@
 
 import Foundation
 
-enum MSALNativeAuthResetPasswordSubmitOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
-    case invalidRequest = "invalid_request"
-    case unauthorizedClient = "unauthorized_client"
-    case expiredToken = "expired_token"
-    case invalidGrant = "invalid_grant"
-    case unknownCase
+/// Conform any decodable enum to this protocol to add an `unknownCase`, that will be returned when the backend introduces
+/// a new case that is not registered in the SDK
+
+protocol MSALNativeAuthUnknownCaseProtocol: RawRepresentable, CaseIterable where RawValue: Decodable & Equatable {
+    static var unknownCase: Self { get }
+}
+
+extension MSALNativeAuthUnknownCaseProtocol {
+    init(rawValue: RawValue) {
+        let value = Self.allCases.first { $0.rawValue == rawValue }
+        self = value ?? Self.unknownCase
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(RawValue.self)
+        let value = Self(rawValue: rawValue)
+        self = value ?? Self.unknownCase
+    }
 }

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthResponseError.swift
@@ -25,9 +25,9 @@
 import Foundation
 
 protocol MSALNativeAuthResponseError: Error, Decodable, Equatable, MSALNativeAuthResponseCorrelatable {
-    associatedtype ErrorCode: RawRepresentable where ErrorCode.RawValue == String
+    associatedtype ErrorCode: RawRepresentable, MSALNativeAuthUnknownCaseProtocol where ErrorCode.RawValue == String
 
-    var error: ErrorCode? { get }
+    var error: ErrorCode { get }
     var errorDescription: String? { get }
     var errorCodes: [Int]? { get }
     var errorURI: String? { get }

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
@@ -33,7 +33,7 @@ enum MSALNativeAuthSubErrorCode: String, Decodable, Equatable, MSALNativeAuthUnk
     case passwordBanned = "password_banned"
     case attributeValidationFailed = "attribute_validation_failed"
     case invalidOOBValue = "invalid_oob_value"
-    case unknownCase
+    case unknown
 
     var isAnyPasswordError: Bool {
         switch self {
@@ -46,7 +46,7 @@ enum MSALNativeAuthSubErrorCode: String, Decodable, Equatable, MSALNativeAuthUnk
             return true
         case .attributeValidationFailed,
              .invalidOOBValue,
-             .unknownCase:
+             .unknown:
             return false
         }
     }

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthSubErrorCode: String, Decodable, CaseIterable, Equatable, MSALNativeAuthUnknownCaseProtocol {
+enum MSALNativeAuthSubErrorCode: String, Decodable, Equatable, MSALNativeAuthUnknownCaseProtocol {
     case passwordTooWeak = "password_too_weak"
     case passwordTooShort = "password_too_short"
     case passwordTooLong = "password_too_long"

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthSubErrorCode: String, Decodable, CaseIterable, Equatable {
+enum MSALNativeAuthSubErrorCode: String, Decodable, CaseIterable, Equatable, MSALNativeAuthUnknownCaseProtocol {
     case passwordTooWeak = "password_too_weak"
     case passwordTooShort = "password_too_short"
     case passwordTooLong = "password_too_long"
@@ -33,6 +33,7 @@ enum MSALNativeAuthSubErrorCode: String, Decodable, CaseIterable, Equatable {
     case passwordBanned = "password_banned"
     case attributeValidationFailed = "attribute_validation_failed"
     case invalidOOBValue = "invalid_oob_value"
+    case unknownCase
 
     var isAnyPasswordError: Bool {
         switch self {
@@ -44,7 +45,8 @@ enum MSALNativeAuthSubErrorCode: String, Decodable, CaseIterable, Equatable {
              .passwordBanned:
             return true
         case .attributeValidationFailed,
-             .invalidOOBValue:
+             .invalidOOBValue,
+             .unknownCase:
             return false
         }
     }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthResetPasswordChallengeOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
+enum MSALNativeAuthResetPasswordChallengeOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case expiredToken = "expired_token"

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCode.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-enum MSALNativeAuthResetPasswordChallengeOauth2ErrorCode: String, Decodable, CaseIterable {
+enum MSALNativeAuthResetPasswordChallengeOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case expiredToken = "expired_token"
     case unsupportedChallengeType = "unsupported_challenge_type"
+    case unknownCase
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCode.swift
@@ -29,5 +29,5 @@ enum MSALNativeAuthResetPasswordChallengeOauth2ErrorCode: String, Decodable, MSA
     case unauthorizedClient = "unauthorized_client"
     case expiredToken = "expired_token"
     case unsupportedChallengeType = "unsupported_challenge_type"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseError.swift
@@ -71,6 +71,7 @@ extension MSALNativeAuthResetPasswordChallengeResponseError {
              .unauthorizedClient,
              .unsupportedChallengeType,
              .expiredToken,
+             .unknownCase,
              .none:
             return .init(
                 type: .generalError,
@@ -88,6 +89,7 @@ extension MSALNativeAuthResetPasswordChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
+             .unknownCase,
              .none:
             return .init(
                 message: errorDescription,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseError.swift
@@ -45,7 +45,7 @@ struct MSALNativeAuthResetPasswordChallengeResponseError: MSALNativeAuthResponse
     }
 
     init(
-        error: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode = .unknownCase,
+        error: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode = .unknown,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,
@@ -71,7 +71,7 @@ extension MSALNativeAuthResetPasswordChallengeResponseError {
              .unauthorizedClient,
              .unsupportedChallengeType,
              .expiredToken,
-             .unknownCase:
+             .unknown:
             return .init(
                 type: .generalError,
                 message: errorDescription,
@@ -88,7 +88,7 @@ extension MSALNativeAuthResetPasswordChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
-             .unknownCase:
+             .unknown:
             return .init(
                 message: errorDescription,
                 correlationId: correlationId,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseError.swift
@@ -26,7 +26,7 @@ import Foundation
 
 struct MSALNativeAuthResetPasswordChallengeResponseError: MSALNativeAuthResponseError {
 
-    let error: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode?
+    let error: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode
     let errorDescription: String?
     let errorCodes: [Int]?
     let errorURI: String?
@@ -45,7 +45,7 @@ struct MSALNativeAuthResetPasswordChallengeResponseError: MSALNativeAuthResponse
     }
 
     init(
-        error: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode? = nil,
+        error: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode = .unknownCase,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,
@@ -71,8 +71,7 @@ extension MSALNativeAuthResetPasswordChallengeResponseError {
              .unauthorizedClient,
              .unsupportedChallengeType,
              .expiredToken,
-             .unknownCase,
-             .none:
+             .unknownCase:
             return .init(
                 type: .generalError,
                 message: errorDescription,
@@ -89,8 +88,7 @@ extension MSALNativeAuthResetPasswordChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
-             .unknownCase,
-             .none:
+             .unknownCase:
             return .init(
                 message: errorDescription,
                 correlationId: correlationId,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthResetPasswordContinueOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
+enum MSALNativeAuthResetPasswordContinueOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case invalidGrant = "invalid_grant"

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCode.swift
@@ -24,10 +24,11 @@
 
 import Foundation
 
-enum MSALNativeAuthResetPasswordContinueOauth2ErrorCode: String, Decodable, CaseIterable {
+enum MSALNativeAuthResetPasswordContinueOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case invalidGrant = "invalid_grant"
     case expiredToken = "expired_token"
     case verificationRequired = "verification_required"
+    case unknownCase
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCode.swift
@@ -30,5 +30,5 @@ enum MSALNativeAuthResetPasswordContinueOauth2ErrorCode: String, Decodable, MSAL
     case invalidGrant = "invalid_grant"
     case expiredToken = "expired_token"
     case verificationRequired = "verification_required"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
@@ -49,7 +49,7 @@ struct MSALNativeAuthResetPasswordContinueResponseError: MSALNativeAuthResponseE
     }
 
     init(
-        error: MSALNativeAuthResetPasswordContinueOauth2ErrorCode = .unknownCase,
+        error: MSALNativeAuthResetPasswordContinueOauth2ErrorCode = .unknown,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
@@ -87,7 +87,7 @@ extension MSALNativeAuthResetPasswordContinueResponseError {
              .expiredToken,
              .invalidRequest,
              .verificationRequired,
-             .unknownCase:
+             .unknown:
             return .init(
                 type: .generalError,
                 message: errorDescription,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
@@ -87,6 +87,7 @@ extension MSALNativeAuthResetPasswordContinueResponseError {
              .expiredToken,
              .invalidRequest,
              .verificationRequired,
+             .unknownCase,
              .none:
             return .init(
                 type: .generalError,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseError.swift
@@ -26,7 +26,7 @@ import Foundation
 
 struct MSALNativeAuthResetPasswordContinueResponseError: MSALNativeAuthResponseError {
 
-    let error: MSALNativeAuthResetPasswordContinueOauth2ErrorCode?
+    let error: MSALNativeAuthResetPasswordContinueOauth2ErrorCode
     let subError: MSALNativeAuthSubErrorCode?
     let errorDescription: String?
     let errorCodes: [Int]?
@@ -49,7 +49,7 @@ struct MSALNativeAuthResetPasswordContinueResponseError: MSALNativeAuthResponseE
     }
 
     init(
-        error: MSALNativeAuthResetPasswordContinueOauth2ErrorCode? = nil,
+        error: MSALNativeAuthResetPasswordContinueOauth2ErrorCode = .unknownCase,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
@@ -87,8 +87,7 @@ extension MSALNativeAuthResetPasswordContinueResponseError {
              .expiredToken,
              .invalidRequest,
              .verificationRequired,
-             .unknownCase,
-             .none:
+             .unknownCase:
             return .init(
                 type: .generalError,
                 message: errorDescription,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
+enum MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
     case invalidGrant = "invalid_grant"
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift
@@ -24,10 +24,11 @@
 
 import Foundation
 
-enum MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode: String, Decodable, CaseIterable {
+enum MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
     case invalidGrant = "invalid_grant"
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case expiredToken = "expired_token"
     case userNotFound = "user_not_found"
+    case unknownCase
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode.swift
@@ -30,5 +30,5 @@ enum MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode: String, Decodable
     case unauthorizedClient = "unauthorized_client"
     case expiredToken = "expired_token"
     case userNotFound = "user_not_found"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
@@ -83,6 +83,7 @@ extension MSALNativeAuthResetPasswordPollCompletionResponseError {
              .expiredToken,
              .invalidRequest,
              .userNotFound,
+             .unknownCase,
              .none:
             return .init(
                 type: .generalError,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
@@ -47,7 +47,7 @@ struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthRes
     }
 
     init(
-        error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode = .unknownCase,
+        error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode = .unknown,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
@@ -83,7 +83,7 @@ extension MSALNativeAuthResetPasswordPollCompletionResponseError {
              .expiredToken,
              .invalidRequest,
              .userNotFound,
-             .unknownCase:
+             .unknown:
             return .init(
                 type: .generalError,
                 message: errorDescription,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseError.swift
@@ -26,7 +26,7 @@ import Foundation
 
 struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthResponseError {
 
-    let error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode?
+    let error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode
     let subError: MSALNativeAuthSubErrorCode?
     let errorDescription: String?
     let errorCodes: [Int]?
@@ -47,7 +47,7 @@ struct MSALNativeAuthResetPasswordPollCompletionResponseError: MSALNativeAuthRes
     }
 
     init(
-        error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode? = nil,
+        error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode = .unknownCase,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
@@ -83,8 +83,7 @@ extension MSALNativeAuthResetPasswordPollCompletionResponseError {
              .expiredToken,
              .invalidRequest,
              .userNotFound,
-             .unknownCase,
-             .none:
+             .unknownCase:
             return .init(
                 type: .generalError,
                 message: errorDescription,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCode.swift
@@ -29,5 +29,5 @@ enum MSALNativeAuthResetPasswordStartOauth2ErrorCode: String, Decodable, MSALNat
     case unauthorizedClient = "unauthorized_client"
     case userNotFound = "user_not_found"
     case unsupportedChallengeType = "unsupported_challenge_type"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthResetPasswordStartOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
+enum MSALNativeAuthResetPasswordStartOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case userNotFound = "user_not_found"

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCode.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-enum MSALNativeAuthResetPasswordStartOauth2ErrorCode: String, Decodable, CaseIterable {
+enum MSALNativeAuthResetPasswordStartOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case userNotFound = "user_not_found"
     case unsupportedChallengeType = "unsupported_challenge_type"
+    case unknownCase
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartResponseError.swift
@@ -26,7 +26,7 @@ import Foundation
 
 struct MSALNativeAuthResetPasswordStartResponseError: MSALNativeAuthResponseError {
 
-    let error: MSALNativeAuthResetPasswordStartOauth2ErrorCode?
+    let error: MSALNativeAuthResetPasswordStartOauth2ErrorCode
     let errorDescription: String?
     let errorCodes: [Int]?
     let errorURI: String?
@@ -45,7 +45,7 @@ struct MSALNativeAuthResetPasswordStartResponseError: MSALNativeAuthResponseErro
     }
 
     init(
-        error: MSALNativeAuthResetPasswordStartOauth2ErrorCode? = nil,
+        error: MSALNativeAuthResetPasswordStartOauth2ErrorCode = .unknownCase,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartResponseError.swift
@@ -45,7 +45,7 @@ struct MSALNativeAuthResetPasswordStartResponseError: MSALNativeAuthResponseErro
     }
 
     init(
-        error: MSALNativeAuthResetPasswordStartOauth2ErrorCode = .unknownCase,
+        error: MSALNativeAuthResetPasswordStartOauth2ErrorCode = .unknown,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitOauth2ErrorCode.swift
@@ -29,5 +29,5 @@ enum MSALNativeAuthResetPasswordSubmitOauth2ErrorCode: String, Decodable, MSALNa
     case unauthorizedClient = "unauthorized_client"
     case expiredToken = "expired_token"
     case invalidGrant = "invalid_grant"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthResetPasswordSubmitOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
+enum MSALNativeAuthResetPasswordSubmitOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case expiredToken = "expired_token"

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
@@ -47,7 +47,7 @@ struct MSALNativeAuthResetPasswordSubmitResponseError: MSALNativeAuthResponseErr
     }
 
     init(
-        error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode = .unknownCase,
+        error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode = .unknown,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
@@ -82,7 +82,7 @@ extension MSALNativeAuthResetPasswordSubmitResponseError {
         case .unauthorizedClient,
              .expiredToken,
              .invalidRequest,
-             .unknownCase:
+             .unknown:
             return .init(
                 type: .generalError,
                 message: errorDescription,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
@@ -26,7 +26,7 @@ import Foundation
 
 struct MSALNativeAuthResetPasswordSubmitResponseError: MSALNativeAuthResponseError {
 
-    let error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode?
+    let error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode
     let subError: MSALNativeAuthSubErrorCode?
     let errorDescription: String?
     let errorCodes: [Int]?
@@ -47,7 +47,7 @@ struct MSALNativeAuthResetPasswordSubmitResponseError: MSALNativeAuthResponseErr
     }
 
     init(
-        error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode? = nil,
+        error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode = .unknownCase,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
@@ -82,8 +82,7 @@ extension MSALNativeAuthResetPasswordSubmitResponseError {
         case .unauthorizedClient,
              .expiredToken,
              .invalidRequest,
-             .unknownCase,
-             .none:
+             .unknownCase:
             return .init(
                 type: .generalError,
                 message: errorDescription,

--- a/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseError.swift
@@ -82,6 +82,7 @@ extension MSALNativeAuthResetPasswordSubmitResponseError {
         case .unauthorizedClient,
              .expiredToken,
              .invalidRequest,
+             .unknownCase,
              .none:
             return .init(
                 type: .generalError,

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeOauth2ErrorCode.swift
@@ -24,10 +24,11 @@
 
 import Foundation
 
-enum MSALNativeAuthSignInChallengeOauth2ErrorCode: String, Decodable {
+enum MSALNativeAuthSignInChallengeOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case invalidGrant = "invalid_grant"
     case expiredToken = "expired_token"
     case unsupportedChallengeType = "unsupported_challenge_type"
+    case unknownCase
 }

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeOauth2ErrorCode.swift
@@ -30,5 +30,5 @@ enum MSALNativeAuthSignInChallengeOauth2ErrorCode: String, Decodable, MSALNative
     case invalidGrant = "invalid_grant"
     case expiredToken = "expired_token"
     case unsupportedChallengeType = "unsupported_challenge_type"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
@@ -26,7 +26,7 @@ import Foundation
 
 struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
 
-    let error: MSALNativeAuthSignInChallengeOauth2ErrorCode?
+    let error: MSALNativeAuthSignInChallengeOauth2ErrorCode
     let errorDescription: String?
     let errorCodes: [Int]?
     let errorURI: String?
@@ -43,7 +43,7 @@ struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthSignInChallengeOauth2ErrorCode? = nil,
+        error: MSALNativeAuthSignInChallengeOauth2ErrorCode = .unknownCase,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
@@ -43,7 +43,7 @@ struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthSignInChallengeOauth2ErrorCode = .unknownCase,
+        error: MSALNativeAuthSignInChallengeOauth2ErrorCode = .unknown,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthSignInInitiateOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
+enum MSALNativeAuthSignInInitiateOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case userNotFound = "user_not_found"

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateOauth2ErrorCode.swift
@@ -29,5 +29,5 @@ enum MSALNativeAuthSignInInitiateOauth2ErrorCode: String, Decodable, MSALNativeA
     case unauthorizedClient = "unauthorized_client"
     case userNotFound = "user_not_found"
     case unsupportedChallengeType = "unsupported_challenge_type"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateOauth2ErrorCode.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-enum MSALNativeAuthSignInInitiateOauth2ErrorCode: String, Decodable, CaseIterable {
+enum MSALNativeAuthSignInInitiateOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case userNotFound = "user_not_found"
     case unsupportedChallengeType = "unsupported_challenge_type"
+    case unknownCase
 }

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateResponseError.swift
@@ -43,7 +43,7 @@ struct MSALNativeAuthSignInInitiateResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthSignInInitiateOauth2ErrorCode = .unknownCase,
+        error: MSALNativeAuthSignInInitiateOauth2ErrorCode = .unknown,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInInitiateResponseError.swift
@@ -26,7 +26,7 @@ import Foundation
 
 struct MSALNativeAuthSignInInitiateResponseError: MSALNativeAuthResponseError {
 
-    let error: MSALNativeAuthSignInInitiateOauth2ErrorCode?
+    let error: MSALNativeAuthSignInInitiateOauth2ErrorCode
     let errorDescription: String?
     let errorCodes: [Int]?
     let errorURI: String?
@@ -43,7 +43,7 @@ struct MSALNativeAuthSignInInitiateResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthSignInInitiateOauth2ErrorCode? = nil,
+        error: MSALNativeAuthSignInInitiateOauth2ErrorCode = .unknownCase,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCode.swift
@@ -24,9 +24,10 @@
 
 import Foundation
 
-enum MSALNativeAuthSignUpChallengeOauth2ErrorCode: String, Decodable, CaseIterable {
+enum MSALNativeAuthSignUpChallengeOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case unsupportedChallengeType = "unsupported_challenge_type"
     case expiredToken = "expired_token"
+    case unknownCase
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthSignUpChallengeOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
+enum MSALNativeAuthSignUpChallengeOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case unsupportedChallengeType = "unsupported_challenge_type"

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCode.swift
@@ -29,5 +29,5 @@ enum MSALNativeAuthSignUpChallengeOauth2ErrorCode: String, Decodable, MSALNative
     case unauthorizedClient = "unauthorized_client"
     case unsupportedChallengeType = "unsupported_challenge_type"
     case expiredToken = "expired_token"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
-    let error: MSALNativeAuthSignUpChallengeOauth2ErrorCode?
+    let error: MSALNativeAuthSignUpChallengeOauth2ErrorCode
     let errorDescription: String?
     let errorCodes: [Int]?
     let errorURI: String?
@@ -42,7 +42,7 @@ struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthSignUpChallengeOauth2ErrorCode? = nil,
+        error: MSALNativeAuthSignUpChallengeOauth2ErrorCode = .unknownCase,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,
@@ -66,8 +66,7 @@ extension MSALNativeAuthSignUpChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
-             .unknownCase,
-             .none:
+             .unknownCase:
             return .init(
                 type: .generalError,
                 message: errorDescription,
@@ -84,8 +83,7 @@ extension MSALNativeAuthSignUpChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
-             .unknownCase,
-             .none:
+             .unknownCase:
             return .init(
                 message: errorDescription,
                 correlationId: correlationId,
@@ -101,8 +99,7 @@ extension MSALNativeAuthSignUpChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
-             .unknownCase,
-             .none:
+             .unknownCase:
             return .init(
                 type: .generalError,
                 message: errorDescription,

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
@@ -66,6 +66,7 @@ extension MSALNativeAuthSignUpChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
+             .unknownCase,
              .none:
             return .init(
                 type: .generalError,
@@ -83,6 +84,7 @@ extension MSALNativeAuthSignUpChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
+             .unknownCase,
              .none:
             return .init(
                 message: errorDescription,
@@ -99,6 +101,7 @@ extension MSALNativeAuthSignUpChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
+             .unknownCase,
              .none:
             return .init(
                 type: .generalError,

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseError.swift
@@ -42,7 +42,7 @@ struct MSALNativeAuthSignUpChallengeResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthSignUpChallengeOauth2ErrorCode = .unknownCase,
+        error: MSALNativeAuthSignUpChallengeOauth2ErrorCode = .unknown,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,
@@ -66,7 +66,7 @@ extension MSALNativeAuthSignUpChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
-             .unknownCase:
+             .unknown:
             return .init(
                 type: .generalError,
                 message: errorDescription,
@@ -83,7 +83,7 @@ extension MSALNativeAuthSignUpChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
-             .unknownCase:
+             .unknown:
             return .init(
                 message: errorDescription,
                 correlationId: correlationId,
@@ -99,7 +99,7 @@ extension MSALNativeAuthSignUpChallengeResponseError {
              .unsupportedChallengeType,
              .expiredToken,
              .invalidRequest,
-             .unknownCase:
+             .unknown:
             return .init(
                 type: .generalError,
                 message: errorDescription,

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCode.swift
@@ -33,5 +33,5 @@ enum MSALNativeAuthSignUpContinueOauth2ErrorCode: String, Decodable, MSALNativeA
     case attributesRequired = "attributes_required"
     case verificationRequired = "verification_required"
     case credentialRequired = "credential_required"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthSignUpContinueOauth2ErrorCode: String, Decodable, CaseIterable {
+enum MSALNativeAuthSignUpContinueOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case invalidGrant = "invalid_grant"
@@ -33,4 +33,5 @@ enum MSALNativeAuthSignUpContinueOauth2ErrorCode: String, Decodable, CaseIterabl
     case attributesRequired = "attributes_required"
     case verificationRequired = "verification_required"
     case credentialRequired = "credential_required"
+    case unknownCase
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthSignUpContinueOauth2ErrorCode: String, Decodable, CaseIterable, MSALNativeAuthUnknownCaseProtocol {
+enum MSALNativeAuthSignUpContinueOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case invalidGrant = "invalid_grant"

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
-    let error: MSALNativeAuthSignUpContinueOauth2ErrorCode?
+    let error: MSALNativeAuthSignUpContinueOauth2ErrorCode
     let subError: MSALNativeAuthSubErrorCode?
     let errorDescription: String?
     let errorCodes: [Int]?
@@ -52,7 +52,7 @@ struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthSignUpContinueOauth2ErrorCode? = nil,
+        error: MSALNativeAuthSignUpContinueOauth2ErrorCode = .unknownCase,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
@@ -97,8 +97,7 @@ extension MSALNativeAuthSignUpContinueResponseError {
              .attributesRequired,
              .verificationRequired,
              .credentialRequired,
-             .unknownCase,
-             .none:
+             .unknownCase:
             return .init(
                 type: .generalError,
                 message: errorDescription,
@@ -127,8 +126,7 @@ extension MSALNativeAuthSignUpContinueResponseError {
              .attributesRequired,
              .verificationRequired,
              .credentialRequired,
-             .unknownCase,
-             .none:
+             .unknownCase:
             return .init(
                 type: .generalError,
                 message: errorDescription,

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
@@ -97,6 +97,7 @@ extension MSALNativeAuthSignUpContinueResponseError {
              .attributesRequired,
              .verificationRequired,
              .credentialRequired,
+             .unknownCase,
              .none:
             return .init(
                 type: .generalError,
@@ -126,6 +127,7 @@ extension MSALNativeAuthSignUpContinueResponseError {
              .attributesRequired,
              .verificationRequired,
              .credentialRequired,
+             .unknownCase,
              .none:
             return .init(
                 type: .generalError,

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseError.swift
@@ -52,7 +52,7 @@ struct MSALNativeAuthSignUpContinueResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthSignUpContinueOauth2ErrorCode = .unknownCase,
+        error: MSALNativeAuthSignUpContinueOauth2ErrorCode = .unknown,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
@@ -97,7 +97,7 @@ extension MSALNativeAuthSignUpContinueResponseError {
              .attributesRequired,
              .verificationRequired,
              .credentialRequired,
-             .unknownCase:
+             .unknown:
             return .init(
                 type: .generalError,
                 message: errorDescription,
@@ -126,7 +126,7 @@ extension MSALNativeAuthSignUpContinueResponseError {
              .attributesRequired,
              .verificationRequired,
              .credentialRequired,
-             .unknownCase:
+             .unknown:
             return .init(
                 type: .generalError,
                 message: errorDescription,

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthSignUpStartOauth2ErrorCode: String, Decodable, CaseIterable, Equatable, MSALNativeAuthUnknownCaseProtocol {
+enum MSALNativeAuthSignUpStartOauth2ErrorCode: String, Decodable, Equatable, MSALNativeAuthUnknownCaseProtocol {
     case invalidGrant = "invalid_grant"
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCode.swift
@@ -32,5 +32,5 @@ enum MSALNativeAuthSignUpStartOauth2ErrorCode: String, Decodable, Equatable, MSA
     case userAlreadyExists = "user_already_exists"
     case attributesRequired = "attributes_required"
     case unsupportedAuthMethod = "unsupported_auth_method"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthSignUpStartOauth2ErrorCode: String, Decodable, CaseIterable, Equatable {
+enum MSALNativeAuthSignUpStartOauth2ErrorCode: String, Decodable, CaseIterable, Equatable, MSALNativeAuthUnknownCaseProtocol {
     case invalidGrant = "invalid_grant"
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
@@ -32,4 +32,5 @@ enum MSALNativeAuthSignUpStartOauth2ErrorCode: String, Decodable, CaseIterable, 
     case userAlreadyExists = "user_already_exists"
     case attributesRequired = "attributes_required"
     case unsupportedAuthMethod = "unsupported_auth_method"
+    case unknownCase
 }

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
@@ -100,6 +100,7 @@ extension MSALNativeAuthSignUpStartResponseError {
              .unsupportedChallengeType,
              .unsupportedAuthMethod,
              .invalidRequest,
+             .unknownCase,
              .none:
             return .init(
                 type: .generalError,

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
@@ -26,7 +26,7 @@ import Foundation
 
 struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
 
-    let error: MSALNativeAuthSignUpStartOauth2ErrorCode?
+    let error: MSALNativeAuthSignUpStartOauth2ErrorCode
     let subError: MSALNativeAuthSubErrorCode?
     let errorDescription: String?
     let errorCodes: [Int]?
@@ -51,7 +51,7 @@ struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthSignUpStartOauth2ErrorCode? = nil,
+        error: MSALNativeAuthSignUpStartOauth2ErrorCode = .unknownCase,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
@@ -100,8 +100,7 @@ extension MSALNativeAuthSignUpStartResponseError {
              .unsupportedChallengeType,
              .unsupportedAuthMethod,
              .invalidRequest,
-             .unknownCase,
-             .none:
+             .unknownCase:
             return .init(
                 type: .generalError,
                 message: message ?? errorDescription,

--- a/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseError.swift
@@ -51,7 +51,7 @@ struct MSALNativeAuthSignUpStartResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthSignUpStartOauth2ErrorCode = .unknownCase,
+        error: MSALNativeAuthSignUpStartOauth2ErrorCode = .unknown,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,
@@ -100,7 +100,7 @@ extension MSALNativeAuthSignUpStartResponseError {
              .unsupportedChallengeType,
              .unsupportedAuthMethod,
              .invalidRequest,
-             .unknownCase:
+             .unknown:
             return .init(
                 type: .generalError,
                 message: message ?? errorDescription,

--- a/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenOauth2ErrorCode.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-enum MSALNativeAuthTokenOauth2ErrorCode: String, Decodable {
+enum MSALNativeAuthTokenOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
     case unauthorizedClient = "unauthorized_client"
     case invalidClient = "invalid_client"
@@ -36,4 +36,5 @@ enum MSALNativeAuthTokenOauth2ErrorCode: String, Decodable {
     case authorizationPending = "authorization_pending"
     case slowDown = "slow_down"
     case userNotFound = "user_not_found"
+    case unknownCase
 }

--- a/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenOauth2ErrorCode.swift
@@ -36,5 +36,5 @@ enum MSALNativeAuthTokenOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknow
     case authorizationPending = "authorization_pending"
     case slowDown = "slow_down"
     case userNotFound = "user_not_found"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
@@ -26,7 +26,7 @@ import Foundation
 
 struct MSALNativeAuthTokenResponseError: MSALNativeAuthResponseError {
 
-    let error: MSALNativeAuthTokenOauth2ErrorCode?
+    let error: MSALNativeAuthTokenOauth2ErrorCode
     let subError: MSALNativeAuthSubErrorCode?
     let errorDescription: String?
     let errorCodes: [Int]?
@@ -47,7 +47,7 @@ struct MSALNativeAuthTokenResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthTokenOauth2ErrorCode? = nil,
+        error: MSALNativeAuthTokenOauth2ErrorCode = .unknownCase,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,

--- a/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/token/MSALNativeAuthTokenResponseError.swift
@@ -47,7 +47,7 @@ struct MSALNativeAuthTokenResponseError: MSALNativeAuthResponseError {
     }
 
     init(
-        error: MSALNativeAuthTokenOauth2ErrorCode = .unknownCase,
+        error: MSALNativeAuthTokenOauth2ErrorCode = .unknown,
         subError: MSALNativeAuthSubErrorCode? = nil,
         errorDescription: String? = nil,
         errorCodes: [Int]? = nil,

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
@@ -89,13 +89,9 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
             return .error(.userNotFound(apiError))
         case .unsupportedChallengeType:
             return .error(.unsupportedChallengeType(apiError))
-        case .none:
-            return .error(.unexpectedError(.init(
-                errorDescription: apiError.errorDescription,
-                errorCodes: apiError.errorCodes,
-                errorURI: apiError.errorURI,
-                correlationId: apiError.correlationId
-            )))
+        case .none,
+             .unknownCase:
+            return .error(.unexpectedError(apiError))
         }
     }
 
@@ -189,13 +185,9 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
         case .verificationRequired:
             MSALLogger.log(level: .error, context: context, format: "verificationRequired is not supported yet")
             return .unexpectedError(nil)
-        case .none:
-            return .unexpectedError(.init(
-                errorDescription: apiError.errorDescription,
-                errorCodes: apiError.errorCodes,
-                errorURI: apiError.errorURI,
-                correlationId: apiError.correlationId
-            ))
+        case .none,
+             .unknownCase:
+            return .unexpectedError(apiError)
         }
     }
 
@@ -236,13 +228,9 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
              .unauthorizedClient,
              .expiredToken:
             return .error(apiError)
-        case .none:
-            return .unexpectedError(.init(
-                errorDescription: apiError.errorDescription,
-                errorCodes: apiError.errorCodes,
-                errorURI: apiError.errorURI,
-                correlationId: apiError.correlationId
-            ))
+        case .none,
+             .unknownCase:
+            return .unexpectedError(apiError)
         }
     }
 
@@ -288,13 +276,9 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
              .unauthorizedClient,
              .expiredToken:
             return .error(apiError)
-        case .none:
-            return .unexpectedError(.init(
-                errorDescription: apiError.errorDescription,
-                errorCodes: apiError.errorCodes,
-                errorURI: apiError.errorURI,
-                correlationId: apiError.correlationId
-            ))
+        case .none,
+             .unknownCase:
+            return .unexpectedError(apiError)
         }
     }
 }

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
@@ -89,7 +89,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
             return .error(.userNotFound(apiError))
         case .unsupportedChallengeType:
             return .error(.unsupportedChallengeType(apiError))
-        case .unknownCase:
+        case .unknown:
             return .error(.unexpectedError(apiError))
         }
     }
@@ -143,7 +143,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
             MSALLogger.log(level: .info, context: context, format: "resetpassword/challenge: Unable to decode error response: \(error)")
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
-        if apiError.error == .unknownCase {
+        if apiError.error == .unknown {
             return .unexpectedError(apiError)
         }
         return .error(apiError)
@@ -185,7 +185,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
         case .verificationRequired:
             MSALLogger.log(level: .error, context: context, format: "verificationRequired is not supported yet")
             return .unexpectedError(nil)
-        case .unknownCase:
+        case .unknown:
             return .unexpectedError(apiError)
         }
     }
@@ -227,7 +227,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
              .unauthorizedClient,
              .expiredToken:
             return .error(apiError)
-        case .unknownCase:
+        case .unknown:
             return .unexpectedError(apiError)
         }
     }
@@ -274,7 +274,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
              .unauthorizedClient,
              .expiredToken:
             return .error(apiError)
-        case .unknownCase:
+        case .unknown:
             return .unexpectedError(apiError)
         }
     }

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
@@ -89,8 +89,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
             return .error(.userNotFound(apiError))
         case .unsupportedChallengeType:
             return .error(.unsupportedChallengeType(apiError))
-        case .none,
-             .unknownCase:
+        case .unknownCase:
             return .error(.unexpectedError(apiError))
         }
     }
@@ -133,8 +132,9 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
             }
         case .password,
              .otp:
-            MSALLogger.log(level: .error, context: context, format: "ChallengeType not expected")
-            return .unexpectedError(.init())
+            let errorDescription = MSALNativeAuthErrorMessage.unexpectedChallengeType
+            MSALLogger.log(level: .error, context: context, format: errorDescription)
+            return .unexpectedError(.init(errorDescription: errorDescription))
         }
     }
 
@@ -143,8 +143,8 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
             MSALLogger.log(level: .info, context: context, format: "resetpassword/challenge: Unable to decode error response: \(error)")
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
-        if apiError.error == .none {
-            return .unexpectedError(.init(errorDescription: apiError.errorDescription))
+        if apiError.error == .unknownCase {
+            return .unexpectedError(apiError)
         }
         return .error(apiError)
     }
@@ -185,8 +185,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
         case .verificationRequired:
             MSALLogger.log(level: .error, context: context, format: "verificationRequired is not supported yet")
             return .unexpectedError(nil)
-        case .none,
-             .unknownCase:
+        case .unknownCase:
             return .unexpectedError(apiError)
         }
     }
@@ -228,8 +227,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
              .unauthorizedClient,
              .expiredToken:
             return .error(apiError)
-        case .none,
-             .unknownCase:
+        case .unknownCase:
             return .unexpectedError(apiError)
         }
     }
@@ -276,8 +274,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
              .unauthorizedClient,
              .expiredToken:
             return .error(apiError)
-        case .none,
-             .unknownCase:
+        case .unknownCase:
             return .unexpectedError(apiError)
         }
     }

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -139,13 +139,9 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                 return .error(.expiredToken(error))
             case .unsupportedChallengeType:
                 return .error(.unsupportedChallengeType(error))
-            case .none:
-                return .error(.unexpectedError(.init(
-                    errorDescription: error.errorDescription,
-                    errorCodes: error.errorCodes,
-                    errorURI: error.errorURI,
-                    correlationId: error.correlationId
-                )))
+            case .none,
+                 .unknownCase:
+                return .error(.unexpectedError(error))
             }
     }
 
@@ -159,13 +155,9 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                 return .error(.unsupportedChallengeType(error))
             case .userNotFound:
                 return .error(.userNotFound(error))
-            case .none:
-                return .error(.unexpectedError(.init(
-                    errorDescription: error.errorDescription,
-                    errorCodes: error.errorCodes,
-                    errorURI: error.errorURI,
-                    correlationId: error.correlationId
-                )))
+            case .none,
+                 .unknownCase:
+                return .error(.unexpectedError(error))
             }
     }
 }

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -139,8 +139,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                 return .error(.expiredToken(error))
             case .unsupportedChallengeType:
                 return .error(.unsupportedChallengeType(error))
-            case .none,
-                 .unknownCase:
+            case .unknownCase:
                 return .error(.unexpectedError(error))
             }
     }
@@ -155,8 +154,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                 return .error(.unsupportedChallengeType(error))
             case .userNotFound:
                 return .error(.userNotFound(error))
-            case .none,
-                 .unknownCase:
+            case .unknownCase:
                 return .error(.unexpectedError(error))
             }
     }

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -139,7 +139,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                 return .error(.expiredToken(error))
             case .unsupportedChallengeType:
                 return .error(.unsupportedChallengeType(error))
-            case .unknownCase:
+            case .unknown:
                 return .error(.unexpectedError(error))
             }
     }
@@ -154,7 +154,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                 return .error(.unsupportedChallengeType(error))
             case .userNotFound:
                 return .error(.userNotFound(error))
-            case .unknownCase:
+            case .unknown:
                 return .error(.unexpectedError(error))
             }
     }

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -92,7 +92,8 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             apiError,
             knownErrorDescription: MSALNativeAuthESTSApiErrorDescriptions.clientIdParameterIsEmptyOrNotValid.rawValue):
             return .unauthorizedClient(apiError)
-        case .none:
+        case .none,
+             .unknownCase:
             return .unexpectedError(.init(
                 errorDescription: apiError.errorDescription,
                 errorCodes: apiError.errorCodes,
@@ -158,8 +159,8 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             MSALLogger.log(level: .error, context: context, format: "signup/challenge: Unable to decode error response: \(error)")
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
-        if apiError.error == .none {
-            return .unexpectedError(.init(errorDescription: apiError.errorDescription))
+        if apiError.error == .unknownCase {
+            return .unexpectedError(apiError)
         }
 
         return .error(apiError)
@@ -218,13 +219,9 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
              .userAlreadyExists,
              .invalidRequest:
             return .error(apiError)
-        case .none:
-            return .unexpectedError(.init(
-                errorDescription: apiError.errorDescription,
-                errorCodes: apiError.errorCodes,
-                errorURI: apiError.errorURI,
-                correlationId: apiError.correlationId
-            ))
+        case .none,
+             .unknownCase:
+            return .unexpectedError(apiError)
         }
     }
 
@@ -256,6 +253,8 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
                 )
                 return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
             }
+        case .unknownCase:
+            return .unexpectedError(apiError)
         }
     }
 

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -82,7 +82,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
                     context: context,
                     format: "Missing expected fields in signup/start for attribute_validation_failed error"
                 )
-                return .unexpectedError(.init(errorDescription: apiError.errorDescription))
+                return .unexpectedError(apiError)
             }
         case .invalidRequest where isSignUpStartInvalidRequestParameter(
             apiError,
@@ -92,14 +92,8 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             apiError,
             knownErrorDescription: MSALNativeAuthESTSApiErrorDescriptions.clientIdParameterIsEmptyOrNotValid.rawValue):
             return .unauthorizedClient(apiError)
-        case .none,
-             .unknownCase:
-            return .unexpectedError(.init(
-                errorDescription: apiError.errorDescription,
-                errorCodes: apiError.errorCodes,
-                errorURI: apiError.errorURI,
-                correlationId: apiError.correlationId
-            ))
+        case .unknownCase:
+            return .unexpectedError(apiError)
         default:
             return .error(apiError)
         }
@@ -219,8 +213,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
              .userAlreadyExists,
              .invalidRequest:
             return .error(apiError)
-        case .none,
-             .unknownCase:
+        case .unknownCase:
             return .unexpectedError(apiError)
         }
     }

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -92,7 +92,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             apiError,
             knownErrorDescription: MSALNativeAuthESTSApiErrorDescriptions.clientIdParameterIsEmptyOrNotValid.rawValue):
             return .unauthorizedClient(apiError)
-        case .unknownCase:
+        case .unknown:
             return .unexpectedError(apiError)
         default:
             return .error(apiError)
@@ -153,7 +153,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
             MSALLogger.log(level: .error, context: context, format: "signup/challenge: Unable to decode error response: \(error)")
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
-        if apiError.error == .unknownCase {
+        if apiError.error == .unknown {
             return .unexpectedError(apiError)
         }
 
@@ -213,7 +213,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
              .userAlreadyExists,
              .invalidRequest:
             return .error(apiError)
-        case .unknownCase:
+        case .unknown:
             return .unexpectedError(apiError)
         }
     }
@@ -246,7 +246,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
                 )
                 return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
             }
-        case .unknownCase:
+        case .unknown:
             return .unexpectedError(apiError)
         }
     }

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -119,13 +119,9 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
                 return .error(.slowDown(responseError))
             case .userNotFound:
                 return .error(.userNotFound(responseError))
-            case .none:
-                return .error(.unexpectedError(.init(
-                    errorDescription: responseError.errorDescription,
-                    errorCodes: responseError.errorCodes,
-                    errorURI: responseError.errorURI,
-                    correlationId: responseError.correlationId
-                )))
+            case .none,
+                 .unknownCase:
+                return .error(.unexpectedError(responseError))
             }
         }
 

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -119,7 +119,7 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
                 return .error(.slowDown(responseError))
             case .userNotFound:
                 return .error(.userNotFound(responseError))
-            case .unknownCase:
+            case .unknown:
                 return .error(.unexpectedError(responseError))
             }
         }

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -119,8 +119,7 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
                 return .error(.slowDown(responseError))
             case .userNotFound:
                 return .error(.userNotFound(responseError))
-            case .none,
-                 .unknownCase:
+            case .unknownCase:
                 return .error(.unexpectedError(responseError))
             }
         }

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -99,7 +99,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.expectedContext = expectedContext
         signInRequestProviderMock.throwingInitError = ErrorMock.error
 
-        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
+        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, message: "SignIn Initiate: Cannot create Initiate request object", correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
 
@@ -474,7 +474,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.expectedContext = expectedContext
         signInRequestProviderMock.throwingInitError = MSALNativeAuthError(message: nil, correlationId: defaultUUID)
 
-        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
+        let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, message: "SignIn Initiate: Cannot create Initiate request object", correlationId: defaultUUID))
 
         let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
 

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestErrorHandlerTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestErrorHandlerTests.swift
@@ -294,8 +294,8 @@ class MSALNativeAuthResponseErrorHandlerTests: XCTestCase {
                 expectation.fulfill()
                 return
             }
-            XCTAssertEqual(error.error, .unknownCase)
-            XCTAssertEqual(error.subError, .unknownCase)
+            XCTAssertEqual(error.error, .unknown)
+            XCTAssertEqual(error.subError, .unknown)
             XCTAssertEqual(error.errorDescription, "API Description")
             XCTAssertEqual(error.errorURI, HttpModuleMockConfigurator.baseUrl.absoluteString)
             expectation.fulfill()

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthUnknownCaseProtocolTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthUnknownCaseProtocolTests.swift
@@ -30,50 +30,50 @@ final class MSALNativeAuthUnknownCaseProtocolTests: XCTestCase {
     func test_decodeKnownValue() throws {
         let json = """
         {
-            "main": "fish and chips",
-            "withCoffee": true,
-            "fruit": "apple"
+            "errorType": "invalid_grant",
+            "errorDescription": "This is an error description",
+            "errorCodes": [50076]
         }
         """
 
         let data = json.data(using: .utf8)!
 
-        let menu = try JSONDecoder().decode(ApiRestaurantMenu.self, from: data)
+        let apiError = try JSONDecoder().decode(ApiErrorResponse.self, from: data)
 
-        XCTAssertNotNil(menu)
-        XCTAssertEqual(menu.main, "fish and chips")
-        XCTAssertTrue(menu.withCoffee)
-        XCTAssertEqual(menu.fruit, .apple)
+        XCTAssertNotNil(apiError)
+        XCTAssertEqual(apiError.errorType, .invalidGrant)
+        XCTAssertEqual(apiError.errorDescription, "This is an error description")
+        XCTAssertEqual(apiError.errorCodes, [50076])
     }
 
     func test_decodingAnUnknownValue_produces_aNotNilApiModel() throws {
         let json = """
         {
-            "main": "fish and chips",
-            "withCoffee": true,
-            "fruit": "pomelo"
+            "errorType": "new_error_type_unknown_to_the_SDK",
+            "errorDescription": "This is an error description",
+            "errorCodes": [50076]
         }
         """
 
         let data = json.data(using: .utf8)!
 
-        let menu = try JSONDecoder().decode(ApiRestaurantMenu.self, from: data)
+        let apiError = try JSONDecoder().decode(ApiErrorResponse.self, from: data)
 
-        XCTAssertNotNil(menu)
-        XCTAssertEqual(menu.main, "fish and chips")
-        XCTAssertTrue(menu.withCoffee)
-        XCTAssertEqual(menu.fruit, .unknownCase)
+        XCTAssertNotNil(apiError)
+        XCTAssertEqual(apiError.errorType, .unknownCase)
+        XCTAssertEqual(apiError.errorDescription, "This is an error description")
+        XCTAssertEqual(apiError.errorCodes, [50076])
     }
 }
 
-struct ApiRestaurantMenu: Decodable {
-    let main: String
-    let withCoffee: Bool
-    let fruit: ApiFruitEnum
+private struct ApiErrorResponse: Decodable {
+    let errorType: ApiErrorTypeEnum
+    let errorDescription: String
+    let errorCodes: [Int]
 }
 
-enum ApiFruitEnum: String, Decodable, CaseIterable, Equatable, MSALNativeAuthUnknownCaseProtocol {
-    case apple = "apple"
-    case banana = "banana"
+private enum ApiErrorTypeEnum: String, Decodable, Equatable, MSALNativeAuthUnknownCaseProtocol {
+    case invalidGrant = "invalid_grant"
+    case unauthorizedClient = "unauthorized_client"
     case unknownCase
 }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthUnknownCaseProtocolTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthUnknownCaseProtocolTests.swift
@@ -60,7 +60,7 @@ final class MSALNativeAuthUnknownCaseProtocolTests: XCTestCase {
         let apiError = try JSONDecoder().decode(ApiErrorResponse.self, from: data)
 
         XCTAssertNotNil(apiError)
-        XCTAssertEqual(apiError.errorType, .unknownCase)
+        XCTAssertEqual(apiError.errorType, .unknown)
         XCTAssertEqual(apiError.errorDescription, "This is an error description")
         XCTAssertEqual(apiError.errorCodes, [50076])
     }
@@ -75,5 +75,5 @@ private struct ApiErrorResponse: Decodable {
 private enum ApiErrorTypeEnum: String, Decodable, Equatable, MSALNativeAuthUnknownCaseProtocol {
     case invalidGrant = "invalid_grant"
     case unauthorizedClient = "unauthorized_client"
-    case unknownCase
+    case unknown
 }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthUnknownCaseProtocolTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthUnknownCaseProtocolTests.swift
@@ -1,0 +1,79 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthUnknownCaseProtocolTests: XCTestCase {
+
+    func test_decodeKnownValue() throws {
+        let json = """
+        {
+            "main": "fish and chips",
+            "withCoffee": true,
+            "fruit": "apple"
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+
+        let menu = try JSONDecoder().decode(ApiRestaurantMenu.self, from: data)
+
+        XCTAssertNotNil(menu)
+        XCTAssertEqual(menu.main, "fish and chips")
+        XCTAssertTrue(menu.withCoffee)
+        XCTAssertEqual(menu.fruit, .apple)
+    }
+
+    func test_decodingAnUnknownValue_produces_aNotNilApiModel() throws {
+        let json = """
+        {
+            "main": "fish and chips",
+            "withCoffee": true,
+            "fruit": "pomelo"
+        }
+        """
+
+        let data = json.data(using: .utf8)!
+
+        let menu = try JSONDecoder().decode(ApiRestaurantMenu.self, from: data)
+
+        XCTAssertNotNil(menu)
+        XCTAssertEqual(menu.main, "fish and chips")
+        XCTAssertTrue(menu.withCoffee)
+        XCTAssertEqual(menu.fruit, .unknownCase)
+    }
+}
+
+struct ApiRestaurantMenu: Decodable {
+    let main: String
+    let withCoffee: Bool
+    let fruit: ApiFruitEnum
+}
+
+enum ApiFruitEnum: String, Decodable, CaseIterable, Equatable, MSALNativeAuthUnknownCaseProtocol {
+    case apple = "apple"
+    case banana = "banana"
+    case unknownCase
+}

--- a/MSAL/test/unit/native_auth/network/errors/MSALNativeAuthSubErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/MSALNativeAuthSubErrorCodeTests.swift
@@ -29,7 +29,7 @@ final class MSALNativeAuthSubErrorCodeTests: XCTestCase {
     private typealias sut = MSALNativeAuthSubErrorCode
 
     func test_allCases() {
-        XCTAssertEqual(sut.allCases.count, 8)
+        XCTAssertEqual(sut.allCases.count, 9)
     }
 
     func test_passwordTooWeak() {

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeOauth2ErrorCodeTests.swift
@@ -30,7 +30,7 @@ final class MSALNativeAuthResetPasswordChallengeOauth2ErrorCodeTests: XCTestCase
     private typealias sut = MSALNativeAuthResetPasswordChallengeOauth2ErrorCode
     
     func test_allCases() {
-        XCTAssertEqual(sut.allCases.count, 4)
+        XCTAssertEqual(sut.allCases.count, 5)
     }
     
     func test_invalidRequest() {

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
@@ -139,8 +139,8 @@ final class MSALNativeAuthResetPasswordChallengeResponseErrorTests: XCTestCase {
         XCTAssertEqual(error.errorUri, testErrorUri)
     }
 
-    func test_toResendCodePublicError_errorUnknownCase() {
-        sut = createApiResendCodeError(type: .unknownCase)
+    func test_toResendCodePublicError_errorUnknown() {
+        sut = createApiResendCodeError(type: .unknown)
         let error = sut.toResendCodePublicError(correlationId: correlationId)
 
         XCTAssertEqual(error.errorDescription, testDescription)

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordChallengeResponseErrorTests.swift
@@ -138,4 +138,14 @@ final class MSALNativeAuthResetPasswordChallengeResponseErrorTests: XCTestCase {
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.errorUri, testErrorUri)
     }
+
+    func test_toResendCodePublicError_errorUnknownCase() {
+        sut = createApiResendCodeError(type: .unknownCase)
+        let error = sut.toResendCodePublicError(correlationId: correlationId)
+
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
+    }
 }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueOauth2ErrorCodeTests.swift
@@ -30,7 +30,7 @@ final class MSALNativeAuthResetPasswordContinueOauth2ErrorCodeTests: XCTestCase 
     private typealias sut = MSALNativeAuthResetPasswordContinueOauth2ErrorCode
 
     func test_allCases() {
-        XCTAssertEqual(sut.allCases.count, 5)
+        XCTAssertEqual(sut.allCases.count, 6)
     }
     
     func test_invalidRequest() {

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
@@ -111,4 +111,26 @@ final class MSALNativeAuthResetPasswordContinueResponseErrorTests: XCTestCase {
         XCTAssertEqual(error.errorCodes, testErrorCodes)
         XCTAssertEqual(error.errorUri, testErrorUri)
     }
+
+    func test_toResetPasswordStartPublicError_errorUnknownCase() {
+        sut = createApiError(type: .unknownCase, subError: .invalidOOBValue)
+        let error = sut.toVerifyCodePublicError(correlationId: correlationId)
+
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
+    }
+
+    func test_toResetPasswordStartPublicError_suberrorUnknownCase() {
+        sut = createApiError(type: .invalidGrant, subError: .unknownCase)
+        let error = sut.toVerifyCodePublicError(correlationId: correlationId)
+
+        XCTAssertEqual(error.type, .generalError)
+        XCTAssertEqual(error.errorDescription, testDescription)
+        XCTAssertEqual(error.correlationId, correlationId)
+        XCTAssertEqual(error.errorCodes, testErrorCodes)
+        XCTAssertEqual(error.errorUri, testErrorUri)
+    }
 }

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordContinueResponseErrorTests.swift
@@ -112,8 +112,8 @@ final class MSALNativeAuthResetPasswordContinueResponseErrorTests: XCTestCase {
         XCTAssertEqual(error.errorUri, testErrorUri)
     }
 
-    func test_toResetPasswordStartPublicError_errorUnknownCase() {
-        sut = createApiError(type: .unknownCase, subError: .invalidOOBValue)
+    func test_toResetPasswordStartPublicError_errorUnknown() {
+        sut = createApiError(type: .unknown, subError: .invalidOOBValue)
         let error = sut.toVerifyCodePublicError(correlationId: correlationId)
 
         XCTAssertEqual(error.type, .generalError)
@@ -123,8 +123,8 @@ final class MSALNativeAuthResetPasswordContinueResponseErrorTests: XCTestCase {
         XCTAssertEqual(error.errorUri, testErrorUri)
     }
 
-    func test_toResetPasswordStartPublicError_suberrorUnknownCase() {
-        sut = createApiError(type: .invalidGrant, subError: .unknownCase)
+    func test_toResetPasswordStartPublicError_suberrorUnknown() {
+        sut = createApiError(type: .invalidGrant, subError: .unknown)
         let error = sut.toVerifyCodePublicError(correlationId: correlationId)
 
         XCTAssertEqual(error.type, .generalError)

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCodeTests.swift
@@ -30,7 +30,7 @@ final class MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCodeTests: XCTes
     private typealias sut = MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode
 
     func test_allCases() {
-        XCTAssertEqual(sut.allCases.count, 5)
+        XCTAssertEqual(sut.allCases.count, 6)
     }
 
     func test_invalidGrant() {

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
@@ -71,12 +71,12 @@ final class MSALNativeAuthResetPasswordPollCompletionResponseErrorTests: XCTestC
         testPasswordRequiredError(code: .userNotFound, expectedErrorType: .generalError)
     }
 
-    func test_toPasswordRequiredPublicError_errorUnknownCase() {
-        testPasswordRequiredError(code: .unknownCase, expectedErrorType: .generalError)
+    func test_toPasswordRequiredPublicError_errorUnknown() {
+        testPasswordRequiredError(code: .unknown, expectedErrorType: .generalError)
     }
 
-    func test_toPasswordRequiredPublicError_suberrorUnknownCase() {
-        testPasswordRequiredError(code: .userNotFound, subError: .unknownCase, expectedErrorType: .generalError)
+    func test_toPasswordRequiredPublicError_suberrorUnknown() {
+        testPasswordRequiredError(code: .userNotFound, subError: .unknown, expectedErrorType: .generalError)
     }
 
     // MARK: private methods

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift
@@ -70,7 +70,15 @@ final class MSALNativeAuthResetPasswordPollCompletionResponseErrorTests: XCTestC
     func test_toPasswordRequiredPublicError_userNotFound() {
         testPasswordRequiredError(code: .userNotFound, expectedErrorType: .generalError)
     }
-    
+
+    func test_toPasswordRequiredPublicError_errorUnknownCase() {
+        testPasswordRequiredError(code: .unknownCase, expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_suberrorUnknownCase() {
+        testPasswordRequiredError(code: .userNotFound, subError: .unknownCase, expectedErrorType: .generalError)
+    }
+
     // MARK: private methods
     
     private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, expectedErrorType: PasswordRequiredError.ErrorType) {

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordStartOauth2ErrorCodeTests.swift
@@ -30,7 +30,7 @@ final class MSALNativeAuthResetPasswordStartOauth2ErrorCodeTests: XCTestCase {
     private typealias sut = MSALNativeAuthResetPasswordStartOauth2ErrorCode
 
     func test_allCases() {
-        XCTAssertEqual(sut.allCases.count, 4)
+        XCTAssertEqual(sut.allCases.count, 5)
     }
     
     func test_invalidRequest() {

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitOauth2ErrorCodeTests.swift
@@ -30,7 +30,7 @@ final class MSALNativeAuthResetPasswordSubmitOauth2ErrorCodeTests: XCTestCase {
     private typealias sut = MSALNativeAuthResetPasswordSubmitOauth2ErrorCode
     
     func test_allCases() {
-        XCTAssertEqual(sut.allCases.count, 4)
+        XCTAssertEqual(sut.allCases.count, 5)
     }
     
     func test_invalidRequest() {

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
@@ -67,12 +67,12 @@ final class MSALNativeAuthResetPasswordSubmitResponseErrorTests: XCTestCase {
         testPasswordRequiredError(code: .invalidGrant, subError: .passwordBanned, expectedErrorType: .invalidPassword)
     }
 
-    func test_toPasswordRequiredPublicError_errorUnknownCase() {
-        testPasswordRequiredError(code: .unknownCase, subError: .passwordBanned, expectedErrorType: .generalError)
+    func test_toPasswordRequiredPublicError_errorUnknown() {
+        testPasswordRequiredError(code: .unknown, subError: .passwordBanned, expectedErrorType: .generalError)
     }
 
-    func test_toPasswordRequiredPublicError_suberrorUnknownCase() {
-        testPasswordRequiredError(code: .invalidGrant, subError: .unknownCase, expectedErrorType: .generalError)
+    func test_toPasswordRequiredPublicError_suberrorUnknown() {
+        testPasswordRequiredError(code: .invalidGrant, subError: .unknown, expectedErrorType: .generalError)
     }
 
     // MARK: private methods

--- a/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/reset_password/MSALNativeAuthResetPasswordSubmitResponseErrorTests.swift
@@ -66,7 +66,15 @@ final class MSALNativeAuthResetPasswordSubmitResponseErrorTests: XCTestCase {
     func test_toPasswordRequiredPublicError_passwordBanned() {
         testPasswordRequiredError(code: .invalidGrant, subError: .passwordBanned, expectedErrorType: .invalidPassword)
     }
-    
+
+    func test_toPasswordRequiredPublicError_errorUnknownCase() {
+        testPasswordRequiredError(code: .unknownCase, subError: .passwordBanned, expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_suberrorUnknownCase() {
+        testPasswordRequiredError(code: .invalidGrant, subError: .unknownCase, expectedErrorType: .generalError)
+    }
+
     // MARK: private methods
     
     private func testPasswordRequiredError(code: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, expectedErrorType: PasswordRequiredError.ErrorType) {

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests.swift
@@ -30,7 +30,7 @@ final class MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests: XCTestCase {
     private typealias sut = MSALNativeAuthSignUpChallengeOauth2ErrorCode
     
     func test_allCases() {
-        XCTAssertEqual(sut.allCases.count, 4)
+        XCTAssertEqual(sut.allCases.count, 5)
     }
     
     func test_invalidRequest() {

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
@@ -87,8 +87,8 @@ final class MSALNativeAuthSignUpChallengeResponseErrorTests: XCTestCase {
         testSignUpChallengeErrorToPasswordRequired(code: .invalidRequest, expectedErrorType: .generalError)
     }
 
-    func test_toPasswordRequiredPublicError_errorUnknownCase() {
-        testSignUpChallengeErrorToPasswordRequired(code: .unknownCase, expectedErrorType: .generalError)
+    func test_toPasswordRequiredPublicError_errorUnknown() {
+        testSignUpChallengeErrorToPasswordRequired(code: .unknown, expectedErrorType: .generalError)
     }
 
     // MARK: private methods

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpChallengeResponseErrorTests.swift
@@ -86,7 +86,11 @@ final class MSALNativeAuthSignUpChallengeResponseErrorTests: XCTestCase {
     func test_toPasswordRequiredPublicError_invalidRequest() {
         testSignUpChallengeErrorToPasswordRequired(code: .invalidRequest, expectedErrorType: .generalError)
     }
-        
+
+    func test_toPasswordRequiredPublicError_errorUnknownCase() {
+        testSignUpChallengeErrorToPasswordRequired(code: .unknownCase, expectedErrorType: .generalError)
+    }
+
     // MARK: private methods
     
     private func testSignUpChallengeErrorToSignUpStart(code: MSALNativeAuthSignUpChallengeOauth2ErrorCode, expectedErrorType: SignUpStartError.ErrorType) {

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueOauth2ErrorCodeTests.swift
@@ -30,7 +30,7 @@ final class MSALNativeAuthSignUpContinueOauth2ErrorCodeTests: XCTestCase {
     private typealias sut = MSALNativeAuthSignUpContinueOauth2ErrorCode
 
     func test_allCases() {
-        XCTAssertEqual(sut.allCases.count, 8)
+        XCTAssertEqual(sut.allCases.count, 9)
     }
 
     func test_invalidRequest() {

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
@@ -95,12 +95,12 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
         testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .invalidOOBValue, expectedErrorType: .invalidCode)
     }
 
-    func test_toVerifyCodePublicError_errorUnknownCase() {
-        testSignUpContinueErrorToVerifyCode(code: .unknownCase, expectedErrorType: .generalError)
+    func test_toVerifyCodePublicError_errorUnknown() {
+        testSignUpContinueErrorToVerifyCode(code: .unknown, expectedErrorType: .generalError)
     }
 
-    func test_toVerifyCodePublicError_suberrorUnknownCase() {
-        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .unknownCase, expectedErrorType: .generalError)
+    func test_toVerifyCodePublicError_suberrorUnknown() {
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .unknown, expectedErrorType: .generalError)
     }
 
     // MARK: - toPasswordRequiredPublicError tests
@@ -165,12 +165,12 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
         testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .invalidOOBValue, expectedErrorType: .generalError)
     }
 
-    func test_toPasswordRequiredPublicError_errorUnknownCase() {
-        testSignUpContinueErrorToPasswordRequired(code: .unknownCase, subError: .invalidOOBValue, expectedErrorType: .generalError)
+    func test_toPasswordRequiredPublicError_errorUnknown() {
+        testSignUpContinueErrorToPasswordRequired(code: .unknown, subError: .invalidOOBValue, expectedErrorType: .generalError)
     }
 
-    func test_toPasswordRequiredPublicError_suberrorUnknownCase() {
-        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .unknownCase, expectedErrorType: .generalError)
+    func test_toPasswordRequiredPublicError_suberrorUnknown() {
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .unknown, expectedErrorType: .generalError)
     }
 
     // MARK: - toAttributesRequiredPublicError tests
@@ -235,12 +235,12 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
         testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .invalidOOBValue)
     }
 
-    func test_toAttributesRequiredPublicError_errorUnknownCase() {
-        testSignUpContinueErrorToAttributesRequired(code: .unknownCase, subError: .invalidOOBValue)
+    func test_toAttributesRequiredPublicError_errorUnknown() {
+        testSignUpContinueErrorToAttributesRequired(code: .unknown, subError: .invalidOOBValue)
     }
 
-    func test_toAttributesRequiredPublicError_suberrorUnknownCase() {
-        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .unknownCase)
+    func test_toAttributesRequiredPublicError_suberrorUnknown() {
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .unknown)
     }
 
     // MARK: private methods

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpContinueResponseErrorTests.swift
@@ -94,7 +94,15 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
     func test_toVerifyCodePublicError_invalidOOBValue() {
         testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .invalidOOBValue, expectedErrorType: .invalidCode)
     }
-    
+
+    func test_toVerifyCodePublicError_errorUnknownCase() {
+        testSignUpContinueErrorToVerifyCode(code: .unknownCase, expectedErrorType: .generalError)
+    }
+
+    func test_toVerifyCodePublicError_suberrorUnknownCase() {
+        testSignUpContinueErrorToVerifyCode(code: .invalidGrant, subError: .unknownCase, expectedErrorType: .generalError)
+    }
+
     // MARK: - toPasswordRequiredPublicError tests
     
     func test_toPasswordRequiredPublicError_invalidRequest() {
@@ -156,7 +164,15 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
     func test_toPasswordRequiredPublicError_invalidOOBValue() {
         testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .invalidOOBValue, expectedErrorType: .generalError)
     }
-    
+
+    func test_toPasswordRequiredPublicError_errorUnknownCase() {
+        testSignUpContinueErrorToPasswordRequired(code: .unknownCase, subError: .invalidOOBValue, expectedErrorType: .generalError)
+    }
+
+    func test_toPasswordRequiredPublicError_suberrorUnknownCase() {
+        testSignUpContinueErrorToPasswordRequired(code: .invalidGrant, subError: .unknownCase, expectedErrorType: .generalError)
+    }
+
     // MARK: - toAttributesRequiredPublicError tests
     
     func test_toAttributesRequiredPublicError_invalidRequest() {
@@ -218,7 +234,15 @@ final class MSALNativeAuthSignUpContinueResponseErrorTests: XCTestCase {
     func test_toAttributesRequiredPublicError_invalidOOBValue() {
         testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .invalidOOBValue)
     }
-    
+
+    func test_toAttributesRequiredPublicError_errorUnknownCase() {
+        testSignUpContinueErrorToAttributesRequired(code: .unknownCase, subError: .invalidOOBValue)
+    }
+
+    func test_toAttributesRequiredPublicError_suberrorUnknownCase() {
+        testSignUpContinueErrorToAttributesRequired(code: .invalidGrant, subError: .unknownCase)
+    }
+
     // MARK: private methods
     
     private func testSignUpContinueErrorToVerifyCode(code: MSALNativeAuthSignUpContinueOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, expectedErrorType: VerifyCodeError.ErrorType) {

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartOauth2ErrorCodeTests.swift
@@ -30,7 +30,7 @@ final class MSALNativeAuthSignUpStartOauth2ErrorCodeTests: XCTestCase {
     private typealias sut = MSALNativeAuthSignUpStartOauth2ErrorCode
 
     func test_allCases() {
-        XCTAssertEqual(sut.allCases.count, 7)
+        XCTAssertEqual(sut.allCases.count, 8)
     }
 
     func test_invalidGrant() {

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
@@ -83,12 +83,12 @@ final class MSALNativeAuthSignUpStartResponseErrorTests: XCTestCase {
         testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .attributeValidationFailed, expectedErrorType: .generalError)
     }
 
-    func test_toSignUpStartPublicError_errorUnknownCase() {
-        testSignUpStartErrorToSignUpStart(code: .unknownCase, subError: .attributeValidationFailed, expectedErrorType: .generalError)
+    func test_toSignUpStartPublicError_errorUnknown() {
+        testSignUpStartErrorToSignUpStart(code: .unknown, subError: .attributeValidationFailed, expectedErrorType: .generalError)
     }
 
-    func test_toSignUpStartPublicError_suberrorUnknownCase() {
-        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .unknownCase, expectedErrorType: .generalError)
+    func test_toSignUpStartPublicError_suberrorUnknown() {
+        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .unknown, expectedErrorType: .generalError)
     }
 
     // MARK: private methods

--- a/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/sign_up/MSALNativeAuthSignUpStartResponseErrorTests.swift
@@ -83,6 +83,14 @@ final class MSALNativeAuthSignUpStartResponseErrorTests: XCTestCase {
         testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .attributeValidationFailed, expectedErrorType: .generalError)
     }
 
+    func test_toSignUpStartPublicError_errorUnknownCase() {
+        testSignUpStartErrorToSignUpStart(code: .unknownCase, subError: .attributeValidationFailed, expectedErrorType: .generalError)
+    }
+
+    func test_toSignUpStartPublicError_suberrorUnknownCase() {
+        testSignUpStartErrorToSignUpStart(code: .invalidGrant, subError: .unknownCase, expectedErrorType: .generalError)
+    }
+
     // MARK: private methods
     
     private func testSignUpStartErrorToSignUpStart(code: MSALNativeAuthSignUpStartOauth2ErrorCode, subError: MSALNativeAuthSubErrorCode? = nil, expectedErrorType: SignUpStartError.ErrorType) {

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
@@ -77,10 +77,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     }
 
     func test_whenResetPasswordStartErrorResponseIsNotExpected_itReturnsUnexpectedError() {
-        let error = createResetPasswordStartError(
-            error: nil,
-            errorDescription: "API error message"
-        )
+        let error = MSALNativeAuthResetPasswordStartResponseError(errorDescription: "API error message")
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -88,7 +85,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     }
 
     func test_whenResetPasswordStartErrorResponseUserNotFound_itReturnsRelatedError() {
-        let error = createResetPasswordStartError(error: .userNotFound)
+        let error = MSALNativeAuthResetPasswordStartResponseError(error: .userNotFound)
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -98,7 +95,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     }
     
     func test_whenResetPasswordStartErrorResponseUnauthorizedClient_itReturnsRelatedError() {
-        let error = createResetPasswordStartError(error: .unauthorizedClient)
+        let error = MSALNativeAuthResetPasswordStartResponseError(error: .unauthorizedClient)
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -108,7 +105,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     }
     
     func test_whenResetPasswordStartErrorResponseUnsupportedChallengeType_itReturnsRelatedError() {
-        let error = createResetPasswordStartError(error: .unsupportedChallengeType)
+        let error = MSALNativeAuthResetPasswordStartResponseError(error: .unsupportedChallengeType)
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -118,7 +115,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     }
     
     func test_whenResetPasswordStartInvalidRequestUserDoesntHaveAPwd_itReturnsRelatedError() {
-        let error = createResetPasswordStartError(error: .invalidRequest, errorCodes: [500222])
+        let error = MSALNativeAuthResetPasswordStartResponseError(error: .invalidRequest, errorCodes: [500222])
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -128,7 +125,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     }
     
     func test_whenResetPasswordStartInvalidRequestGenericErrorCode_itReturnsRelatedError() {
-        let error = createResetPasswordStartError(error: .invalidRequest, errorCodes: [90023])
+        let error = MSALNativeAuthResetPasswordStartResponseError(error: .invalidRequest, errorCodes: [90023])
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -138,7 +135,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     }
     
     func test_whenResetPasswordStartInvalidRequestNoErrorCode_itReturnsRelatedError() {
-        let error = createResetPasswordStartError(error: .invalidRequest)
+        let error = MSALNativeAuthResetPasswordStartResponseError(error: .invalidRequest)
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -210,14 +207,11 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         )
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(.init()))
+        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedChallengeType)))
     }
 
     func test_whenResetPasswordChallengeErrorResponseIsNotExpected_itReturnsUnexpectedError() {
-        let error = createResetPasswordChallengeError(
-            error: nil,
-            errorDescription: "API error message"
-        )
+        let error = MSALNativeAuthResetPasswordChallengeResponseError(errorDescription: "API error message")
         let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -225,7 +219,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     }
 
     func test_whenResetPasswordChallengeErrorResponseIsExpected_itReturnsError() {
-        let error = createResetPasswordChallengeError(error: .expiredToken)
+        let error = MSALNativeAuthResetPasswordChallengeResponseError(error: .expiredToken)
 
         let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .failure(error)
 
@@ -234,7 +228,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .expiredToken = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -253,10 +247,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
     }
 
     func test_whenResetPasswordContinueErrorResponseIsNotExpected_itReturnsUnexpectedError() {
-        let error = createResetPasswordContinueError(
-            error: nil,
-            errorDescription: "API error message"
-        )
+        let error = MSALNativeAuthResetPasswordContinueResponseError(errorDescription: "API error message")
         let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -286,7 +277,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .unauthorizedClient = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -297,7 +288,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidGrant = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -308,7 +299,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .expiredToken = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -319,7 +310,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidRequest = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -345,7 +336,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .passwordTooWeak = error.subError {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -356,7 +347,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .passwordTooShort = error.subError {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -367,7 +358,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .passwordTooLong = error.subError {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -378,7 +369,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .passwordRecentlyUsed = error.subError {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -389,7 +380,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .passwordBanned = error.subError {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -400,7 +391,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidRequest = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -411,7 +402,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .unauthorizedClient = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -422,15 +413,12 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .expiredToken = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
     func test_whenResetPasswordSubmitErrorResponseIsNotExpected_itReturnsUnexpectedError() {
-        let error = createResetPasswordSubmitError(
-            error: nil,
-            errorDescription: "API error message"
-        )
+        let error = MSALNativeAuthResetPasswordSubmitResponseError(errorDescription: "API error message")
         let response: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -459,7 +447,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .passwordTooWeak = error.subError {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -470,7 +458,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .passwordTooShort = error.subError {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -481,7 +469,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .passwordTooLong = error.subError {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -492,7 +480,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .passwordRecentlyUsed = error.subError {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -503,7 +491,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .passwordBanned = error.subError {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -514,7 +502,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidRequest = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -525,7 +513,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .unauthorizedClient = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -536,15 +524,12 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .expiredToken = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
     func test_whenResetPasswordPollCompletionErrorResponseIsNotExpected_itReturnsUnexpectedError() {
-        let error = createResetPasswordPollCompletionError(
-            error: nil,
-            errorDescription: "API error message"
-        )
+        let error = MSALNativeAuthResetPasswordPollCompletionResponseError(errorDescription: "API error message")
         let response: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -559,7 +544,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         expectedContinuationToken: String? = nil
     ) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
         let response: Result<MSALNativeAuthResetPasswordContinueResponse, Error> = .failure(
-            createResetPasswordContinueError(
+            MSALNativeAuthResetPasswordContinueResponseError(
                 error: expectedError,
                 subError: expectedSubError,
                 continuationToken: expectedContinuationToken
@@ -574,7 +559,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         expectedSubError: MSALNativeAuthSubErrorCode? = nil
     ) -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
         let response: Result<MSALNativeAuthResetPasswordSubmitResponse, Error> = .failure(
-            createResetPasswordSubmitError(
+            MSALNativeAuthResetPasswordSubmitResponseError(
                 error: expectedError,
                 subError: expectedSubError
             )
@@ -588,110 +573,12 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
         expectedSubError: MSALNativeAuthSubErrorCode? = nil
     ) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
         let response: Result<MSALNativeAuthResetPasswordPollCompletionResponse, Error> = .failure(
-            createResetPasswordPollCompletionError(
+            MSALNativeAuthResetPasswordPollCompletionResponseError(
                 error: expectedError,
                 subError: expectedSubError
             )
         )
 
         return sut.validate(response, with: context)
-    }
-
-    private func createResetPasswordStartError(
-        error: MSALNativeAuthResetPasswordStartOauth2ErrorCode? = nil,
-        errorDescription: String? = nil,
-        errorCodes: [Int]? = nil,
-        errorURI: String? = nil,
-        innerErrors: [MSALNativeAuthInnerError]? = nil,
-        target: String? = nil
-    ) -> MSALNativeAuthResetPasswordStartResponseError {
-        .init(
-            error: error,
-            errorDescription: errorDescription,
-            errorCodes: errorCodes,
-            errorURI: errorURI,
-            innerErrors: innerErrors,
-            target: target
-        )
-    }
-
-    private func createResetPasswordChallengeError(
-        error: MSALNativeAuthResetPasswordChallengeOauth2ErrorCode? = nil,
-        errorDescription: String? = nil,
-        errorCodes: [Int]? = nil,
-        errorURI: String? = nil,
-        innerErrors: [MSALNativeAuthInnerError]? = nil,
-        target: String? = nil
-    ) -> MSALNativeAuthResetPasswordChallengeResponseError {
-        .init(
-            error: error,
-            errorDescription: errorDescription,
-            errorCodes: errorCodes,
-            errorURI: errorURI,
-            innerErrors: innerErrors,
-            target: target
-        )
-    }
-
-    private func createResetPasswordContinueError(
-        error: MSALNativeAuthResetPasswordContinueOauth2ErrorCode? = nil,
-        subError: MSALNativeAuthSubErrorCode? = nil,
-        errorDescription: String? = nil,
-        errorCodes: [Int]? = nil,
-        errorURI: String? = nil,
-        innerErrors: [MSALNativeAuthInnerError]? = nil,
-        target: String? = nil,
-        continuationToken: String? = nil
-    ) -> MSALNativeAuthResetPasswordContinueResponseError {
-        .init(
-            error: error,
-            subError: subError,
-            errorDescription: errorDescription,
-            errorCodes: errorCodes,
-            errorURI: errorURI,
-            innerErrors: innerErrors,
-            target: target,
-            continuationToken: continuationToken
-        )
-    }
-
-    private func createResetPasswordSubmitError(
-        error: MSALNativeAuthResetPasswordSubmitOauth2ErrorCode? = nil,
-        subError: MSALNativeAuthSubErrorCode? = nil,
-        errorDescription: String? = nil,
-        errorCodes: [Int]? = nil,
-        errorURI: String? = nil,
-        innerErrors: [MSALNativeAuthInnerError]? = nil,
-        target: String? = nil
-    ) -> MSALNativeAuthResetPasswordSubmitResponseError {
-        .init(
-            error: error,
-            subError: subError,
-            errorDescription: errorDescription,
-            errorCodes: errorCodes,
-            errorURI: errorURI,
-            innerErrors: innerErrors,
-            target: target
-        )
-    }
-
-    private func createResetPasswordPollCompletionError(
-        error: MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCode? = nil,
-        subError: MSALNativeAuthSubErrorCode? = nil,
-        errorDescription: String? = nil,
-        errorCodes: [Int]? = nil,
-        errorURI: String? = nil,
-        innerErrors: [MSALNativeAuthInnerError]? = nil,
-        target: String? = nil
-    ) -> MSALNativeAuthResetPasswordPollCompletionResponseError {
-        .init(
-            error: error,
-            subError: subError,
-            errorDescription: errorDescription,
-            errorCodes: errorCodes,
-            errorURI: errorURI,
-            innerErrors: innerErrors,
-            target: target
-        )
     }
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
@@ -333,13 +333,13 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
 
     func test_whenSignUpChallengeErrorResponseIsNotExpected_it_returns_unexpectedError() {
         let error = createSignUpChallengeError(
-            error: nil,
+            error: .unknownCase,
             errorDescription: "API error message"
         )
         let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "API error message")))
+        XCTAssertEqual(result, .unexpectedError(.init(error: .unknownCase, errorDescription: "API error message")))
     }
 
     func test_whenSignUpChallengeErrorResponseIsExpected_it_returns_error() {

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
@@ -59,10 +59,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpStartErrorResponseIsNotExpected_it_returns_unexpectedError() {
-        let error = createSignUpStartError(
-            error: nil,
-            errorDescription: "API error message"
-        )
+        let error = MSALNativeAuthSignUpStartResponseError(errorDescription: "API error message")
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -82,7 +79,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpStart_attributeValidationFailed_it_returns_attributeValidationFailed() {
-        let error = createSignUpStartError(
+        let error = MSALNativeAuthSignUpStartResponseError(
             error: .invalidGrant,
             subError: .attributeValidationFailed,
             invalidAttributes: [MSALNativeAuthErrorBasicAttribute(name: "city")]
@@ -91,7 +88,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
 
         let result = sut.validate(response, with: context)
 
-        guard case .attributeValidationFailed(let error, let invalidAttributes) = result else {
+        guard case .attributeValidationFailed(_, let invalidAttributes) = result else {
             return XCTFail("Unexpected response")
         }
 
@@ -99,7 +96,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpStart_attributeValidationFailed_but_invalidAttributesIsEmpty_it_returns_attributeValidationFailed() {
-        let error = createSignUpStartError(
+        let error = MSALNativeAuthSignUpStartResponseError(
             error: .invalidGrant,
             subError: .attributeValidationFailed,
             invalidAttributes: []
@@ -107,11 +104,11 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(.init()))
+        XCTAssertEqual(result, .unexpectedError(.init(error: .invalidGrant, subError: .attributeValidationFailed, invalidAttributes: [])))
     }
 
     func test_whenSignUpStart_attributeValidationFailed_but_invalidAttributesIsNil_it_returns_attributeValidationFailed() {
-        let error = createSignUpStartError(
+        let error = MSALNativeAuthSignUpStartResponseError(
             error: .invalidGrant,
             subError: .attributeValidationFailed,
             invalidAttributes: nil
@@ -119,11 +116,11 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(.init()))
+        XCTAssertEqual(result, .unexpectedError(.init(error: .invalidGrant, subError: .attributeValidationFailed)))
     }
 
     func test_whenSignUpStartErrorResponseIsExpected_it_returns_error() {
-        let error = createSignUpStartError(error: .userAlreadyExists)
+        let error = MSALNativeAuthSignUpStartResponseError(error: .userAlreadyExists)
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -131,7 +128,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .userAlreadyExists = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -139,7 +136,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         let attributes = [MSALNativeAuthErrorBasicAttribute(name: "attribute")]
         let errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidRequestParameter.rawValue, Int.max]
 
-        let apiError = createSignUpStartError(
+        let apiError = MSALNativeAuthSignUpStartResponseError(
             error: .invalidRequest,
             errorDescription: "username parameter is empty or not valid",
             errorCodes: errorCodes,
@@ -162,7 +159,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         let attributes = [MSALNativeAuthErrorBasicAttribute(name: "attribute")]
         let errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidRequestParameter.rawValue, Int.max]
         
-        let apiError = createSignUpStartError(
+        let apiError = MSALNativeAuthSignUpStartResponseError(
             error: .invalidRequest,
             errorDescription: "client_id parameter is empty or not valid",
             errorCodes: errorCodes,
@@ -185,7 +182,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         let attributes = [MSALNativeAuthErrorBasicAttribute(name: "attribute")]
         let errorCodes = [Int.max]
 
-        let apiError = createSignUpStartError(
+        let apiError = MSALNativeAuthSignUpStartResponseError(
             error: .invalidRequest,
             errorDescription: "aDescription",
             errorCodes: errorCodes,
@@ -332,7 +329,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpChallengeErrorResponseIsNotExpected_it_returns_unexpectedError() {
-        let error = createSignUpChallengeError(
+        let error = MSALNativeAuthSignUpChallengeResponseError(
             error: .unknownCase,
             errorDescription: "API error message"
         )
@@ -343,7 +340,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpChallengeErrorResponseIsExpected_it_returns_error() {
-        let error = createSignUpChallengeError(error: .expiredToken)
+        let error = MSALNativeAuthSignUpChallengeResponseError(error: .expiredToken)
 
         let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .failure(error)
 
@@ -352,7 +349,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .expiredToken = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -377,10 +374,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
     }
 
     func test_whenSignUpContinueErrorResponseIsNotExpected_it_returns_unexpectedError() {
-        let error = createSignUpContinueError(
-            error: nil,
-            errorDescription: "API error message"
-        )
+        let error = MSALNativeAuthSignUpContinueResponseError(errorDescription: "API error message")
         let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
@@ -394,7 +388,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidGrant = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
         if case .invalidOOBValue = error.subError {} else {
             XCTFail("Unexpected suberror: \(String(describing: error.subError))")
@@ -408,7 +402,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidGrant = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
         if case .passwordTooWeak = error.subError {} else {
             XCTFail("Unexpected suberror: \(String(describing: error.subError))")
@@ -422,7 +416,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidGrant = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
         if case .passwordTooShort = error.subError {} else {
             XCTFail("Unexpected suberror: \(String(describing: error.subError))")
@@ -436,7 +430,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidGrant = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
         if case .passwordTooLong = error.subError {} else {
             XCTFail("Unexpected suberror: \(String(describing: error.subError))")
@@ -450,7 +444,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidGrant = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
         if case .passwordRecentlyUsed = error.subError {} else {
             XCTFail("Unexpected suberror: \(String(describing: error.subError))")
@@ -464,7 +458,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidGrant = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
         if case .passwordBanned = error.subError {} else {
             XCTFail("Unexpected suberror: \(String(describing: error.subError))")
@@ -488,7 +482,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidRequest = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -562,7 +556,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .unauthorizedClient = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -573,7 +567,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidGrant = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -584,7 +578,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .expiredToken = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -595,7 +589,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .invalidRequest = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -606,7 +600,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             return XCTFail("Unexpected response")
         }
         if case .userAlreadyExists = error.error {} else {
-            XCTFail("Unexpected error: \(error.error?.rawValue ?? "Code not decoded")")
+            XCTFail("Unexpected error: \(error.error.rawValue)")
         }
     }
 
@@ -619,7 +613,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         errorCodes: [Int]? = nil
     ) -> MSALNativeAuthSignUpContinueValidatedResponse {
         let response: Result<MSALNativeAuthSignUpContinueResponse, Error> = .failure(
-            createSignUpContinueError(
+            MSALNativeAuthSignUpContinueResponseError(
                 error: expectedError,
                 subError: expectedSubError,
                 errorCodes: errorCodes,
@@ -630,71 +624,5 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
         )
 
         return sut.validate(response, with: context)
-    }
-
-    private func createSignUpStartError(
-        error: MSALNativeAuthSignUpStartOauth2ErrorCode? = nil,
-        subError: MSALNativeAuthSubErrorCode? = nil,
-        errorDescription: String? = nil,
-        errorCodes: [Int]? = nil,
-        errorURI: String? = nil,
-        innerErrors: [MSALNativeAuthInnerError]? = nil,
-        continuationToken: String? = nil,
-        unverifiedAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil,
-        invalidAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil
-    ) -> MSALNativeAuthSignUpStartResponseError {
-        .init(
-            error: error,
-            subError: subError,
-            errorDescription: errorDescription,
-            errorCodes: errorCodes,
-            errorURI: errorURI,
-            innerErrors: innerErrors,
-            continuationToken: continuationToken,
-            unverifiedAttributes: unverifiedAttributes,
-            invalidAttributes: invalidAttributes
-        )
-    }
-
-    private func createSignUpChallengeError(
-        error: MSALNativeAuthSignUpChallengeOauth2ErrorCode? = nil,
-        errorDescription: String? = nil,
-        errorCodes: [Int]? = nil,
-        errorURI: String? = nil,
-        innerErrors: [MSALNativeAuthInnerError]? = nil
-    ) -> MSALNativeAuthSignUpChallengeResponseError {
-        .init(
-            error: error,
-            errorDescription: errorDescription,
-            errorCodes: errorCodes,
-            errorURI: errorURI,
-            innerErrors: innerErrors
-        )
-    }
-
-    private func createSignUpContinueError(
-        error: MSALNativeAuthSignUpContinueOauth2ErrorCode? = nil,
-        subError: MSALNativeAuthSubErrorCode? = nil,
-        errorDescription: String? = nil,
-        errorCodes: [Int]? = nil,
-        errorURI: String? = nil,
-        innerErrors: [MSALNativeAuthInnerError]? = nil,
-        continuationToken: String? = nil,
-        requiredAttributes: [MSALNativeAuthRequiredAttributeInternal]? = nil,
-        unverifiedAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil,
-        invalidAttributes: [MSALNativeAuthErrorBasicAttribute]? = nil
-    ) -> MSALNativeAuthSignUpContinueResponseError {
-        .init(
-            error: error,
-            subError: subError,
-            errorDescription: errorDescription,
-            errorCodes: errorCodes,
-            errorURI: errorURI,
-            innerErrors: innerErrors,
-            continuationToken: continuationToken,
-            requiredAttributes: requiredAttributes,
-            unverifiedAttributes: unverifiedAttributes,
-            invalidAttributes: invalidAttributes
-        )
     }
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
@@ -330,13 +330,13 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
 
     func test_whenSignUpChallengeErrorResponseIsNotExpected_it_returns_unexpectedError() {
         let error = MSALNativeAuthSignUpChallengeResponseError(
-            error: .unknownCase,
+            error: .unknown,
             errorDescription: "API error message"
         )
         let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .failure(error)
 
         let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(.init(error: .unknownCase, errorDescription: "API error message")))
+        XCTAssertEqual(result, .unexpectedError(.init(error: .unknown, errorDescription: "API error message")))
     }
 
     func test_whenSignUpChallengeErrorResponseIsExpected_it_returns_error() {


### PR DESCRIPTION
## Proposed changes

When we get from the API an unknown case on any of the Oauth2ErrorCode or SubErrorCode enums, the decoding of the api error fails, losing the information that does come in the response, like errorDescription, errorCodes, etc.

This PR creates a protocol that adds a new case `unknownCase` to each enum that conforms to it. The protocol overwrites the decoding of the enum by setting `unknownCase` if a case cannot be decoded.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)