### PR TITLE
Add visionOS support to MSAL iOS test targets and additional configs

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -7775,7 +7775,6 @@
 				);
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
-				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
@@ -7809,7 +7808,6 @@
 				);
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
-				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/unit-test-host.app/unit-test-host";
@@ -7870,7 +7868,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
-				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Debug;
@@ -7886,7 +7883,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
-				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Release;

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -318,6 +318,14 @@
 		8D35C8F12A97BD2300BEC29A /* MSALNativeAuthRequiredAttributeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D35C8F02A97BD2300BEC29A /* MSALNativeAuthRequiredAttributeOptions.swift */; };
 		8D61F9A12A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D61F9A02A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift */; };
 		8DDF473F2A98FE1C00126A47 /* MSALNativeAuthRequiredAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDF473E2A98FE1C00126A47 /* MSALNativeAuthRequiredAttribute.swift */; };
+		91AA24592BDF643A005037EA /* MSAL_Test_App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91AA24582BDF643A005037EA /* MSAL_Test_App.swift */; };
+		91AA245B2BDF643A005037EA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91AA245A2BDF643A005037EA /* ContentView.swift */; };
+		91AA245D2BDF6440005037EA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 91AA245C2BDF6440005037EA /* Assets.xcassets */; };
+		91AA24602BDF6441005037EA /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 91AA245F2BDF6441005037EA /* Preview Assets.xcassets */; };
+		91AA24732BDF6D17005037EA /* MSALTestAppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91AA24722BDF6D17005037EA /* MSALTestAppView.swift */; };
+		91AA247C2BDF6D84005037EA /* MSALTestAppVisionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91AA247B2BDF6D84005037EA /* MSALTestAppVisionViewController.swift */; };
+		91AA247D2BDF6DC1005037EA /* MSAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D65A6F431E3FD30A00C69FBA /* MSAL.framework */; };
+		91AA247E2BDF6DC1005037EA /* MSAL.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D65A6F431E3FD30A00C69FBA /* MSAL.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		94E876CE1E492D6000FB96ED /* MSALAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 94E876CB1E492D6000FB96ED /* MSALAuthority.m */; };
 		960751BB2183E82C00F2BF2F /* MSALAccountIdTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 960751BA2183E82C00F2BF2F /* MSALAccountIdTests.m */; };
 		960751BC2183E82C00F2BF2F /* MSALAccountIdTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 960751BA2183E82C00F2BF2F /* MSALAccountIdTests.m */; };
@@ -1212,6 +1220,13 @@
 			remoteGlobalIDString = D65A6F421E3FD30A00C69FBA;
 			remoteInfo = "MSAL (iOS Framework)";
 		};
+		91AA247F2BDF6DC1005037EA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D6DFF39A1E2579360012891A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D65A6F421E3FD30A00C69FBA;
+			remoteInfo = "MSAL (iOS Framework)";
+		};
 		B21FA9BB2204DC5700806B68 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D6A206191FC50A4D00755A51 /* IdentityCore.xcodeproj */;
@@ -1383,6 +1398,17 @@
 			dstSubfolderSpec = 10;
 			files = (
 				1E97064822FA502700364AFA /* MSAL.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		91AA24812BDF6DC1005037EA /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				91AA247E2BDF6DC1005037EA /* MSAL.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1590,6 +1616,16 @@
 		8D35C8F02A97BD2300BEC29A /* MSALNativeAuthRequiredAttributeOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequiredAttributeOptions.swift; sourceTree = "<group>"; };
 		8D61F9A02A66AC9D00468E18 /* MSALNativeAuthRequestableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequestableTests.swift; sourceTree = "<group>"; };
 		8DDF473E2A98FE1C00126A47 /* MSALNativeAuthRequiredAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequiredAttribute.swift; sourceTree = "<group>"; };
+		91AA24522BDF6439005037EA /* MSAL Test App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MSAL Test App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		91AA24582BDF643A005037EA /* MSAL_Test_App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSAL_Test_App.swift; sourceTree = "<group>"; };
+		91AA245A2BDF643A005037EA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		91AA245C2BDF6440005037EA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		91AA245F2BDF6441005037EA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		91AA24612BDF6441005037EA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		91AA24722BDF6D17005037EA /* MSALTestAppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALTestAppView.swift; sourceTree = "<group>"; };
+		91AA247B2BDF6D84005037EA /* MSALTestAppVisionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALTestAppVisionViewController.swift; sourceTree = "<group>"; };
+		91AA24822BDF6DDE005037EA /* MSAL Test App (visionOS).entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "MSAL Test App (visionOS).entitlements"; sourceTree = "<group>"; };
+		91AA248C2BDF72FC005037EA /* MSAL_Test_App-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSAL_Test_App-Bridging-Header.h"; sourceTree = "<group>"; };
 		94E876B01E4556B400FB96ED /* MSAL.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSAL.pch; sourceTree = "<group>"; };
 		94E876CA1E492D6000FB96ED /* MSALAuthority.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSALAuthority.h; sourceTree = "<group>"; };
 		94E876CB1E492D6000FB96ED /* MSALAuthority.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSALAuthority.m; sourceTree = "<group>"; };
@@ -2192,6 +2228,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		91AA244F2BDF6439005037EA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				91AA247D2BDF6DC1005037EA /* MSAL.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		962E37B51E720C5D00DE71FE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -2589,6 +2633,38 @@
 				28F19BEA2A2F884D00575581 /* Array+joinScopes.swift */,
 			);
 			path = extension;
