### PR TITLE
Bypassing redirect URI validation for nil URI if developers set bypassRedirectUriValidation property

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -879,7 +879,7 @@
     // Nested auth protocol
     msidParams.nestedAuthBrokerClientId = self.internalConfig.nestedAuthBrokerClientId;
     msidParams.nestedAuthBrokerRedirectUri = self.internalConfig.nestedAuthBrokerRedirectUri;
-    msidParams.skipSendRedirectUri = parameters.skipSendRedirectUri;
+    msidParams.skipSendRedirectUri = [NSStringFromClass([self class]) isEqualToString:@"MSAL.MSALNativeAuthPublicClientApplication"];
     
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, msidParams,
                  @"-[MSALPublicClientApplication acquireTokenSilentForScopes:%@\n"

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -879,6 +879,7 @@
     // Nested auth protocol
     msidParams.nestedAuthBrokerClientId = self.internalConfig.nestedAuthBrokerClientId;
     msidParams.nestedAuthBrokerRedirectUri = self.internalConfig.nestedAuthBrokerRedirectUri;
+    msidParams.skipSendRedirectUri = parameters.skipSendRedirectUri;
     
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, msidParams,
                  @"-[MSALPublicClientApplication acquireTokenSilentForScopes:%@\n"

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -211,7 +211,7 @@
                                                                     bypassRedirectValidation:config.bypassRedirectURIValidation
                                                                                        error:&msidError];
     
-    if (!msalRedirectUri)
+    if (!msalRedirectUri && !config.bypassRedirectURIValidation)
     {
         if (error) *error = [MSALErrorConverter msalErrorFromMsidError:msidError];
         return nil;
@@ -879,7 +879,7 @@
     // Nested auth protocol
     msidParams.nestedAuthBrokerClientId = self.internalConfig.nestedAuthBrokerClientId;
     msidParams.nestedAuthBrokerRedirectUri = self.internalConfig.nestedAuthBrokerRedirectUri;
-    msidParams.skipSendRedirectUri = [NSStringFromClass([self class]) isEqualToString:@"MSAL.MSALNativeAuthPublicClientApplication"];
+    msidParams.bypassRedirectURIValidation = self.internalConfig.bypassRedirectURIValidation;
     
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, msidParams,
                  @"-[MSALPublicClientApplication acquireTokenSilentForScopes:%@\n"

--- a/MSAL/src/configuration/MSALPublicClientApplicationConfig.m
+++ b/MSAL/src/configuration/MSALPublicClientApplicationConfig.m
@@ -130,6 +130,7 @@ static double defaultTokenExpirationBuffer = 300; //in seconds, ensures catching
     item->_verifiedRedirectUri = [_verifiedRedirectUri copyWithZone:zone];
     item->_extraQueryParameters = [_extraQueryParameters copyWithZone:zone];
     item->_multipleCloudsSupported = _multipleCloudsSupported;
+    item->_bypassRedirectURIValidation = _bypassRedirectURIValidation;
     return item;
 }
 

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -245,6 +245,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         return responseValidator.validate(result, with: context)
     }
 
