### PR TITLE
Convert MSAL release pipeline to onebranch

### DIFF
--- a/azure_pipelines/spm-framework.yml
+++ b/azure_pipelines/spm-framework.yml
@@ -13,6 +13,10 @@ variables:
     value: 'MSAL ObjC Service Connection'
   - name: 'docsRepositoryBranch' # Name of the branch where public reference docs will be pushed for github page
     value: 'gh-pages'
+  - name: LinuxContainerImage
+    value: onebranch.azurecr.io/linux/ubuntu-2004:latest
+  - name: ob_outputDirectory
+    value: '$(Build.SourcesDirectory)/out'
 
 trigger:
   branches:
@@ -28,390 +32,480 @@ resources:
   repositories:
   - repository: msalRepository
     type: github
-    endpoint: 'GitHub for AzureAD and Azure-Samples (as aadidgit service)'
+    endpoint: 'MSAL ObjC Service Connection'
     name: $(repositoryName)
     ref: $(repositoryBranch)
-
-jobs:
-- job: BuildXcFrameworks
-  displayName: Build MSAL framework and release
-  pool:
-    vmImage: 'macOS-13'
-    timeOutInMinutes: 20
-
-  steps:
-  - checkout: msalRepository
-    clean: true
-    submodules: true
-    fetchDepth: 1
-    persistCredentials: false
-  - task: Xcode@5
-    displayName: Build archive for iOS Simulator
-    inputs:
-      actions: 'archive'
-      sdk: 'iphonesimulator'
-      xcWorkspacePath: 'MSAL.xcworkspace'
-      scheme: 'MSAL (iOS Framework)'
-      packageApp: false
-      args: 'SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath $(Build.binariesDirectory)/iOS-Sim'
-      exportPath: $(Build.binariesDirectory)/iOS-Sim
-  - task: Xcode@5
-    displayName: Build archive for iOS device
-    inputs:
-      actions: 'archive'
-      sdk: 'iphoneos'
-      xcWorkspacePath: 'MSAL.xcworkspace'
-      scheme: 'MSAL (iOS Framework)'
-      packageApp: false
-      destinationTypeOption: 'devices'
-      args: 'SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath $(Build.binariesDirectory)/iOS'
-      exportPath: $(Build.binariesDirectory)/iOS
-  - task: Xcode@5
-    displayName: Build archive for macOS
-    inputs:
-      actions: 'archive'
-      sdk: 'macosx'
-      xcWorkspacePath: 'MSAL.xcworkspace'
-      scheme: 'MSAL (Mac Framework)'
-      packageApp: false
-      args: 'SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath $(Build.binariesDirectory)/macOS'
-      exportPath: $(Build.binariesDirectory)/macOS
-  - task: Bash@3
-    displayName: Build xcframework from archives
-    inputs:
-      workingDirectory: $(Build.binariesDirectory)
-      targetType: 'inline'
-      script: |
-        # Building xcframework
-        cd $(Build.BinariesDirectory)
-        
-        echo "Build Dir = $(pwd)"
-        
-        xcodebuild -create-xcframework \
-        -framework $(Build.binariesDirectory)/iOS.xcarchive/Products/Library/Frameworks/MSAL.framework \
-        -framework $(Build.binariesDirectory)/iOS-Sim.xcarchive/Products/Library/Frameworks/MSAL.framework \
-        -framework $(Build.binariesDirectory)/macOS.xcarchive/Products/Library/Frameworks/MSAL.framework \
-        -output $(Build.ArtifactStagingDirectory)/MSAL.xcframework
-      failOnStderr: true
-  - task: Bash@3
-    displayName: Zip xcframework for codesigning
-    inputs:
-      workingDirectory: $(Build.ArtifactStagingDirectory)
-      targetType: 'inline'
-      script: |
-        # Zipping xcframework. -y : including symlinks (Need to preserve symlinks in xcframework so that codesign validation doesn't fail) -v : verbose logging
-        zip -r $(Build.ArtifactStagingDirectory)/MSAL.zip MSAL.xcframework -y -v
-      failOnStderr: true
-  - task: UseDotNet@2
-    inputs:
-      packageType: 'runtime'
-      version: '6.0.0'
-      installationPath: '/Users/runner/.dotnet'
-  - task: EsrpCodeSigning@2
-    inputs:
-      ConnectedServiceName: 'MSAL ESRP CodeSign Service Connection'
-      FolderPath: '$(Build.ArtifactStagingDirectory)'
-      Pattern: 'MSAL.zip'
-      signConfigType: 'inlineSignParams'
-      SessionTimeout: '60'
-      MaxConcurrency: '50'
-      MaxRetryAttempts: '5'
-      UseMinimatch: false
-      inlineOperation: |
-        [
-          {
-            "keyCode": "CP-233039-Apple",
-            "operationCode": "iOSSdkSign",
-            "parameters": {},
-           "toolName": "sign",
-            "toolVersion": "1.0"
-          }
-        ]
-  - task: Bash@3
-    displayName: Zip and unzip # Task to unzip signed contents and repackage it into MSAL.xcframework
-    inputs:
-      targetType: 'inline'
-      script: |
-        # Codesigning service explodes xcframework in output zip. Need to re-package contents into xcframework
-        # Extract code signature and add it into built xcframework
-        unzip MSAL.zip _CodeSignature\* -d MSAL.xcframework
-        # Delete zip file
-        rm MSAL.zip
-        # Delete md file created by codesigning service
-        rm *.md
-        # Zip xcframework into zip file with symlinks preserved and delete xcframework
-        zip -r MSAL.zip MSAL.xcframework -y -m
-      workingDirectory: '$(Build.ArtifactStagingDirectory)'
-      failOnStderr: true
-  - task: Bash@3
-    displayName: Calculate checksum | extract release version from changelog
-    inputs:
-      targetType: 'inline'
-      script: |
-        chksm=$(shasum -a 256 $(Build.ArtifactStagingDirectory)/MSAL.zip | cut -d ' ' -f 1)
-        echo "##vso[task.setvariable variable=frameworkChecksum]${chksm}"
-        
-        #Regex for semver versioning
-        ver=$(egrep -om1 '\[((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\]' CHANGELOG.md | sed -E -e "s/\[|\]//g")
-        echo "##vso[task.setvariable variable=releaseVersion]${ver}"
-      workingDirectory: '$(Build.SourcesDirectory)'
-      failOnStderr: true
-      noProfile: false
-      noRc: false
-      
-  - task: Shellpp@0
-    displayName: Generating release archive zips
-    inputs:
-      type: 'FilePath'
-      scriptPath: 'ReleaseArchive.sh'
-      args: '$(releaseVersion) $(Build.ArtifactStagingDirectory)'
-      
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: 'Generate SBOM file'
-    inputs:
-      BuildDropPath: '$(Build.ArtifactStagingDirectory)'
-      
-  - task: PublishPipelineArtifact@1
-    inputs:
-      targetPath: $(Build.ArtifactStagingDirectory)
-      artifactName: Artifact
-      
-  - task: Bash@3
-    displayName: Common Core - extract release version from changelog | Build release notes
-    inputs:
-      targetType: 'inline'
-      script: |
-        #Regex for semver versioning
-        cc_ver=$(egrep -om1 '((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)' MSAL/IdentityCore/changelog.txt)
-        echo "##vso[task.setvariable variable=commonCoreReleaseVersion]${cc_ver}"
-
-        chlg="## Release Notes"$'\n'
-        if [ ! -e "MSAL/IdentityCore/changelog.txt" ]; then
-          echo "CHANGELOG NOT FOUND!"
-        else
-          fl=0
-          while read p; do
-            if [[ "$p" =~ 'Version' ]]; then
-              fl=$((fl + 1))
-              if [ $fl -gt 1 ]
-              then
-                  break
+  - repository: onebranchTemplates
+    type: git
+    name: OneBranch.Pipelines/GovernedTemplates
+    ref: refs/heads/main
+extends:
+  template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
+  parameters:
+    globalSdl:
+    # Possible tool configurations: https://eng.ms/docs/products/onebranch/securitycompliancegovernanceandpolicies/sdlforcontainerizedworkflows/customizesdlforcontainerbuilds
+      tsa:
+        enabled: true
+        breakOnFailure: true
+        serviceTreeID: 'f30afd49-f4fa-4b35-8c51-59db11493d48'
+      credscan:
+        enabled: true
+        breakOnFailure: true
+      policheck:
+        enabled: true
+        break: true
+        severity: Warning
+      armory:
+        enabled: true
+        break: true
+      perStage:
+        sdl_sources:
+          checkout_all_repos: true
+    stages:
+    - stage: Pull_Build_CodeSign_Repository
+      dependsOn:
+      - sdl_sources
+      condition: succeeded('sdl_sources')
+      jobs:
+      - job: BuildXcFrameworks
+        displayName: Build MSAL framework and release
+        pool:
+          type: linux
+          isCustom: true
+          name: Azure Pipelines
+          vmImage: 'macOS-13'
+          timeOutInMinutes: 65
+        variables:
+          ob_outputDirectory: '$(Build.SourcesDirectory)/out' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+        steps:
+        - checkout: msalRepository
+          clean: true
+          submodules: true
+          fetchDepth: 1
+          persistCredentials: false
+        - task: Xcode@5
+          displayName: Build archive for iOS Simulator
+          inputs:
+            actions: 'archive'
+            sdk: 'iphonesimulator'
+            xcWorkspacePath: 'MSAL.xcworkspace'
+            scheme: 'MSAL (iOS Framework)'
+            packageApp: false
+            args: 'SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath $(Build.binariesDirectory)/iOS-Sim'
+            exportPath: $(Build.binariesDirectory)/iOS-Sim
+        - task: Xcode@5
+          displayName: Build archive for iOS device
+          inputs:
+            actions: 'archive'
+            sdk: 'iphoneos'
+            xcWorkspacePath: 'MSAL.xcworkspace'
+            scheme: 'MSAL (iOS Framework)'
+            packageApp: false
+            destinationTypeOption: 'devices'
+            args: 'SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath $(Build.binariesDirectory)/iOS'
+            exportPath: $(Build.binariesDirectory)/iOS
+        - task: Xcode@5
+          displayName: Build archive for macOS
+          inputs:
+            actions: 'archive'
+            sdk: 'macosx'
+            xcWorkspacePath: 'MSAL.xcworkspace'
+            scheme: 'MSAL (Mac Framework)'
+            packageApp: false
+            args: 'SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath $(Build.binariesDirectory)/macOS'
+            exportPath: $(Build.binariesDirectory)/macOS
+        - task: Bash@3
+          displayName: Build xcframework from archives
+          inputs:
+            workingDirectory: $(Build.binariesDirectory)
+            targetType: 'inline'
+            script: |
+              # Building xcframework
+              cd $(Build.BinariesDirectory)
+              
+              echo "Build Dir = $(pwd)"
+              
+              xcodebuild -create-xcframework \
+              -framework $(Build.binariesDirectory)/iOS.xcarchive/Products/Library/Frameworks/MSAL.framework \
+              -framework $(Build.binariesDirectory)/iOS-Sim.xcarchive/Products/Library/Frameworks/MSAL.framework \
+              -framework $(Build.binariesDirectory)/macOS.xcarchive/Products/Library/Frameworks/MSAL.framework \
+              -output $(Build.ArtifactStagingDirectory)/MSAL.xcframework
+            failOnStderr: true
+        - task: Bash@3
+          displayName: Zip xcframework for codesigning
+          inputs:
+            workingDirectory: $(Build.ArtifactStagingDirectory)
+            targetType: 'inline'
+            script: |
+              # Zipping xcframework. -y : including symlinks (Need to preserve symlinks in xcframework so that codesign validation doesn't fail) -v : verbose logging
+              zip -r $(Build.ArtifactStagingDirectory)/MSAL.zip MSAL.xcframework -y -v
+            failOnStderr: true
+        - task: UseDotNet@2
+          inputs:
+            packageType: 'runtime'
+            version: '6.0.0'
+            installationPath: '/Users/runner/.dotnet'
+        - task: EsrpCodeSigning@2
+          inputs:
+            ConnectedServiceName: 'MSAL ESRP CodeSign Service Connection'
+            FolderPath: '$(Build.ArtifactStagingDirectory)'
+            Pattern: 'MSAL.zip'
+            signConfigType: 'inlineSignParams'
+            SessionTimeout: '60'
+            MaxConcurrency: '50'
+            MaxRetryAttempts: '5'
+            UseMinimatch: false
+            inlineOperation: |
+              [
+                {
+                  "keyCode": "CP-233039-Apple",
+                  "operationCode": "iOSSdkSign",
+                  "parameters": {},
+                "toolName": "sign",
+                  "toolVersion": "1.0"
+                }
+              ]
+        - task: Bash@3
+          displayName: Zip and unzip # Task to unzip signed contents and repackage it into MSAL.xcframework
+          inputs:
+            targetType: 'inline'
+            script: |
+              # Codesigning service explodes xcframework in output zip. Need to re-package contents into xcframework
+              # Extract code signature and add it into built xcframework
+              unzip MSAL.zip _CodeSignature\* -d MSAL.xcframework
+              # Delete zip file
+              rm MSAL.zip
+              # Delete md file created by codesigning service
+              rm *.md
+              # Zip xcframework into zip file with symlinks preserved and delete xcframework
+              zip -r MSAL.zip MSAL.xcframework -y -m
+            workingDirectory: '$(Build.ArtifactStagingDirectory)'
+            failOnStderr: true
+        - task: Bash@3
+          displayName: Calculate checksum | extract release version from changelog
+          inputs:
+            targetType: 'inline'
+            script: |
+              chksm=$(shasum -a 256 $(Build.ArtifactStagingDirectory)/MSAL.zip | cut -d ' ' -f 1)
+              echo "##vso[task.setvariable variable=frameworkChecksum]${chksm}"
+              
+              #Regex for semver versioning
+              ver=$(egrep -om1 '\[((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)\]' CHANGELOG.md | sed -E -e "s/\[|\]//g")
+              echo "##vso[task.setvariable variable=releaseVersion]${ver}"
+            workingDirectory: '$(Build.SourcesDirectory)'
+            failOnStderr: true
+            noProfile: false
+            noRc: false
+            
+        - task: Shellpp@0
+          displayName: Generating release archive zips
+          inputs:
+            type: 'FilePath'
+            scriptPath: 'ReleaseArchive.sh'
+            args: '$(releaseVersion) $(Build.ArtifactStagingDirectory)'
+            
+        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+          displayName: 'Generate SBOM file'
+          inputs:
+            BuildDropPath: '$(Build.ArtifactStagingDirectory)'
+        - task: Bash@3
+          displayName: Create and copy built artifact to /out
+          inputs:
+            targetType: 'inline'
+            script: |
+              if [ ! -d "out" ]; then
+                  mkdir -p "out"
+                  echo "Folder created successfully!"
               fi