+			sourceTree = "<group>";
+		};
+		91AA245E2BDF6441005037EA /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				91AA245F2BDF6441005037EA /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		91AA246F2BDF6610005037EA /* vision */ = {
+			isa = PBXGroup;
+			children = (
+				91AA24702BDF669F005037EA /* resources */,
+				91AA24582BDF643A005037EA /* MSAL_Test_App.swift */,
+				91AA245A2BDF643A005037EA /* ContentView.swift */,
+				91AA24722BDF6D17005037EA /* MSALTestAppView.swift */,
+				91AA247B2BDF6D84005037EA /* MSALTestAppVisionViewController.swift */,
+				91AA248C2BDF72FC005037EA /* MSAL_Test_App-Bridging-Header.h */,
+			);
+			path = vision;
+			sourceTree = "<group>";
+		};
+		91AA24702BDF669F005037EA /* resources */ = {
+			isa = PBXGroup;
+			children = (
+				91AA24822BDF6DDE005037EA /* MSAL Test App (visionOS).entitlements */,
+				91AA24612BDF6441005037EA /* Info.plist */,
+				91AA245C2BDF6440005037EA /* Assets.xcassets */,
+				91AA245E2BDF6441005037EA /* Preview Content */,
+			);
+			path = resources;
 			sourceTree = "<group>";
 		};
 		94E876C91E492D2800FB96ED /* instance */ = {
@@ -3031,6 +3107,7 @@
 		D61A647D1E5AA7C60086D120 /* app */ = {
 			isa = PBXGroup;
 			children = (
+				91AA246F2BDF6610005037EA /* vision */,
 				D61A647E1E5AA7C60086D120 /* ios */,
 				D61A648B1E5AA7C60086D120 /* mac */,
 				D61A64AF1E5AAC5C0086D120 /* MSALTestAppSettings.h */,
@@ -3503,6 +3580,7 @@
 				04A6B59C2269286F0035C7C2 /* libMSAL (macOS Static Library).a */,
 				B295A16422D0348400FFB313 /* unit-test-host-mac.app */,
 				28D1D56C29BF62E900CE75F4 /* MSAL iOS Native Auth Integration Tests.xctest */,
+				91AA24522BDF6439005037EA /* MSAL Test App.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -4684,6 +4762,27 @@
 			productReference = 28D1D56C29BF62E900CE75F4 /* MSAL iOS Native Auth Integration Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		91AA24512BDF6439005037EA /* MSAL Test App (visionOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 91AA246B2BDF6441005037EA /* Build configuration list for PBXNativeTarget "MSAL Test App (visionOS)" */;
+			buildPhases = (
+				91AA244E2BDF6439005037EA /* Sources */,
+				91AA244F2BDF6439005037EA /* Frameworks */,
+				91AA24502BDF6439005037EA /* Resources */,
+				91AA24812BDF6DC1005037EA /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				91AA24802BDF6DC1005037EA /* PBXTargetDependency */,
+			);
+			name = "MSAL Test App (visionOS)";
+			packageProductDependencies = (
+			);
+			productName = "MSAL Test App (visionOS)";
+			productReference = 91AA24522BDF6439005037EA /* MSAL Test App.app */;
+			productType = "com.apple.product-type.application";
+		};
 		962E37A61E720C5D00DE71FE /* MSAL Test Automation (iOS) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 962E37B91E720C5D00DE71FE /* Build configuration list for PBXNativeTarget "MSAL Test Automation (iOS)" */;
@@ -4887,7 +4986,7 @@
 		D6DFF39A1E2579360012891A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1410;
+				LastSwiftUpdateCheck = 1520;
 				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
@@ -4916,6 +5015,9 @@
 					28D1D56B29BF62E900CE75F4 = {
 						CreatedOnToolsVersion = 14.1;
 						TestTargetID = D672279E1EBD111900F3422A;
+					};
+					91AA24512BDF6439005037EA = {
+						CreatedOnToolsVersion = 15.2;
 					};
 					962E37A61E720C5D00DE71FE = {
 						DevelopmentTeam = UBF8T346G9;
@@ -5019,6 +5121,7 @@
 				04A6B59B2269286F0035C7C2 /* MSAL (Mac Static Library) */,
 				B295A16322D0348400FFB313 /* unit-test-host-mac */,
 				28D1D56B29BF62E900CE75F4 /* MSAL iOS Native Auth Integration Tests */,
+				91AA24512BDF6439005037EA /* MSAL Test App (visionOS) */,
 			);
 		};
 /* End PBXProject section */
@@ -5125,6 +5228,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				9B235D9D2A3CC71C00657331 /* NativeAuthEndToEndTestPlan.xctestplan in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		91AA24502BDF6439005037EA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				91AA24602BDF6441005037EA /* Preview Assets.xcassets in Resources */,
+				91AA245D2BDF6440005037EA /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5473,6 +5585,17 @@
 				E26E39242A4C2D7400063C07 /* SignUpDelegateSpies.swift in Sources */,
 				E272C4EC2A4447520013B805 /* MSALNativeAuthSignUpUsernameEndToEndTests.swift in Sources */,
 				28D1D59229C2231C00CE75F4 /* MockAPIHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		91AA244E2BDF6439005037EA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				91AA245B2BDF643A005037EA /* ContentView.swift in Sources */,
+				91AA247C2BDF6D84005037EA /* MSALTestAppVisionViewController.swift in Sources */,
+				91AA24732BDF6D17005037EA /* MSALTestAppView.swift in Sources */,
+				91AA24592BDF643A005037EA /* MSAL_Test_App.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6126,6 +6249,11 @@
 			target = D65A6F421E3FD30A00C69FBA /* MSAL (iOS Framework) */;
 			targetProxy = 58BBA13B25C141D1007B3EF6 /* PBXContainerItemProxy */;
 		};
+		91AA24802BDF6DC1005037EA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D65A6F421E3FD30A00C69FBA /* MSAL (iOS Framework) */;
+			targetProxy = 91AA247F2BDF6DC1005037EA /* PBXContainerItemProxy */;
+		};
 		B21FA9C12204DC6F00806B68 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "IdentityLabAutomation iOS";
@@ -6575,6 +6703,165 @@
 					$IDCORE_PATH/src,
 				);
 				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		91AA24622BDF6441005037EA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_ENTITLEMENTS = "test/app/vision/resources/MSAL Test App (visionOS).entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_ASSET_PATHS = "\"test/app/vision/resources/Preview Content\"";
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = test/app/vision/resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSALTestApp;
+				PRODUCT_NAME = "MSAL Test App";
+				SDKROOT = xros;
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "test/app/vision/MSAL_Test_App-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Debug;
+		};
+		91AA24632BDF6441005037EA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_ENTITLEMENTS = "test/app/vision/resources/MSAL Test App (visionOS).entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_ASSET_PATHS = "\"test/app/vision/resources/Preview Content\"";
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = test/app/vision/resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSALTestApp;
+				PRODUCT_NAME = "MSAL Test App";
+				SDKROOT = xros;
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "test/app/vision/MSAL_Test_App-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
+				VALIDATE_PRODUCT = YES;
+				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Release;
 		};
