### PR TITLE
improve visionOS xcconfig and xcframework build process

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 54;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		6D2177E52B8D89B700C41C1C /* MSAL (xcframework) */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 6D2177E62B8D89B700C41C1C /* Build configuration list for PBXAggregateTarget "MSAL (xcframework)" */;
+			buildPhases = (
+				6D2177E92B8D89F700C41C1C /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = "MSAL (xcframework)";
+			productName = MSAL;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		04A6B5AE226936F30035C7C2 /* MSALFramework.m in Sources */ = {isa = PBXBuildFile; fileRef = D61F5BC91E59359900912CB8 /* MSALFramework.m */; };
 		04A6B5AF226936F40035C7C2 /* MSALFramework.m in Sources */ = {isa = PBXBuildFile; fileRef = D61F5BC91E59359900912CB8 /* MSALFramework.m */; };
@@ -303,6 +317,7 @@
 		609AF9332256BD0C00E2978D /* MSALAccountsProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 609AF9322256BD0C00E2978D /* MSALAccountsProviderTests.m */; };
 		6525115A29CD84A000D3B876 /* MSALPublicClientApplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D673F07C1E4AAB0D0018BA91 /* MSALPublicClientApplicationTests.m */; };
 		6577FFC829CC2E4B003235A6 /* MSALDeviceInfoProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B253153A23DD717900432133 /* MSALDeviceInfoProviderTests.m */; };
+		6DD793B32B8D43A5002BA788 /* libIdentityCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 919BDFDD2B633E8800DA8C53 /* libIdentityCore.a */; };
 		886F515829CCA50300F09471 /* MSALCIAMAuthority.h in Headers */ = {isa = PBXBuildFile; fileRef = 886F515729CCA50300F09471 /* MSALCIAMAuthority.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		886F515929CCA50300F09471 /* MSALCIAMAuthority.h in Headers */ = {isa = PBXBuildFile; fileRef = 886F515729CCA50300F09471 /* MSALCIAMAuthority.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		886F515A29CCA50300F09471 /* MSALCIAMAuthority.h in Headers */ = {isa = PBXBuildFile; fileRef = 886F515729CCA50300F09471 /* MSALCIAMAuthority.h */; };
@@ -495,7 +510,6 @@
 		919BDFCB2B633E8800DA8C53 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A206331FC5109400755A51 /* SafariServices.framework */; };
 		919BDFCC2B633E8800DA8C53 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A206311FC5108000755A51 /* UIKit.framework */; };
 		919BDFCD2B633E8800DA8C53 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A2062F1FC5106F00755A51 /* Security.framework */; };
-		919BDFDF2B633F0B00DA8C53 /* libIdentityCore visionOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 919BDFDD2B633E8800DA8C53 /* libIdentityCore visionOS.a */; };
 		91D745DA2B69D5470070CC18 /* RealityKitContent in Frameworks */ = {isa = PBXBuildFile; productRef = 91D745D92B69D5470070CC18 /* RealityKitContent */; };
 		91D745DC2B69D5470070CC18 /* MSAL_Test_App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D745DB2B69D5470070CC18 /* MSAL_Test_App.swift */; };
 		91D745DE2B69D5470070CC18 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D745DD2B69D5470070CC18 /* ContentView.swift */; };
@@ -504,7 +518,6 @@
 		91D745EA2B69D8D90070CC18 /* MSALTestAppVisionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D745E82B69D8D30070CC18 /* MSALTestAppVisionViewController.swift */; };
 		91D745EC2B69D9300070CC18 /* MSAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 919BDFD32B633E8800DA8C53 /* MSAL.framework */; };
 		91D745ED2B69D9300070CC18 /* MSAL.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 919BDFD32B633E8800DA8C53 /* MSAL.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		91D745F22B6A1D320070CC18 /* MSALTestAppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D745F12B6A1D320070CC18 /* MSALTestAppView.swift */; };
 		91D745F32B6A1DA30070CC18 /* MSALTestAppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D745F12B6A1D320070CC18 /* MSALTestAppView.swift */; };
 		94E876CE1E492D6000FB96ED /* MSALAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 94E876CB1E492D6000FB96ED /* MSALAuthority.m */; };
 		960751BB2183E82C00F2BF2F /* MSALAccountIdTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 960751BA2183E82C00F2BF2F /* MSALAccountIdTests.m */; };
@@ -1394,6 +1407,13 @@
 			remoteGlobalIDString = D65A6F421E3FD30A00C69FBA;
 			remoteInfo = "MSAL (iOS Framework)";
 		};
+		6DD793B12B8D4397002BA788 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D6A206191FC50A4D00755A51 /* IdentityCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 917A6EB42B6332CD005D855F;
+			remoteInfo = "IdentityCore visionOS";
+		};
 		919BDFDC2B633E8800DA8C53 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D6A206191FC50A4D00755A51 /* IdentityCore.xcodeproj */;
@@ -1802,6 +1822,43 @@
 		609AF9322256BD0C00E2978D /* MSALAccountsProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAccountsProviderTests.m; sourceTree = "<group>"; };
 		609AF958225B348900E2978D /* MSALTenantProfile+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSALTenantProfile+Internal.h"; sourceTree = "<group>"; };
 		60DEF15A1E67756800966664 /* MSAL Test App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = "MSAL Test App.entitlements"; path = "../../../../MSAL Test App.entitlements"; sourceTree = "<group>"; };
+		6DD793952B8D390E002BA788 /* msal__unit_test_host__vision.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = msal__unit_test_host__vision.xcconfig; sourceTree = "<group>"; };
+		6DD793962B8D390E002BA788 /* msal__test_app__vision.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = msal__test_app__vision.xcconfig; sourceTree = "<group>"; };
+		6DD793972B8D390E002BA788 /* msal__ui_test__vision.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = msal__ui_test__vision.xcconfig; sourceTree = "<group>"; };
+		6DD793982B8D390E002BA788 /* msal__automation_app__vision.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = msal__automation_app__vision.xcconfig; sourceTree = "<group>"; };
+		6DD793992B8D390E002BA788 /* msal__common__framework__vision.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = msal__common__framework__vision.xcconfig; sourceTree = "<group>"; };
+		6DD7939A2B8D390E002BA788 /* msal__common__vision.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = msal__common__vision.xcconfig; sourceTree = "<group>"; };
+		6DD7939B2B8D390E002BA788 /* msal__framework__vision.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = msal__framework__vision.xcconfig; sourceTree = "<group>"; };
+		6DD7939C2B8D390E002BA788 /* msal__unit_test__vision.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = msal__unit_test__vision.xcconfig; sourceTree = "<group>"; };
+		6DD7939D2B8D390E002BA788 /* msal__static__lib__vision.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = msal__static__lib__vision.xcconfig; sourceTree = "<group>"; };
+		6DF3FDC72B8DAE5A002A9FE6 /* MSAL_Framework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSAL_Framework.h; sourceTree = "<group>"; };
+		6DF3FEAE2B8DD81E002A9FE6 /* MSIDTokenCacheItem+Automation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSIDTokenCacheItem+Automation.m"; sourceTree = "<group>"; };
+		6DF3FEAF2B8DD81E002A9FE6 /* MSALResult+Automation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSALResult+Automation.m"; sourceTree = "<group>"; };
+		6DF3FEB02B8DD81E002A9FE6 /* MSALUser+Automation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MSALUser+Automation.m"; sourceTree = "<group>"; };
+		6DF3FEB12B8DD81E002A9FE6 /* MSIDTokenCacheItem+Automation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSIDTokenCacheItem+Automation.h"; sourceTree = "<group>"; };
+		6DF3FEB22B8DD81E002A9FE6 /* MSALUser+Automation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSALUser+Automation.h"; sourceTree = "<group>"; };
+		6DF3FEB32B8DD81E002A9FE6 /* MSALResult+Automation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSALResult+Automation.h"; sourceTree = "<group>"; };
+		6DF3FEB42B8DD81E002A9FE6 /* MSALAutoAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAutoAppDelegate.m; sourceTree = "<group>"; };
+		6DF3FEB62B8DD81E002A9FE6 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		6DF3FEB72B8DD81E002A9FE6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6DF3FEB82B8DD81E002A9FE6 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		6DF3FEBA2B8DD81E002A9FE6 /* MSALAutomationReadAccountsAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALAutomationReadAccountsAction.h; sourceTree = "<group>"; };
+		6DF3FEBB2B8DD81E002A9FE6 /* MSALAutomationExpireATAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALAutomationExpireATAction.h; sourceTree = "<group>"; };
+		6DF3FEBC2B8DD81E002A9FE6 /* MSALAutomationRemoveAccountAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALAutomationRemoveAccountAction.h; sourceTree = "<group>"; };
+		6DF3FEBD2B8DD81E002A9FE6 /* MSALAutomationInvalidateRTAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAutomationInvalidateRTAction.m; sourceTree = "<group>"; };
+		6DF3FEBE2B8DD81E002A9FE6 /* MSALAutomationAcquireTokenSilentAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALAutomationAcquireTokenSilentAction.h; sourceTree = "<group>"; };
+		6DF3FEBF2B8DD81E002A9FE6 /* MSALAutomationAcquireTokenAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALAutomationAcquireTokenAction.h; sourceTree = "<group>"; };
+		6DF3FEC02B8DD81E002A9FE6 /* MSALAutomationBaseAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAutomationBaseAction.m; sourceTree = "<group>"; };
+		6DF3FEC12B8DD81E002A9FE6 /* MSALAutomationExpireATAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAutomationExpireATAction.m; sourceTree = "<group>"; };
+		6DF3FEC22B8DD81E002A9FE6 /* MSALAutomationReadAccountsAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAutomationReadAccountsAction.m; sourceTree = "<group>"; };
+		6DF3FEC32B8DD81E002A9FE6 /* MSALAutomationAcquireTokenSilentAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAutomationAcquireTokenSilentAction.m; sourceTree = "<group>"; };
+		6DF3FEC42B8DD81E002A9FE6 /* MSALAutomationAcquireTokenAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAutomationAcquireTokenAction.m; sourceTree = "<group>"; };
+		6DF3FEC52B8DD81E002A9FE6 /* MSALAutomationInvalidateRTAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALAutomationInvalidateRTAction.h; sourceTree = "<group>"; };
+		6DF3FEC62B8DD81E002A9FE6 /* MSALAutomationRemoveAccountAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAutomationRemoveAccountAction.m; sourceTree = "<group>"; };
+		6DF3FEC72B8DD81E002A9FE6 /* MSALAutomationBaseAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALAutomationBaseAction.h; sourceTree = "<group>"; };
+		6DF3FEC82B8DD81E002A9FE6 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		6DF3FEC92B8DD81E002A9FE6 /* MSALAutomation.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MSALAutomation.entitlements; sourceTree = "<group>"; };
+		6DF3FECA2B8DD81E002A9FE6 /* MSALAutoAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALAutoAppDelegate.h; sourceTree = "<group>"; };
 		886F515729CCA50300F09471 /* MSALCIAMAuthority.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALCIAMAuthority.h; sourceTree = "<group>"; };
 		886F516329CCA58900F09471 /* MSALCIAMAuthority.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALCIAMAuthority.m; sourceTree = "<group>"; };
 		88A25ED229E7185B00066311 /* MSALCIAMAuthorityTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALCIAMAuthorityTests.m; sourceTree = "<group>"; };
@@ -1811,9 +1868,8 @@
 		8D61F9A02A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequestableTests.swift; sourceTree = "<group>"; };
 		8DDF473E2A98FE1C00126A47 /* MSALNativeAuthRequiredAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequiredAttribute.swift; sourceTree = "<group>"; };
 		919BDFD32B633E8800DA8C53 /* MSAL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MSAL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		919BDFDE2B633E8800DA8C53 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "/Users/mihai/Documents/code/broker_visionOS/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks/microsoft-authentication-library-for-objc/MSAL/Info.plist"; sourceTree = "<absolute>"; };
+		919BDFDE2B633E8800DA8C53 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		91D745D52B69D5470070CC18 /* MSAL Test App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MSAL Test App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		91D745D82B69D5470070CC18 /* RealityKitContent */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RealityKitContent; sourceTree = "<group>"; };
 		91D745DB2B69D5470070CC18 /* MSAL_Test_App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSAL_Test_App.swift; sourceTree = "<group>"; };
 		91D745DD2B69D5470070CC18 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		91D745DF2B69D54B0070CC18 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -2423,8 +2479,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				919BDFC82B633E8800DA8C53 /* AuthenticationServices.framework in Frameworks */,