-            fi
+            workingDirectory: '$(Build.SourcesDirectory)'
+            failOnStderr: true
+        - task: CopyFiles@2
+          displayName: Copy framework for onebranch published artifacts
+          inputs:
+            SourceFolder: '$(Build.ArtifactStagingDirectory)'
+            Contents: 'MSAL.zip'
+            TargetFolder: '$(Build.SourcesDirectory)/out'
+        - task: PublishPipelineArtifact@1
+          inputs:
+            targetPath: '$(Build.SourcesDirectory)/out/MSAL.zip'
+            artifact: 'drop_Pull_Build_CodeSign_Repository_BuildXcFrameworks'
+            publishLocation: 'pipeline'
+    - stage: Create_Common_core_release
+      jobs:
+      - job: Common_core_release
+        pool:
+          type: linux
+          isCustom: true
+          name: Azure Pipelines
+          vmImage: 'macOS-13'
+          timeOutInMinutes: 65
+        steps:
+        - task: Bash@3
+          displayName: Common Core - extract release version from changelog | Build release notes
+          inputs:
+            targetType: 'inline'
+            script: |
+              #Regex for semver versioning
+              cc_ver=$(egrep -om1 '((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)' MSAL/IdentityCore/changelog.txt)
+              echo "##vso[task.setvariable variable=commonCoreReleaseVersion]${cc_ver}"
 