@@ -7384,6 +7671,15 @@
 			buildConfigurations = (
 				28D1D57329BF62E900CE75F4 /* Debug */,
 				28D1D57429BF62E900CE75F4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		91AA246B2BDF6441005037EA /* Build configuration list for PBXNativeTarget "MSAL Test App (visionOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				91AA24622BDF6441005037EA /* Debug */,
+				91AA24632BDF6441005037EA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1626,6 +1626,7 @@
 		91AA247B2BDF6D84005037EA /* MSALTestAppVisionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALTestAppVisionViewController.swift; sourceTree = "<group>"; };
 		91AA24822BDF6DDE005037EA /* MSAL Test App (visionOS).entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "MSAL Test App (visionOS).entitlements"; sourceTree = "<group>"; };
 		91AA248C2BDF72FC005037EA /* MSAL_Test_App-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSAL_Test_App-Bridging-Header.h"; sourceTree = "<group>"; };
+		91AA248D2BDF7A41005037EA /* msal__test_app__vision.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = msal__test_app__vision.xcconfig; sourceTree = "<group>"; };
 		94E876B01E4556B400FB96ED /* MSAL.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSAL.pch; sourceTree = "<group>"; };
 		94E876CA1E492D6000FB96ED /* MSALAuthority.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSALAuthority.h; sourceTree = "<group>"; };
 		94E876CB1E492D6000FB96ED /* MSALAuthority.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSALAuthority.m; sourceTree = "<group>"; };
@@ -3376,6 +3377,7 @@
 				D65A6FEC1E40002800C69FBA /* msal__unit_test__mac.xcconfig */,
 				D67227BC1EBD302800F3422A /* msal__unit_test_host__ios.xcconfig */,
 				D65A6FF11E4026C000C69FBA /* msal__release.xcconfig */,
+				91AA248D2BDF7A41005037EA /* msal__test_app__vision.xcconfig */,
 			);
 			path = xcconfig;
 			sourceTree = "<group>";

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1310,13 +1310,6 @@
 			remoteGlobalIDString = D65A6F4F1E3FD32D00C69FBA;
 			remoteInfo = "MSAL (Mac Framework)";
 		};
-		D67227941EBD108C00F3422A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D6DFF39A1E2579360012891A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D61A64321E5A29580086D120;
-			remoteInfo = "MSAL Test App (iOS)";
-		};
 		D67227981EBD10B500F3422A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D6DFF39A1E2579360012891A /* Project object */;
@@ -1372,13 +1365,6 @@
 			proxyType = 2;
 			remoteGlobalIDString = D626FF681FBA6EDF00EE4487;
 			remoteInfo = "IdentityCoreTests Mac";
-		};
-		D6BFE3DA1EB42D3200F2B7E8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D6DFF39A1E2579360012891A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 962E37A61E720C5D00DE71FE;
-			remoteInfo = "MSAL Test Automation (iOS)";
 		};
 		E7A6569524FEE45300931BAE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -4851,8 +4837,6 @@
 			dependencies = (
 				231CE9D91FEC677D00E95D3E /* PBXTargetDependency */,
 				D61F5BC71E59333000912CB8 /* PBXTargetDependency */,
-				D6BFE3DB1EB42D3200F2B7E8 /* PBXTargetDependency */,
-				D67227951EBD108C00F3422A /* PBXTargetDependency */,
 				D67227B71EBD112800F3422A /* PBXTargetDependency */,
 			);
 			name = "MSAL iOS Unit Tests";
@@ -6192,11 +6176,6 @@
 			target = D65A6F4F1E3FD32D00C69FBA /* MSAL (Mac Framework) */;
 			targetProxy = D65A6FD61E3FF49C00C69FBA /* PBXContainerItemProxy */;
 		};
-		D67227951EBD108C00F3422A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D61A64321E5A29580086D120 /* MSAL Test App (iOS) */;
-			targetProxy = D67227941EBD108C00F3422A /* PBXContainerItemProxy */;
-		};
 		D67227991EBD10B500F3422A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D65A6F421E3FD30A00C69FBA /* MSAL (iOS Framework) */;
@@ -6206,11 +6185,6 @@
 			isa = PBXTargetDependency;
 			target = D672279E1EBD111900F3422A /* unit-test-host */;
 			targetProxy = D67227B61EBD112800F3422A /* PBXContainerItemProxy */;
-		};
-		D6BFE3DB1EB42D3200F2B7E8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 962E37A61E720C5D00DE71FE /* MSAL Test Automation (iOS) */;
-			targetProxy = D6BFE3DA1EB42D3200F2B7E8 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -7236,8 +7210,11 @@
 					"@loader_path/Frameworks",
 				);
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/unit-test-host.app/unit-test-host";
 				USER_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -7267,7 +7244,10 @@
 					"@loader_path/Frameworks",
 				);
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/unit-test-host.app/unit-test-host";
 				USER_HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -7325,6 +7305,9 @@
 				ENABLE_BITCODE = NO;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Debug;
 		};
@@ -7338,6 +7321,9 @@
 				ENABLE_BITCODE = NO;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Release;
 		};

--- a/MSAL/test/app/vision/ContentView.swift
+++ b/MSAL/test/app/vision/ContentView.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+import SwiftUI
+import RealityKit
+
+struct ContentView: View {
+    var body: some View {
+
+        VStack {
+            MSALTestAppView()
+        }
+        
+    }
+}
+
+#Preview(windowStyle: .automatic) {
+    ContentView()
+}

--- a/MSAL/test/app/vision/MSALTestAppView.swift
+++ b/MSAL/test/app/vision/MSALTestAppView.swift
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+import SwiftUI
+
+struct MSALTestAppView: UIViewControllerRepresentable {
+    typealias UIViewControllerType = MSALTestAppVisionViewController
+    
+    func makeUIViewController(context: Context) -> MSALTestAppVisionViewController {
+        let vc = MSALTestAppVisionViewController()
+        
+        return vc
+    }
+    
+    func updateUIViewController(_ uiViewController: MSALTestAppVisionViewController, context: Context) {
+        // nothing for now
+    }
+
+}
+
+#Preview {
+    MSALTestAppView()
+}