-				919BDFDF2B633F0B00DA8C53 /* libIdentityCore visionOS.a in Frameworks */,
 				919BDFC92B633E8800DA8C53 /* WebKit.framework in Frameworks */,
+				6DD793B32B8D43A5002BA788 /* libIdentityCore.a in Frameworks */,
 				919BDFCB2B633E8800DA8C53 /* SafariServices.framework in Frameworks */,
 				919BDFCC2B633E8800DA8C53 /* UIKit.framework in Frameworks */,
 				919BDFCD2B633E8800DA8C53 /* Security.framework in Frameworks */,
@@ -2835,6 +2891,72 @@
 			path = extension;
 			sourceTree = "<group>";
 		};
+		6DF3FDC62B8DAE5A002A9FE6 /* MSAL Framework */ = {
+			isa = PBXGroup;
+			children = (
+				6DF3FDC72B8DAE5A002A9FE6 /* MSAL_Framework.h */,
+			);
+			path = "MSAL Framework";
+			sourceTree = "<group>";
+		};
+		6DF3FEAC2B8DD81E002A9FE6 /* vision */ = {
+			isa = PBXGroup;
+			children = (
+				6DF3FEAD2B8DD81E002A9FE6 /* util */,
+				6DF3FEB42B8DD81E002A9FE6 /* MSALAutoAppDelegate.m */,
+				6DF3FEB52B8DD81E002A9FE6 /* resources */,
+				6DF3FEB82B8DD81E002A9FE6 /* main.m */,
+				6DF3FEB92B8DD81E002A9FE6 /* actions */,
+				6DF3FEC82B8DD81E002A9FE6 /* Launch Screen.storyboard */,
+				6DF3FEC92B8DD81E002A9FE6 /* MSALAutomation.entitlements */,
+				6DF3FECA2B8DD81E002A9FE6 /* MSALAutoAppDelegate.h */,
+			);
+			path = vision;
+			sourceTree = "<group>";
+		};
+		6DF3FEAD2B8DD81E002A9FE6 /* util */ = {
+			isa = PBXGroup;
+			children = (
+				6DF3FEAE2B8DD81E002A9FE6 /* MSIDTokenCacheItem+Automation.m */,
+				6DF3FEAF2B8DD81E002A9FE6 /* MSALResult+Automation.m */,
+				6DF3FEB02B8DD81E002A9FE6 /* MSALUser+Automation.m */,
+				6DF3FEB12B8DD81E002A9FE6 /* MSIDTokenCacheItem+Automation.h */,
+				6DF3FEB22B8DD81E002A9FE6 /* MSALUser+Automation.h */,
+				6DF3FEB32B8DD81E002A9FE6 /* MSALResult+Automation.h */,
+			);
+			path = util;
+			sourceTree = "<group>";
+		};
+		6DF3FEB52B8DD81E002A9FE6 /* resources */ = {
+			isa = PBXGroup;
+			children = (
+				6DF3FEB62B8DD81E002A9FE6 /* Images.xcassets */,
+				6DF3FEB72B8DD81E002A9FE6 /* Info.plist */,
+			);
+			path = resources;
+			sourceTree = "<group>";
+		};
+		6DF3FEB92B8DD81E002A9FE6 /* actions */ = {
+			isa = PBXGroup;
+			children = (
+				6DF3FEBA2B8DD81E002A9FE6 /* MSALAutomationReadAccountsAction.h */,
+				6DF3FEBB2B8DD81E002A9FE6 /* MSALAutomationExpireATAction.h */,
+				6DF3FEBC2B8DD81E002A9FE6 /* MSALAutomationRemoveAccountAction.h */,
+				6DF3FEBD2B8DD81E002A9FE6 /* MSALAutomationInvalidateRTAction.m */,
+				6DF3FEBE2B8DD81E002A9FE6 /* MSALAutomationAcquireTokenSilentAction.h */,
+				6DF3FEBF2B8DD81E002A9FE6 /* MSALAutomationAcquireTokenAction.h */,
+				6DF3FEC02B8DD81E002A9FE6 /* MSALAutomationBaseAction.m */,
+				6DF3FEC12B8DD81E002A9FE6 /* MSALAutomationExpireATAction.m */,
+				6DF3FEC22B8DD81E002A9FE6 /* MSALAutomationReadAccountsAction.m */,
+				6DF3FEC32B8DD81E002A9FE6 /* MSALAutomationAcquireTokenSilentAction.m */,
+				6DF3FEC42B8DD81E002A9FE6 /* MSALAutomationAcquireTokenAction.m */,
+				6DF3FEC52B8DD81E002A9FE6 /* MSALAutomationInvalidateRTAction.h */,
+				6DF3FEC62B8DD81E002A9FE6 /* MSALAutomationRemoveAccountAction.m */,
+				6DF3FEC72B8DD81E002A9FE6 /* MSALAutomationBaseAction.h */,
+			);
+			path = actions;
+			sourceTree = "<group>";
+		};
 		919BDFE02B633F4400DA8C53 /* vision */ = {
 			isa = PBXGroup;
 			children = (
@@ -2854,14 +2976,6 @@
 				91D745F12B6A1D320070CC18 /* MSALTestAppView.swift */,
 			);
 			path = vision;
-			sourceTree = "<group>";
-		};
-		91D745D72B69D5470070CC18 /* Packages */ = {
-			isa = PBXGroup;
-			children = (
-				91D745D82B69D5470070CC18 /* RealityKitContent */,
-			);
-			path = Packages;
 			sourceTree = "<group>";
 		};
 		91D745E12B69D54B0070CC18 /* Preview Content */ = {
@@ -2968,6 +3082,7 @@
 			children = (
 				B2BB737F2112C351000EA4C5 /* tests */,
 				962E37BF1E720E4F00DE71FE /* ios */,
+				6DF3FEAC2B8DD81E002A9FE6 /* vision */,
 			);
 			path = automation;
 			sourceTree = "<group>";
@@ -3575,23 +3690,32 @@
 		D65A6FBC1E3FF46100C69FBA /* xcconfig */ = {
 			isa = PBXGroup;
 			children = (
+				6DD793982B8D390E002BA788 /* msal__automation_app__vision.xcconfig */,
+				6DD793992B8D390E002BA788 /* msal__common__framework__vision.xcconfig */,
+				6DD7939A2B8D390E002BA788 /* msal__common__vision.xcconfig */,
+				6DD7939B2B8D390E002BA788 /* msal__framework__vision.xcconfig */,
+				6DD7939D2B8D390E002BA788 /* msal__static__lib__vision.xcconfig */,
+				6DD793962B8D390E002BA788 /* msal__test_app__vision.xcconfig */,
+				6DD793972B8D390E002BA788 /* msal__ui_test__vision.xcconfig */,
+				6DD7939C2B8D390E002BA788 /* msal__unit_test__vision.xcconfig */,
+				6DD793952B8D390E002BA788 /* msal__unit_test_host__vision.xcconfig */,
 				962E37A51E720B7E00DE71FE /* msal__automation_app__ios.xcconfig */,
-				D65A6FEE1E400B1100C69FBA /* msal__common.xcconfig */,
-				D65A6FE61E3FFFD300C69FBA /* msal__common__ios.xcconfig */,
 				D65A6FF21E40270600C69FBA /* msal__common__framework__ios.xcconfig */,
+				D65A6FE61E3FFFD300C69FBA /* msal__common__ios.xcconfig */,
+				D65A6FE71E40002800C69FBA /* msal__framework__ios.xcconfig */,
+				04A6B584226921CD0035C7C2 /* msal__static__lib__ios.xcconfig */,
+				D61A64661E5AA6B40086D120 /* msal__test_app__ios.xcconfig */,
+				B2BB73962112C4B3000EA4C5 /* msal__ui_test__ios.xcconfig */,
+				D65A6FE91E40002800C69FBA /* msal__unit_test__ios.xcconfig */,
+				D67227BC1EBD302800F3422A /* msal__unit_test_host__ios.xcconfig */,
 				D65A6FEF1E4024C800C69FBA /* msal__common__framework__mac.xcconfig */,
 				D65A6FEA1E40002800C69FBA /* msal__common__mac.xcconfig */,
-				D65A6FF01E4026B900C69FBA /* msal__debug.xcconfig */,
-				D65A6FE71E40002800C69FBA /* msal__framework__ios.xcconfig */,
 				D65A6FEB1E40002800C69FBA /* msal__framework__mac.xcconfig */,
-				04A6B584226921CD0035C7C2 /* msal__static__lib__ios.xcconfig */,
 				04A6B585226921CD0035C7C2 /* msal__static__lib__mac.xcconfig */,
-				D61A64661E5AA6B40086D120 /* msal__test_app__ios.xcconfig */,
 				D61A64671E5AA6BE0086D120 /* msal__test_app__mac.xcconfig */,
-				D65A6FE91E40002800C69FBA /* msal__unit_test__ios.xcconfig */,
-				B2BB73962112C4B3000EA4C5 /* msal__ui_test__ios.xcconfig */,
 				D65A6FEC1E40002800C69FBA /* msal__unit_test__mac.xcconfig */,
-				D67227BC1EBD302800F3422A /* msal__unit_test_host__ios.xcconfig */,
+				D65A6FEE1E400B1100C69FBA /* msal__common.xcconfig */,
+				D65A6FF01E4026B900C69FBA /* msal__debug.xcconfig */,
 				D65A6FF11E4026C000C69FBA /* msal__release.xcconfig */,
 			);
 			path = xcconfig;
@@ -3725,6 +3849,7 @@
 			children = (
 				D6A206231FC50A4D00755A51 /* libIdentityCore.a */,
 				D6A206251FC50A4D00755A51 /* libIdentityCore.a */,
+				919BDFDD2B633E8800DA8C53 /* libIdentityCore.a */,
 				D6A206271FC50A4D00755A51 /* libIdentityTest.a */,
 				D6A206291FC50A4D00755A51 /* libIdentityTest.a */,
 				D6A2062B1FC50A4D00755A51 /* IdentityCoreTests.xctest */,
@@ -3735,7 +3860,6 @@
 				B21FA9BC2204DC5700806B68 /* libIdentityAutomationTestLib iOS.a */,
 				B21FA9BE2204DC5700806B68 /* libIdentityAutomationTestLib Mac.a */,
 				E7A6569624FEE45300931BAE /* libIdentityCoreSwift.a */,
-				919BDFDD2B633E8800DA8C53 /* libIdentityCore visionOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3774,7 +3898,7 @@
 				D61F5B691E53FCA100912CB8 /* test */,
 				D65A6FB71E3FF44A00C69FBA /* resources */,
 				D65A6FBC1E3FF46100C69FBA /* xcconfig */,
-				91D745D72B69D5470070CC18 /* Packages */,
+				6DF3FDC62B8DAE5A002A9FE6 /* MSAL Framework */,
 				D6DFF3A31E2579360012891A /* Products */,
 				D6A2062E1FC5106F00755A51 /* Frameworks */,
 				D6A206191FC50A4D00755A51 /* IdentityCore.xcodeproj */,
@@ -5103,6 +5227,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6DD793B22B8D4397002BA788 /* PBXTargetDependency */,
 			);
 			name = "MSAL (visionOS Framework)";
 			productName = "MSAL (Framework)";
@@ -5260,6 +5385,7 @@
 				D65A6F4C1E3FD32D00C69FBA /* Frameworks */,
 				D65A6F4D1E3FD32D00C69FBA /* Headers */,
 				D65A6F4E1E3FD32D00C69FBA /* Resources */,
+				6DF3FDEC2B8DC0AA002A9FE6 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -5366,6 +5492,9 @@
 						CreatedOnToolsVersion = 14.1;
 						TestTargetID = D672279E1EBD111900F3422A;
 					};
+					6D2177E52B8D89B700C41C1C = {
+						CreatedOnToolsVersion = 15.2;
+					};
 					91D745D42B69D5470070CC18 = {
 						CreatedOnToolsVersion = 15.2;
 					};
@@ -5458,21 +5587,22 @@
 			projectRoot = "";
 			targets = (
 				D65A6F421E3FD30A00C69FBA /* MSAL (iOS Framework) */,
-				D65A6FC01E3FF47D00C69FBA /* MSAL iOS Unit Tests */,
 				D65A6F4F1E3FD32D00C69FBA /* MSAL (Mac Framework) */,
-				D65A6FCF1E3FF49C00C69FBA /* MSAL Mac Unit Tests */,
+				919BDE782B633E8800DA8C53 /* MSAL (visionOS Framework) */,
+				6D2177E52B8D89B700C41C1C /* MSAL (xcframework) */,
 				D61A64321E5A29580086D120 /* MSAL Test App (iOS) */,
+				1E614BD922558D8300EBF62F /* MSAL Test App (Mac) */,
+				91D745D42B69D5470070CC18 /* MSAL Test App (visonOS) */,
+				D65A6FC01E3FF47D00C69FBA /* MSAL iOS Unit Tests */,
+				D65A6FCF1E3FF49C00C69FBA /* MSAL Mac Unit Tests */,
 				962E37A61E720C5D00DE71FE /* MSAL Test Automation (iOS) */,
 				D672279E1EBD111900F3422A /* unit-test-host */,
 				B2BB736F2112C32C000EA4C5 /* InteractiveiOSTests */,
 				B29E2ACD21238F5200B170ED /* MultiAppiOSTests */,
-				1E614BD922558D8300EBF62F /* MSAL Test App (Mac) */,
 				04A6B57A226921890035C7C2 /* MSAL (iOS Static Library) */,
 				04A6B59B2269286F0035C7C2 /* MSAL (Mac Static Library) */,
 				B295A16322D0348400FFB313 /* unit-test-host-mac */,
 				28D1D56B29BF62E900CE75F4 /* MSAL iOS Native Auth Integration Tests */,
-				919BDE782B633E8800DA8C53 /* MSAL (visionOS Framework) */,
-				91D745D42B69D5470070CC18 /* MSAL Test App (visonOS) */,
 			);
 		};
 /* End PBXProject section */
