### PR TITLE
ID Token should be updated when Access Token is refreshed/acquired silently

### DIFF
--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -83,7 +83,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
         return nil
     }
 
-    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> RefreshTokenCredentialControllerResponse {
+    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens, userAccountResult: MSALNativeAuthUserAccountResult) async -> RefreshTokenCredentialControllerResponse {
         MSALLogger.log(level: .verbose, context: context, format: "Refresh started")
         let telemetryEvent = makeAndStartTelemetryEvent(id: .telemetryApiIdRefreshToken, context: context)
         let scopes = authTokens.accessToken.scopes.array as? [String] ?? []
@@ -104,7 +104,8 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
             response,
             scopes: scopes,
             context: context,
-            telemetryEvent: telemetryEvent
+            telemetryEvent: telemetryEvent,
+            userAccountResult: userAccountResult
         )
     }
 
@@ -147,7 +148,8 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
         _ response: MSALNativeAuthTokenValidatedResponse,
         scopes: [String],
         context: MSALNativeAuthRequestContext,
-        telemetryEvent: MSIDTelemetryAPIEvent?
+        telemetryEvent: MSIDTelemetryAPIEvent?,
+        userAccountResult: MSALNativeAuthUserAccountResult
     ) -> RefreshTokenCredentialControllerResponse {
         let config = factory.makeMSIDConfiguration(scopes: scopes)
         switch response {
@@ -156,7 +158,8 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 tokenResponse: tokenResponse,
                 telemetryEvent: telemetryEvent,
                 context: context,
-                config: config
+                config: config,
+                userAccountResult: userAccountResult
             )
         case .error(let errorType):
             let error = errorType.convertToRetrieveAccessTokenError(correlationId: context.correlationId())
@@ -173,7 +176,8 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
         tokenResponse: MSIDTokenResponse,
         telemetryEvent: MSIDTelemetryAPIEvent?,
         context: MSALNativeAuthRequestContext,
-        config: MSIDConfiguration
+        config: MSIDConfiguration,
+        userAccountResult: MSALNativeAuthUserAccountResult
     ) -> RefreshTokenCredentialControllerResponse {
         do {
             let tokenResult = try cacheTokenResponse(tokenResponse, context: context, msidConfiguration: config)
@@ -182,12 +186,40 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
                 context: context,
                 format: "Refresh Token completed successfully")
             // TODO: Handle tokenResult.refreshToken as? MSIDRefreshToken in a safer way
-            return .init(
-                .success(MSALNativeAuthTokenResult(authTokens: MSALNativeAuthTokens(
-                    accessToken: tokenResult.accessToken,
-                    refreshToken: tokenResult.refreshToken as? MSIDRefreshToken,
-                    rawIdToken: tokenResult.rawIdToken
-                ))),
+            let authTokens = MSALNativeAuthTokens(
+                accessToken: tokenResult.accessToken,
+                refreshToken: tokenResult.refreshToken as? MSIDRefreshToken,
+                rawIdToken: tokenResult.rawIdToken
+            )
+            var jsonDictionary: [AnyHashable: Any]?
+            do {
+                let claims = try MSIDIdTokenClaims.init(rawIdToken: tokenResult.rawIdToken)
+                jsonDictionary = claims.jsonDictionary()
+                if jsonDictionary == nil {
+                    MSALLogger.log(
+                        level: .error,
+                        context: context,
+                        format: "Initialising account without claims")
+                }
+            } catch {
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "Claims for account could not be created - \(error)" )
+            }
+            guard let account = MSALAccount.init(msidAccount: tokenResult.account,
+                                                 createTenantProfile: false,
+                                                 accountClaims: jsonDictionary) else {
+                let error = RetrieveAccessTokenError(type: .generalError, correlationId: context.correlationId())
+                MSALLogger.log(
+                    level: .error,
+                    context: context,
+                    format: "Account could not be created")
+                stopTelemetryEvent(telemetryEvent, context: context, error: error)
+                return .init(.failure(error), correlationId: context.correlationId())
+            }
+            userAccountResult.refreshData(authTokens: authTokens, account: account)
+            return .init(.success(MSALNativeAuthTokenResult(authTokens: authTokens)),
                 correlationId: context.correlationId(),
                 telemetryUpdate: { [weak self] result in
                 telemetryEvent?.setUserInformation(tokenResult.account)

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -174,6 +174,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
         }
     }
 
+    // swiftlint:disable:next function_body_length
     private func handleMSIDTokenResponse(
         tokenResponse: MSIDTokenResponse,
         telemetryEvent: MSIDTelemetryAPIEvent?,

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -83,7 +83,9 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
         return nil
     }
 
-    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens, userAccountResult: MSALNativeAuthUserAccountResult) async -> RefreshTokenCredentialControllerResponse {
+    func refreshToken(context: MSALNativeAuthRequestContext,
+                      authTokens: MSALNativeAuthTokens,
+                      userAccountResult: MSALNativeAuthUserAccountResult) async -> RefreshTokenCredentialControllerResponse {
         MSALLogger.log(level: .verbose, context: context, format: "Refresh started")
         let telemetryEvent = makeAndStartTelemetryEvent(id: .telemetryApiIdRefreshToken, context: context)
         let scopes = authTokens.accessToken.scopes.array as? [String] ?? []

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
@@ -29,5 +29,7 @@ protocol MSALNativeAuthCredentialsControlling {
     MSALNativeAuthControllerTelemetryWrapper<Result<MSALNativeAuthTokenResult, RetrieveAccessTokenError>>
 
     func retrieveUserAccountResult(context: MSALNativeAuthRequestContext) -> MSALNativeAuthUserAccountResult?
-    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens, userAccountResult: MSALNativeAuthUserAccountResult) async -> RefreshTokenCredentialControllerResponse
+    func refreshToken(context: MSALNativeAuthRequestContext, 
+                      authTokens: MSALNativeAuthTokens,
+                      userAccountResult: MSALNativeAuthUserAccountResult) async -> RefreshTokenCredentialControllerResponse
 }

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
@@ -29,7 +29,7 @@ protocol MSALNativeAuthCredentialsControlling {
     MSALNativeAuthControllerTelemetryWrapper<Result<MSALNativeAuthTokenResult, RetrieveAccessTokenError>>
 
     func retrieveUserAccountResult(context: MSALNativeAuthRequestContext) -> MSALNativeAuthUserAccountResult?
-    func refreshToken(context: MSALNativeAuthRequestContext, 
+    func refreshToken(context: MSALNativeAuthRequestContext,
                       authTokens: MSALNativeAuthTokens,
                       userAccountResult: MSALNativeAuthUserAccountResult) async -> RefreshTokenCredentialControllerResponse
 }

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsControlling.swift
@@ -29,5 +29,5 @@ protocol MSALNativeAuthCredentialsControlling {
     MSALNativeAuthControllerTelemetryWrapper<Result<MSALNativeAuthTokenResult, RetrieveAccessTokenError>>
 
     func retrieveUserAccountResult(context: MSALNativeAuthRequestContext) -> MSALNativeAuthUserAccountResult?
-    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens) async -> RefreshTokenCredentialControllerResponse
+    func refreshToken(context: MSALNativeAuthRequestContext, authTokens: MSALNativeAuthTokens, userAccountResult: MSALNativeAuthUserAccountResult) async -> RefreshTokenCredentialControllerResponse
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -37,9 +37,14 @@ extension MSALNativeAuthUserAccountResult {
         if forceRefresh || self.authTokens.accessToken.isExpired() {
             let controllerFactory = MSALNativeAuthControllerFactory(config: configuration)
             let credentialsController = controllerFactory.makeCredentialsController(cacheAccessor: cacheAccessor)
-            return await credentialsController.refreshToken(context: context, authTokens: authTokens)
+            return await credentialsController.refreshToken(context: context, authTokens: authTokens, userAccountResult: self)
         } else {
             return .init(.success(MSALNativeAuthTokenResult(authTokens: authTokens)), correlationId: correlationId)
         }
+    }
+
+    func refreshData(authTokens: MSALNativeAuthTokens, account: MSALAccount) {
+        self.authTokens = authTokens
+        self.account = account
     }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -27,9 +27,9 @@ import Foundation
 /// Class that groups account and token information.
 @objc public class MSALNativeAuthUserAccountResult: NSObject {
     /// The account object that holds account information.
-    @objc public let account: MSALAccount
+    @objc public var account: MSALAccount
 
-    let authTokens: MSALNativeAuthTokens
+    var authTokens: MSALNativeAuthTokens
     let configuration: MSALNativeAuthConfiguration
     private let cacheAccessor: MSALNativeAuthCacheInterface
 

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -33,7 +33,7 @@ import Foundation
     let configuration: MSALNativeAuthConfiguration
     private let cacheAccessor: MSALNativeAuthCacheInterface
 
-    /// Get the ID token for the account.
+    /// Get the latest ID token for the account.
     @objc public var idToken: String? {
         authTokens.rawIdToken
     }

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthCredentialsControllerTests.swift
@@ -73,13 +73,13 @@ final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
 
     // MARK: get native user account tests
 
-    func test_whenNoAccountPresent_shouldReturnNoAccounts() {
+    func test_whenNoAccountPresent_shouldReturnNoUserAccountResult() {
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let accountResult = sut.retrieveUserAccountResult(context: expectedContext)
         XCTAssertNil(accountResult)
     }
 
-    func test_whenNoTokenPresent_shouldReturnNoAccounts() {
+    func test_whenNoTokenPresent_shouldReturnNoUserAccountResult() {
         let account = MSALNativeAuthUserAccountResultStub.account
         let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
         let userAccountResult = MSALNativeAuthUserAccountResult(
@@ -95,7 +95,7 @@ final class MSALNativeAuthCredentialsControllerTests: MSALNativeAuthTestCase {
         XCTAssertNil(accountResult)
     }
 
-    func test_whenAccountSet_shouldReturnAccount() async {
+    func test_whenAccountSet_shouldReturnUserAccountResult() async {
         let account = MSALNativeAuthUserAccountResultStub.account
         let authTokens = MSALNativeAuthUserAccountResultStub.authTokens
 

--- a/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/factories/MSALNativeAuthResultFactoryTests.swift
@@ -53,63 +53,97 @@ final class MSALNativeAuthResultFactoryTests: XCTestCase {
         XCTAssertEqual(result.clientId, DEFAULT_TEST_CLIENT_ID)
         XCTAssertEqual(result.target, "<scope_1> <scope_2>")
     }
-    
-    func test_makeUserAccount_returnExpectedResult() {
-        let accessTokenString = "accessToken"
+
+    func test_makeAccount_withInvalidIdToken_shouldNotCreateClaims() {
+        let idToken = "invalidIdToken"
+        let username = "username"
+        let tokenResult = getMSIDTokenResultFromData(idToken: idToken, username: username)
+        let context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        let account = sut.makeAccount(tokenResult: tokenResult!, context: context)
+        XCTAssertEqual(account.username, "username")
+        XCTAssertNil(account.accountClaims)
+    }
+
+    func test_makeAccount_withValidIdToken_returnsExpectedResult() {
         let idToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ii1LSTNROW5OUjdiUm9meG1lWm9YcWJIWkdldyJ9.eyJhdWQiOiJmODdmN2Q2NS1jZjY2LTQzNzAtYTllZi0yNGQzNzBlZDllNjQiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZmU2MjYwOTYtZWQ5Ny00NTA0LTg4ZTMtNTVhMzNkMmVkNGQ2L3YyLjAiLCJpYXQiOjE2OTUwMzMzMDYsIm5iZiI6MTY5NTAzMzMwNiwiZXhwIjoxNjk1MDM3MjA2LCJhaW8iOiJBVFFBeS84VUFBQUFyeVNpU1Rsa0dHNTl0VHFmcWdHU1ZZRWY4RzRQbldDSnlUZ2hXdzdDU2MvRGZwMWxYRXI0T1JTWFBJbzdzaldnIiwibmFtZSI6InVua25vd24iLCJvaWQiOiIzYzIwZWM4Zi0xNzVkLTQxMjgtODZhMy01MDM5MDRhNDRiMTUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkdWFsdGFnaG1zZnQrc2lnbnVwMzFAb3V0bG9vay5jb20iLCJyaCI6IjAuQWM4QWxtQmlfcGZ0QkVXSTQxV2pQUzdVMW1WOWZfaG16M0JEcWU4azAzRHRubVRQQUJJLiIsInN1YiI6ImcwLTc0U3hHUnhSTjBqT19hXzY4bG9adGVsY1EwdTJFX3hyYmNBaGRtWjAiLCJ0aWQiOiJmZTYyNjA5Ni1lZDk3LTQ1MDQtODhlMy01NWEzM2QyZWQ0ZDYiLCJ1dGkiOiJGeWxCbk9nYkwwQy0zX0Z1Ym5VQUFBIiwidmVyIjoiMi4wIiwiZGF0ZU9mQmlydGgiOiIwMS8wMS8yMDAwIiwiY3VzdG9tUm9sZXMiOlsiV3JpdGVyIiwiRWRpdG9yIl0sImFwaVZlcnNpb24iOiIxLjAuMCIsImNvcnJlbGF0aW9uSWQiOiI4ZmM5M2FlYi01ZmMxLTQzOWQtYjM4OC1kYmY0YjM4ZGM3ODUifQ.rBu4Vw3ftWivyNXaDC7fB6HAB7TucGK1BUbSOt_ZW-ivsPLpHK7A4E0i8hu8Qs-zade6Fsp2deSaZNNLLNQCSDav7iMKZukNwQviWOG_Uvz31GVpkh1l26xTs3dlKS-6NjdwpkvccEg1VeIW-pyC_7RLAaCb1uzMoKFn7mA6meFCYBVnEZ3lRSw0_XtoKrcw5hJfvST4MOe7EJw2a2DH-fu1DDh-5FbCP4Y_nn6esre0I_Q0EwuF_4TYTESy_vqHwXZcTKZq34-5x4thRPGE1I_CBEJZkKXIWC6z788zEXSgnHvRfGEH52bRo_ZuPsftV1R1M9os0wPzgBOWwvMzOA"
         let username = "username"
-        let scopes = ["scope1", "scope2"]
-        let expiresOn = Date()
-        let accessToken = MSIDAccessToken()
-        accessToken.accessToken = accessTokenString
-        accessToken.accountIdentifier = MSIDAccountIdentifier(displayableId: username, homeAccountId: "")
-        accessToken.expiresOn = expiresOn
-        accessToken.scopes = NSOrderedSet(array: scopes)
-        let refreshToken = MSIDRefreshToken()
-        refreshToken.refreshToken = "refreshToken"
-        let msidAccount = MSIDAccount()
-        msidAccount.username = username
-        guard let tokenResult = MSIDTokenResult(accessToken: accessToken, refreshToken: refreshToken, idToken: idToken, account: msidAccount, authority: MSALNativeAuthNetworkStubs.msidAuthority, correlationId: UUID(), tokenResponse: nil) else {
-            XCTFail("Unexpected nil token")
-            return
-        }
+        let tokenResult = getMSIDTokenResultFromData(idToken: idToken, username: username)
         let context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
-        guard let accountResult = sut.makeUserAccountResult(tokenResult: tokenResult, context: context) else {
-            XCTFail("Unexpected nil account")
-            return
-        }
-        XCTAssertEqual(accountResult.account.username, username)
-        XCTAssertEqual(accountResult.idToken, idToken)
-        XCTAssertNotNil(accountResult.account.accountClaims)
-        XCTAssertEqual(accountResult.account.accountClaims?.count, 21)
+        let account = sut.makeAccount(tokenResult: tokenResult!, context: context)
+        XCTAssertEqual(account.username, "username")
+        XCTAssertNotNil(account.accountClaims)
+        XCTAssertEqual(account.accountClaims?.count, 21)
+    }
+
+    func test_makeAuthTokens_withNilRefreshToken_shouldNotCreateAuthTokens() {
+        let idToken = "correctIdToken"
+        let username = "username"
+        let tokenResult = getMSIDTokenResultFromData(idToken: idToken, username: username)
+        tokenResult?.refreshToken = nil
+        let context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        let authTokens = sut.makeAuthTokens(tokenResult: tokenResult!, context: context)
+        XCTAssertNil(authTokens)
+    }
+
+    func test_makeAuthTokens_withNonNilRefreshToken_shouldCreateAuthTokens() {
+        let idToken = "correctIdToken"
+        let username = "username"
+        let tokenResult = getMSIDTokenResultFromData(idToken: idToken, username: username)
+        let context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        let authTokens = sut.makeAuthTokens(tokenResult: tokenResult!, context: context)
+        XCTAssertNotNil(authTokens)
+        XCTAssertEqual(authTokens?.accessToken.accessToken, "accessToken")
+        XCTAssertEqual(authTokens?.refreshToken?.refreshToken, "refreshToken")
+        XCTAssertEqual(authTokens?.rawIdToken, idToken)
     }
 
     func test_makeUserAccount_withIncorrectIdToken_accountClaimsNotPresent() {
-        let accessTokenString = "accessToken"
-        let idToken = "idToken"
+        let idToken = "invalidIdToken"
         let username = "username"
-        let scopes = ["scope1", "scope2"]
-        let expiresOn = Date()
-        let accessToken = MSIDAccessToken()
-        accessToken.accessToken = accessTokenString
-        accessToken.accountIdentifier = MSIDAccountIdentifier(displayableId: username, homeAccountId: "")
-        accessToken.expiresOn = expiresOn
-        accessToken.scopes = NSOrderedSet(array: scopes)
-        let refreshToken = MSIDRefreshToken()
-        refreshToken.refreshToken = "refreshToken"
-        let msidAccount = MSIDAccount()
-        msidAccount.username = username
-        guard let tokenResult = MSIDTokenResult(accessToken: accessToken, refreshToken: refreshToken, idToken: idToken, account: msidAccount, authority: MSALNativeAuthNetworkStubs.msidAuthority, correlationId: UUID(), tokenResponse: nil) else {
-            XCTFail("Unexpected nil token")
-            return
-        }
+        let tokenResult = getMSIDTokenResultFromData(idToken: idToken, username: username)
         let context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
-        guard let accountResult = sut.makeUserAccountResult(tokenResult: tokenResult, context: context) else {
+        guard let accountResult = sut.makeUserAccountResult(tokenResult: tokenResult!, context: context) else {
             XCTFail("Unexpected nil account")
             return
         }
         XCTAssertEqual(accountResult.account.username, username)
         XCTAssertEqual(accountResult.idToken, idToken)
         XCTAssertNil(accountResult.account.accountClaims)
+    }
+
+    func test_makeUserAccount_returnsExpectedResult() {
+        let idToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ii1LSTNROW5OUjdiUm9meG1lWm9YcWJIWkdldyJ9.eyJhdWQiOiJmODdmN2Q2NS1jZjY2LTQzNzAtYTllZi0yNGQzNzBlZDllNjQiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZmU2MjYwOTYtZWQ5Ny00NTA0LTg4ZTMtNTVhMzNkMmVkNGQ2L3YyLjAiLCJpYXQiOjE2OTUwMzMzMDYsIm5iZiI6MTY5NTAzMzMwNiwiZXhwIjoxNjk1MDM3MjA2LCJhaW8iOiJBVFFBeS84VUFBQUFyeVNpU1Rsa0dHNTl0VHFmcWdHU1ZZRWY4RzRQbldDSnlUZ2hXdzdDU2MvRGZwMWxYRXI0T1JTWFBJbzdzaldnIiwibmFtZSI6InVua25vd24iLCJvaWQiOiIzYzIwZWM4Zi0xNzVkLTQxMjgtODZhMy01MDM5MDRhNDRiMTUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJkdWFsdGFnaG1zZnQrc2lnbnVwMzFAb3V0bG9vay5jb20iLCJyaCI6IjAuQWM4QWxtQmlfcGZ0QkVXSTQxV2pQUzdVMW1WOWZfaG16M0JEcWU4azAzRHRubVRQQUJJLiIsInN1YiI6ImcwLTc0U3hHUnhSTjBqT19hXzY4bG9adGVsY1EwdTJFX3hyYmNBaGRtWjAiLCJ0aWQiOiJmZTYyNjA5Ni1lZDk3LTQ1MDQtODhlMy01NWEzM2QyZWQ0ZDYiLCJ1dGkiOiJGeWxCbk9nYkwwQy0zX0Z1Ym5VQUFBIiwidmVyIjoiMi4wIiwiZGF0ZU9mQmlydGgiOiIwMS8wMS8yMDAwIiwiY3VzdG9tUm9sZXMiOlsiV3JpdGVyIiwiRWRpdG9yIl0sImFwaVZlcnNpb24iOiIxLjAuMCIsImNvcnJlbGF0aW9uSWQiOiI4ZmM5M2FlYi01ZmMxLTQzOWQtYjM4OC1kYmY0YjM4ZGM3ODUifQ.rBu4Vw3ftWivyNXaDC7fB6HAB7TucGK1BUbSOt_ZW-ivsPLpHK7A4E0i8hu8Qs-zade6Fsp2deSaZNNLLNQCSDav7iMKZukNwQviWOG_Uvz31GVpkh1l26xTs3dlKS-6NjdwpkvccEg1VeIW-pyC_7RLAaCb1uzMoKFn7mA6meFCYBVnEZ3lRSw0_XtoKrcw5hJfvST4MOe7EJw2a2DH-fu1DDh-5FbCP4Y_nn6esre0I_Q0EwuF_4TYTESy_vqHwXZcTKZq34-5x4thRPGE1I_CBEJZkKXIWC6z788zEXSgnHvRfGEH52bRo_ZuPsftV1R1M9os0wPzgBOWwvMzOA"
+        let username = "username"
+        let tokenResult = getMSIDTokenResultFromData(idToken: idToken, username: username)
+        let context = MSALNativeAuthRequestContext(correlationId: .init(uuidString: DEFAULT_TEST_UID)!)
+        guard let accountResult = sut.makeUserAccountResult(tokenResult: tokenResult!, context: context) else {
+            XCTFail("Unexpected nil user account result")
+            return
+        }
+        XCTAssertEqual(accountResult.account.username, "username")
+        XCTAssertEqual(accountResult.idToken, idToken)
+        XCTAssertNotNil(accountResult.account.accountClaims)
+        XCTAssertEqual(accountResult.account.accountClaims?.count, 21)
+    }
+
+    func getMSIDTokenResultFromData(idToken: String, username: String) -> MSIDTokenResult? {
+        let accessTokenString = "accessToken"
+        let username = "username"
+        let scopes = ["scope1", "scope2"]
+        let expiresOn = Date()
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = accessTokenString
+        accessToken.accountIdentifier = MSIDAccountIdentifier(displayableId: username, homeAccountId: "")
+        accessToken.expiresOn = expiresOn
+        accessToken.scopes = NSOrderedSet(array: scopes)
+        let refreshToken = MSIDRefreshToken()
+        refreshToken.refreshToken = "refreshToken"
+        let msidAccount = MSIDAccount()
+        msidAccount.username = username
+        guard let tokenResult = MSIDTokenResult(accessToken: accessToken, refreshToken: refreshToken, idToken: idToken, account: msidAccount, authority: MSALNativeAuthNetworkStubs.msidAuthority, correlationId: UUID(), tokenResponse: nil) else {
+            XCTFail("Unexpected nil token")
+            return nil
+        }
+        return tokenResult
     }
 }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthCredentialsControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthCredentialsControllerMock.swift
@@ -31,7 +31,9 @@ class MSALNativeAuthCredentialsControllerMock: MSALNativeAuthCredentialsControll
     var refreshTokenResult: RefreshTokenCredentialControllerResponse!
     var accountResult: MSALNativeAuthUserAccountResult?
 
-    func refreshToken(context: MSAL.MSALNativeAuthRequestContext, authTokens: MSAL.MSALNativeAuthTokens) async -> RefreshTokenCredentialControllerResponse {
+    func refreshToken(context: MSALNativeAuthRequestContext,
+                      authTokens: MSALNativeAuthTokens,
+                      userAccountResult: MSALNativeAuthUserAccountResult) async -> RefreshTokenCredentialControllerResponse {
         return refreshTokenResult
     }
 

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
@@ -31,7 +31,29 @@ class MSALNativeAuthResultFactoryMock: MSALNativeAuthResultBuildable {
     var config: MSAL.MSALNativeAuthConfiguration = MSALNativeAuthConfigStubs.configuration
     
     private(set) var makeMsidConfigurationResult: MSIDConfiguration?
+    private(set) var makeAccount: MSALAccount?
+    private(set) var makeNativeAuthTokens: MSALNativeAuthTokens?
     private(set) var makeNativeAuthUserAccountResult: MSALNativeAuthUserAccountResult?
+
+    func mockMakeAccount(_ account: MSALAccount) {
+        self.makeAccount = account
+    }
+
+    func makeAccount(tokenResult: MSIDTokenResult, context: MSIDRequestContext) -> MSALAccount {
+        return makeAccount ?? MSALAccount.init(msidAccount: tokenResult.account, createTenantProfile: false)
+    }
+
+    func mockMakeNativeAuthTokens(_ authTokens: MSALNativeAuthTokens) {
+        self.makeNativeAuthTokens = authTokens
+    }
+
+    func makeAuthTokens(tokenResult: MSIDTokenResult, context: MSIDRequestContext) -> MSAL.MSALNativeAuthTokens? {
+        return makeNativeAuthTokens ?? MSALNativeAuthTokens(
+            accessToken: tokenResult.accessToken,
+            refreshToken: tokenResult.refreshToken as? MSIDRefreshToken,
+            rawIdToken: tokenResult.rawIdToken
+        )
+    }
 
     func mockMakeUserAccountResult(_ result: MSALNativeAuthUserAccountResult) {
         self.makeNativeAuthUserAccountResult = result


### PR DESCRIPTION
## Proposed changes

The Auth Tokens present in the UserAccountResult and specifically the ID Token alongside the MSALAccount get updated when a refresh token operation happens

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information
To test this, the test case Verify split issuer needs to be run. The UserAccountResult returned when the getAccount is called, needs to have the ID Token updated when refreshToken is called and the MSALAccount should have the Account Claims updated