--- a/MSAL/test/app/vision/MSALTestAppVisionViewController.swift
+++ b/MSAL/test/app/vision/MSALTestAppVisionViewController.swift
@@ -1,0 +1,599 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+import Foundation
+
+class MSALTestAppVisionViewController: UIViewController
+{
+    
+    // Update the below to your client ID you received in the portal. The below is for running the demo only
+    let kClientID = "66855f8a-60cd-445e-a9bb-8cd8eadbd3fa"
+    let kGraphEndpoint = "https://graph.microsoft.com/"
+    let kAuthority = "https://login.microsoftonline.com/common"
+    let kRedirectUri = "msauth.com.microsoft.MSALTestApp://auth"
+    
+    let kScopes: [String] = ["user.read"]
+    
+    let kDeviceIdClaimValue = "{\"access_token\":{\"deviceid\":{\"essential\":true}}}"
+    
+    var accessToken = String()
+    var applicationContext : MSALPublicClientApplication?
+    var webViewParamaters : MSALWebviewParameters?
+
+    var loggingText: UITextView!
+    var signOutButton: UIButton!
+    var callGraphButton: UIButton!
+    var usernameLabel: UILabel!
+    
+    var webviewTypeSegmentControl: UISegmentedControl!
+    var claimsSegmentControl: UISegmentedControl!
+    
+    var currentAccount: MSALAccount?
+    
+    var currentDeviceMode: MSALDeviceMode?
+
+    /**
+        Setup public client application in viewDidLoad
+    */
+
+    override func viewDidLoad() {
+
+        super.viewDidLoad()
+
+        initUI()
+        
+        do {
+            try self.initMSAL()
+        } catch let error {
+            self.updateLogging(text: "Unable to create Application Context \(error)")
+        }
+        
+        self.loadCurrentAccount()
+        self.refreshDeviceMode()
+        self.platformViewDidLoadSetup()
+    }
+    
+    func platformViewDidLoadSetup() {
+                
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(appCameToForeGround(notification:)),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
+        
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+
+        super.viewWillAppear(animated)
+        self.loadCurrentAccount()
+    }
+    
+    @objc func appCameToForeGround(notification: Notification) {
+        self.loadCurrentAccount()
+    }
+}
+
+
+// MARK: Initialization
+
+extension MSALTestAppVisionViewController {
+    
+    /**
+     
+     Initialize a MSALPublicClientApplication with a given clientID and authority
+     
+     - clientId:            The clientID of your application, you should get this from the app portal.
+     - redirectUri:         A redirect URI of your application, you should get this from the app portal.
+     If nil, MSAL will create one by default. i.e./ msauth.<bundleID>://auth
+     - authority:           A URL indicating a directory that MSAL can use to obtain tokens. In Azure AD
+     it is of the form https://<instance/<tenant>, where <instance> is the
+     directory host (e.g. https://login.microsoftonline.com) and <tenant> is a
+     identifier within the directory itself (e.g. a domain associated to the
+     tenant, such as contoso.onmicrosoft.com, or the GUID representing the
+     TenantID property of the directory)
+     - error                The error that occurred creating the application object, if any, if you're
+     not interested in the specific error pass in nil.
+     */
+    func initMSAL() throws {
+        
+        guard let authorityURL = URL(string: kAuthority) else {
+            self.updateLogging(text: "Unable to create authority URL")
+            return
+        }
+        
+        let authority = try MSALAADAuthority(url: authorityURL)
+        
+        let msalConfiguration = MSALPublicClientApplicationConfig(clientId: kClientID,
+                                                                  redirectUri: kRedirectUri,
+                                                                  authority: authority)
+        self.applicationContext = try MSALPublicClientApplication(configuration: msalConfiguration)
+        self.initWebViewParams()
+    }
+    
+    func initWebViewParams() {
+        self.webViewParamaters = MSALWebviewParameters(authPresentationViewController: self)
+    }
+}
+
+// MARK: Shared device
+
+extension MSALTestAppVisionViewController {
+    
+    @objc func getDeviceMode(_ sender: UIButton) {
+        
+        if #available(iOS 13.0, *) {
+            self.applicationContext?.getDeviceInformation(with: nil, completionBlock: { (deviceInformation, error) in
+                
+                guard let deviceInfo = deviceInformation else {
+                    self.updateLogging(text: "Device info not returned. Error: \(String(describing: error))")
+                    return
+                }
+                
+                let isSharedDevice = deviceInfo.deviceMode == .shared
+                let modeString = isSharedDevice ? "shared" : "private"
+                self.updateLogging(text: "Received device info. Device is in the \(modeString) mode.")
+            })
+        } else {
+            self.updateLogging(text: "Running on older iOS. GetDeviceInformation API is unavailable.")
+        }
+    }
+}
+
+
+// MARK: Acquiring and using token
+
+extension MSALTestAppVisionViewController {
+    
+    /**
+     This will invoke the authorization flow.
+     */
+    
+    @objc func callGraphAPI(_ sender: UIButton) {
+        
+        self.loadCurrentAccount { (account) in
+            
+            guard let currentAccount = account else {
+                
+                // We check to see if we have a current logged in account.
+                // If we don't, then we need to sign someone in.
+                self.acquireTokenInteractively()
+                return
+            }
+            
+            self.acquireTokenSilently(currentAccount)
+        }
+    }
+    
+    func acquireTokenInteractively() {
+        
+        guard let applicationContext = self.applicationContext else { return }
+        
+        guard let webViewParameters = self.webViewParamaters else { return }
+        webViewParameters.webviewType = self.getWebviewType();
+
+        let parameters = MSALInteractiveTokenParameters(scopes: kScopes, webviewParameters: webViewParameters)
+        parameters.promptType = .selectAccount
+        
+        if let claimRequest = self.getClaimsRequest()
+        {
+            parameters.claimsRequest = claimRequest
+        }
+        
+        applicationContext.acquireToken(with: parameters) { (result, error) in
+            
+            if let error = error {
+                
+                self.updateLogging(text: "Could not acquire token: \(error)")
+                return
+            }
+            
+            guard let result = result else {
+                
+                self.updateLogging(text: "Could not acquire token: No result returned")
+                return
+            }
+            
+            self.accessToken = result.accessToken
+            self.updateLogging(text: "Access token is \(self.accessToken)")
+            self.updateCurrentAccount(account: result.account)
+            self.getContentWithToken()
+        }
+    }
+    
+    func acquireTokenSilently(_ account : MSALAccount!) {
+        
+        guard let applicationContext = self.applicationContext else { return }
+        
+        /**
+         
+         Acquire a token for an existing account silently
+         
+         - forScopes:           Permissions you want included in the access token received
+         in the result in the completionBlock. Not all scopes are
+         guaranteed to be included in the access token returned.
+         - account:             An account object that we retrieved from the application object before that the
+         authentication flow will be locked down to.
+         - completionBlock:     The completion block that will be called when the authentication
+         flow completes, or encounters an error.
+         */
+        
+        let parameters = MSALSilentTokenParameters(scopes: kScopes, account: account)
+        
+        applicationContext.acquireTokenSilent(with: parameters) { (result, error) in
+            
+            if let error = error {
+                
+                let nsError = error as NSError
+                
+                // interactionRequired means we need to ask the user to sign-in. This usually happens
+                // when the user's Refresh Token is expired or if the user has changed their password
+                // among other possible reasons.
+                
+                if (nsError.domain == MSALErrorDomain) {
+                    
+                    if (nsError.code == MSALError.interactionRequired.rawValue) {
+                        
+                        DispatchQueue.main.async {
+                            self.acquireTokenInteractively()
+                        }
+                        return
+                    }
+                }
+                
+                self.updateLogging(text: "Could not acquire token silently: \(error)")
+                return
+            }
+            
+            guard let result = result else {
+                
+                self.updateLogging(text: "Could not acquire token: No result returned")
+                return
+            }
+            
+            self.accessToken = result.accessToken
+            self.updateLogging(text: "Refreshed Access token is \(self.accessToken)")
+            self.updateSignOutButton(enabled: true)
+            self.getContentWithToken()
+        }
+    }
+    
+    func getGraphEndpoint() -> String {
+        return kGraphEndpoint.hasSuffix("/") ? (kGraphEndpoint + "v1.0/me/") : (kGraphEndpoint + "/v1.0/me/");
+    }
+    
+    /**
+     This will invoke the call to the Microsoft Graph API. It uses the
+     built in URLSession to create a connection.
+     */
+    
+    func getContentWithToken() {
+        
+        // Specify the Graph API endpoint
+        let graphURI = getGraphEndpoint()
+        let url = URL(string: graphURI)
+        var request = URLRequest(url: url!)
+        
+        // Set the Authorization header for the request. We use Bearer tokens, so we specify Bearer + the token we got from the result
+        request.setValue("Bearer \(self.accessToken)", forHTTPHeaderField: "Authorization")
+        
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            
+            if let error = error {
+                self.updateLogging(text: "Couldn't get graph result: \(error)")
+                return
+            }
+            
+            guard let result = try? JSONSerialization.jsonObject(with: data!, options: []) else {
+                
+                self.updateLogging(text: "Couldn't deserialize result JSON")
+                return
+            }
+            
+            self.updateLogging(text: "Result from Graph: \(result))")
+            
+            }.resume()
+    }
+
+}
+
+
+// MARK: Get account and removing cache
+
+extension MSALTestAppVisionViewController {
+    
+    typealias AccountCompletion = (MSALAccount?) -> Void
+
+    func loadCurrentAccount(completion: AccountCompletion? = nil) {
+        
+        guard let applicationContext = self.applicationContext else { return }
+        
+        let msalParameters = MSALParameters()
+        msalParameters.completionBlockQueue = DispatchQueue.main
+                
+        // Note that this sample showcases an app that signs in a single account at a time
+        // If you're building a more complex app that signs in multiple accounts at the same time, you'll need to use a different account retrieval API that specifies account identifier
+        // For example, see "accountsFromDeviceForParameters:completionBlock:" - https://azuread.github.io/microsoft-authentication-library-for-objc/Classes/MSALPublicClientApplication.html#/c:objc(cs)MSALPublicClientApplication(im)accountsFromDeviceForParameters:completionBlock:
+        applicationContext.getCurrentAccount(with: msalParameters, completionBlock: { (currentAccount, previousAccount, error) in
+            
+            if let error = error {
+                self.updateLogging(text: "Couldn't query current account with error: \(error)")
+                return
+            }
+            
+            if let currentAccount = currentAccount {
+                
+                self.updateLogging(text: "Found a signed in account \(String(describing: currentAccount.username)). Updating data for that account...")
+                
+                self.updateCurrentAccount(account: currentAccount)
+                
+                if let completion = completion {
+                    completion(self.currentAccount)
+                }
+                
+                return
+            }
+            
+            // If testing with Microsoft's shared device mode, see the account that has been signed out from another app. More details here:
+            // https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-ios-shared-devices
+            if let previousAccount = previousAccount {
+                
+                self.updateLogging(text: "The account with username \(String(describing: previousAccount.username)) has been signed out.")
+                
+            } else {
+                
+                self.updateLogging(text: "Account signed out. Updating UX")
+            }
+            
+            self.accessToken = ""
+            self.updateCurrentAccount(account: nil)
+            
+            if let completion = completion {
+                completion(nil)
+            }
+        })
+    }
+    
+    /**
+     This action will invoke the remove account APIs to clear the token cache
+     to sign out a user from this application.
+     */
+    @objc func signOut(_ sender: UIButton) {
+        
+        guard let applicationContext = self.applicationContext else { return }
+        
+        guard let account = self.currentAccount else { return }
+        
+        do {
+            
+            /**
+             Removes all tokens from the cache for this application for the provided account
+             
+             - account:    The account to remove from the cache
+             */
+            
+            let signoutParameters = MSALSignoutParameters(webviewParameters: self.webViewParamaters!)
+            
+            // If testing with Microsoft's shared device mode, trigger signout from browser. More details here:
+            // https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-ios-shared-devices
+            
+            if (self.currentDeviceMode == .shared) {
+                signoutParameters.signoutFromBrowser = true
+            } else {
+                signoutParameters.signoutFromBrowser = false
+            }
+            
+            applicationContext.signout(with: account, signoutParameters: signoutParameters, completionBlock: {(success, error) in
+                
+                if let error = error {
+                    self.updateLogging(text: "Couldn't sign out account with error: \(error)")
+                    return
+                }
+                
+                self.updateLogging(text: "Sign out completed successfully")
+                self.accessToken = ""
+                self.updateCurrentAccount(account: nil)
+            })
+            
+        }
+    }
+}
+
+// MARK: Shared Device Helpers
+extension MSALTestAppVisionViewController {
+    
+    func refreshDeviceMode() {
+        
+        if #available(iOS 13.0, *) {
+            self.applicationContext?.getDeviceInformation(with: nil, completionBlock: { (deviceInformation, error) in
+                
+                guard let deviceInfo = deviceInformation else {
+                    return
+                }
+                
+                self.currentDeviceMode = deviceInfo.deviceMode
+            })
+        }
+    }
+}
+
+// MARK: Toggle Reading Helpers
+extension MSALTestAppVisionViewController {
+
+    func getWebviewType() -> MSALWebviewType
+    {
+        if (self.webviewTypeSegmentControl.selectedSegmentIndex == 1)
+        {
+            return MSALWebviewType.wkWebView
+        }
+        else
+        {
+            return MSALWebviewType.authenticationSession
+        }
+    }
+    
+    func getClaimsRequest() -> MSALClaimsRequest?
+    {
+        if (self.claimsSegmentControl.selectedSegmentIndex == 1)
+        {
+            return MSALClaimsRequest(jsonString: kDeviceIdClaimValue, error: nil)
+        }
+        
+        return nil
+    }
+}
+
+// MARK: UI Helpers
+extension MSALTestAppVisionViewController {
+    
+    func initUI() {
+        
+        usernameLabel = UILabel()
+        usernameLabel.translatesAutoresizingMaskIntoConstraints = false
+        usernameLabel.text = ""
+        usernameLabel.textColor = .darkGray
+        usernameLabel.textAlignment = .right
+        
+        self.view.addSubview(usernameLabel)
+        
+        usernameLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 50.0).isActive = true
+        usernameLabel.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -10.0).isActive = true
+        usernameLabel.widthAnchor.constraint(equalToConstant: 300.0).isActive = true
+        usernameLabel.heightAnchor.constraint(equalToConstant: 50.0).isActive = true
+        
+        // Add call Graph button
+        callGraphButton  = UIButton()
+        callGraphButton.translatesAutoresizingMaskIntoConstraints = false
+        callGraphButton.setTitle("Call Microsoft Graph API", for: .normal)
+        //callGraphButton.setTitleColor(.white, for: .normal)
+        callGraphButton.addTarget(self, action: #selector(callGraphAPI(_:)), for: .touchUpInside)
+        self.view.addSubview(callGraphButton)
+        
+        callGraphButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        callGraphButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 120.0).isActive = true
+        callGraphButton.widthAnchor.constraint(equalToConstant: 300.0).isActive = true
+        callGraphButton.heightAnchor.constraint(equalToConstant: 50.0).isActive = true
+        
+        // Add sign out button
+        signOutButton = UIButton()
+        signOutButton.translatesAutoresizingMaskIntoConstraints = false
+        signOutButton.setTitle("Sign Out", for: .normal)
+        //signOutButton.setTitleColor(.white, for: .normal)
+        signOutButton.setTitleColor(.gray, for: .disabled)
+        signOutButton.addTarget(self, action: #selector(signOut(_:)), for: .touchUpInside)
+        self.view.addSubview(signOutButton)
+        
+        signOutButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        signOutButton.topAnchor.constraint(equalTo: callGraphButton.bottomAnchor, constant: 10.0).isActive = true
+        signOutButton.widthAnchor.constraint(equalToConstant: 150.0).isActive = true
+        signOutButton.heightAnchor.constraint(equalToConstant: 50.0).isActive = true
+        
+        let deviceModeButton = UIButton()
+        deviceModeButton.translatesAutoresizingMaskIntoConstraints = false
+        deviceModeButton.setTitle("Get device info", for: .normal);
+        //deviceModeButton.setTitleColor(.white, for: .normal);
+        deviceModeButton.addTarget(self, action: #selector(getDeviceMode(_:)), for: .touchUpInside)
+        self.view.addSubview(deviceModeButton)
+        
+        deviceModeButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        deviceModeButton.topAnchor.constraint(equalTo: signOutButton.bottomAnchor, constant: 10.0).isActive = true
+        deviceModeButton.widthAnchor.constraint(equalToConstant: 150.0).isActive = true
+        deviceModeButton.heightAnchor.constraint(equalToConstant: 50.0).isActive = true
+        
+        // Add webviewType toggle
+        webviewTypeSegmentControl = UISegmentedControl()
+        webviewTypeSegmentControl.translatesAutoresizingMaskIntoConstraints = false
+        webviewTypeSegmentControl.insertSegment(withTitle: "System Browser", at: 0, animated: false)
+        webviewTypeSegmentControl.insertSegment(withTitle: "WKWebview", at: 1, animated: false)
+        webviewTypeSegmentControl.selectedSegmentIndex = 0
+        self.view.addSubview(webviewTypeSegmentControl)
+        
+        webviewTypeSegmentControl.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        webviewTypeSegmentControl.topAnchor.constraint(equalTo: deviceModeButton.bottomAnchor, constant: 10.0).isActive = true
+        webviewTypeSegmentControl.widthAnchor.constraint(equalToConstant: 500.0).isActive = true
+        webviewTypeSegmentControl.heightAnchor.constraint(equalToConstant: 50.0).isActive = true
+        
+        // Add deviceID claim toggle
+        claimsSegmentControl = UISegmentedControl()
+        claimsSegmentControl.translatesAutoresizingMaskIntoConstraints = false
+        claimsSegmentControl.insertSegment(withTitle: "None", at: 0, animated: false)
+        claimsSegmentControl.insertSegment(withTitle: "deviceID", at: 1, animated: false)
+        claimsSegmentControl.selectedSegmentIndex = 0
+        self.view.addSubview(claimsSegmentControl)
+        
+        claimsSegmentControl.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        claimsSegmentControl.topAnchor.constraint(equalTo: webviewTypeSegmentControl.bottomAnchor, constant: 10.0).isActive = true
+        claimsSegmentControl.widthAnchor.constraint(equalToConstant: 500.0).isActive = true
+        claimsSegmentControl.heightAnchor.constraint(equalToConstant: 50.0).isActive = true
+        
+        // Add logging textfield
+        loggingText = UITextView()
+        loggingText.isUserInteractionEnabled = false
+        loggingText.translatesAutoresizingMaskIntoConstraints = false
+        
+        self.view.addSubview(loggingText)
+        
+        loggingText.topAnchor.constraint(equalTo: claimsSegmentControl.bottomAnchor, constant: 10.0).isActive = true
+        loggingText.leftAnchor.constraint(equalTo: self.view.leftAnchor, constant: 10.0).isActive = true
+        loggingText.rightAnchor.constraint(equalTo: self.view.rightAnchor, constant: -10.0).isActive = true
+        loggingText.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: 10.0).isActive = true
+    }
+    
+    func updateLogging(text : String) {
+        
+        if Thread.isMainThread {
+            self.loggingText.text = text
+        } else {
+            DispatchQueue.main.async {
+                self.loggingText.text = text
+            }
+        }
+    }
+    
+    func updateSignOutButton(enabled : Bool) {
+        if Thread.isMainThread {
+            self.signOutButton.isEnabled = enabled
+        } else {
+            DispatchQueue.main.async {
+                self.signOutButton.isEnabled = enabled
+            }
+        }
+    }
+    
+    func updateAccountLabel() {
+        
+        guard let currentAccount = self.currentAccount else {
+            self.usernameLabel.text = "Signed out"
+            return
+        }
+        
+        self.usernameLabel.text = currentAccount.username
+    }
+    
+    func updateCurrentAccount(account: MSALAccount?) {
+        self.currentAccount = account
+        self.updateAccountLabel()
+        self.updateSignOutButton(enabled: account != nil)
+    }
+}

