### PR TITLE
Add SPM validation in each PR

### DIFF
--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -98,7 +98,7 @@ jobs:
     clean: true
     submodules: true
     fetchDepth: 1
-    persistCredentials: true
+    persistCredentials: false
     path: s
 
   - script: |

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -110,8 +110,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        UUID_LOCAL=$(uuidgen)
-        BRANCH_NAME_LOCAL="$(Build.SourceBranchName)-temp-${UUID_LOCAL}"
+        BRANCH_NAME_LOCAL="$(Build.SourceBranchName)-temp"
         echo "##vso[task.setvariable variable=BRANCH_NAME]${BRANCH_NAME_LOCAL}"
       
   - task: Bash@3

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -98,7 +98,7 @@ jobs:
     clean: true
     submodules: true
     fetchDepth: 1
-    persistCredentials: false
+    persistCredentials: true
     path: s
 
   - script: |

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -127,9 +127,10 @@ jobs:
       targetType: 'inline'
       script: |
         sh spm-integration-test.sh "${BRANCH_NAME}"
-    continueOnError: true
+    continueOnError: false
 
   - task: Bash@3
+    condition: always()
     displayName: Cleanup
     inputs:
       targetType: 'inline'

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -83,4 +83,31 @@ jobs:
       testResultsFiles: '$(Agent.BuildDirectory)/s/build/reports/*'
       failTaskOnFailedTests: true
       testRunTitle: 'Test Run - $(target)'
-  
+
+- job: 'Validate_SPM_Integration'
+  displayName: Validate SPM Integration
+  pool:
+    vmImage: 'macOS-13'
+    timeOutInMinutes: 15
+  workspace:
+    clean: all
+
+  steps:
+
+  - checkout: self
+    clean: true
+    submodules: true
+    fetchDepth: 1
+    persistCredentials: true
+    path: s
+
+  - script: |
+      /bin/bash -c "sudo xcode-select -s /Applications/Xcode_15.0.1.app"
+    displayName: 'Switch to use Xcode 15.0.1'
+
+  - task: Bash@3
+    displayName: Run SPM integration test script
+    inputs:
+      targetType: 'inline'
+      script: 
+        sh spm-integration-test.sh "$(Build.SourceBranchName)"

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -102,12 +102,43 @@ jobs:
     path: s
 
   - script: |
-      /bin/bash -c "sudo xcode-select -s /Applications/Xcode_15.0.1.app"
-    displayName: 'Switch to use Xcode 15.0.1'
+        /bin/bash -c "sudo xcode-select -s /Applications/Xcode_14.3.app"
+    displayName: 'Switch to use Xcode 14.3'
+
+  - task: Bash@3
+    displayName: Set variable BRANCH_NAME to a temporary branch
+    inputs:
+      targetType: 'inline'
+      script: |
+        UUID_LOCAL=$(uuidgen)
+        BRANCH_NAME_LOCAL="$(Build.SourceBranchName)-temp-${UUID_LOCAL}"
+        echo "##vso[task.setvariable variable=BRANCH_NAME]${BRANCH_NAME_LOCAL}"
+      
+  - task: Bash@3
+    displayName: Checkout to temporary branch
+    inputs:
+      targetType: 'inline'
+      script: |
+        git checkout -b "${BRANCH_NAME}"
 
   - task: Bash@3
     displayName: Run SPM integration test script
     inputs:
       targetType: 'inline'
+      script: |
+        sh spm-integration-test.sh "${BRANCH_NAME}"
+    continueOnError: true
+
+  - task: Bash@3
+    displayName: Cleanup
+    inputs:
+      targetType: 'inline'
       script: 
-        sh spm-integration-test.sh "$(Build.SourceBranchName)"
+        cd ../..
+        rm -rf "$SAMPLE_APP_TEMP_DIR" archive framework MSAL.zip
+        git checkout -- .
+        git fetch --quiet
+        git switch "$(Build.SourceBranchName)"
+        git branch -D "$BRANCH_NAME"
+        git push origin --delete "$BRANCH_NAME"
+