-            if [[ ($fl -eq 1)  && !("$p" =~ ^\*\s+) ]]; then
-              chlg="$chlg"$'\n'"$p"
-            fi
-          done < "MSAL/IdentityCore/changelog.txt"
-        fi
-        echo "chlg = ${chlg}"
-        echo "${chlg}" > cc-release-notes.md
+              chlg="## Release Notes"$'\n'
+              if [ ! -e "MSAL/IdentityCore/changelog.txt" ]; then
+                echo "CHANGELOG NOT FOUND!"
+              else
+                fl=0
+                while read p; do
+                  if [[ "$p" =~ 'Version' ]]; then
+                    fl=$((fl + 1))
+                    if [ $fl -gt 1 ]
+                    then
+                        break
+                    fi
+                  fi
 
-      workingDirectory: '$(Build.SourcesDirectory)'
-      failOnStderr: true
-      noProfile: false
-      noRc: false
-  - task: GitHubRelease@1
-    displayName: Generate Common Core Github Release
-    inputs:
-      gitHubConnection: '$(GithubServiceConnection)'
-      repositoryName: 'AzureAD/microsoft-authentication-library-common-for-objc'
-      action: 'create'
-      target: 'main'
-      tagSource: 'userSpecifiedTag'
-      tag: '$(commonCoreReleaseVersion)'
-      title: '$(commonCoreReleaseVersion)'
-      releaseNotesFilePath: 'cc-release-notes.md'
-      changeLogCompareToRelease: 'lastFullRelease'
-      changeLogType: 'issueBased'
-      assets: |
-        *.abcd
-  - task: InstallSSHKey@0
-    displayName: Install SSH Key for MSAL Github Repo
-    inputs:
-      knownHostsEntry: '$(sshKnownHosts)'
-      sshPublicKey: '$(sshPublicKey)'
-      sshKeySecureFile: 'msal_objc_private_key'
-      addEntryToConfig: true
-      configHostAlias: 'ADO Release Pipeline Public Key'
-      configHostname: 'github.com'
-  - task: Bash@3
-    displayName: Update package.swift with url & checksum & git push
-    inputs:
-      targetType: 'inline'
-      script: |
-        rm -rf cc-release-notes.md
-        ssh-keyscan github.com | tee -a ~/.ssh/known_hosts
-        git remote set-url origin git@github.com:$(repositoryName).git
+                  if [[ ($fl -eq 1)  && !("$p" =~ ^\*\s+) ]]; then
+                    chlg="$chlg"$'\n'"$p"
+                  fi
+                done < "MSAL/IdentityCore/changelog.txt"
+              fi
+              echo "chlg = ${chlg}"
+              echo "${chlg}" > cc-release-notes.md
 