--- a/MSAL/test/app/vision/MSAL_Test_App-Bridging-Header.h
+++ b/MSAL/test/app/vision/MSAL_Test_App-Bridging-Header.h
@@ -1,0 +1,31 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+#ifndef MSAL_Test_App_Bridging_Header_h
+#define MSAL_Test_App_Bridging_Header_h
+
+#import <MSAL/MSAL.h>
+
+#endif /* MSAL_Test_App_Bridging_Header_h */

--- a/MSAL/test/app/vision/MSAL_Test_App.swift
+++ b/MSAL/test/app/vision/MSAL_Test_App.swift
@@ -1,0 +1,57 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+
+import SwiftUI
+
+@main
+struct MSAL_Test_App: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .onReceive(NotificationCenter.default.publisher(for: UIApplication.didFinishLaunchingNotification)) { _ in
+                    
+                    MSALGlobalConfig.loggerConfig.setLogCallback { (logLevel, message, containsPII) in
+                        
+                        // If PiiLoggingEnabled is set YES, this block will potentially contain sensitive information (Personally Identifiable Information), but not all messages will contain it.
+                        // containsPII == YES indicates if a particular message contains PII.
+                        // You might want to capture PII only in debug builds, or only if you take necessary actions to handle PII properly according to legal requirements of the region
+                        if let displayableMessage = message {
+                            if (!containsPII) {
+                                #if DEBUG
+                                // NB! This sample uses print just for testing purposes
+                                // You should only ever log to NSLog in debug mode to prevent leaking potentially sensitive information
+                                print(displayableMessage)
+                                #endif
+                            }
+                        }
+                    }
+                }
+            
+                .onOpenURL { (url) in
+                    MSALPublicClientApplication.handleMSALResponse(url, sourceApplication: nil)
+                }
+        }
+    }
+}