--- a/spm-integration-test.sh
+++ b/spm-integration-test.sh
@@ -78,8 +78,8 @@ cd ../..
 rm -rf "$SAMPLE_APP_TEMP_DIR" archive framework MSAL.zip
 
 git checkout -- .
-git fetch
-git switch dev
+git fetch --quiet
+git switch "$1"
 
 git branch -D "$BRANCH_NAME"
 git push origin --delete "$BRANCH_NAME"

--- a/spm-integration-test.sh
+++ b/spm-integration-test.sh
@@ -1,61 +1,46 @@
-UUID=$(uuidgen)
-BRANCH_NAME="$1-temp-${UUID}"
+BRANCH_NAME="$1"
 SAMPLE_APP_TEMP_DIR="NativeAuthSampleAppTemp"
 current_date=$(date +"%Y-%m-%d %H:%M:%S")
 
+set -e
+
 # Build framework
 
-git checkout -b "$BRANCH_NAME"
-rm -rf archive framework MSAL.zip
+echo "Building framework"
 
 xcodebuild -sdk iphonesimulator -configuration Release -workspace MSAL.xcworkspace -scheme "MSAL (iOS Framework)" archive SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath archive/iOSSimulator CODE_SIGNING_ALLOWED=NO -quiet > build.log 2>&1
-XCBUILD_STATUS_SIM=$?
-if [ $XCBUILD_STATUS_SIM -ne 0 ]; then
-  echo "** Build xcframework Error **"
-  exit 1
-fi
-
 xcodebuild -sdk iphoneos -configuration Release -workspace MSAL.xcworkspace -scheme "MSAL (iOS Framework)" archive SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath archive/iOS CODE_SIGNING_ALLOWED=NO -quiet > build.log 2>&1
-XCBUILD_STATUS_IPHONE=$?
-if [ $XCBUILD_STATUS_IPHONE -ne 0 ]; then
-  echo "** Build xcframework Error **"
-  exit 1
-fi
-
 xcodebuild -sdk macosx -configuration Release -workspace MSAL.xcworkspace -scheme "MSAL (Mac Framework)" archive SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath archive/macOS CODE_SIGNING_ALLOWED=NO -quiet > build.log 2>&1
-XCBUILD_STATUS_MAC=$?
-if [ $XCBUILD_STATUS_MAC -ne 0 ]; then
-  echo "** Build xcframework Error **"
-  exit 1
-fi
 
 xcodebuild -create-xcframework -framework archive/iOSSimulator.xcarchive/Products/Library/Frameworks/MSAL.framework -framework archive/iOS.xcarchive/Products/Library/Frameworks/MSAL.framework -framework archive/macOS.xcarchive/Products/Library/Frameworks/MSAL.framework -output framework/MSAL.xcframework > build.log 2>&1
-XCBUILD_STATUS_FRAMEWORK=$?
-if [ $XCBUILD_STATUS_FRAMEWORK -ne 0 ]; then
-  echo "** Build xcframework Error **"
-  exit 1
-fi
 
+echo "Creating MSAL.zip"
 zip -r MSAL.zip framework/MSAL.xcframework -y -v
+
+echo "Calculating checksum"
 CHECKSUM=$(swift package compute-checksum MSAL.zip)
 if [ -z "$CHECKSUM" ]; then
   echo "** Checksum could not be obtained **"
   exit 1
 fi
 
-NEW_URL="https://github.com/AzureAD/microsoft-authentication-library-for-objc/raw/$BRANCH_NAME/MSAL.zip/"
+echo "Updating Package.swift"
+
+NEW_URL="https://github.com/AzureAD/microsoft-authentication-library-for-objc/raw/$BRANCH_NAME/MSAL.zip"
 
 sed -i '' "s#url: \"[^\"]*\"#url: \"$NEW_URL\"#" Package.swift
 sed -i '' "s#checksum: \"[^\"]*\"#checksum: \"$CHECKSUM\"#" Package.swift