-        authorName=$(git log -1 --pretty=format:'%an')
-        authorEmail=$(git log -1 --pretty=format:'%ae')
-        git config --global user.email "${authorEmail}"
-        git config --global user.name "${authorName}"
+            workingDirectory: '$(Build.SourcesDirectory)'
+            failOnStderr: true
+            noProfile: false
+            noRc: false
+        - task: GitHubRelease@1
+          displayName: Generate Common Core Github Release
+          inputs:
+            gitHubConnection: '$(GithubServiceConnection)'
+            repositoryName: 'AzureAD/microsoft-authentication-library-common-for-objc'
+            action: 'create'
+            target: 'main'
+            tagSource: 'userSpecifiedTag'
+            tag: '$(commonCoreReleaseVersion)'
+            title: '$(commonCoreReleaseVersion)'
+            releaseNotesFilePath: 'cc-release-notes.md'
+            changeLogCompareToRelease: 'lastFullRelease'
+            changeLogType: 'issueBased'
+            assets: |
+              *.abcd
+    - stage: MSAL_Release
+      jobs:
+      - job: MSAL_release
+        pool:
+          type: linux
+          isCustom: true
+          name: Azure Pipelines
+          vmImage: 'macOS-13'
+          timeOutInMinutes: 65
+        steps:
+        - task: InstallSSHKey@0
+          displayName: Install SSH Key for MSAL Github Repo
+          inputs:
+            knownHostsEntry: '$(sshKnownHosts)'
+            sshPublicKey: '$(sshPublicKey)'
+            sshKeySecureFile: 'msal_objc_private_key'
+            addEntryToConfig: true
+            configHostAlias: 'ADO Release Pipeline Public Key'
+            configHostname: 'github.com'
+        - task: Bash@3
+          displayName: Update package.swift with url & checksum & git push
+          inputs:
+            targetType: 'inline'
+            script: |
+              rm -rf cc-release-notes.md
+              ssh-keyscan github.com | tee -a ~/.ssh/known_hosts
+              git remote set-url origin git@github.com:$(repositoryName).git
 