--- a/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Content.imageset/Contents.json
+++ b/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "vision",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Contents.json
+++ b/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Contents.json
+++ b/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.solidimagestacklayer"
+    },
+    {
+      "filename" : "Middle.solidimagestacklayer"
+    },
+    {
+      "filename" : "Back.solidimagestacklayer"
+    }
+  ]
+}

--- a/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Content.imageset/Contents.json
+++ b/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "vision",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Contents.json
+++ b/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Content.imageset/Contents.json
+++ b/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "vision",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Contents.json
+++ b/MSAL/test/app/vision/resources/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MSAL/test/app/vision/resources/Assets.xcassets/Contents.json
+++ b/MSAL/test/app/vision/resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MSAL/test/app/vision/resources/Info.plist
+++ b/MSAL/test/app/vision/resources/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>msauth.com.microsoft.MSALTestApp</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>msauthv3</string>
+		<string>msauthv2</string>
+	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationPreferredDefaultSceneSessionRole</key>
+		<string>UIWindowSceneSessionRoleApplication</string>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+</dict>
+</plist>

--- a/MSAL/test/app/vision/resources/MSAL Test App (visionOS).entitlements
+++ b/MSAL/test/app/vision/resources/MSAL Test App (visionOS).entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.microsoft.MSALTestApp</string>
+		<string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
+	</array>
+</dict>
+</plist>