+
+echo "Pushing MSAL.zip and Package.swift to $BRANCH_NAME"
 
 git add MSAL.zip Package.swift
 
 git commit -m "Publish temporary Swift Package $current_date"
 git push -f origin "$BRANCH_NAME"
 
-echo "MSAL.zip pushed to temporary branch: $BRANCH_NAME"
-
 # Download Sample App
+
+echo "Downloading and updating Sample App to use temporary Swift Package"
 
 mkdir -p "$SAMPLE_APP_TEMP_DIR"
 cd "$SAMPLE_APP_TEMP_DIR"
@@ -68,23 +53,7 @@ sed -i '' "s#minimumVersion = [0-9.]*;#branch = $BRANCH_NAME;#" NativeAuthSample
 
 rm -f NativeAuthSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
 
+echo "Running the Sample App with the temporary Swift Package"
+
 xcodebuild -resolvePackageDependencies
-xcodebuild -scheme NativeAuthSampleApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest' clean build
-BUILD_STATUS=$?
-
-# Cleanup
-
-cd ../..
-rm -rf "$SAMPLE_APP_TEMP_DIR" archive framework MSAL.zip
-
-git checkout -- .
-git fetch --quiet
-git switch "$1"
-
-git branch -D "$BRANCH_NAME"
-git push origin --delete "$BRANCH_NAME"
-
-if [ $BUILD_STATUS -ne 0 ]; then
-	echo "** Sample App build error **"
-	exit 1
-fi
+xcodebuild -scheme NativeAuthSampleApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.4' clean build