-        git fetch origin $(repositoryBranch) -q
-        git checkout FETCH_HEAD -q
-        git checkout -b update-package-for-$(releaseVersion) -q
+              authorName=$(git log -1 --pretty=format:'%an')
+              authorEmail=$(git log -1 --pretty=format:'%ae')
+              git config --global user.email "${authorEmail}"
+              git config --global user.name "${authorName}"
 
-        if [ ! -e Package.swift ]; then
-            echo -e "// swift-tools-version:5.3\n" >> Package.swift
-            cat >> Package.swift << EOF
-        import PackageDescription
+              git fetch origin $(repositoryBranch) -q
+              git checkout FETCH_HEAD -q
+              git checkout -b update-package-for-$(releaseVersion) -q
 
-        let package = Package(
-          name: "MSAL",
-          platforms: [
-                .macOS(.v10_12),.iOS(.v11)
-          ],
-          products: [
-              .library(
-                  name: "MSAL",
-                  targets: ["MSAL"]),
-          ],
-          targets: [
-              .binaryTarget(name: "MSAL", url: "https://github.com/$(repositoryName)/releases/download/releaseTag1.2.3/MSAL.zip", checksum: "abcdefabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234")
-          ]
-        )
-        EOF
-        fi
-        perl -i -pe's/checksum:\s+\"[\da-fA-F]{64}\"/checksum: \"$(frameworkChecksum)\"/' Package.swift
-        perl -i -pe's/releases\/download\/[0-9a-zA-Z\.].+\//releases\/download\/$(releaseVersion)\//' Package.swift
-        perl -i -pe's/s\.version\s+=\s+".*"/s.version      = \"$(releaseVersion)\"/' MSAL.podspec
-        plutil -replace CFBundleShortVersionString -string $(releaseVersion) MSAL/resources/ios/Info.plist
-        plutil -replace CFBundleShortVersionString -string $(releaseVersion) MSAL/resources/mac/Info.plist
-        majorVer=$(echo $(releaseVersion) | cut -d"." -f1)
-        minorVer=$(echo $(releaseVersion) | cut -d"." -f2)
-        patchVer=$(echo $(releaseVersion) | cut -d"." -f3)
+              if [ ! -e Package.swift ]; then
+                  echo -e "// swift-tools-version:5.3\n" >> Package.swift
+                  cat >> Package.swift << EOF
+              import PackageDescription
 
