### PR TITLE
Create a triggering pipeline for ADO

### DIFF
--- a/azure_pipelines/msal-release-ado-trigger.yml
+++ b/azure_pipelines/msal-release-ado-trigger.yml
@@ -1,0 +1,9 @@
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - CHANGELOG.md
+
+pr: none


### PR DESCRIPTION
## Proposed changes

Pipelines defined in Azure DevOps don't have support for triggering based off of changes to github repositories.
Adding a middle-man pipeline which will trigger the ADO pipeline.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