--- a/spm-integration-test.sh
+++ b/spm-integration-test.sh
@@ -1,0 +1,90 @@
+UUID=$(uuidgen)
+BRANCH_NAME="$1-temp-${UUID}"
+SAMPLE_APP_TEMP_DIR="NativeAuthSampleAppTemp"
+current_date=$(date +"%Y-%m-%d %H:%M:%S")
+
+# Build framework
+
+git checkout -b "$BRANCH_NAME"
+rm -rf archive framework MSAL.zip
+
+xcodebuild -sdk iphonesimulator -configuration Release -workspace MSAL.xcworkspace -scheme "MSAL (iOS Framework)" archive SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath archive/iOSSimulator CODE_SIGNING_ALLOWED=NO -quiet > build.log 2>&1
+XCBUILD_STATUS_SIM=$?
+if [ $XCBUILD_STATUS_SIM -ne 0 ]; then
+  echo "** Build xcframework Error **"
+  exit 1
+fi
+
+xcodebuild -sdk iphoneos -configuration Release -workspace MSAL.xcworkspace -scheme "MSAL (iOS Framework)" archive SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath archive/iOS CODE_SIGNING_ALLOWED=NO -quiet > build.log 2>&1
+XCBUILD_STATUS_IPHONE=$?
+if [ $XCBUILD_STATUS_IPHONE -ne 0 ]; then
+  echo "** Build xcframework Error **"
+  exit 1
+fi
+
+xcodebuild -sdk macosx -configuration Release -workspace MSAL.xcworkspace -scheme "MSAL (Mac Framework)" archive SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath archive/macOS CODE_SIGNING_ALLOWED=NO -quiet > build.log 2>&1
+XCBUILD_STATUS_MAC=$?
+if [ $XCBUILD_STATUS_MAC -ne 0 ]; then
+  echo "** Build xcframework Error **"
+  exit 1
+fi
+
+xcodebuild -create-xcframework -framework archive/iOSSimulator.xcarchive/Products/Library/Frameworks/MSAL.framework -framework archive/iOS.xcarchive/Products/Library/Frameworks/MSAL.framework -framework archive/macOS.xcarchive/Products/Library/Frameworks/MSAL.framework -output framework/MSAL.xcframework > build.log 2>&1
+XCBUILD_STATUS_FRAMEWORK=$?
+if [ $XCBUILD_STATUS_FRAMEWORK -ne 0 ]; then
+  echo "** Build xcframework Error **"
+  exit 1
+fi
+
+zip -r MSAL.zip framework/MSAL.xcframework -y -v
+CHECKSUM=$(swift package compute-checksum MSAL.zip)
+if [ -z "$CHECKSUM" ]; then
+  echo "** Checksum could not be obtained **"
+  exit 1
+fi
+
+NEW_URL="https://github.com/AzureAD/microsoft-authentication-library-for-objc/raw/$BRANCH_NAME/MSAL.zip/"
+
+sed -i '' "s#url: \"[^\"]*\"#url: \"$NEW_URL\"#" Package.swift
+sed -i '' "s#checksum: \"[^\"]*\"#checksum: \"$CHECKSUM\"#" Package.swift
+
+git add MSAL.zip Package.swift
+
+git commit -m "Publish temporary Swift Package $current_date"
+git push -f origin "$BRANCH_NAME"
+
+echo "MSAL.zip pushed to temporary branch: $BRANCH_NAME"
+
+# Download Sample App
+
+mkdir -p "$SAMPLE_APP_TEMP_DIR"
+cd "$SAMPLE_APP_TEMP_DIR"
+
+git clone https://github.com/Azure-Samples/ms-identity-ciam-native-auth-ios-sample.git
+cd ms-identity-ciam-native-auth-ios-sample
+
+sed -i '' 's#kind = upToNextMinorVersion;#kind = branch;#' NativeAuthSampleApp.xcodeproj/project.pbxproj
+sed -i '' "s#minimumVersion = [0-9.]*;#branch = $BRANCH_NAME;#" NativeAuthSampleApp.xcodeproj/project.pbxproj
+
+rm -f NativeAuthSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+
+xcodebuild -resolvePackageDependencies
+xcodebuild -scheme NativeAuthSampleApp -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14,OS=latest' clean build
+BUILD_STATUS=$?
+
+# Cleanup
+
+cd ../..
+rm -rf "$SAMPLE_APP_TEMP_DIR" archive framework MSAL.zip
+
+git checkout -- .
+git fetch
+git switch dev
+
+git branch -D "$BRANCH_NAME"
+git push origin --delete "$BRANCH_NAME"
+
+if [ $BUILD_STATUS -ne 0 ]; then
+	echo "** Sample App build error **"
+	exit 1
+fi


### PR DESCRIPTION
## Proposed changes

This PR adds a new check in the pr-validation.yml. It consists in an integration of the changes of the current branch into the [NativeAuth Sample App](https://github.com/Azure-Samples/ms-identity-ciam-native-auth-ios-sample) using a Swift Package.

These are the steps that are done:

- Creates MSAL.zip of the xcframework.
	- It configures the URL and the checksum so the Sample App will use the changes we want to test.
- Pushes it to a temporary branch.
- Clones the NativeAuth Sample App repo, and configures it to download the Swift Package from the temporary branch.
- Builds the Sample App.
- Cleans up.

Note: I have checked the `build.py` script and I think it's different enough from what we are trying to do here, so I thought it is better to have two separate jobs, even if both scripts build the framework. I'm open to discussion on this.

The time it takes the PR-validation hasn't been incremented, as it runs in parallel and this job takes ~6-10 min.

The following tests have been done:

- Test 1: (Pre)configure the sample app to use a new public method published in the current branch of MSAL.
- Test 2: Make a breaking change in MSAL, the Sample App shouldn't work.
- Test 3: If any build fails, the pipeline fails (and the temporary branch is deleted).
- Test 4: If for any reason the checksum calculation doesn't work, the pipeline fails (and the temporary branch is deleted).

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)