@@ -5485,10 +5615,10 @@
 			remoteRef = 231CE9D21FEC641D00E95D3E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		919BDFDD2B633E8800DA8C53 /* libIdentityCore visionOS.a */ = {
+		919BDFDD2B633E8800DA8C53 /* libIdentityCore.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libIdentityCore visionOS.a";
+			path = libIdentityCore.a;
 			remoteRef = 919BDFDC2B633E8800DA8C53 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -5693,6 +5823,43 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		6D2177E92B8D89F700C41C1C /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 12;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\nARCHIVES_DIR=\"$PROJECT_DIR/../archives\"\necho $ARCHIVES_DIR\nfind $ARCHIVES_DIR -name '*.xcarchive' -type d -exec rm -rf {} +\nfind $ARCHIVES_DIR -name '*.xcframework' -type d -exec rm -rf {} +\n\nxcodebuild archive \\\n    -project \"MSAL.xcodeproj\" \\\n    -scheme \"MSAL (Mac Framework)\" \\\n    -configuration \"Release\" \\\n    -destination \"generic/platform=macOS\" \\\n    -archivePath \"$ARCHIVES_DIR/macOS\" \\\n    SKIP_INSTALL=NO \\\n    BUILD_LIBRARY_FOR_DISTRIBUTION=YES\n\n\nxcodebuild archive \\\n    -project \"MSAL.xcodeproj\" \\\n    -scheme \"MSAL (iOS Framework)\" \\\n    -configuration \"Release\" \\\n    -destination \"generic/platform=iOS\" \\\n    -archivePath \"$ARCHIVES_DIR/iOS\" \\\n    SKIP_INSTALL=NO \\\n    BUILD_LIBRARY_FOR_DISTRIBUTION=YES\n\nxcodebuild archive \\\n    -project \"MSAL.xcodeproj\" \\\n    -scheme \"MSAL (iOS Framework)\" \\\n    -configuration \"Release\" \\\n    -destination \"generic/platform=iOS Simulator\" \\\n    -archivePath \"$ARCHIVES_DIR/iOS-Simulator\" \\\n    SKIP_INSTALL=NO \\\n    BUILD_LIBRARY_FOR_DISTRIBUTION=YES\n\nxcodebuild archive \\\n    -project \"MSAL.xcodeproj\" \\\n    -scheme \"MSAL (visionOS Framework)\" \\\n    -configuration \"Release\" \\\n    -destination \"generic/platform=visionOS\" \\\n    -archivePath \"$ARCHIVES_DIR/visionOS\" \\\n    SKIP_INSTALL=NO \\\n    BUILD_LIBRARY_FOR_DISTRIBUTION=YES\n\nxcodebuild archive \\\n    -project \"MSAL.xcodeproj\" \\\n    -scheme \"MSAL (visionOS Framework)\" \\\n    -configuration \"Release\" \\\n    -destination \"generic/platform=visionOS Simulator\" \\\n    -archivePath \"$ARCHIVES_DIR/visionOS-Simulator\" \\\n    SKIP_INSTALL=NO \\\n    BUILD_LIBRARY_FOR_DISTRIBUTION=YES\n\nrm -rf \"$ARCHIVES_DIR/MSAL.xcframework\"\nxcodebuild -create-xcframework \\\n        -framework \"$ARCHIVES_DIR/macOS.xcarchive/Products/Library/Frameworks/MSAL.framework\" \\\n        -framework \"$ARCHIVES_DIR/iOS.xcarchive/Products/Library/Frameworks/MSAL.framework\" \\\n        -framework \"$ARCHIVES_DIR/iOS-Simulator.xcarchive/Products/Library/Frameworks/MSAL.framework\" \\\n        -framework \"$ARCHIVES_DIR/visionOS.xcarchive/Products/Library/Frameworks/MSAL.framework\" \\\n        -framework \"$ARCHIVES_DIR/visionOS-Simulator.xcarchive/Products/Library/Frameworks/MSAL.framework\" \\\n        -output \"$ARCHIVES_DIR/MSAL.xcframework\"\n        \nfind $ARCHIVES_DIR -name '*.xcarchive' -type d -exec rm -rf {} +\ncodesign --timestamp -s \"Apple Distribution\" MSAL.xcframework \ncodesign -dv MSAL.xcframework\n\nexit 0\n";
+			showEnvVarsInLog = 0;
+		};
+		6DF3FDEC2B8DC0AA002A9FE6 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
 		919BDFCF2B633E8800DA8C53 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -6278,7 +6445,6 @@
 				DEF9D989296EC26A006CB384 /* MSALNativeAuthCurrentRequestTelemetry.swift in Sources */,
 				B253151B23DD607600432133 /* MSALDeviceInformation.m in Sources */,
 				9BD2763D2A0D3DBD00FBD033 /* MSALNativeAuthResetPasswordController.swift in Sources */,
-				91D745F22B6A1D320070CC18 /* MSALTestAppView.swift in Sources */,
 				E224F7492B18F2FE000A7B2E /* SignInAfterResetPasswordError.swift in Sources */,
 				E2C61FED29DEDA9500F15203 /* MSALNativeAuthSignUpContinueOauth2ErrorCode.swift in Sources */,
 				963377C1211E14C600943EE0 /* MSALWebviewType.m in Sources */,
@@ -6701,6 +6867,11 @@
 			target = D65A6F421E3FD30A00C69FBA /* MSAL (iOS Framework) */;
 			targetProxy = 58BBA13B25C141D1007B3EF6 /* PBXContainerItemProxy */;
 		};