--- a/MSAL/test/app/vision/resources/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/MSAL/test/app/vision/resources/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MSAL/xcconfig/msal__common__ios.xcconfig
+++ b/MSAL/xcconfig/msal__common__ios.xcconfig
@@ -1,2 +1,3 @@
 #include "../IdentityCore/IdentityCore/xcconfig/identitycore__common__ios.xcconfig"
 ARCHS[sdk=iphoneos*] = $(ARCHS_STANDARD)
+ARCHS[sdk=xros*] = $(ARCHS_STANDARD)

--- a/MSAL/xcconfig/msal__static__lib__ios.xcconfig
+++ b/MSAL/xcconfig/msal__static__lib__ios.xcconfig
@@ -3,10 +3,7 @@
 // Force the linker to resolve symbols.
 GENERATE_MASTER_OBJECT_FILE = YES
 
-// Add armv7s and arm64e to standard ARCHs.
-ARCHS = $(ARCHS_STANDARD) armv7s arm64e
-ARCHS[sdk=iphoneos*] = $(ARCHS_STANDARD) armv7s arm64e
-ARCHS[sdk=xros*] = $(ARCHS_STANDARD) armv7s arm64e
+ARCHS = $(ARCHS_STANDARD)
 
 // Activate full bitcode on release configuration for real devices.
 OTHER_CFLAGS[config=Release][sdk=iphoneos*] = $(OTHER_CFLAGS) -fembed-bitcode

--- a/MSAL/xcconfig/msal__static__lib__ios.xcconfig
+++ b/MSAL/xcconfig/msal__static__lib__ios.xcconfig
@@ -6,6 +6,7 @@ GENERATE_MASTER_OBJECT_FILE = YES
 // Add armv7s and arm64e to standard ARCHs.
 ARCHS = $(ARCHS_STANDARD) armv7s arm64e
 ARCHS[sdk=iphoneos*] = $(ARCHS_STANDARD) armv7s arm64e
+ARCHS[sdk=xros*] = $(ARCHS_STANDARD) armv7s arm64e
 
 // Activate full bitcode on release configuration for real devices.
 OTHER_CFLAGS[config=Release][sdk=iphoneos*] = $(OTHER_CFLAGS) -fembed-bitcode

--- a/MSAL/xcconfig/msal__test_app__vision.xcconfig
+++ b/MSAL/xcconfig/msal__test_app__vision.xcconfig
@@ -1,0 +1,8 @@
+#include "msal__common__ios.xcconfig"
+
+INFOPLIST_FILE = test/app/vision/resources/Info.plist;
+PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSALTestApp;
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+PRODUCT_NAME = MSAL Test App;
+OTHER_LDFLAGS = "-ObjC";

--- a/MSAL/xcconfig/msal__test_app__vision.xcconfig
+++ b/MSAL/xcconfig/msal__test_app__vision.xcconfig
@@ -1,8 +1,8 @@
 #include "msal__common__ios.xcconfig"
 
-INFOPLIST_FILE = test/app/vision/resources/Info.plist;
-PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSALTestApp;
-ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-PRODUCT_NAME = MSAL Test App;
-OTHER_LDFLAGS = "-ObjC";
+INFOPLIST_FILE = test/app/vision/resources/Info.plist
+PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.MSALTestApp
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon
+ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage
+PRODUCT_NAME = MSAL Test App
+OTHER_LDFLAGS = "-ObjC"

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -19,12 +19,14 @@ trigger:
 jobs:
 - job: 'Validate_Pull_Request'
   strategy:
-    maxParallel: 2
+    maxParallel: 3
     matrix:
       IOS_FRAMEWORK: 
         target: "iosFramework iosTestApp sampleIosApp sampleIosAppSwift"
       MAC_FRAMEWORK: 
         target: "macFramework"
