### PR TITLE
Move access token info inside MSALNativeAuthTokenResult

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		23FB5C1E22542B99002BF1EB /* MSALJsonDeserializable.h in Headers */ = {isa = PBXBuildFile; fileRef = 23FB5C1C22542B99002BF1EB /* MSALJsonDeserializable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2826932A2A0974750037B93A /* MSALNativeAuthTokenRequestParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282693272A0974740037B93A /* MSALNativeAuthTokenRequestParameters.swift */; };
 		2826933B2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2826933A2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift */; };
+		285D0D692B99C14F002A1D4A /* MSALNativeAuthAccessTokenResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285D0D682B99C14F002A1D4A /* MSALNativeAuthAccessTokenResult.swift */; };
 		285F36082A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F36072A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift */; };
 		2877081F2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2877081E2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift */; };
 		287708222A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287708212A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift */; };
@@ -1540,6 +1541,7 @@
 		23FB5C1C22542B99002BF1EB /* MSALJsonDeserializable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALJsonDeserializable.h; sourceTree = "<group>"; };
 		282693272A0974740037B93A /* MSALNativeAuthTokenRequestParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenRequestParameters.swift; sourceTree = "<group>"; };
 		2826933A2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInParameters.swift; sourceTree = "<group>"; };
+		285D0D682B99C14F002A1D4A /* MSALNativeAuthAccessTokenResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthAccessTokenResult.swift; sourceTree = "<group>"; };
 		285F36072A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInControlling.swift; sourceTree = "<group>"; };
 		2877081E2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInChallengeValidatedResponse.swift; sourceTree = "<group>"; };
 		287708212A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalChannelType.swift; sourceTree = "<group>"; };
@@ -3941,6 +3943,7 @@
 				9BD78D7A2A126A1500AA7E12 /* MSALNativeAuthChallengeTypes.h */,
 				DE8BE7DB2A1F6BD2009642A5 /* MSALNativeAuthUserAccountResult.swift */,
 				E2D3BC4E2A7BE1C4009C4D1F /* MSALNativeAuthUserAccountResult+Internal.swift */,
+				285D0D682B99C14F002A1D4A /* MSALNativeAuthAccessTokenResult.swift */,
 			);
 			path = public;
 			sourceTree = "<group>";
@@ -5791,6 +5794,7 @@
 				E2F626A72A780F3D00C4A303 /* SignUpStates+Internal.swift in Sources */,
 				2826932A2A0974750037B93A /* MSALNativeAuthTokenRequestParameters.swift in Sources */,
 				28EDF93E29E6D43900A99F2A /* SignUpStartError.swift in Sources */,
+				285D0D692B99C14F002A1D4A /* MSALNativeAuthAccessTokenResult.swift in Sources */,
 				DE94C9F029F2AF5E00C1EC1F /* MSALNativeAuthResetPasswordChallengeRequestParameters.swift in Sources */,
 				D61BD2B31EBD09F90007E484 /* MSALPromptType.m in Sources */,
 				DEC1E425298BE18A00948BED /* MSALNativeAuthServerTelemetry.swift in Sources */,

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -241,7 +241,7 @@
 		23FB5C1E22542B99002BF1EB /* MSALJsonDeserializable.h in Headers */ = {isa = PBXBuildFile; fileRef = 23FB5C1C22542B99002BF1EB /* MSALJsonDeserializable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2826932A2A0974750037B93A /* MSALNativeAuthTokenRequestParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282693272A0974740037B93A /* MSALNativeAuthTokenRequestParameters.swift */; };
 		2826933B2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2826933A2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift */; };
-		285D0D692B99C14F002A1D4A /* MSALNativeAuthAccessTokenResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285D0D682B99C14F002A1D4A /* MSALNativeAuthAccessTokenResult.swift */; };
+		285D0D692B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285D0D682B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift */; };
 		285F36082A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F36072A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift */; };
 		2877081F2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2877081E2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift */; };
 		287708222A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287708212A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift */; };
@@ -1541,7 +1541,7 @@
 		23FB5C1C22542B99002BF1EB /* MSALJsonDeserializable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALJsonDeserializable.h; sourceTree = "<group>"; };
 		282693272A0974740037B93A /* MSALNativeAuthTokenRequestParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenRequestParameters.swift; sourceTree = "<group>"; };
 		2826933A2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInParameters.swift; sourceTree = "<group>"; };
-		285D0D682B99C14F002A1D4A /* MSALNativeAuthAccessTokenResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthAccessTokenResult.swift; sourceTree = "<group>"; };
+		285D0D682B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenResult.swift; sourceTree = "<group>"; };
 		285F36072A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInControlling.swift; sourceTree = "<group>"; };
 		2877081E2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInChallengeValidatedResponse.swift; sourceTree = "<group>"; };
 		287708212A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalChannelType.swift; sourceTree = "<group>"; };
@@ -3943,7 +3943,7 @@
 				9BD78D7A2A126A1500AA7E12 /* MSALNativeAuthChallengeTypes.h */,
 				DE8BE7DB2A1F6BD2009642A5 /* MSALNativeAuthUserAccountResult.swift */,
 				E2D3BC4E2A7BE1C4009C4D1F /* MSALNativeAuthUserAccountResult+Internal.swift */,
-				285D0D682B99C14F002A1D4A /* MSALNativeAuthAccessTokenResult.swift */,
+				285D0D682B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift */,
 			);
 			path = public;
 			sourceTree = "<group>";
@@ -5794,7 +5794,7 @@
 				E2F626A72A780F3D00C4A303 /* SignUpStates+Internal.swift in Sources */,
 				2826932A2A0974750037B93A /* MSALNativeAuthTokenRequestParameters.swift in Sources */,
 				28EDF93E29E6D43900A99F2A /* SignUpStartError.swift in Sources */,