+		6DD793B22B8D4397002BA788 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "IdentityCore visionOS";
+			targetProxy = 6DD793B12B8D4397002BA788 /* PBXContainerItemProxy */;
+		};
 		91D745EF2B69D9300070CC18 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 919BDE782B633E8800DA8C53 /* MSAL (visionOS Framework) */;
@@ -6879,6 +7050,7 @@
 		};
 		1E614BEC22558D8300EBF62F /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D61A64671E5AA6BE0086D120 /* msal__test_app__mac.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -6951,6 +7123,7 @@
 		};
 		1E614BED22558D8300EBF62F /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D61A64671E5AA6BE0086D120 /* msal__test_app__mac.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -7168,9 +7341,25 @@
 			};
 			name = Release;
 		};
+		6D2177E72B8D89B700C41C1C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		6D2177E82B8D89B700C41C1C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		919BDFD12B633E8800DA8C53 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D65A6FE71E40002800C69FBA /* msal__framework__ios.xcconfig */;
+			baseConfigurationReference = 6DD7939B2B8D390E002BA788 /* msal__framework__vision.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -7205,7 +7394,7 @@
 		};
 		919BDFD22B633E8800DA8C53 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D65A6FE71E40002800C69FBA /* msal__framework__ios.xcconfig */;
+			baseConfigurationReference = 6DD7939B2B8D390E002BA788 /* msal__framework__vision.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -7238,6 +7427,7 @@
 		};
 		91D745E62B69D54C0070CC18 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6DD793962B8D390E002BA788 /* msal__test_app__vision.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -7319,6 +7509,7 @@
 		};
 		91D745E72B69D54C0070CC18 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6DD793962B8D390E002BA788 /* msal__test_app__vision.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -8183,6 +8374,15 @@
 			buildConfigurations = (
 				28D1D57329BF62E900CE75F4 /* Debug */,
 				28D1D57429BF62E900CE75F4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6D2177E62B8D89B700C41C1C /* Build configuration list for PBXAggregateTarget "MSAL (xcframework)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6D2177E72B8D89B700C41C1C /* Debug */,