+    // swiftlint:disable:next function_body_length
     private func handleSignUpChallengeResult(
         _ result: MSALNativeAuthSignUpChallengeValidatedResponse,
         username: String,

--- a/MSAL/src/public/MSALSilentTokenParameters.h
+++ b/MSAL/src/public/MSALSilentTokenParameters.h
@@ -43,6 +43,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL forceRefresh;
 
 /**
+ Ignore the redirect URI when sending requests for Native Auth flows.
+ */
+@property (nonatomic) BOOL skipSendRedirectUri;
+
+/**
  1. When Sso Extension is presenting on the device
     Default is YES. when Sso Extension failed to return a (new) access token, tries with existing refresh token in the cache, and return results.
     If set to NO, when Sso Extension failed to return a (new) access token, ignores existing refresh token in local cahce, and return Sso Extension error.

--- a/MSAL/src/public/MSALSilentTokenParameters.h
+++ b/MSAL/src/public/MSALSilentTokenParameters.h
@@ -43,11 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL forceRefresh;
 
 /**
- Ignore the redirect URI when sending requests for Native Auth flows.
- */
-@property (nonatomic) BOOL skipSendRedirectUri;
-
-/**
  1. When Sso Extension is presenting on the device
     Default is YES. when Sso Extension failed to return a (new) access token, tries with existing refresh token in the cache, and return results.
     If set to NO, when Sso Extension failed to return a (new) access token, ignores existing refresh token in local cahce, and return Sso Extension error.

--- a/MSAL/test/unit/MSALPublicClientApplicationConfigTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationConfigTests.m
@@ -78,6 +78,7 @@
     XCTAssertNil(config.sliceConfig.slice);
     XCTAssertNil(config.sliceConfig);
     XCTAssertNotNil(config.cacheConfig);
+    XCTAssertEqual(config.bypassRedirectURIValidation, NO);
 #if TARGET_OS_IPHONE
     XCTAssertEqualObjects(config.cacheConfig.keychainSharingGroup, @"com.microsoft.adalcache");
 #endif
@@ -104,6 +105,7 @@
     XCTAssertNil(copiedConfig.sliceConfig.slice);
     XCTAssertNil(copiedConfig.sliceConfig);
     XCTAssertNotNil(copiedConfig.cacheConfig);
+    XCTAssertEqual(copiedConfig.bypassRedirectURIValidation, NO);
 #if TARGET_OS_IPHONE
     XCTAssertEqualObjects(copiedConfig.cacheConfig.keychainSharingGroup, @"com.microsoft.adalcache");
 #endif
@@ -124,6 +126,7 @@
     config.sliceConfig = [[MSALSliceConfig alloc] initWithSlice:@"myslice" dc:@"mydc"];
     config.cacheConfig.keychainSharingGroup = @"my.test.group";
     config.extendedLifetimeEnabled = YES;
+    config.bypassRedirectURIValidation = YES;
     
     MSALPublicClientApplicationConfig *copiedConfig = [config copy];
     XCTAssertNotNil(copiedConfig);
@@ -140,6 +143,7 @@
     XCTAssertEqualObjects(copiedConfig.sliceConfig.slice, @"myslice");
     XCTAssertNotNil(copiedConfig.sliceConfig);
     XCTAssertNotNil(copiedConfig.cacheConfig);
+    XCTAssertEqual(copiedConfig.bypassRedirectURIValidation, YES);
 #if TARGET_OS_IPHONE
     XCTAssertEqualObjects(copiedConfig.cacheConfig.keychainSharingGroup, @"my.test.group");
 #endif

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -238,21 +238,6 @@
 #endif
 }
 
-- (void)testInitWithConfigurationAndAuthorityAndRedirectUri_whenNilRedirectUriAndNotByPassValidation_shouldReturnNilApplicationAndError
-{
-    __auto_type authority = [@"https://login.microsoftonline.com/common" msalAuthority];
-    
-    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"client_id" redirectUri:nil authority:authority];
-    config.knownAuthorities = @[authority];
-    config.bypassRedirectURIValidation = false;
-    
-    NSError *error = nil;
-    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
-    
-    XCTAssertNil(application);
-    XCTAssertNotNil(error);
-}
-
 - (void)testInitWithConfigurationAndAuthorityAndRedirectUri_whenNilRedirectUriAndByPassValidation_shouldReturnApplicationAndNilError
 {
     __auto_type authority = [@"https://login.microsoftonline.com/common" msalAuthority];

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -238,6 +238,36 @@
 #endif
 }
 
+- (void)testInitWithConfigurationAndAuthorityAndRedirectUri_whenNilRedirectUriAndNotByPassValidation_shouldReturnNilApplicationAndError
+{
+    __auto_type authority = [@"https://login.microsoftonline.com/common" msalAuthority];
+    
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"client_id" redirectUri:nil authority:authority];
+    config.knownAuthorities = @[authority];
+    config.bypassRedirectURIValidation = false;
+    
+    NSError *error = nil;
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
+    
+    XCTAssertNil(application);
+    XCTAssertNotNil(error);
+}
+
+- (void)testInitWithConfigurationAndAuthorityAndRedirectUri_whenNilRedirectUriAndByPassValidation_shouldReturnApplicationAndNilError
+{
+    __auto_type authority = [@"https://login.microsoftonline.com/common" msalAuthority];
+    
+    MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:@"client_id" redirectUri:nil authority:authority];
+    config.knownAuthorities = @[authority];
+    config.bypassRedirectURIValidation = true;
+    
+    NSError *error = nil;
+    MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithConfiguration:config error:&error];
+    
+    XCTAssertNotNil(application);
+    XCTAssertNil(error);
+}
+
 #if TARGET_OS_IPHONE
 
 - (void)testInitWithClientId_whenSchemeNotRegistered_shouldReturnNilApplicationAndFillError


### PR DESCRIPTION
## Proposed changes

Bypassing redirect URI validation for nil URI if developers set `bypassRedirectUriValidation` property. This PR has a dependency on: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1375.

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