-        perl -i -pe"s/MSAL_VER_HIGH\s+.*$/MSAL_VER_HIGH       $majorVer/" MSAL/src/MSAL_Internal.h
-        perl -i -pe"s/MSAL_VER_LOW\s+.*$/MSAL_VER_LOW        $minorVer/" MSAL/src/MSAL_Internal.h
-        perl -i -pe"s/MSAL_VER_PATCH\s+.*$/MSAL_VER_PATCH      $patchVer/" MSAL/src/MSAL_Internal.h
+              let package = Package(
+                name: "MSAL",
+                platforms: [
+                      .macOS(.v10_12),.iOS(.v11)
+                ],
+                products: [
+                    .library(
+                        name: "MSAL",
+                        targets: ["MSAL"]),
+                ],
+                targets: [
+                    .binaryTarget(name: "MSAL", url: "https://github.com/$(repositoryName)/releases/download/releaseTag1.2.3/MSAL.zip", checksum: "abcdefabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234")
+                ]
+              )
+              EOF
+              fi
+              perl -i -pe's/checksum:\s+\"[\da-fA-F]{64}\"/checksum: \"$(frameworkChecksum)\"/' Package.swift
+              perl -i -pe's/releases\/download\/[0-9a-zA-Z\.].+\//releases\/download\/$(releaseVersion)\//' Package.swift
+              perl -i -pe's/s\.version\s+=\s+".*"/s.version      = \"$(releaseVersion)\"/' MSAL.podspec
+              plutil -replace CFBundleShortVersionString -string $(releaseVersion) MSAL/resources/ios/Info.plist
+              plutil -replace CFBundleShortVersionString -string $(releaseVersion) MSAL/resources/mac/Info.plist
+              majorVer=$(echo $(releaseVersion) | cut -d"." -f1)
+              minorVer=$(echo $(releaseVersion) | cut -d"." -f2)
+              patchVer=$(echo $(releaseVersion) | cut -d"." -f3)
 
-        git add Package.swift
-        git add MSAL.podspec
-        git add MSAL/resources/ios/Info.plist
-        git add MSAL/resources/mac/Info.plist
-        git add MSAL/src/MSAL_Internal.h
+              perl -i -pe"s/MSAL_VER_HIGH\s+.*$/MSAL_VER_HIGH       $majorVer/" MSAL/src/MSAL_Internal.h
+              perl -i -pe"s/MSAL_VER_LOW\s+.*$/MSAL_VER_LOW        $minorVer/" MSAL/src/MSAL_Internal.h
+              perl -i -pe"s/MSAL_VER_PATCH\s+.*$/MSAL_VER_PATCH      $patchVer/" MSAL/src/MSAL_Internal.h
 
-        author=$(git log -1 --pretty=format:'%an <%ae>')
-        git commit -a -m "Updating MSAL framework checksum & url for $(releaseVersion) [skip ci]" -q --author="${author}"
+              git add Package.swift
+              git add MSAL.podspec
+              git add MSAL/resources/ios/Info.plist
+              git add MSAL/resources/mac/Info.plist
+              git add MSAL/src/MSAL_Internal.h
 