+				6D2177E82B8D89B700C41C1C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MSAL/MSAL.xcodeproj/xcshareddata/xcschemes/MSAL (visionOS Framework).xcscheme
+++ b/MSAL/MSAL.xcodeproj/xcshareddata/xcschemes/MSAL (visionOS Framework).xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "919BDE782B633E8800DA8C53"
+               BuildableName = "MSAL.framework"
+               BlueprintName = "MSAL (visionOS Framework)"
+               ReferencedContainer = "container:MSAL.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "919BDE782B633E8800DA8C53"
+            BuildableName = "MSAL.framework"
+            BlueprintName = "MSAL (visionOS Framework)"
+            ReferencedContainer = "container:MSAL.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MSAL/MSAL.xcodeproj/xcshareddata/xcschemes/MSAL (xcframework).xcscheme
+++ b/MSAL/MSAL.xcodeproj/xcshareddata/xcschemes/MSAL (xcframework).xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6D2177E52B8D89B700C41C1C"
+               BuildableName = "MSAL (xcframework)"
+               BlueprintName = "MSAL (xcframework)"
+               ReferencedContainer = "container:MSAL.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6D2177E52B8D89B700C41C1C"
+            BuildableName = "MSAL (xcframework)"
+            BlueprintName = "MSAL (xcframework)"
+            ReferencedContainer = "container:MSAL.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MSAL/MSAL.xcodeproj/xcshareddata/xcschemes/MSAL Test App (visonOS).xcscheme
+++ b/MSAL/MSAL.xcodeproj/xcshareddata/xcschemes/MSAL Test App (visonOS).xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "91D745D42B69D5470070CC18"
+               BuildableName = "MSAL Test App.app"
+               BlueprintName = "MSAL Test App (visonOS)"
+               ReferencedContainer = "container:MSAL.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "91D745D42B69D5470070CC18"
+            BuildableName = "MSAL Test App.app"
+            BlueprintName = "MSAL Test App (visonOS)"
+            ReferencedContainer = "container:MSAL.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "91D745D42B69D5470070CC18"
+            BuildableName = "MSAL Test App.app"
+            BlueprintName = "MSAL Test App (visonOS)"
+            ReferencedContainer = "container:MSAL.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MSAL/resources/vision/Info.plist
+++ b/MSAL/resources/vision/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.2.21</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/MSAL/test/automation/vision/Launch Screen.storyboard
+++ b/MSAL/test/automation/vision/Launch Screen.storyboard
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright © 2017 Microsoft. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MSAL" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="centerX" secondItem="obG-Y5-kRd" secondAttribute="centerX" id="5cz-MP-9tL"/>
+                            <constraint firstAttribute="centerX" secondItem="GJd-Yh-RWb" secondAttribute="centerX" id="Q3B-4B-g5h"/>
+                            <constraint firstItem="obG-Y5-kRd" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" constant="20" symbolic="YES" id="SfN-ll-jLj"/>
+                            <constraint firstAttribute="bottom" secondItem="obG-Y5-kRd" secondAttribute="bottom" constant="20" id="Y44-ml-fuU"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="bottom" multiplier="1/3" constant="1" id="moa-c2-u7t"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" constant="20" symbolic="YES" id="x7j-FC-K8j"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/MSAL/test/automation/vision/MSALAutoAppDelegate.h
+++ b/MSAL/test/automation/vision/MSALAutoAppDelegate.h
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <UIKit/UIKit.h>
+
+@interface MSALAutoAppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/MSAL/test/automation/vision/MSALAutoAppDelegate.m
+++ b/MSAL/test/automation/vision/MSALAutoAppDelegate.m
@@ -1,0 +1,92 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALAutoAppDelegate.h"
+#import "MSALPublicClientApplication.h"
+#import "MSIDAutomationMainViewController.h"
+#import <MSAL/MSAL.h>
+
+@implementation MSALAutoAppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+    (void)application;
+    (void)launchOptions;
+    [MSALGlobalConfig.loggerConfig setLogCallback:^(__unused MSALLogLevel level, NSString * _Nullable message, __unused BOOL containsPII) {
+        [MSIDAutomationMainViewController forwardIdentitySDKLog:message];
+    }];
+    
+    return YES;
+}
+							
+- (void)applicationWillResignActive:(UIApplication *)application
+{
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+    
+    (void)application;
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later. 
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    
+    (void)application;
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application
+{
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+    
+    (void)application;
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application
+{
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    
+    (void)application;
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application
+{
+    (void)application;
+}
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options
+{
+    (void)app;
+    (void)options;
+    
+    [MSALPublicClientApplication handleMSALResponse:url sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]];
+   
+    return YES;
+}
+
+
+@end

--- a/MSAL/test/automation/vision/MSALAutomation.entitlements
+++ b/MSAL/test/automation/vision/MSALAutomation.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.microsoft.MSALAutomationApp</string>
+		<string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
+		<string>$(AppIdentifierPrefix)com.microsoft.workplacejoin</string>
+	</array>
+</dict>
+</plist>

--- a/MSAL/test/automation/vision/actions/MSALAutomationAcquireTokenAction.h
+++ b/MSAL/test/automation/vision/actions/MSALAutomationAcquireTokenAction.h
@@ -1,0 +1,37 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import "MSALAutomationBaseAction.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALAutomationAcquireTokenAction : MSALAutomationBaseAction
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/test/automation/vision/actions/MSALAutomationAcquireTokenAction.m
+++ b/MSAL/test/automation/vision/actions/MSALAutomationAcquireTokenAction.m
@@ -1,0 +1,201 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALAutomationAcquireTokenAction.h"
+#import "MSIDAutomation.h"
+#import "MSIDAutomationTestResult.h"
+#import <MSAL/MSAL.h>
+#import "NSOrderedSet+MSIDExtensions.h"
+#import "MSIDAutomationMainViewController.h"
+#import "MSIDAutomationTestRequest.h"
+#import "MSIDAutomationActionConstants.h"
+#import "MSIDAutomationActionManager.h"
+#import "MSIDAutomationPassedInWebViewController.h"
+#import "MSALInteractiveTokenParameters.h"
+#import "MSALClaimsRequest.h"
+#import "MSALWebviewParameters.h"
+#import "MSIDCertAuthHandler.h"
+
+@implementation MSALAutomationAcquireTokenAction
+
++ (void)load
+{
+    [[MSIDAutomationActionManager sharedInstance] registerAction:[MSALAutomationAcquireTokenAction new]];
+    [MSIDAutomationPassedInWebViewController setCancelTappedCallback:^{
+        [MSALPublicClientApplication cancelCurrentWebAuthSession];
+    }];
+}
+
+- (NSString *)actionIdentifier
+{
+    return MSID_AUTO_ACQUIRE_TOKEN_ACTION_IDENTIFIER;
+}
+
+- (BOOL)needsRequestParameters
+{
+    return YES;
+}
+
+- (void)performActionWithParameters:(MSIDAutomationTestRequest *)testRequest
+                containerController:(MSIDAutomationMainViewController *)containerController
+                    completionBlock:(MSIDAutoCompletionBlock)completionBlock
+{
+    NSError *applicationError = nil;
+    MSALPublicClientApplication *application = [self applicationWithParameters:testRequest error:&applicationError];
+
+    if (!application)
+    {
+        MSIDAutomationTestResult *result = [self testResultWithMSALError:applicationError];
+        completionBlock(result);
+        return;
+    }
+
+    NSError *accountError = nil;
+    MSALAccount *account = [self accountWithParameters:testRequest application:application error:&accountError];
+
+    if (accountError)
+    {
+        MSIDAutomationTestResult *result = [self testResultWithMSALError:applicationError];
+        completionBlock(result);
+        return;
+    }
+
+    NSOrderedSet *scopes = [NSOrderedSet msidOrderedSetFromString:testRequest.requestScopes];
+    NSOrderedSet *extraScopes = [NSOrderedSet msidOrderedSetFromString:testRequest.extraScopes];
+    NSUUID *correlationId = [NSUUID new];
+    
+    MSALClaimsRequest *claimsRequest = nil;
+    
+    if (testRequest.claims.length)
+    {
+        NSError *claimsError;
+        claimsRequest = [[MSALClaimsRequest alloc] initWithJsonString:testRequest.claims error:&claimsError];
+        if (claimsError)
+        {
+            MSIDAutomationTestResult *result = [self testResultWithMSALError:claimsError];
+            completionBlock(result);
+            return;
+        }
+    }
+    
+    NSDictionary *extraQueryParameters = testRequest.extraQueryParameters;
+
+    MSALPromptType promptType = MSALPromptTypeDefault;
+
+    if ([testRequest.promptBehavior isEqualToString:@"force"])
+    {
+        promptType = MSALPromptTypeLogin;
+    }
+    else if ([testRequest.promptBehavior isEqualToString:@"consent"])
+    {
+        promptType = MSALPromptTypeConsent;
+    }
+    else if ([testRequest.promptBehavior isEqualToString:@"create"])
+    {
+        promptType = MSALPromptTypeCreate;
+    }
+    else if ([testRequest.promptBehavior isEqualToString:@"prompt_if_necessary"])
+    {
+        promptType = MSALPromptTypePromptIfNecessary;
+    }
+    else if ([testRequest.promptBehavior isEqualToString:@"select_account"])
+    {
+        promptType = MSALPromptTypeSelectAccount;
+    }
+
+    MSALAuthority *acquireTokenAuthority = nil;
+
+    if (testRequest.acquireTokenAuthority)
+    {
+        NSURL *authorityUrl = [[NSURL alloc] initWithString:testRequest.acquireTokenAuthority];
+        acquireTokenAuthority = [MSALAuthority authorityWithURL:authorityUrl error:nil];
+    }
+    
+    UIViewController *parentController = containerController;
+    
+    if (containerController.presentedViewController)
+    {
+        parentController = containerController.presentedViewController;
+    }
+    
+    MSALWebviewParameters *webviewParameters= [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:parentController];
+    
+    MSIDWebviewType webviewSelection = testRequest.webViewType;
+    
+    switch (webviewSelection) {
+        case MSIDWebviewTypeWKWebView:
+            webviewParameters.webviewType = MSALWebviewTypeWKWebView;
+            break;
+            
+        case MSIDWebviewTypeDefault:
+            webviewParameters.webviewType = MSALWebviewTypeDefault;
+            break;
+            
+        case MSIDWebviewTypeSafariViewController:
+            webviewParameters.webviewType = MSALWebviewTypeSafariViewController;
+            break;
+            
+        case MSIDWebviewTypeAuthenticationSession:
+            webviewParameters.webviewType = MSALWebviewTypeAuthenticationSession;
+            break;
+            
+        default:
+            break;
+    }
+    
+    if (testRequest.usePassedWebView)
+    {
+        webviewParameters.webviewType = MSALWebviewTypeWKWebView;
+        webviewParameters.customWebview = containerController.passedinWebView;
+        [containerController showPassedInWebViewControllerWithContext:@{@"context": application}];
+        webviewParameters.parentViewController = containerController;
+    }
+    
+    if (testRequest.disableCertBasedAuth)
+    {
+        [[MSIDCertAuthHandler class] performSelector:@selector(disableCertBasedAuth)];
+    }
+    
+    MSALInteractiveTokenParameters *parameters = [[MSALInteractiveTokenParameters alloc] initWithScopes:scopes.array
+                                                                                          webviewParameters:webviewParameters];
+    parameters.extraScopesToConsent = extraScopes.array;
+    parameters.account = account;
+    parameters.loginHint = testRequest.loginHint;
+    parameters.promptType = promptType;
+    parameters.extraQueryParameters = extraQueryParameters;
+    parameters.claimsRequest = claimsRequest;
+    parameters.authority = acquireTokenAuthority;
+    parameters.correlationId = correlationId;
+        
+    [application acquireTokenWithParameters:parameters completionBlock:^(MSALResult *result, NSError *error)
+     {
+         MSIDAutomationTestResult *testResult = [self testResultWithMSALResult:result error:error];
+         completionBlock(testResult);
+     }];
+}
+
+@end

--- a/MSAL/test/automation/vision/actions/MSALAutomationAcquireTokenSilentAction.h
+++ b/MSAL/test/automation/vision/actions/MSALAutomationAcquireTokenSilentAction.h
@@ -1,0 +1,37 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import "MSALAutomationBaseAction.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALAutomationAcquireTokenSilentAction : MSALAutomationBaseAction
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/test/automation/vision/actions/MSALAutomationAcquireTokenSilentAction.m
+++ b/MSAL/test/automation/vision/actions/MSALAutomationAcquireTokenSilentAction.m
@@ -1,0 +1,133 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALAutomationAcquireTokenSilentAction.h"
+#import "MSIDAutomationTestRequest.h"
+#import "MSALAuthority.h"
+#import "MSALPublicClientApplication.h"
+#import "MSIDAutomationActionConstants.h"
+#import "MSIDAutomationActionManager.h"
+#import "MSIDAutomationTestResult.h"
+#import "MSIDAutomationErrorResult.h"
+#import "MSALSilentTokenParameters.h"
+#import "MSALError.h"
+#import "MSALClaimsRequest.h"
+
+@implementation MSALAutomationAcquireTokenSilentAction
+
++ (void)load
+{
+    [[MSIDAutomationActionManager sharedInstance] registerAction:[MSALAutomationAcquireTokenSilentAction new]];
+}
+
+- (NSString *)actionIdentifier
+{
+    return MSID_AUTO_ACQUIRE_TOKEN_SILENT_ACTION_IDENTIFIER;
+}
+
+- (BOOL)needsRequestParameters
+{
+    return YES;
+}
+
+- (void)performActionWithParameters:(MSIDAutomationTestRequest *)testRequest
+                containerController:(__unused MSIDAutoViewController *)containerController
+                    completionBlock:(MSIDAutoCompletionBlock)completionBlock
+{
+    NSError *applicationError = nil;
+    MSALPublicClientApplication *application = [self applicationWithParameters:testRequest error:nil];
+
+    if (!application)
+    {
+        MSIDAutomationTestResult *result = [self testResultWithMSALError:applicationError];
+        completionBlock(result);
+        return;
+    }
+
+    NSError *accountError = nil;
+    MSALAccount *account = [self accountWithParameters:testRequest application:application error:&accountError];
+
+    if (!account)
+    {
+        MSIDAutomationTestResult *result = nil;
+
+        if (accountError)
+        {
+            result = [self testResultWithMSALError:accountError];
+        }
+        else
+        {
+            NSError *error = MSIDCreateError(MSALErrorDomain, MSALErrorInteractionRequired, @"no account", nil, nil, nil, nil, nil, YES);
+
+            result = [[MSIDAutomationErrorResult alloc] initWithAction:self.actionIdentifier
+                                                                 error:error
+                                                        additionalInfo:nil];
+        }
+
+        completionBlock(result);
+        return;
+    }
+
+    NSOrderedSet *scopes = [NSOrderedSet msidOrderedSetFromString:testRequest.requestScopes];
+    BOOL forceRefresh = testRequest.forceRefresh;
+    NSUUID *correlationId = [NSUUID new];
+
+    MSALAuthority *silentAuthority = nil;
+
+    if (testRequest.acquireTokenAuthority)
+    {
+        // In case we want to pass a different authority to silent call, we can use "silent authority" parameter
+        silentAuthority = [MSALAuthority authorityWithURL:[NSURL URLWithString:testRequest.acquireTokenAuthority] error:nil];
+    }
+    
+    MSALClaimsRequest *claimsRequest = nil;
+    
+    if (testRequest.claims.length)
+    {
+        NSError *claimsError;
+        claimsRequest = [[MSALClaimsRequest alloc] initWithJsonString:testRequest.claims error:&claimsError];
+        if (claimsError)
+        {
+            MSIDAutomationTestResult *result = [self testResultWithMSALError:claimsError];
+            completionBlock(result);
+            return;
+        }
+    }
+    
+    MSALSilentTokenParameters *parameters = [[MSALSilentTokenParameters alloc] initWithScopes:[scopes array] account:account];
+    parameters.authority = silentAuthority;
+    parameters.forceRefresh = forceRefresh;
+    parameters.correlationId = correlationId;
+    parameters.completionBlockQueue = dispatch_get_main_queue();
+    [application acquireTokenSilentWithParameters:parameters completionBlock:^(MSALResult *result, NSError *error)
+     {
+        MSIDAutomationTestResult *testResult = [self testResultWithMSALResult:result error:error];
+        completionBlock(testResult);
+     }];
+}
+
+@end

--- a/MSAL/test/automation/vision/actions/MSALAutomationBaseAction.h
+++ b/MSAL/test/automation/vision/actions/MSALAutomationBaseAction.h
@@ -1,0 +1,60 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import "MSIDAutomationTestAction.h"
+
+@class MSALPublicClientApplication;
+@class MSIDAutomationTestResult;
+@class MSALAccount;
+@class MSALResult;
+@class MSIDAutomationTestRequest;
+@class MSIDLegacyTokenCacheAccessor;
+@class MSIDDefaultTokenCacheAccessor;
+@class MSIDAccountCredentialCache;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALAutomationBaseAction : NSObject <MSIDAutomationTestAction>
+
+@property (nonatomic, strong) MSIDLegacyTokenCacheAccessor *legacyAccessor;
+@property (nonatomic, strong) MSIDDefaultTokenCacheAccessor *defaultAccessor;
+@property (nonatomic, strong) MSIDAccountCredentialCache *accountCredentialCache;
+
+- (MSALPublicClientApplication *)applicationWithParameters:(MSIDAutomationTestRequest *)parameters
+                                                     error:(NSError **)error;
+
+- (MSIDAutomationTestResult *)testResultWithMSALError:(NSError *)error;
+- (MSIDAutomationTestResult *)testResultWithMSALResult:(MSALResult *)msalResult error:(NSError *)error;
+
+- (MSALAccount *)accountWithParameters:(MSIDAutomationTestRequest *)parameters
+                           application:(MSALPublicClientApplication *)application
+                                 error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/test/automation/vision/actions/MSALAutomationBaseAction.m
+++ b/MSAL/test/automation/vision/actions/MSALAutomationBaseAction.m
@@ -1,0 +1,173 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALAutomationBaseAction.h"
+#import <MSAL/MSAL.h>
+#import "MSIDAutomationTestRequest.h"
+#import "MSIDLegacyTokenCacheAccessor.h"
+#import "MSIDDefaultTokenCacheAccessor.h"
+#import "MSIDAccountCredentialCache.h"
+#import "MSIDKeychainTokenCache.h"
+#import "MSIDAutomationTestResult.h"
+#import "MSALResult+Automation.h"
+#import "MSIDAutomationErrorResult.h"
+#import "MSIDAutomationSuccessResult.h"
+#import "MSALAccount.h"
+#import "MSALAccount+Internal.h"
+#import "MSALTenantProfile.h"
+#import "MSALSliceConfig.h"
+
+@implementation MSALAutomationBaseAction
+
+#pragma mark - Init
+
+- (instancetype)init
+{
+    self = [super init];
+
+    if (self)
+    {
+        self.legacyAccessor = [[MSIDLegacyTokenCacheAccessor alloc] initWithDataSource:MSIDKeychainTokenCache.defaultKeychainCache otherCacheAccessors:nil];
+        self.defaultAccessor = [[MSIDDefaultTokenCacheAccessor alloc] initWithDataSource:MSIDKeychainTokenCache.defaultKeychainCache otherCacheAccessors:@[self.legacyAccessor]];
+        self.accountCredentialCache = [[MSIDAccountCredentialCache alloc] initWithDataSource:MSIDKeychainTokenCache.defaultKeychainCache];
+    }
+
+    return self;
+}
+
+#pragma mark - MSIDAutomationTestAction
+
+- (NSString *)actionIdentifier
+{
+    return @"base_action";
+}
+
+- (BOOL)needsRequestParameters
+{
+    return NO;
+}
+
+- (void)performActionWithParameters:(__unused MSIDAutomationTestRequest *)parameters
+                containerController:(__unused MSIDAutomationMainViewController *)containerController
+                    completionBlock:(__unused MSIDAutoCompletionBlock)completionBlock
+{
+    NSAssert(NO, @"Abstract method, it should never be called!");
+}
+
+#pragma mark - Helpers
+
+- (MSALPublicClientApplication *)applicationWithParameters:(MSIDAutomationTestRequest *)parameters
+                                                     error:(NSError **)error
+{
+    BOOL validateAuthority = parameters.validateAuthority;
+
+    MSALAuthority *authority = nil;
+
+    if (parameters.configurationAuthority)
+    {
+        NSURL *authorityUrl = [[NSURL alloc] initWithString:parameters.configurationAuthority];
+        authority = [MSALAuthority authorityWithURL:authorityUrl error:nil];
+    }
+    
+    
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:parameters.clientId
+                                                                                                redirectUri:parameters.redirectUri
+                                                                                                  authority:authority];
+    
+    if (!validateAuthority)
+    {
+        config.knownAuthorities = @[config.authority];
+    }
+    
+    config.sliceConfig = [[MSALSliceConfig alloc] initWithSlice:parameters.sliceParameters[@"slice"] dc:parameters.sliceParameters[@"dc"]];
+    config.multipleCloudsSupported = parameters.instanceAware;
+    
+    MSALPublicClientApplication *clientApplication = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:error];
+  
+    return clientApplication;
+}
+
+- (MSALAccount *)accountWithParameters:(MSIDAutomationTestRequest *)parameters
+                           application:(MSALPublicClientApplication *)application
+                                 error:(NSError **)error
+{
+    NSString *accountIdentifier = parameters.homeAccountIdentifier;
+
+    if (accountIdentifier)
+    {
+        return [application accountForIdentifier:accountIdentifier error:error];
+    }
+    else if (parameters.legacyAccountIdentifier)
+    {
+        return [application accountForUsername:parameters.legacyAccountIdentifier error:error];
+    }
+        
+    return nil;
+}
+
+- (MSIDAutomationTestResult *)testResultWithMSALError:(NSError *)error
+{
+    return [[MSIDAutomationErrorResult alloc] initWithAction:self.actionIdentifier
+                                                       error:error
+                                              additionalInfo:nil];
+}
+
+- (MSIDAutomationTestResult *)testResultWithMSALResult:(MSALResult *)msalResult error:(NSError *)error
+{
+    if (error)
+    {
+        return [self testResultWithMSALError:error];
+    }
+
+    NSString *scopeString = [msalResult.scopes componentsJoinedByString:@" "];
+    NSInteger expiresOn = [msalResult.expiresOn timeIntervalSince1970];
+
+    MSIDAutomationUserInformation *userInfo = [MSIDAutomationUserInformation new];
+    userInfo.objectId = msalResult.tenantProfile.claims[@"oid"];
+    userInfo.tenantId = msalResult.tenantProfile.tenantId;
+    userInfo.username = msalResult.account.username;
+    userInfo.homeAccountId = msalResult.account.homeAccountId.identifier;
+    userInfo.localAccountId = msalResult.tenantProfile.identifier;
+    userInfo.homeObjectId = msalResult.account.homeAccountId.objectId;
+    userInfo.homeTenantId = msalResult.account.homeAccountId.tenantId;
+    userInfo.environment = msalResult.account.environment;
+
+    MSIDAutomationTestResult *result = [[MSIDAutomationSuccessResult alloc] initWithAction:self.actionIdentifier
+                                                                               accessToken:msalResult.accessToken
+                                                                              refreshToken:@""
+                                                                                   idToken:msalResult.idToken
+                                                                                 authority:msalResult.authority.url.absoluteString
+                                                                                    target:scopeString
+                                                                             expiresOnDate:expiresOn
+                                                                                    isMRRT:YES
+                                                                           userInformation:userInfo
+                                                                            additionalInfo:nil];
+
+    return result;
+}
+
+@end