+      VISION_FRAMEWORK:
+        target: "visionOSFramework visionOSTestApp visionOSSampleApp visionOSSampleAppSwift"
   displayName: Validate Pull Request
   pool:
     vmImage: 'macOS-14'
@@ -54,6 +56,24 @@ jobs:
   - task: ComponentGovernanceComponentDetection@0
     inputs:
       alertWarningLevel: Low
+# The following is needed to install the visionOS SDK on macos-14 vm image which
+# doesn't have visionOS installed by default.
+# TODO: Remove when macos-14-arm64 is supported on ADO.
+  - task: Bash@3
+    displayName: download visionOS SDK
+    inputs:
+      targetType: 'inline'
+      script: |
+        if [ $(target) == 'vision_library' ]; then
+            echo "Downloading simulator for visionOS"
+            sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+            defaults write com.apple.dt.Xcode AllowUnsupportedVisionOSHost -bool YES
+            defaults write com.apple.CoreSimulator AllowUnsupportedVisionOSHost -bool YES
+            xcodebuild -downloadPlatform visionOS
+        else
+            echo "Not visionOS job, no download needed"
+        fi
+      failOnStderr: false
   - task: Bash@3
     displayName: Run Build script & check for Errors
     inputs:

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -64,6 +64,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
+        echo $(target)
         if [ $(target) == 'visionOSFramework visionOSTestApp visionOSSampleApp visionOSSampleAppSwift' ]; then
             echo "Downloading simulator for visionOS"
             sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -26,7 +26,7 @@ jobs:
       MAC_FRAMEWORK: 
         target: "macFramework"
       VISION_FRAMEWORK:
-        target: "visionOSFramework visionOSTestApp visionOSSampleApp visionOSSampleAppSwift"
+        target: "visionOSFramework"
   displayName: Validate Pull Request
   pool:
     vmImage: 'macOS-14'
@@ -65,7 +65,7 @@ jobs:
       targetType: 'inline'
       script: |
         echo $(target)
-        if [ $(target) == 'visionOSFramework visionOSTestApp visionOSSampleApp visionOSSampleAppSwift' ]; then
+        if [ $(target) == 'visionOSFramework' ]; then
             echo "Downloading simulator for visionOS"
             sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
             defaults write com.apple.dt.Xcode AllowUnsupportedVisionOSHost -bool YES

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -64,7 +64,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        if [ $(target) == 'vision_library' ]; then
+        if [ $(target) == 'visionOSFramework visionOSTestApp visionOSSampleApp visionOSSampleAppSwift' ]; then
             echo "Downloading simulator for visionOS"
             sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
             defaults write com.apple.dt.Xcode AllowUnsupportedVisionOSHost -bool YES

--- a/build.py
+++ b/build.py
@@ -41,7 +41,7 @@ ios_sim_dest = "-destination 'platform=iOS Simulator,name=" + ios_sim_device_typ
 ios_sim_flags = "-sdk iphonesimulator CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
 
 vision_sim_device_type = "Apple Vision Pro"
-vision_sim_device_exact_name = vision_sim_device_type + " Simulator \(1.2\)"
+vision_sim_device_exact_name = vision_sim_device_type + " (1.2)"
 vision_sim_dest = "-destination 'platform=visionOS Simulator,name=" + vision_sim_device_type + ",OS=1.2'"
 vision_sim_flags = "-sdk xrsimulator CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
 

--- a/build.py
+++ b/build.py
@@ -202,7 +202,7 @@ class BuildTarget:
 
 		if (self.platform == "iOS") :
 			command += " " + ios_sim_flags + " " + ios_sim_dest
-   
+            
         if (self.platform == "visionOS") :
             command += " " + vision_sim_flags + " " + vision_sim_dest
 		

--- a/build.py
+++ b/build.py
@@ -40,9 +40,8 @@ ios_sim_device_exact_name = ios_sim_device_type + " Simulator \(17.5\)"
 ios_sim_dest = "-destination 'platform=iOS Simulator,name=" + ios_sim_device_type + ",OS=17.5'"
 ios_sim_flags = "-sdk iphonesimulator CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
 
-vision_sim_device_type = "Apple Vision Pro"
-vision_sim_device_exact_name = vision_sim_device_type + " (1.2)"
-vision_sim_dest = "-destination 'platform=visionOS Simulator,name=" + vision_sim_device_type + ",OS=1.2'"
+vision_sim_device_exact_name = "Apple Vision Pro"
+vision_sim_dest = "-destination 'platform=visionOS Simulator,name=" + vision_sim_device_exact_name + ",OS=1.2'"
 vision_sim_flags = "-sdk xrsimulator CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
 
 default_workspace = "MSAL.xcworkspace"

--- a/build.py
+++ b/build.py
@@ -202,9 +202,9 @@ class BuildTarget:
 
 		if (self.platform == "iOS") :
 			command += " " + ios_sim_flags + " " + ios_sim_dest
-            
-        if (self.platform == "visionOS") :
-            command += " " + vision_sim_flags + " " + vision_sim_dest
+
+		if (self.platform == "visionOS") :
+			command += " " + vision_sim_flags + " " + vision_sim_dest
 		
 		if (xcpretty) :
 			command += " | xcpretty"
@@ -294,8 +294,8 @@ class BuildTarget:
 		if (self.platform == "iOS") :
 			return device_guids.get_ios(ios_sim_device_exact_name)
    
-        if (self.platform == "visionOS") :
-            return device_guids.get_ios(vision_sim_device_exact_name)
+		if (self.platform == "visionOS") :
+			return device_guids.get_ios(vision_sim_device_exact_name)
 		
 		if (self.platform == "Mac") :
 			return device_guids.get_mac().decode(sys.stdout.encoding)
@@ -406,15 +406,16 @@ def launch_simulator(targets) :
         if target.platform == "iOS" :
             print("Booting iOS simulator...")
             command = "xcrun simctl boot " + device_guids.get_ios(ios_sim_device_exact_name)
+            
             break
         else :
             print("Booting visionOS simulator...")
             command = "xcrun simctl boot " + device_guids.get_ios(vision_sim_device_exact_name)
+            print(command)
             break
-	print(command)
-	
+    print(command)
 	# This spawns a new process without us having to wait for it
-	subprocess.Popen(command, shell = True)
+    subprocess.Popen(command, shell = True)
 
 clean = True
 
@@ -439,7 +440,6 @@ for spec in target_specifiers :
 		targets.append(BuildTarget(spec))
 
 if requires_simulator(targets) :
-    launch_simulator()
     launch_simulator(targets)
 
 # start by cleaning up any derived data that might be lying around


### PR DESCRIPTION
## Proposed changes

This PR adds support for MSAL iOS unit testing on visionOS.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