-        git checkout $(repositoryBranch) -q
-        git merge update-package-for-$(releaseVersion) -q
-        git push origin $(repositoryBranch) -q
-        git branch -d update-package-for-$(releaseVersion) -q
-      workingDirectory: '$(Build.SourcesDirectory)'
-      failOnStderr: false
-      noProfile: false
-      noRc: false
-  - task: Bash@3
-    displayName: Build release notes
-    inputs:
-      targetType: 'inline'
-      script: |
-        chlg="## Release Notes"$'\n'
-        if [ ! -e CHANGELOG.md ]; then
-          echo "CHANGELOG NOT FOUND!"
-        else
-          fl=0
-        while read p; do
-            if [[ $p =~ ^\#\#.*$ ]]; then
-                fl=$((fl + 1))
-                if [ $fl -gt 1 ]
-                then
-                    break
-                fi
-            fi
+              author=$(git log -1 --pretty=format:'%an <%ae>')
+              git commit -a -m "Updating MSAL framework checksum & url for $(releaseVersion) [skip ci]" -q --author="${author}"
 
-            if [[ ($fl -eq 1)  && !($p =~ ^\#\#) ]]; then
-                chlg="$chlg"$'\n'"$p"
-            fi
-        done <CHANGELOG.md
-        fi
-        echo "chlg = ${chlg}"
-        echo "${chlg}" > release-notes.md
+              git checkout $(repositoryBranch) -q
+              git merge update-package-for-$(releaseVersion) -q
+              git push origin $(repositoryBranch) -q
+              git branch -d update-package-for-$(releaseVersion) -q
+            workingDirectory: '$(Build.SourcesDirectory)'
+            failOnStderr: false
+            noProfile: false
+            noRc: false
+        - task: Bash@3
+          displayName: Build release notes
+          inputs:
+            targetType: 'inline'
+            script: |
+              chlg="## Release Notes"$'\n'
+              if [ ! -e CHANGELOG.md ]; then
+                echo "CHANGELOG NOT FOUND!"
+              else
+                fl=0
+              while read p; do
+                  if [[ $p =~ ^\#\#.*$ ]]; then
+                      fl=$((fl + 1))
+                      if [ $fl -gt 1 ]
+                      then
+                          break
+                      fi
+                  fi
 
-      workingDirectory: '$(Build.SourcesDirectory)'
-      failOnStderr: true
-      noProfile: false
-      noRc: false
-  - task: GitHubRelease@1
-    displayName: Generate MSAL Github Release
-    inputs:
-      gitHubConnection: '$(GithubServiceConnection)'
-      repositoryName: '$(repositoryName)'
-      action: 'create'
-      target: '$(repositoryBranch)'
-      tagSource: 'userSpecifiedTag'
-      tag: '$(releaseVersion)'
-      title: '$(releaseVersion)'
-      releaseNotesFilePath: 'release-notes.md'
-      assets: |
-        $(Build.ArtifactStagingDirectory)/*.zip
-        $(Build.ArtifactStagingDirectory)/*.tar.gz
-      changeLogCompareToRelease: 'lastFullRelease'
-      changeLogType: 'issueBased'
-  - task: Bash@3
-    displayName: Push pod to Cocoapods
-    inputs:
-      targetType: 'inline'
-      script: |
-        # Release to CocoaPods
-        # Do not use "--use-libraries" option because native auth code doesn't support static library yet
-        pod trunk push --allow-warnings MSAL.podspec
-        #pod trunk me
-      workingDirectory: '$(Build.SourcesDirectory)'
-    env:
-      COCOAPODS_TRUNK_TOKEN: $(COCOAPODS_TRUNK_TOKEN)
-  - task: Bash@3
-    displayName: Install Sourcekitten
-    inputs:
-      targetType: 'inline'
-      script: |
-        brew install sourcekitten
-  - task: Bash@3
-    displayName: Build MSAL docs via Jazzy
-    inputs:
-      filePath: 'build_docs.sh'
-  - task: Bash@3
-    displayName: Push docs to github page for repository
-    inputs:
-      targetType: 'inline'
-      script: |
-        # NOTE : This should be the last step since it changes branch from main to $(docsRepositoryBranch)
-        if [ ! -d "docs.temp" ]; then
-            echo "Docs were not generated in previous step!"
-        else
-            authorName=$(git log -1 --pretty=format:'%an')
-            authorEmail=$(git log -1 --pretty=format:'%ae')
-            git config --global user.email "${authorEmail}"
-            git config --global user.name "${authorName}"
+                  if [[ ($fl -eq 1)  && !($p =~ ^\#\#) ]]; then
+                      chlg="$chlg"$'\n'"$p"
+                  fi
+              done <CHANGELOG.md
+              fi
+              echo "chlg = ${chlg}"
+              echo "${chlg}" > release-notes.md
 
-            author=$(git log -1 --pretty=format:'%an <%ae>')
-            # Create a temp branch to cherry pick doc changes
-            git checkout -b 'update-docs-for-release-$(releaseVersion)'
-            git add docs.temp/docs/*
-            git commit -m 'adding docs for release' --author="${author}" --status
+            workingDirectory: '$(Build.SourcesDirectory)'
+            failOnStderr: true
+            noProfile: false
+            noRc: false
+        - task: GitHubRelease@1
+          displayName: Generate MSAL Github Release
+          inputs:
+            gitHubConnection: '$(GithubServiceConnection)'
+            repositoryName: '$(repositoryName)'
+            action: 'create'
+            target: '$(repositoryBranch)'
+            tagSource: 'userSpecifiedTag'
+            tag: '$(releaseVersion)'
+            title: '$(releaseVersion)'
+            releaseNotesFilePath: 'release-notes.md'
+            assets: |
+              $(Build.ArtifactStagingDirectory)/*.zip
+              $(Build.ArtifactStagingDirectory)/*.tar.gz
+            changeLogCompareToRelease: 'lastFullRelease'
+            changeLogType: 'issueBased'
+    - stage: Push_to_external_library_repositories
+      jobs:
+      - job: Push_to_external_library_repositories
+        pool:
+          type: linux
+          isCustom: true
+          name: Azure Pipelines
+          vmImage: 'macOS-13'
+          timeOutInMinutes: 65
+        steps:
+        - task: Bash@3
+          displayName: Push pod to Cocoapods
+          inputs:
+            targetType: 'inline'
+            script: |
+              # Release to CocoaPods
+              # Do not use "--use-libraries" option because native auth code doesn't support static library yet
+              pod trunk push --allow-warnings MSAL.podspec
+              #pod trunk me
+            workingDirectory: '$(Build.SourcesDirectory)'
+          env:
+            COCOAPODS_TRUNK_TOKEN: $(COCOAPODS_TRUNK_TOKEN)
+    - stage: Generate_and_push_MSAL_docs
+      jobs:
+      - job: Generate_and_push_MSAL_documentation
+        pool:
+          type: linux
+          isCustom: true
+          name: Azure Pipelines
+          vmImage: 'macOS-13'
+          timeOutInMinutes: 65
+        steps:
+        - task: Bash@3
+          displayName: Install Sourcekitten
+          inputs:
+            targetType: 'inline'
+            script: |
+              brew install sourcekitten
+        - task: Bash@3
+          displayName: Build MSAL docs via Jazzy
+          inputs:
+            filePath: 'build_docs.sh'
+        - task: Bash@3
+          displayName: Push docs to github page for repository
+          inputs:
+            targetType: 'inline'
+            script: |
+              # NOTE : This should be the last step since it changes branch from main to $(docsRepositoryBranch)
+              if [ ! -d "docs.temp" ]; then
+                  echo "Docs were not generated in previous step!"
+              else
+                  authorName=$(git log -1 --pretty=format:'%an')
+                  authorEmail=$(git log -1 --pretty=format:'%ae')
+                  git config --global user.email "${authorEmail}"
+                  git config --global user.name "${authorName}"
 
-            # Cleanup
-            rm -rf docs.temp
-            git fetch origin $(docsRepositoryBranch)
-            git checkout FETCH_HEAD
-            git checkout $(docsRepositoryBranch)
-            git clean -fd
+                  author=$(git log -1 --pretty=format:'%an <%ae>')
+                  # Create a temp branch to cherry pick doc changes
+                  git checkout -b 'update-docs-for-release-$(releaseVersion)'
+                  git add docs.temp/docs/*
+                  git commit -m 'adding docs for release' --author="${author}" --status
 
-            # Get previously commited changes for docs
-            git cherry-pick --strategy-option theirs "update-docs-for-release-$(releaseVersion)"
+                  # Cleanup
+                  rm -rf docs.temp
+                  git fetch origin $(docsRepositoryBranch)
+                  git checkout FETCH_HEAD
+                  git checkout $(docsRepositoryBranch)
+                  git clean -fd
 
-            # Copy files in docs.temp folder to root
-            \cp -r docs.temp/docs/* .
+                  # Get previously commited changes for docs
+                  git cherry-pick --strategy-option theirs "update-docs-for-release-$(releaseVersion)"
 
-            # Push changes to docsRepositoryBranch branch
-            git add -A
-            git commit -m 'Update docs for release $(releaseVersion)' --status  --author="${author}"
-            git push origin $(docsRepositoryBranch)
-        fi
-      workingDirectory: '$(Build.SourcesDirectory)'
-      failOnStderr: false
-      noProfile: false
-      noRc: false
+                  # Copy files in docs.temp folder to root
+                  \cp -r docs.temp/docs/* .
+
+                  # Push changes to docsRepositoryBranch branch
+                  git add -A
+                  git commit -m 'Update docs for release $(releaseVersion)' --status  --author="${author}"
+                  git push origin $(docsRepositoryBranch)
+              fi
+            workingDirectory: '$(Build.SourcesDirectory)'
+            failOnStderr: false
+            noProfile: false
+            noRc: false


### PR DESCRIPTION
This pull request to `azure_pipelines/spm-framework.yml` includes changes to improve the Azure DevOps pipeline for the MSAL Objective-C framework. The most important changes include the addition of new pipeline variables, changes to the repository resources, modifications to the job steps, and the creation of new pipeline stages.

Addition of new pipeline variables:
* [`azure_pipelines/spm-framework.yml`](diffhunk://#diff-5e2b86e2ca7383d6aba9b45b6716f11a3ac5aded8dd9f8c264f3f7e259e653d9R16-R19): Added `LinuxContainerImage` and `ob_outputDirectory` variables for the Linux container image and the output directory respectively.

Changes to repository resources:
* [`azure_pipelines/spm-framework.yml`](diffhunk://#diff-5e2b86e2ca7383d6aba9b45b6716f11a3ac5aded8dd9f8c264f3f7e259e653d9L31-R79): Changed the `endpoint` of the `msalRepository` to 'MSAL ObjC Service Connection' and added a new repository `onebranchTemplates` of type `git`. Also extended the pipeline with a new template `v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates` and added parameters for the global Software Development Lifecycle (SDL).

Modifications to job steps:
* [`azure_pipelines/spm-framework.yml`](diffhunk://#diff-5e2b86e2ca7383d6aba9b45b6716f11a3ac5aded8dd9f8c264f3f7e259e653d9L173-R242): Added a bash task to create and copy built artifacts to the `/out` directory and a task to copy the framework for onebranch published artifacts. Changed the target path of the `PublishPipelineArtifact` task.

Creation of new pipeline stages:
* [`azure_pipelines/spm-framework.yml`](diffhunk://#diff-5e2b86e2ca7383d6aba9b45b6716f11a3ac5aded8dd9f8c264f3f7e259e653d9R293-R302): Added new stages `Create_Common_core_release`, `MSAL_Release`, `Push_to_external_library_repositories`, and `Generate_and_push_MSAL_docs` to the pipeline. Each stage includes a job with a specific task. [[1]](diffhunk://#diff-5e2b86e2ca7383d6aba9b45b6716f11a3ac5aded8dd9f8c264f3f7e259e653d9R293-R302) [[2]](diffhunk://#diff-5e2b86e2ca7383d6aba9b45b6716f11a3ac5aded8dd9f8c264f3f7e259e653d9R428-R437) [[3]](diffhunk://#diff-5e2b86e2ca7383d6aba9b45b6716f11a3ac5aded8dd9f8c264f3f7e259e653d9R450-R459)