--- a/MSAL/test/automation/vision/actions/MSALAutomationExpireATAction.h
+++ b/MSAL/test/automation/vision/actions/MSALAutomationExpireATAction.h
@@ -1,0 +1,38 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+
+#import <Foundation/Foundation.h>
+#import "MSALAutomationBaseAction.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALAutomationExpireATAction : MSALAutomationBaseAction
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/test/automation/vision/actions/MSALAutomationExpireATAction.m
+++ b/MSAL/test/automation/vision/actions/MSALAutomationExpireATAction.m
@@ -1,0 +1,95 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+
+#import "MSALAutomationExpireATAction.h"
+#import <MSAL/MSAL.h>
+#import "MSIDAutomationTestRequest.h"
+#import "MSIDAccountIdentifier.h"
+#import "MSIDConfiguration.h"
+#import "MSALAuthority_Internal.h"
+#import "MSIDDefaultTokenCacheAccessor.h"
+#import "MSIDAccessToken.h"
+#import "MSIDAccountCredentialCache.h"
+#import "MSIDAutomationTestResult.h"
+#import "MSIDAutomationActionConstants.h"
+#import "MSIDAutomationActionManager.h"
+
+@implementation MSALAutomationExpireATAction
+
++ (void)load
+{
+    [[MSIDAutomationActionManager sharedInstance] registerAction:[MSALAutomationExpireATAction new]];
+}
+
+- (NSString *)actionIdentifier
+{
+    return MSID_AUTO_EXPIRE_AT_ACTION_IDENTIFIER;
+}
+
+- (BOOL)needsRequestParameters
+{
+    return YES;
+}
+
+- (void)performActionWithParameters:(MSIDAutomationTestRequest *)testRequest
+                containerController:(__unused MSIDAutoViewController *)containerController
+                    completionBlock:(MSIDAutoCompletionBlock)completionBlock
+{
+    NSString *authority = testRequest.cacheAuthority ?: testRequest.configurationAuthority;
+    NSURL *authorityUrl = [NSURL URLWithString:authority];
+
+    MSALAuthority *msalAuthority = [MSALAuthority authorityWithURL:authorityUrl error:nil];
+
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil homeAccountId:testRequest.homeAccountIdentifier];
+
+    MSIDConfiguration *configuration = [[MSIDConfiguration alloc] initWithAuthority:msalAuthority.msidAuthority
+                                                                        redirectUri:nil
+                                                                           clientId:testRequest.clientId
+                                                                             target:testRequest.requestScopes];
+
+    MSIDAccessToken *accessToken = [self.defaultAccessor getAccessTokenForAccount:account
+                                                                    configuration:configuration
+                                                                          context:nil
+                                                                            error:nil];
+
+    if (!accessToken)
+    {
+        MSIDAutomationTestResult *testResult = [[MSIDAutomationTestResult alloc] initWithAction:self.actionIdentifier success:NO additionalInfo:nil];
+        completionBlock(testResult);
+        return;
+    }
+
+    accessToken.expiresOn = [NSDate dateWithTimeIntervalSinceNow:-1.0];
+    BOOL result = [self.accountCredentialCache saveCredential:accessToken.tokenCacheItem context:nil error:nil];
+
+    MSIDAutomationTestResult *testResult = [[MSIDAutomationTestResult alloc] initWithAction:self.actionIdentifier success:result additionalInfo:nil];
+    testResult.actionCount = 1;
+    completionBlock(testResult);
+}
+
+@end

