### PR TITLE
Add privacy manifest to pod spec

### DIFF
--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     :tag => s.version.to_s,
     :submodules => true
   }
-  
+  s.resource_bundles = {"MSAL" => ["MSAL/PrivacyInfo.xcprivacy"]}
   s.default_subspecs ='app-lib'
   
   s.prefix_header_file = "MSAL/src/MSAL.pch"


### PR DESCRIPTION
## Proposed changes

Added privacy manifest to pod spec in response to https://github.com/AzureAD/microsoft-authentication-library-for-objc/issues/2074 

## Type of change

- [ ] Feature work
- [ x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

