### PR TITLE
Fix Build Docs script build

### DIFF
--- a/azure_pipelines/automation.yml
+++ b/azure_pipelines/automation.yml
@@ -72,7 +72,7 @@ jobs:
           -workspace MSAL.xcworkspace \
           -scheme "MSAL Test Automation (iOS)" \
           -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 14,OS=17.2' \
+          -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.4' \
           -derivedDataPath 'build' \
           | tee xcodebuild.log \
           | xcpretty -c
@@ -84,8 +84,8 @@ jobs:
       script: |
         ls build/Build/Products/
         xcodebuild test-without-building \
-            -xctestrun 'build/Build/Products/MSAL Test Automation (iOS)_iphonesimulator17.0-x86_64.xctestrun' \
-            -destination 'platform=iOS Simulator,name=iPhone 14,OS=17.2' \
+            -xctestrun 'build/Build/Products/MSAL Test Automation (iOS)_iphonesimulator16.4-x86_64.xctestrun' \
+            -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.4' \
             -retry-tests-on-failure \
             -parallel-testing-enabled NO \
             -resultBundlePath '$(Agent.BuildDirectory)/s/test_output/report.xcresult'       

--- a/azure_pipelines/spm-framework.yml
+++ b/azure_pipelines/spm-framework.yml
@@ -373,7 +373,7 @@ jobs:
       targetType: 'inline'
       script: |
         # NOTE : This should be the last step since it changes branch from main to $(docsRepositoryBranch)
-        if [ ! -d "docs.temp" ]; then
+        if [ ! -d "docs" ]; then
             echo "Docs were not generated in previous step!"
         else
             authorName=$(git log -1 --pretty=format:'%an')
@@ -384,11 +384,12 @@ jobs:
             author=$(git log -1 --pretty=format:'%an <%ae>')
             # Create a temp branch to cherry pick doc changes
             git checkout -b 'update-docs-for-release-$(releaseVersion)'
-            git add docs.temp/docs/*
+            git add docs/*
             git commit -m 'adding docs for release' --author="${author}" --status
 
             # Cleanup
             rm -rf docs.temp
+            rm -rf docs
             git fetch origin $(docsRepositoryBranch)
             git checkout FETCH_HEAD
             git checkout $(docsRepositoryBranch)
@@ -397,8 +398,8 @@ jobs:
             # Get previously commited changes for docs
             git cherry-pick --strategy-option theirs "update-docs-for-release-$(releaseVersion)"
 
-            # Copy files in docs.temp folder to root
-            \cp -r docs.temp/docs/* .
+            # Copy files in docs folder to root
+            \cp -r docs/* .
 
             # Push changes to docsRepositoryBranch branch
             git add -A

--- a/azure_pipelines/spm-framework.yml
+++ b/azure_pipelines/spm-framework.yml
@@ -36,7 +36,7 @@ jobs:
 - job: BuildXcFrameworks
   displayName: Build MSAL framework and release
   pool:
-    vmImage: 'macOS-11'
+    vmImage: 'macOS-13'
     timeOutInMinutes: 20
 
   steps:
@@ -357,6 +357,12 @@ jobs:
       workingDirectory: '$(Build.SourcesDirectory)'
     env:
       COCOAPODS_TRUNK_TOKEN: $(COCOAPODS_TRUNK_TOKEN)
+  - task: Bash@3
+    displayName: Install Sourcekitten
+    inputs:
+      targetType: 'inline'
+      script: |
+        brew install sourcekitten
   - task: Bash@3
     displayName: Build MSAL docs via Jazzy
     inputs:

--- a/azure_pipelines/spm-framework.yml
+++ b/azure_pipelines/spm-framework.yml
@@ -373,7 +373,7 @@ jobs:
       targetType: 'inline'
       script: |
         # NOTE : This should be the last step since it changes branch from main to $(docsRepositoryBranch)
-        if [ ! -d "docs" ]; then
+        if [ ! -d "docs.temp" ]; then
             echo "Docs were not generated in previous step!"
         else
             authorName=$(git log -1 --pretty=format:'%an')
@@ -384,12 +384,11 @@ jobs:
             author=$(git log -1 --pretty=format:'%an <%ae>')
             # Create a temp branch to cherry pick doc changes
             git checkout -b 'update-docs-for-release-$(releaseVersion)'
-            git add docs/*
+            git add docs.temp/docs/*
             git commit -m 'adding docs for release' --author="${author}" --status
 
             # Cleanup
             rm -rf docs.temp
-            rm -rf docs
             git fetch origin $(docsRepositoryBranch)
             git checkout FETCH_HEAD
             git checkout $(docsRepositoryBranch)
@@ -398,8 +397,8 @@ jobs:
             # Get previously commited changes for docs
             git cherry-pick --strategy-option theirs "update-docs-for-release-$(releaseVersion)"
 
-            # Copy files in docs folder to root
-            \cp -r docs/* .
+            # Copy files in docs.temp folder to root
+            \cp -r docs.temp/docs/* .
 
             # Push changes to docsRepositoryBranch branch
             git add -A

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -21,4 +21,4 @@ sourcekitten doc --objc $(pwd)/MSAL/MSAL.h -- -x objective-c  -isysroot $(xcrun 
 cd ..
 
 # Feed both outputs to Jazzy as a comma-separated list
-jazzy --module MSAL --sourcekitten-sourcefile docs.temp/swiftDoc.json,docs.temp/objcDoc.json --author Microsoft\ Corporation --author_url https://aka.ms/azuread --github_url https://github.com/AzureAD/microsoft-authentication-library-for-objc --theme fullwidth
+jazzy --module MSAL --sourcekitten-sourcefile docs.temp/swiftDoc.json,docs.temp/objcDoc.json --author Microsoft\ Corporation --author_url https://aka.ms/azuread --github_url https://github.com/AzureAD/microsoft-authentication-library-for-objc --theme fullwidth --output docs.temp/docs

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -13,7 +13,7 @@ cp README.md docs.temp/
 
 echo -e "Generating MSAL documentation"
 # Generate Swift SourceKitten output
-sourcekitten doc -- -workspace MSAL.xcworkspace -scheme "MSAL (iOS Framework)" -configuration Debug RUN_CLANG_STATIC_ANALYZER=NO -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -destination 'platform=iOS Simulator' > docs.temp/swiftDoc.json
+sourcekitten doc -- -workspace MSAL.xcworkspace -scheme "MSAL (iOS Framework)" -configuration Debug RUN_CLANG_STATIC_ANALYZER=NO -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.4' > docs.temp/swiftDoc.json
 
 # Generate Objective-C SourceKitten output
 cd docs.temp


### PR DESCRIPTION
## Proposed changes
-Added fix for simulator for automation script
-Changed MacOS for release script from 11 to 13
-Modified build_docs.sh so it works on CI
-Changed output folder for Jazzy from docs to docs.temp/docs so upload script detects it
## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