--- a/MSAL/test/automation/vision/actions/MSALAutomationInvalidateRTAction.h
+++ b/MSAL/test/automation/vision/actions/MSALAutomationInvalidateRTAction.h
@@ -1,0 +1,38 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+
+#import <Foundation/Foundation.h>
+#import "MSALAutomationBaseAction.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALAutomationInvalidateRTAction : MSALAutomationBaseAction
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/test/automation/vision/actions/MSALAutomationInvalidateRTAction.m
+++ b/MSAL/test/automation/vision/actions/MSALAutomationInvalidateRTAction.m
@@ -1,0 +1,96 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+
+#import "MSALAutomationInvalidateRTAction.h"
+#import <MSAL/MSAL.h>
+#import "MSIDAutomationTestRequest.h"
+#import "MSIDAccountIdentifier.h"
+#import "MSIDConfiguration.h"
+#import "MSALAuthority_Internal.h"
+#import "MSIDDefaultTokenCacheAccessor.h"
+#import "MSIDRefreshToken.h"
+#import "MSIDAccountCredentialCache.h"
+#import "MSIDAutomationTestResult.h"
+#import "MSIDAutomationActionConstants.h"
+#import "MSIDAutomationActionManager.h"
+
+@implementation MSALAutomationInvalidateRTAction
+
++ (void)load
+{
+    [[MSIDAutomationActionManager sharedInstance] registerAction:[MSALAutomationInvalidateRTAction new]];
+}
+
+- (NSString *)actionIdentifier
+{
+    return MSID_AUTO_INVALIDATE_RT_ACTION_IDENTIFIER;
+}
+
+- (BOOL)needsRequestParameters
+{
+    return YES;
+}
+
+- (void)performActionWithParameters:(MSIDAutomationTestRequest *)testRequest
+                containerController:(__unused MSIDAutoViewController *)containerController
+                    completionBlock:(MSIDAutoCompletionBlock)completionBlock
+{
+    NSString *authority = testRequest.cacheAuthority ?: testRequest.configurationAuthority;
+    NSURL *authorityUrl = [NSURL URLWithString:authority];
+
+    MSALAuthority *msalAuthority = [MSALAuthority authorityWithURL:authorityUrl error:nil];
+    
+    MSIDAccountIdentifier *account = [[MSIDAccountIdentifier alloc] initWithDisplayableId:nil homeAccountId:testRequest.homeAccountIdentifier];
+
+    MSIDConfiguration *configuration = [[MSIDConfiguration alloc] initWithAuthority:msalAuthority.msidAuthority
+                                                                        redirectUri:nil
+                                                                           clientId:testRequest.clientId
+                                                                             target:testRequest.requestScopes];
+
+    MSIDRefreshToken *refreshToken = [self.defaultAccessor getRefreshTokenWithAccount:account
+                                                                             familyId:nil
+                                                                        configuration:configuration
+                                                                              context:nil
+                                                                                error:nil];
+
+    if (!refreshToken)
+    {
+        MSIDAutomationTestResult *testResult = [[MSIDAutomationTestResult alloc] initWithAction:self.actionIdentifier success:NO additionalInfo:nil];
+        completionBlock(testResult);
+        return;
+    }
+
+    refreshToken.refreshToken = @"bad-refresh-token";
+
+    BOOL result = [self.accountCredentialCache saveCredential:refreshToken.tokenCacheItem context:nil error:nil];
+
+    MSIDAutomationTestResult *testResult = [[MSIDAutomationTestResult alloc] initWithAction:self.actionIdentifier success:result additionalInfo:nil];
+    completionBlock(testResult);
+}
+
+@end

--- a/MSAL/test/automation/vision/actions/MSALAutomationReadAccountsAction.h
+++ b/MSAL/test/automation/vision/actions/MSALAutomationReadAccountsAction.h
@@ -1,0 +1,37 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import "MSALAutomationBaseAction.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALAutomationReadAccountsAction : MSALAutomationBaseAction
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/test/automation/vision/actions/MSALAutomationReadAccountsAction.m
+++ b/MSAL/test/automation/vision/actions/MSALAutomationReadAccountsAction.m
@@ -1,0 +1,100 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALAutomationReadAccountsAction.h"
+#import <MSAL/MSAL.h>
+#import "MSIDAutomationTestResult.h"
+#import "MSIDAutomationTestRequest.h"
+#import "MSALUser+Automation.h"
+#import "MSIDAutomationActionConstants.h"
+#import "MSIDAutomationActionManager.h"
+#import "MSIDAutomationAccountsResult.h"
+#import "MSALAccount+Internal.h"
+#import "MSALTenantProfile.h"
+
+@implementation MSALAutomationReadAccountsAction
+
++ (void)load
+{
+    [[MSIDAutomationActionManager sharedInstance] registerAction:[MSALAutomationReadAccountsAction new]];
+}
+
+- (NSString *)actionIdentifier
+{
+    return MSID_AUTO_READ_ACCOUNTS_ACTION_IDENTIFIER;
+}
+
+- (BOOL)needsRequestParameters
+{
+    return YES;
+}
+
+- (void)performActionWithParameters:(MSIDAutomationTestRequest *)testRequest
+                containerController:(__unused MSIDAutoViewController *)containerController
+                    completionBlock:(MSIDAutoCompletionBlock)completionBlock
+{
+    NSError *applicationError = nil;
+    MSALPublicClientApplication *application = [self applicationWithParameters:testRequest error:&applicationError];
+
+    if (!application)
+    {
+        MSIDAutomationTestResult *result = [self testResultWithMSALError:applicationError];
+        completionBlock(result);
+        return;
+    }
+
+    NSError *error = nil;
+    NSArray *accounts = [application allAccounts:nil];
+
+    if (error)
+    {
+        MSIDAutomationTestResult *result = [self testResultWithMSALError:error];
+        completionBlock(result);
+        return;
+    }
+
+    NSMutableArray *items = [NSMutableArray array];
+
+    for (MSALAccount *account in accounts)
+    {
+        MSIDAutomationUserInformation *userInfo = [MSIDAutomationUserInformation new];
+        userInfo.username = account.username;
+        userInfo.homeAccountId = account.homeAccountId.identifier;
+        userInfo.localAccountId = account.tenantProfiles[0].identifier;
+        userInfo.homeObjectId = account.homeAccountId.objectId;
+        userInfo.homeTenantId = account.homeAccountId.tenantId;
+        userInfo.environment = account.environment;
+        userInfo.objectId = account.tenantProfiles[0].claims[@"oid"];
+        userInfo.tenantId = account.tenantProfiles[0].tenantId;
+        [items addObject:userInfo];
+    }
+
+    MSIDAutomationAccountsResult *result = [[MSIDAutomationAccountsResult alloc] initWithAction:self.actionIdentifier accounts:items additionalInfo:nil];
+    completionBlock(result);
+}
+
+@end

--- a/MSAL/test/automation/vision/actions/MSALAutomationRemoveAccountAction.h
+++ b/MSAL/test/automation/vision/actions/MSALAutomationRemoveAccountAction.h
@@ -1,0 +1,37 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import "MSALAutomationBaseAction.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALAutomationRemoveAccountAction : MSALAutomationBaseAction
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/test/automation/vision/actions/MSALAutomationRemoveAccountAction.m
+++ b/MSAL/test/automation/vision/actions/MSALAutomationRemoveAccountAction.m
@@ -1,0 +1,90 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALAutomationRemoveAccountAction.h"
+#import "MSIDAutomationTestRequest.h"
+#import "MSIDAutomationTestResult.h"
+#import <MSAL/MSAL.h>
+#import "MSIDAutomationActionConstants.h"
+#import "MSIDAutomationActionManager.h"
+
+@implementation MSALAutomationRemoveAccountAction
+
++ (void)load
+{
+    [[MSIDAutomationActionManager sharedInstance] registerAction:[MSALAutomationRemoveAccountAction new]];
+}
+
+- (NSString *)actionIdentifier
+{
+    return MSID_AUTO_REMOVE_ACCOUNT_ACTION_IDENTIFIER;
+}
+
+- (BOOL)needsRequestParameters
+{
+    return YES;
+}
+
+- (void)performActionWithParameters:(MSIDAutomationTestRequest *)testRequest
+                containerController:(__unused MSIDAutoViewController *)containerController
+                    completionBlock:(MSIDAutoCompletionBlock)completionBlock
+{
+    NSError *applicationError = nil;
+    MSALPublicClientApplication *application = [self applicationWithParameters:testRequest error:&applicationError];
+
+    if (!application)
+    {
+        MSIDAutomationTestResult *result = [self testResultWithMSALError:applicationError];
+        completionBlock(result);
+        return;
+    }
+
+    NSError *accountError = nil;
+    MSALAccount *account = [self accountWithParameters:testRequest application:application error:&accountError];
+
+    if (!account)
+    {
+        MSIDAutomationTestResult *result = [self testResultWithMSALError:accountError];
+        completionBlock(result);
+        return;
+    }
+
+    NSError *removeError = nil;
+    BOOL removeResult = [application removeAccount:account error:&removeError];
+
+    if (!removeResult)
+    {
+        MSIDAutomationTestResult *result = [self testResultWithMSALError:removeError];
+        completionBlock(result);
+        return;
+    }
+
+    MSIDAutomationTestResult *result = [[MSIDAutomationTestResult alloc] initWithAction:self.actionIdentifier success:YES additionalInfo:nil];
+    completionBlock(result);
+}
+
+@end

--- a/MSAL/test/automation/vision/main.m
+++ b/MSAL/test/automation/vision/main.m
@@ -1,0 +1,35 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <UIKit/UIKit.h>
+#import "MSALAutoAppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([MSALAutoAppDelegate class]));
+    }
+}

