### PR TITLE
Do not use static library during cocoa pod version update

### DIFF
--- a/azure_pipelines/spm-framework.yml
+++ b/azure_pipelines/spm-framework.yml
@@ -352,7 +352,8 @@ jobs:
       targetType: 'inline'
       script: |
         # Release to CocoaPods
-        pod trunk push --use-libraries --allow-warnings MSAL.podspec
+        # Do not use "--use-libraries" option because native auth code doesn't support static library yet
+        pod trunk push --allow-warnings MSAL.podspec
         #pod trunk me
       workingDirectory: '$(Build.SourcesDirectory)'
     env:


### PR DESCRIPTION
## Proposed changes
The command used to create a new cocoa pod version, used an option to use static library during lint check. Native auth code doens't support static library yet, so this command was failing. The proposed solution is to use the default lint settings, which uses dynamic framework.

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