-				285D0D692B99C14F002A1D4A /* MSALNativeAuthAccessTokenResult.swift in Sources */,
+				285D0D692B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift in Sources */,
 				DE94C9F029F2AF5E00C1EC1F /* MSALNativeAuthResetPasswordChallengeRequestParameters.swift in Sources */,
 				D61BD2B31EBD09F90007E484 /* MSALPromptType.m in Sources */,
 				DEC1E425298BE18A00948BED /* MSALNativeAuthServerTelemetry.swift in Sources */,

--- a/MSAL/src/native_auth/cache/MSALNativeAuthTokens.swift
+++ b/MSAL/src/native_auth/cache/MSALNativeAuthTokens.swift
@@ -25,11 +25,11 @@
 @_implementationOnly import MSAL_Private
 
 class MSALNativeAuthTokens {
-    let accessToken: MSIDAccessToken?
+    let accessToken: MSIDAccessToken
     let refreshToken: MSIDRefreshToken?
     let rawIdToken: String?
 
-    init(accessToken: MSIDAccessToken?, refreshToken: MSIDRefreshToken?, rawIdToken: String?) {
+    init(accessToken: MSIDAccessToken, refreshToken: MSIDRefreshToken?, rawIdToken: String?) {
         self.accessToken = accessToken
         self.refreshToken = refreshToken
         self.rawIdToken = rawIdToken

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -94,7 +94,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
         ) else {
             stopTelemetryEvent(telemetryEvent, context: context, error: MSALNativeAuthInternalError.invalidRequest)
             return .init(
-                .failure(RetrieveAccessTokenError(type: .generalError, correlationId: context.correlationId())), 
+                .failure(RetrieveAccessTokenError(type: .generalError, correlationId: context.correlationId())),
                 correlationId: context.correlationId()
             )
         }

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -86,7 +86,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
     func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> RefreshTokenCredentialControllerResponse {
         MSALLogger.log(level: .verbose, context: context, format: "Refresh started")
         let telemetryEvent = makeAndStartTelemetryEvent(id: .telemetryApiIdRefreshToken, context: context)
-        let scopes = authTokens.accessToken?.scopes.array as? [String] ?? []
+        let scopes = authTokens.accessToken.scopes.array as? [String] ?? []
         guard let request = createRefreshTokenRequest(
             scopes: scopes,
             refreshToken: authTokens.refreshToken?.refreshToken,
@@ -183,7 +183,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 format: "Refresh Token completed successfully")
             // TODO: Handle tokenResult.refreshToken as? MSIDRefreshToken in a safer way
             return .init(
-                .success(MSALNativeAuthAccessTokenResult(authTokens: MSALNativeAuthTokens(
+                .success(MSALNativeAuthTokenResult(authTokens: MSALNativeAuthTokens(
                     accessToken: tokenResult.accessToken,
                     refreshToken: tokenResult.refreshToken as? MSIDRefreshToken,
                     rawIdToken: tokenResult.rawIdToken

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -181,8 +181,13 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 level: .verbose,
                 context: context,
                 format: "Refresh Token completed successfully")
+            // TODO: Handle tokenResult.refreshToken as? MSIDRefreshToken in a safer way
             return .init(
-                .success(tokenResult.accessToken.accessToken),
+                .success(MSALNativeAuthAccessTokenResult(authTokens: MSALNativeAuthTokens(
+                    accessToken: tokenResult.accessToken,
+                    refreshToken: tokenResult.refreshToken as? MSIDRefreshToken,
+                    rawIdToken: tokenResult.rawIdToken
+                ))),
                 correlationId: context.correlationId(),
                 telemetryUpdate: { [weak self] result in
                 telemetryEvent?.setUserInformation(tokenResult.account)

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
@@ -25,7 +25,7 @@
 import Foundation
 
 protocol MSALNativeAuthCredentialsControlling {
-    typealias RefreshTokenCredentialControllerResponse = MSALNativeAuthControllerTelemetryWrapper<Result<MSALNativeAuthAccessTokenResult, RetrieveAccessTokenError>>
+    typealias RefreshTokenCredentialControllerResponse = MSALNativeAuthControllerTelemetryWrapper<Result<MSALNativeAuthTokenResult, RetrieveAccessTokenError>>
 
     func retrieveUserAccountResult(context: MSALNativeAuthRequestContext) -> MSALNativeAuthUserAccountResult?
     func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> RefreshTokenCredentialControllerResponse

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
@@ -25,7 +25,8 @@
 import Foundation
 
 protocol MSALNativeAuthCredentialsControlling {
-    typealias RefreshTokenCredentialControllerResponse = MSALNativeAuthControllerTelemetryWrapper<Result<MSALNativeAuthTokenResult, RetrieveAccessTokenError>>
+    typealias RefreshTokenCredentialControllerResponse =
+    MSALNativeAuthControllerTelemetryWrapper<Result<MSALNativeAuthTokenResult, RetrieveAccessTokenError>>
 
     func retrieveUserAccountResult(context: MSALNativeAuthRequestContext) -> MSALNativeAuthUserAccountResult?
     func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> RefreshTokenCredentialControllerResponse

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
@@ -41,7 +41,6 @@ enum MSALNativeAuthErrorMessage {
     static let generalError = "General error"
     static let invalidCode = "Invalid code"
     static let refreshTokenExpired = "Refresh token is expired"
-    static let tokenNotFound = "Token not found"
     static let redirectUriNotSetWarning = "WARNING ⚠️: redirectUri not set during MSAL Native Auth initialization. Production apps must correctly configure a redirect URI and call acquireToken in response to all browserRequired errors. See https://learn.microsoft.com/entra/identity-platform/redirect-uris-ios"
     static let unexpectedResponseBody = "Unexpected response body received"
     static let unexpectedChallengeType = "Unexpected challenge type"

--- a/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
@@ -108,6 +108,7 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     func convertToRetrieveAccessTokenError(correlationId: UUID) -> RetrieveAccessTokenError {
         switch self {
         case .expiredToken(let apiError),

--- a/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
@@ -108,7 +108,6 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
         }
     }
 
-    // swiftlint:disable:next function_body_length
     func convertToRetrieveAccessTokenError(correlationId: UUID) -> RetrieveAccessTokenError {
         switch self {
         case .expiredToken(let apiError),

--- a/MSAL/src/native_auth/public/MSALNativeAuthAccessTokenResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthAccessTokenResult.swift
@@ -16,17 +16,38 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
+
 
 import Foundation
 
-protocol MSALNativeAuthCredentialsControlling {
-    typealias RefreshTokenCredentialControllerResponse = MSALNativeAuthControllerTelemetryWrapper<Result<MSALNativeAuthAccessTokenResult, RetrieveAccessTokenError>>
+public class MSALNativeAuthAccessTokenResult: NSObject {
+    
+    let authTokens: MSALNativeAuthTokens
+    
+    init(authTokens: MSALNativeAuthTokens) {
+        self.authTokens = authTokens
+    }
+    
+    /**
+     The Access Token requested.
+     Note that if access token is not returned in token response, this property will be returned as an empty string.
+     */
+    @objc public var accessToken: String? {
+        authTokens.accessToken?.accessToken
+    }
+    
+    /// Get the list of permissions for the access token for the account if present.
+    @objc public var scopes: [String] {
+        authTokens.accessToken?.scopes.array as? [String] ?? []
+    }
 
-    func retrieveUserAccountResult(context: MSALNativeAuthRequestContext) -> MSALNativeAuthUserAccountResult?
-    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> RefreshTokenCredentialControllerResponse
+    /// Get the expiration date for the access token for the account if present.
+    @objc public var expiresOn: Date? {
+        authTokens.accessToken?.expiresOn
+    }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthTokenResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthTokenResult.swift
@@ -22,32 +22,31 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-
 import Foundation
 
-public class MSALNativeAuthAccessTokenResult: NSObject {
-    
+public class MSALNativeAuthTokenResult: NSObject {
+
     let authTokens: MSALNativeAuthTokens
-    
+
     init(authTokens: MSALNativeAuthTokens) {
         self.authTokens = authTokens
     }
-    
+
     /**
      The Access Token requested.
      Note that if access token is not returned in token response, this property will be returned as an empty string.
      */
-    @objc public var accessToken: String? {
-        authTokens.accessToken?.accessToken
+    @objc public var accessToken: String {
+        authTokens.accessToken.accessToken
     }
-    
+
     /// Get the list of permissions for the access token for the account if present.
     @objc public var scopes: [String] {
-        authTokens.accessToken?.scopes.array as? [String] ?? []
+        authTokens.accessToken.scopes.array as? [String] ?? []
     }
 
     /// Get the expiration date for the access token for the account if present.
     @objc public var expiresOn: Date? {
-        authTokens.accessToken?.expiresOn
+        authTokens.accessToken.expiresOn
     }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthTokenResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthTokenResult.swift
@@ -40,12 +40,13 @@ public class MSALNativeAuthTokenResult: NSObject {
         authTokens.accessToken.accessToken
     }
 
-    /// Get the list of permissions for the access token for the account if present.
+    /// Get the list of permissions for the access token for the account.
     @objc public var scopes: [String] {
         authTokens.accessToken.scopes.array as? [String] ?? []
     }
 
-    /// Get the expiration date for the access token for the account if present.
+    /// Get the expiration date for the access token for the account.
+    /// This value is calculated based on current UTC time measured locally and the value expiresIn returned from the service
     @objc public var expiresOn: Date? {
         authTokens.accessToken.expiresOn
     }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -34,17 +34,12 @@ extension MSALNativeAuthUserAccountResult {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         let correlationId = context.correlationId()
 
-        if let accessToken = self.authTokens.accessToken {
-            if forceRefresh || accessToken.isExpired() {
-                let controllerFactory = MSALNativeAuthControllerFactory(config: configuration)
-                let credentialsController = controllerFactory.makeCredentialsController(cacheAccessor: cacheAccessor)
-                return await credentialsController.refreshToken(context: context, authTokens: authTokens)
-            } else {
-                return .init(.success(MSALNativeAuthAccessTokenResult(authTokens: authTokens)), correlationId: correlationId)
-            }
+        if forceRefresh || self.authTokens.accessToken.isExpired() {
+            let controllerFactory = MSALNativeAuthControllerFactory(config: configuration)
+            let credentialsController = controllerFactory.makeCredentialsController(cacheAccessor: cacheAccessor)
+            return await credentialsController.refreshToken(context: context, authTokens: authTokens)
         } else {
-            MSALLogger.log(level: .error, context: context, format: "Retrieve Access Token: Existing token not found")
-            return .init(.failure(RetrieveAccessTokenError(type: .tokenNotFound, correlationId: correlationId)), correlationId: correlationId)
+            return .init(.success(MSALNativeAuthTokenResult(authTokens: authTokens)), correlationId: correlationId)
         }
     }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -40,7 +40,7 @@ extension MSALNativeAuthUserAccountResult {
                 let credentialsController = controllerFactory.makeCredentialsController(cacheAccessor: cacheAccessor)
                 return await credentialsController.refreshToken(context: context, authTokens: authTokens)
             } else {
-                return .init(.success(accessToken.accessToken), correlationId: correlationId)
+                return .init(.success(MSALNativeAuthAccessTokenResult(authTokens: authTokens)), correlationId: correlationId)
             }
         } else {
             MSALLogger.log(level: .error, context: context, format: "Retrieve Access Token: Existing token not found")

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -88,7 +88,7 @@ import Foundation
             switch controllerResponse.result {
             case .success(let accessToken):
                 await delegateDispatcher.dispatchAccessTokenRetrieveCompleted(
-                    accessToken: accessToken,
+                    result: accessToken,
                     correlationId: controllerResponse.correlationId
                 )
             case .failure(let error):

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -86,9 +86,9 @@ import Foundation
             let delegateDispatcher = CredentialsDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
-            case .success(let accessToken):
+            case .success(let accessTokenResult):
                 await delegateDispatcher.dispatchAccessTokenRetrieveCompleted(
-                    result: accessToken,
+                    result: accessTokenResult,
                     correlationId: controllerResponse.correlationId
                 )
             case .failure(let error):

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -38,16 +38,6 @@ import Foundation
         authTokens.rawIdToken
     }
 
-    /// Get the list of permissions for the access token for the account if present.
-    @objc public var scopes: [String] {
-        authTokens.accessToken?.scopes.array as? [String] ?? []
-    }
-
-    /// Get the expiration date for the access token for the account if present.
-    @objc public var expiresOn: Date? {
-        authTokens.accessToken?.expiresOn
-    }
-
     init(
         account: MSALAccount,
         authTokens: MSALNativeAuthTokens,

--- a/MSAL/src/native_auth/public/state_machine/delegate/CredentialsDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/CredentialsDelegates.swift
@@ -33,6 +33,6 @@ public protocol CredentialsDelegate {
 
     /// Notifies the delegate that the operation completed successfully.
     /// - Note: If a flow requires this optional method and it is not implemented, then ``onAccessTokenRetrieveError(error:)`` will be called.
-    /// - Parameter accessToken: The access token string.
-    @MainActor @objc optional func onAccessTokenRetrieveCompleted(accessToken: MSALNativeAuthAccessTokenResult)
+    /// - Parameter result: The access token result.
+    @MainActor @objc optional func onAccessTokenRetrieveCompleted(result: MSALNativeAuthTokenResult)
 }

--- a/MSAL/src/native_auth/public/state_machine/delegate/CredentialsDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/CredentialsDelegates.swift
@@ -34,5 +34,5 @@ public protocol CredentialsDelegate {
     /// Notifies the delegate that the operation completed successfully.
     /// - Note: If a flow requires this optional method and it is not implemented, then ``onAccessTokenRetrieveError(error:)`` will be called.
     /// - Parameter accessToken: The access token string.
-    @MainActor @objc optional func onAccessTokenRetrieveCompleted(accessToken: String)
+    @MainActor @objc optional func onAccessTokenRetrieveCompleted(accessToken: MSALNativeAuthAccessTokenResult)
 }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
@@ -26,7 +26,7 @@ import Foundation
 
 final class CredentialsDelegateDispatcher: DelegateDispatcher<CredentialsDelegate> {
 
-    func dispatchAccessTokenRetrieveCompleted(accessToken: String, correlationId: UUID) async {
+    func dispatchAccessTokenRetrieveCompleted(accessToken: MSALNativeAuthAccessTokenResult, correlationId: UUID) async {
         if let onAccessTokenRetrieveCompleted = delegate.onAccessTokenRetrieveCompleted {
             telemetryUpdate?(.success(()))
             await onAccessTokenRetrieveCompleted(accessToken)

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
@@ -26,7 +26,7 @@ import Foundation
 
 final class CredentialsDelegateDispatcher: DelegateDispatcher<CredentialsDelegate> {
 
-    func dispatchAccessTokenRetrieveCompleted(accessToken: MSALNativeAuthAccessTokenResult, correlationId: UUID) async {
+    func dispatchAccessTokenRetrieveCompleted(accessToken: MSALNativeAuthTokenResult, correlationId: UUID) async {
         if let onAccessTokenRetrieveCompleted = delegate.onAccessTokenRetrieveCompleted {
             telemetryUpdate?(.success(()))
             await onAccessTokenRetrieveCompleted(accessToken)

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/CredentialsDelegateDispatcher.swift
@@ -26,10 +26,10 @@ import Foundation
 
 final class CredentialsDelegateDispatcher: DelegateDispatcher<CredentialsDelegate> {
 
-    func dispatchAccessTokenRetrieveCompleted(accessToken: MSALNativeAuthTokenResult, correlationId: UUID) async {
+    func dispatchAccessTokenRetrieveCompleted(result: MSALNativeAuthTokenResult, correlationId: UUID) async {
         if let onAccessTokenRetrieveCompleted = delegate.onAccessTokenRetrieveCompleted {
             telemetryUpdate?(.success(()))
-            await onAccessTokenRetrieveCompleted(accessToken)
+            await onAccessTokenRetrieveCompleted(result)
         } else {
             let error = RetrieveAccessTokenError(
                 type: .generalError,

--- a/MSAL/src/native_auth/public/state_machine/error/RetrieveAccessTokenError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/RetrieveAccessTokenError.swift
@@ -30,7 +30,6 @@ public class RetrieveAccessTokenError: MSALNativeAuthError {
     enum ErrorType: CaseIterable {
         case browserRequired
         case refreshTokenExpired
-        case tokenNotFound
         case generalError
     }
 
@@ -52,8 +51,6 @@ public class RetrieveAccessTokenError: MSALNativeAuthError {
             return MSALNativeAuthErrorMessage.browserRequired
         case .refreshTokenExpired:
             return MSALNativeAuthErrorMessage.refreshTokenExpired
-        case .tokenNotFound:
-            return MSALNativeAuthErrorMessage.tokenNotFound
         case .generalError:
             return MSALNativeAuthErrorMessage.generalError
         }
@@ -67,10 +64,5 @@ public class RetrieveAccessTokenError: MSALNativeAuthError {
     /// Returns `true` if the refresh token has expired.
     public var isRefreshTokenExpired: Bool {
         return type == .refreshTokenExpired
-    }
-
-    /// Returns `true` if the existing token cannot be found.
-    public var isTokenNotFound: Bool {
-        return type == .tokenNotFound
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignUpStates.swift
@@ -77,7 +77,6 @@ public class SignUpBaseState: MSALNativeAuthBaseState {
     public func submitCode(code: String, delegate: SignUpVerifyCodeDelegate) {
         Task {
             let controllerResponse = await submitCodeInternal(code: code)
-            
             let delegateDispatcher = SignUpVerifyCodeDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {

--- a/MSAL/test/unit/native_auth/cache/MSALNativeAuthCacheAccessorTest.swift
+++ b/MSAL/test/unit/native_auth/cache/MSALNativeAuthCacheAccessorTest.swift
@@ -56,7 +56,7 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
         var tokens: MSALNativeAuthTokens? = nil
         
         XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
-        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.accessToken.accessToken, tokenResponse.accessToken)
         XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
         XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
     }
@@ -67,7 +67,7 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
         var tokens: MSALNativeAuthTokens? = nil
         
         XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
-        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.accessToken.accessToken, tokenResponse.accessToken)
         XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
         XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
         
@@ -80,7 +80,7 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
         XCTAssertNoThrow(try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse, configuration: parameters.msidConfiguration, context: contextStub))
 
         XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: parameters.account, configuration: parameters.msidConfiguration, context: contextStub))
-        XCTAssertEqual(tokens?.accessToken?.accessToken, newAccessToken)
+        XCTAssertEqual(tokens?.accessToken.accessToken, newAccessToken)
         XCTAssertEqual(tokens?.refreshToken?.refreshToken, newRefreshToken)
         XCTAssertEqual(tokens?.rawIdToken, newIdToken)
     }
@@ -97,7 +97,7 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
         XCTAssertEqual(account?.environment, "contoso.com")
         XCTAssertNil(account?.accountClaims)
         XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: account!, configuration: parameters.msidConfiguration, context: contextStub))
-        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.accessToken.accessToken, tokenResponse.accessToken)
         XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
         XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
     }
@@ -115,7 +115,7 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
         XCTAssertNil(account?.accountClaims)
         parameters.msidConfiguration = getMSIDConfiguration(host: "https://contoso.com/tfp/tenantName")
         XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: account!, configuration: parameters.msidConfiguration, context: contextStub))
-        XCTAssertEqual(tokens?.accessToken?.accessToken, tokenResponse.accessToken)
+        XCTAssertEqual(tokens?.accessToken.accessToken, tokenResponse.accessToken)
         XCTAssertEqual(tokens?.refreshToken?.refreshToken, tokenResponse.refreshToken)
         XCTAssertEqual(tokens?.rawIdToken, tokenResponse.idToken)
     }
@@ -140,7 +140,7 @@ final class MSALNativeAuthCacheAccessorTest: XCTestCase {
         XCTAssertEqual(account?.environment, "contoso.com")
         XCTAssertNil(account?.accountClaims)
         XCTAssertNoThrow(tokens = try cacheAccessor.getTokens(account: account!, configuration: parameters.msidConfiguration, context: contextStub))
-        XCTAssertEqual(tokens?.accessToken?.accessToken, newAccessToken)
+        XCTAssertEqual(tokens?.accessToken.accessToken, newAccessToken)
         XCTAssertEqual(tokens?.refreshToken?.refreshToken, newRefreshToken)
         XCTAssertEqual(tokens?.rawIdToken, newIdToken)
     }

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
@@ -150,7 +150,7 @@ final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
         let expectedAccessToken = "accessToken"
         let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedResult: MSALNativeAuthTokenResult(authTokens: authTokens))
         helper.expectedAccessToken = authTokens.accessToken.accessToken
-        helper.expecteExpiresOn = authTokens.accessToken.expiresOn
+        helper.expectedExpiresOn = authTokens.accessToken.expiresOn
         helper.expectedScopes = authTokens.accessToken.scopes.array as? [String] ?? []
 
         factory.mockMakeUserAccountResult(userAccountResult)

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
@@ -113,8 +113,6 @@ final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
         let accountResult = sut.retrieveUserAccountResult(context: expectedContext)
         XCTAssertEqual(accountResult?.account.username, account.username)
         XCTAssertEqual(accountResult?.idToken, authTokens.rawIdToken)
-        XCTAssertEqual(accountResult?.scopes, authTokens.accessToken?.scopes.array as? [String])
-        XCTAssertEqual(accountResult?.expiresOn, authTokens.accessToken?.expiresOn)
         XCTAssertTrue(NSDictionary(dictionary: accountResult?.account.accountClaims ?? [:]).isEqual(to: account.accountClaims ?? [:]))
     }
 
@@ -150,7 +148,10 @@ final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
         requestProviderMock.mockRequestRefreshTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
 
         let expectedAccessToken = "accessToken"
-        let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedAccessToken: expectedAccessToken)
+        let helper = CredentialsTestValidatorHelper(expectation: expectation, expectedResult: MSALNativeAuthTokenResult(authTokens: authTokens))
+        helper.expectedAccessToken = authTokens.accessToken.accessToken
+        helper.expecteExpiresOn = authTokens.accessToken.expiresOn
+        helper.expectedScopes = authTokens.accessToken.scopes.array as? [String] ?? []
 
         factory.mockMakeUserAccountResult(userAccountResult)
         tokenResult.accessToken = MSIDAccessToken()
@@ -163,7 +164,7 @@ final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
         helper.onAccessTokenRetrieveCompleted(result)
 
         await fulfillment(of: [expectation], timeout: 1)
-        XCTAssertEqual(expectedAccessToken, authTokens.accessToken?.accessToken)
+        XCTAssertEqual(expectedAccessToken, authTokens.accessToken.accessToken)
     }
 
     func test_whenErrorIsReturnedFromValidator_itIsCorrectlyTranslatedToDelegateError() async  {

--- a/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
@@ -80,8 +80,6 @@ final class MSALNativeAuthResultFactoryTests: XCTestCase {
         }
         XCTAssertEqual(accountResult.account.username, username)
         XCTAssertEqual(accountResult.idToken, idToken)
-        XCTAssertEqual(accountResult.expiresOn, expiresOn)
-        XCTAssertEqual(accountResult.scopes, scopes)
         XCTAssertNotNil(accountResult.account.accountClaims)
         XCTAssertEqual(accountResult.account.accountClaims?.count, 21)
     }
@@ -112,8 +110,6 @@ final class MSALNativeAuthResultFactoryTests: XCTestCase {
         }
         XCTAssertEqual(accountResult.account.username, username)
         XCTAssertEqual(accountResult.idToken, idToken)
-        XCTAssertEqual(accountResult.expiresOn, expiresOn)
-        XCTAssertEqual(accountResult.scopes, scopes)
         XCTAssertNil(accountResult.account.accountClaims)
     }
 }

--- a/MSAL/test/unit/native_auth/mock/CredentialsDelegateSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/CredentialsDelegateSpies.swift
@@ -32,7 +32,7 @@ open class CredentialsDelegateSpy: CredentialsDelegate {
     var expectedResult: MSALNativeAuthTokenResult?
     var expectedAccessToken: String?
     var expectedScopes: [String]?
-    var expecteExpiresOn: Date?
+    var expectedExpiresOn: Date?
 
     init(expectation: XCTestExpectation, expectedError: RetrieveAccessTokenError? = nil, expectedResult: MSALNativeAuthTokenResult? = nil) {
         self.expectation = expectation
@@ -46,7 +46,7 @@ open class CredentialsDelegateSpy: CredentialsDelegate {
             XCTAssertEqual(expectedResult, expectedResult)
             XCTAssertEqual(expectedResult.accessToken, expectedAccessToken)
             XCTAssertEqual(expectedResult.scopes, expectedScopes)
-            XCTAssertEqual(expectedResult.expiresOn, expecteExpiresOn)
+            XCTAssertEqual(expectedResult.expiresOn, expectedExpiresOn)
         } else {
             XCTFail("This method should not be called")
         }

--- a/MSAL/test/unit/native_auth/mock/CredentialsDelegateSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/CredentialsDelegateSpies.swift
@@ -29,18 +29,24 @@ open class CredentialsDelegateSpy: CredentialsDelegate {
 
     private let expectation: XCTestExpectation
     var expectedError: RetrieveAccessTokenError?
+    var expectedResult: MSALNativeAuthTokenResult?
     var expectedAccessToken: String?
-    
-    init(expectation: XCTestExpectation, expectedError: RetrieveAccessTokenError? = nil, expectedAccessToken: String? = nil) {
+    var expectedScopes: [String]?
+    var expecteExpiresOn: Date?
+
+    init(expectation: XCTestExpectation, expectedError: RetrieveAccessTokenError? = nil, expectedResult: MSALNativeAuthTokenResult? = nil) {
         self.expectation = expectation
         self.expectedError = expectedError
-        self.expectedAccessToken = expectedAccessToken
+        self.expectedResult = expectedResult
     }
 
-    public func onAccessTokenRetrieveCompleted(accessToken: String) {
-        if let expectedAccessToken = expectedAccessToken {
+    public func onAccessTokenRetrieveCompleted(result: MSALNativeAuthTokenResult) {
+        if let expectedResult = expectedResult {
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertEqual(expectedAccessToken, accessToken)
+            XCTAssertEqual(expectedResult, expectedResult)
+            XCTAssertEqual(expectedResult.accessToken, expectedAccessToken)
+            XCTAssertEqual(expectedResult.scopes, expectedScopes)
+            XCTAssertEqual(expectedResult.expiresOn, expecteExpiresOn)
         } else {
             XCTFail("This method should not be called")
         }
@@ -84,11 +90,11 @@ final class CredentialsDelegateOptionalMethodsNotImplemented: CredentialsDelegat
 class CredentialsTestValidatorHelper: CredentialsDelegateSpy {
 
     func onAccessTokenRetrieveCompleted(_ response: MSALNativeAuthCredentialsController.RefreshTokenCredentialControllerResponse) {
-        guard case let .success(token) = response.result else {
+        guard case let .success(result) = response.result else {
             return XCTFail("wrong result")
         }
 
-        Task { await self.onAccessTokenRetrieveCompleted(accessToken: token) }
+        Task { await self.onAccessTokenRetrieveCompleted(result: result) }
     }
 
     func onAccessTokenRetrieveError(_ response: MSALNativeAuthCredentialsController.RefreshTokenCredentialControllerResponse) {

--- a/MSAL/test/unit/native_auth/mock/SignInDelegatesSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/SignInDelegatesSpies.swift
@@ -65,7 +65,6 @@ open class SignInPasswordStartDelegateSpy: SignInStartDelegate {
         if let expectedUserAccountResult = expectedUserAccountResult {
             XCTAssertTrue(Thread.isMainThread)
             XCTAssertEqual(expectedUserAccountResult.idToken, result.idToken)
-            XCTAssertEqual(expectedUserAccountResult.scopes, result.scopes)
         } else {
             XCTFail("This method should not be called")
         }
@@ -106,7 +105,6 @@ class SignInPasswordRequiredDelegateSpy: SignInPasswordRequiredDelegate {
         XCTAssertTrue(Thread.isMainThread)
         if let expectedUserAccountResult = expectedUserAccountResult {
             XCTAssertEqual(expectedUserAccountResult.idToken, result.idToken)
-            XCTAssertEqual(expectedUserAccountResult.scopes, result.scopes)
         } else {
             XCTFail("This method should not be called")
         }
@@ -278,7 +276,6 @@ open class SignInVerifyCodeDelegateSpy: SignInVerifyCodeDelegate {
             return
         }
         XCTAssertEqual(expectedUserAccountResult.idToken, result.idToken)
-        XCTAssertEqual(expectedUserAccountResult.scopes, result.scopes)
         XCTAssertTrue(Thread.isMainThread)
         expectation.fulfill()
     }
@@ -329,7 +326,6 @@ open class SignInAfterSignUpDelegateSpy: SignInAfterSignUpDelegate {
             return
         }
         XCTAssertEqual(expectedUserAccountResult.idToken, result.idToken)
-        XCTAssertEqual(expectedUserAccountResult.scopes, result.scopes)
         XCTAssertTrue(Thread.isMainThread)
         expectation.fulfill()
     }
@@ -361,7 +357,6 @@ class SignInAfterResetPasswordDelegateSpy: SignInAfterResetPasswordDelegate {
             return
         }
         XCTAssertEqual(expectedUserAccountResult.idToken, result.idToken)
-        XCTAssertEqual(expectedUserAccountResult.scopes, result.scopes)
         XCTAssertTrue(Thread.isMainThread)
         expectation.fulfill()
     }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
@@ -56,16 +56,19 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
 
     func test_whenValidTokenResponse_validationIsSuccessful() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = nil
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.refreshToken = nil
+        let rawIdToken = "rawIdToken"
+        let authTokens = MSALNativeAuthTokens(accessToken: accessToken,
+                                              refreshToken: refreshToken,
+                                              rawIdToken: rawIdToken)
         let userAccountResult = MSALNativeAuthUserAccountResult(account:
                                                                     MSALNativeAuthUserAccountResultStub.account,
-                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
-                                                                                                 refreshToken: nil,
-                                                                                                 rawIdToken: nil),
+                                                                authTokens:authTokens,
                                                                 configuration: MSALNativeAuthConfigStubs.configuration,
                                                                 cacheAccessor: MSALNativeAuthCacheAccessorMock())
-        let refreshToken = MSIDRefreshToken()
-        refreshToken.familyId = "familyId"
-        refreshToken.refreshToken = "refreshToken"
         let tokenResponse = MSIDCIAMTokenResponse()
         factory.mockMakeUserAccountResult(userAccountResult)
         let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .success(tokenResponse))

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -585,9 +585,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
         let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
-                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
-                                                                                                 refreshToken: nil,
-                                                                                                 rawIdToken: nil),
+                                                                authTokens: MSALNativeAuthUserAccountResultStub.authTokens,
                                                                 configuration: MSALNativeAuthConfigStubs.configuration,
                                                                 cacheAccessor: MSALNativeAuthCacheAccessorMock())
         authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
@@ -687,9 +685,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
         let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
-                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
-                                                                                                 refreshToken: nil,
-                                                                                                 rawIdToken: nil),
+                                                                authTokens: MSALNativeAuthUserAccountResultStub.authTokens,
                                                                 configuration: MSALNativeAuthConfigStubs.configuration,
                                                                 cacheAccessor: MSALNativeAuthCacheAccessorMock())
         authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
@@ -784,9 +780,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
         let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
-                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
-                                                                                                 refreshToken: nil,
-                                                                                                 rawIdToken: nil),
+                                                                authTokens: MSALNativeAuthUserAccountResultStub.authTokens,
                                                                 configuration: MSALNativeAuthConfigStubs.configuration,
                                                                 cacheAccessor: MSALNativeAuthCacheAccessorMock())
         authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
@@ -874,9 +868,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
         let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
-                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
-                                                                                                 refreshToken: nil,
-                                                                                                 rawIdToken: nil),
+                                                                authTokens: MSALNativeAuthUserAccountResultStub.authTokens,
                                                                 configuration: MSALNativeAuthConfigStubs.configuration,
                                                                 cacheAccessor: MSALNativeAuthCacheAccessorMock())
         authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
@@ -974,9 +966,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
         let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
-                                                                authTokens: MSALNativeAuthTokens(accessToken: nil,
-                                                                                                 refreshToken: nil,
-                                                                                                 rawIdToken: nil),
+                                                                authTokens: MSALNativeAuthUserAccountResultStub.authTokens,
                                                                 configuration: MSALNativeAuthConfigStubs.configuration,
                                                                 cacheAccessor: MSALNativeAuthCacheAccessorMock())
         authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -57,30 +57,22 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
 
     func test_whenAccountAndTokenExist_itReturnsCorrectData() {
         let expectation = expectation(description: "CredentialsController")
-        let accessToken = MSIDAccessToken()
-        accessToken.accessToken = "accessToken"
-        let refreshToken = MSIDRefreshToken()
-        refreshToken.refreshToken = "refreshToken"
-        let rawIdToken = "rawIdToken"
-        let authTokens = MSALNativeAuthTokens(accessToken: accessToken,
-                                              refreshToken: refreshToken,
-                                              rawIdToken: rawIdToken)
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
         let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedResult: MSALNativeAuthTokenResult(authTokens: authTokens))
+        mockDelegate.expectedAccessToken = authTokens.accessToken.accessToken
+        mockDelegate.expectedExpiresOn = authTokens.accessToken.expiresOn
+        mockDelegate.expectedScopes = authTokens.accessToken.scopes.array as? [String] ?? []
         sut.getAccessToken(delegate: mockDelegate)
         wait(for: [expectation], timeout: 1)
     }
 
-    func test_whenNoAccessToken_itReturnsCorrectError() {
+    func test_whenNoAccessToken_itReturnsCorrectError() throws {
+        //The MSALNativeAuthTokens accessToken is never nil anymore so we this can't happen anymore
+        try XCTSkipIf(true)
         let expectation = expectation(description: "CredentialsController")
-        let accessToken = MSIDAccessToken()
-        accessToken.accessToken = nil
-        let refreshToken = MSIDRefreshToken()
-        refreshToken.refreshToken = nil
-        let rawIdToken = ""
-        let authTokens = MSALNativeAuthTokens(accessToken: accessToken,
-                                              refreshToken: refreshToken,
-                                              rawIdToken: rawIdToken)
-
+        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
+        authTokens.accessToken.expiresOn = Date(timeIntervalSinceNow: 3600)
+        authTokens.accessToken.accessToken = nil
         sut = MSALNativeAuthUserAccountResult(
             account: account!,
             authTokens: authTokens,
@@ -89,6 +81,9 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         )
         let correlationId = UUID()
         let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .tokenNotFound, correlationId: correlationId, errorCodes: []))
+        mockDelegate.expectedAccessToken = authTokens.accessToken.accessToken
+        mockDelegate.expectedExpiresOn = authTokens.accessToken.expiresOn
+        mockDelegate.expectedScopes = authTokens.accessToken.scopes.array as? [String]
         sut.getAccessToken(correlationId: correlationId, delegate: mockDelegate)
         wait(for: [expectation], timeout: 1)
     }

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -66,28 +66,6 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    func test_whenNoAccessToken_itReturnsCorrectError() throws {
-        //The MSALNativeAuthTokens accessToken is never nil anymore so we this can't happen anymore
-        try XCTSkipIf(true)
-        let expectation = expectation(description: "CredentialsController")
-        let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
-        authTokens.accessToken.expiresOn = Date(timeIntervalSinceNow: 3600)
-        authTokens.accessToken.accessToken = nil
-        sut = MSALNativeAuthUserAccountResult(
-            account: account!,
-            authTokens: authTokens,
-            configuration: MSALNativeAuthConfigStubs.configuration,
-            cacheAccessor: MSALNativeAuthCacheAccessorMock()
-        )
-        let correlationId = UUID()
-        let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedError: RetrieveAccessTokenError(type: .tokenNotFound, correlationId: correlationId, errorCodes: []))
-        mockDelegate.expectedAccessToken = authTokens.accessToken.accessToken
-        mockDelegate.expectedExpiresOn = authTokens.accessToken.expiresOn
-        mockDelegate.expectedScopes = authTokens.accessToken.scopes.array as? [String]
-        sut.getAccessToken(correlationId: correlationId, delegate: mockDelegate)
-        wait(for: [expectation], timeout: 1)
-    }
-
     // MARK: - sign-out tests
 
     func test_signOut_successfullyCallsCacheAccessor() {

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -57,17 +57,33 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
 
     func test_whenAccountAndTokenExist_itReturnsCorrectData() {
         let expectation = expectation(description: "CredentialsController")
-
-        let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedAccessToken: "accessToken")
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = "accessToken"
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.refreshToken = "refreshToken"
+        let rawIdToken = "rawIdToken"
+        let authTokens = MSALNativeAuthTokens(accessToken: accessToken,
+                                              refreshToken: refreshToken,
+                                              rawIdToken: rawIdToken)
+        let mockDelegate = CredentialsDelegateSpy(expectation: expectation, expectedResult: MSALNativeAuthTokenResult(authTokens: authTokens))
         sut.getAccessToken(delegate: mockDelegate)
         wait(for: [expectation], timeout: 1)
     }
 
     func test_whenNoAccessToken_itReturnsCorrectError() {
         let expectation = expectation(description: "CredentialsController")
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = nil
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.refreshToken = nil
+        let rawIdToken = ""
+        let authTokens = MSALNativeAuthTokens(accessToken: accessToken,
+                                              refreshToken: refreshToken,
+                                              rawIdToken: rawIdToken)
+
         sut = MSALNativeAuthUserAccountResult(
             account: account!,
-            authTokens: MSALNativeAuthTokens(accessToken: nil, refreshToken: nil, rawIdToken: nil),
+            authTokens: authTokens,
             configuration: MSALNativeAuthConfigStubs.configuration,
             cacheAccessor: MSALNativeAuthCacheAccessorMock()
         )

--- a/MSAL/test/unit/native_auth/public/error/RetrieveAccessTokenErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/RetrieveAccessTokenErrorTests.swift
@@ -43,7 +43,6 @@ final class RetrieveAccessTokenErrorTests: XCTestCase {
         let sut: [RetrieveAccessTokenError] = [
             .init(type: .browserRequired, correlationId: .init()),
             .init(type: .refreshTokenExpired, correlationId: .init()),
-            .init(type: .tokenNotFound, correlationId: .init()),
             .init(type: .generalError, correlationId: .init())
         ]
 
@@ -65,20 +64,11 @@ final class RetrieveAccessTokenErrorTests: XCTestCase {
         sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
         XCTAssertFalse(sut.isRefreshTokenExpired)
-        XCTAssertFalse(sut.isTokenNotFound)
     }
 
     func test_isRefreshTokenExpired() {
         sut = .init(type: .refreshTokenExpired, correlationId: .init())
         XCTAssertTrue(sut.isRefreshTokenExpired)
         XCTAssertFalse(sut.isBrowserRequired)
-        XCTAssertFalse(sut.isTokenNotFound)
-    }
-
-    func test_isTokenNotFound() {
-        sut = .init(type: .tokenNotFound, correlationId: .init())
-        XCTAssertTrue(sut.isTokenNotFound)
-        XCTAssertFalse(sut.isBrowserRequired)
-        XCTAssertFalse(sut.isRefreshTokenExpired)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/RetrieveAccessTokenErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/RetrieveAccessTokenErrorTests.swift
@@ -30,7 +30,7 @@ final class RetrieveAccessTokenErrorTests: XCTestCase {
     private var sut: RetrieveAccessTokenError!
 
     func test_totalCases() {
-        XCTAssertEqual(RetrieveAccessTokenError.ErrorType.allCases.count, 4)
+        XCTAssertEqual(RetrieveAccessTokenError.ErrorType.allCases.count, 3)
     }
 
     func test_customErrorDescription() {
@@ -49,7 +49,6 @@ final class RetrieveAccessTokenErrorTests: XCTestCase {
         let expectedIdentifiers = [
             MSALNativeAuthErrorMessage.browserRequired,
             MSALNativeAuthErrorMessage.refreshTokenExpired,
-            MSALNativeAuthErrorMessage.tokenNotFound,
             MSALNativeAuthErrorMessage.generalError
         ]
 


### PR DESCRIPTION
## Proposed changes
Make the AccountResult more extensible moving the "scopes" and "expiresOn" attributes at the access token Result level

## Type of change

- [] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