--- a/MSAL/test/automation/vision/resources/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/MSAL/test/automation/vision/resources/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MSAL/test/automation/vision/resources/Images.xcassets/Contents.json
+++ b/MSAL/test/automation/vision/resources/Images.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MSAL/test/automation/vision/resources/Info.plist
+++ b/MSAL/test/automation/vision/resources/Info.plist
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>x-msauth-msalautomationapp</string>
+				<string>msal3c62ac97-29eb-4aed-a3c8-add0298508da</string>
+				<string>msale3b9ad76-9763-4827-b088-80c7a7888f79</string>
+				<string>msal0a7f52dd-260e-432f-94de-b47828c3f372</string>
+				<string>msalb6c69a37-df96-4db0-9088-2ab96e1d8215</string>
+				<string>ms-onedrive</string>
+				<string>msalb6c69a37-df96-4db0-9088-2ab96e1d8215</string>
+				<string>ms-sharepoint-auth</string>
+				<string>msauth.com.microsoft.msal.automationapp</string>
+				<string>msauth.com.microsoft.msalautomationapp</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>Launch Screen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>MainAutomation</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/MSAL/test/automation/vision/util/MSALResult+Automation.h
+++ b/MSAL/test/automation/vision/util/MSALResult+Automation.h
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <MSAL/MSAL.h>
+
+@interface MSALResult (Automation)
+
+- (NSDictionary *)itemAsDictionary;
+
+@end

--- a/MSAL/test/automation/vision/util/MSALResult+Automation.m
+++ b/MSAL/test/automation/vision/util/MSALResult+Automation.m
@@ -1,0 +1,46 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALResult+Automation.h"
+#import "MSALUser+Automation.h"
+#import "MSALTenantProfile.h"
+
+@implementation MSALResult (Automation)
+
+- (NSDictionary *)itemAsDictionary
+{
+    return @{@"access_token" : self.accessToken,
+             @"scopes" : self.scopes,
+             @"tenantId" : (self.tenantProfile.tenantId) ? self.tenantProfile.tenantId : @"",
+             @"expires_on" : [NSString stringWithFormat:@"%f", self.expiresOn.timeIntervalSince1970],
+             @"id_token" : self.idToken ? self.idToken : @"",
+             @"user" : self.account ? [self.account itemAsDictionary] : @"",
+             @"authority" : self.authority ? self.authority.url.absoluteString : @""
+             };
+}
+
+@end

--- a/MSAL/test/automation/vision/util/MSALUser+Automation.h
+++ b/MSAL/test/automation/vision/util/MSALUser+Automation.h
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <MSAL/MSAL.h>
+
+@interface MSALAccount (Automation)
+
+- (NSDictionary *)itemAsDictionary;
+
+@end

--- a/MSAL/test/automation/vision/util/MSALUser+Automation.m
+++ b/MSAL/test/automation/vision/util/MSALUser+Automation.m
@@ -1,0 +1,48 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALUser+Automation.h"
+#import "MSALAccount+Internal.h"
+#import "MSALAccountId.h"
+#import "MSALTenantProfile.h"
+
+@implementation MSALAccount (Automation)
+
+- (NSDictionary *)itemAsDictionary
+{
+    NSMutableDictionary *resultDict = [NSMutableDictionary dictionary];
+    [resultDict setValue:self.username forKey:@"username"];
+    [resultDict setValue:self.homeAccountId.identifier forKey:@"home_account_id"];
+    [resultDict setValue:self.tenantProfiles[0].identifier forKey:@"local_account_id"];
+    [resultDict setValue:self.homeAccountId.objectId forKey:@"homeAccountId.objectId"];
+    [resultDict setValue:self.homeAccountId.tenantId forKey:@"homeAccountId.tenantId"];
+    [resultDict setValue:self.environment forKey:@"environment"];
+    
+    return resultDict;
+}
+
+@end

--- a/MSAL/test/automation/vision/util/MSIDTokenCacheItem+Automation.h
+++ b/MSAL/test/automation/vision/util/MSIDTokenCacheItem+Automation.h
@@ -1,0 +1,35 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSIDCredentialCacheItem.h"
+
+@interface MSIDCredentialCacheItem (Automation)
+
+- (NSDictionary *)itemAsDictionary;
+
+@end
+

--- a/MSAL/test/automation/vision/util/MSIDTokenCacheItem+Automation.m
+++ b/MSAL/test/automation/vision/util/MSIDTokenCacheItem+Automation.m
@@ -1,0 +1,44 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSIDTokenCacheItem+Automation.h"
+#import "MSALUser+Automation.h"
+#import "MSIDAADV2IdTokenClaims.h"
+
+@implementation MSIDCredentialCacheItem (Automation)
+
+- (NSDictionary *)itemAsDictionary
+{
+    MSIDAADV2IdTokenClaims *idToken = [[MSIDAADV2IdTokenClaims alloc] initWithRawIdToken:self.secret error:nil];
+    NSMutableDictionary *resultDict = [[self jsonDictionary] mutableCopy];
+    [resultDict setValue:idToken.tenantId forKey:@"tenant_id"];
+    
+    return resultDict;
+}
+
+@end
+

--- a/MSAL/xcconfig/msal__automation_app__vision.xcconfig
+++ b/MSAL/xcconfig/msal__automation_app__vision.xcconfig
@@ -1,0 +1,7 @@
+#include "msal__common__vision.xcconfig"
+
+INFOPLIST_FILE = test/automation/vision/resources/info.plist;
+PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSALAutomationApp;
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+PRODUCT_NAME = MSAL Automation App;
+USER_HEADER_SEARCH_PATHS = $IDCORE_PATH/tests/automation/** $IDCORE_PATH/src/**;

--- a/MSAL/xcconfig/msal__common__framework__vision.xcconfig
+++ b/MSAL/xcconfig/msal__common__framework__vision.xcconfig
@@ -1,0 +1,7 @@
+CURRENT_PROJECT_VERSION = 1;
+DYLIB_COMPATIBILITY_VERSION = 1;
+DYLIB_CURRENT_VERSION = 1;
+DYLIB_INSTALL_NAME_BASE = @rpath;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+VERSIONING_SYSTEM = "apple-generic";
+VERSION_INFO_PREFIX = "";

--- a/MSAL/xcconfig/msal__common__vision.xcconfig
+++ b/MSAL/xcconfig/msal__common__vision.xcconfig
@@ -1,0 +1,2 @@
+#include "../IdentityCore/IdentityCore/xcconfig/identitycore__common__vision.xcconfig"
+ARCHS[sdk=xros*] = $(ARCHS_STANDARD)

--- a/MSAL/xcconfig/msal__framework__vision.xcconfig
+++ b/MSAL/xcconfig/msal__framework__vision.xcconfig
@@ -1,0 +1,8 @@
+#include "msal__common__vision.xcconfig"
+#include "msal__common__framework__vision.xcconfig"
+
+DEFINES_MODULE = YES;
+INFOPLIST_FILE = resources/vision/Info.plist;
+PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSAL;
+PRODUCT_NAME = MSAL;
+

--- a/MSAL/xcconfig/msal__static__lib__vision.xcconfig
+++ b/MSAL/xcconfig/msal__static__lib__vision.xcconfig
@@ -1,0 +1,14 @@
+#include "msal__framework__vision.xcconfig"
+
+// Force the linker to resolve symbols.
+GENERATE_MASTER_OBJECT_FILE = YES
+
+// Add armv7s and arm64e to standard ARCHs.
+ARCHS = $(ARCHS_STANDARD) armv7s arm64e
+ARCHS[sdk=xros*] = $(ARCHS_STANDARD) armv7s arm64e
+
+// Activate full bitcode on release configuration for real devices.
+OTHER_CFLAGS[config=Release][sdk=xros*] = $(OTHER_CFLAGS) -fembed-bitcode
+
+// Build static library.
+MACH_O_TYPE = staticlib

--- a/MSAL/xcconfig/msal__test_app__vision.xcconfig
+++ b/MSAL/xcconfig/msal__test_app__vision.xcconfig
@@ -1,0 +1,9 @@
+#include "msal__common__vision.xcconfig"
+
+INFOPLIST_FILE = test/app/vision/resources/Info.plist;
+PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSALTestApp;
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+PRODUCT_NAME = MSAL Test App;
+OTHER_LDFLAGS = "-ObjC";
+

--- a/MSAL/xcconfig/msal__ui_test__vision.xcconfig
+++ b/MSAL/xcconfig/msal__ui_test__vision.xcconfig
@@ -1,0 +1,6 @@
+#include "msal__common__vision.xcconfig"
+
+INFOPLIST_FILE = test/unit/resources/vision/Info.plist;
+PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.InteractiveVisionTests;
+PRODUCT_NAME = "InteractiveVisionTests";
+USER_HEADER_SEARCH_PATHS = $IDCORE_PATH/tests/automation/** $IDCORE_PATH/src/**;

--- a/MSAL/xcconfig/msal__unit_test__vision.xcconfig
+++ b/MSAL/xcconfig/msal__unit_test__vision.xcconfig
@@ -1,0 +1,6 @@
+#include "msal__common__vision.xcconfig"
+
+INFOPLIST_FILE = test/automation/tests/interactive/Info.plist;
+PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSAL-Vision-Unit-Tests;
+PRODUCT_NAME = "MSAL-Vision-UI-Tests";
+GCC_WARN_UNUSED_PARAMETER = NO

--- a/MSAL/xcconfig/msal__unit_test_host__vision.xcconfig
+++ b/MSAL/xcconfig/msal__unit_test_host__vision.xcconfig
@@ -1,0 +1,8 @@
+#include "msal__common__vision.xcconfig"
+
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+INFOPLIST_FILE = test/unit/vision/unit-test-host/Info.plist;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.unit-test-host;
+PRODUCT_NAME = unit-test-host;
+GCC_WARN_UNUSED_PARAMETER = NO

--- a/archives/Package.swift
+++ b/archives/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.9
+
+import PackageDescription
+
+let package = Package(
+  name: "MSAL",
+  platforms: [
+    .macOS(.v10_13),.iOS(.v14), .visionOS(.v1)
+  ],
+  products: [
+      .library(name: "MSAL", targets: ["MSAL"]),
+  ],
+  targets: [
+      .binaryTarget(name: "MSAL", path: "MSAL.xcframework")
+  ]
+)


### PR DESCRIPTION


## Proposed changes

developer could directly build xcframework using MASL xcframework aggregate target, and generated the swift package in ./archives folder.

## Type of change

- [x] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

