### PR TITLE
Unify log levels in Native Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-
-TBD:
+## [1.4.1]:
 * Update Native Auth logging levels for improved clarity and consistency. #2184
 
 ## [1.4.0]:
 * Add platform sequence param. #2192
-* Native auth can now store multiple access tokens related to different resources. #2159
+* Native auth can now store multiple access tokens related to different resources.
 
 ## [1.3.3]
 * Update common core submodule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+
+TBD:
+* Update Native Auth logging levels for improved clarity and consistency. #2184
+
 ## [1.4.0]:
 * Add platform sequence param. #2192
-* Native auth can now store multiple access tokens related to different resources.
+* Native auth can now store multiple access tokens related to different resources. #2159
 
 ## [1.3.3]
 * Update common core submodule.

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
@@ -170,7 +170,7 @@ extension MSALNativeAuthTokenController {
             // If there is an account existing already in the cache, we remove it
             try clearAccount(msidConfiguration: msidConfiguration, context: context)
         } catch {
-            MSALLogger.log(level: .error, context: context, format: "Error clearing account \(error) (ignoring)")
+            MSALLogger.log(level: .warning, context: context, format: "Error clearing account \(error) (ignoring)")
         }
         do {
             let result = try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse,
@@ -178,7 +178,7 @@ extension MSALNativeAuthTokenController {
                                                                            context: context)
             return result
         } catch {
-            MSALLogger.log(level: .error, context: context, format: "Error caching response: \(error) (ignoring)")
+            MSALLogger.log(level: .warning, context: context, format: "Error caching response: \(error) (ignoring)")
         }
         return nil
     }
@@ -194,12 +194,12 @@ extension MSALNativeAuthTokenController {
                                                   context: context)
                 }
             } else {
-                MSALLogger.log(level: .error,
+                MSALLogger.log(level: .warning,
                                context: context,
                                format: "Error creating MSIDAccountIdentifier out of MSALAccount (ignoring)")
             }
         } catch {
-            MSALLogger.log(level: .error, context: context, format: "Error clearing previous account (ignoring)")
+            MSALLogger.log(level: .warning, context: context, format: "Error clearing previous account (ignoring)")
         }
     }
 

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -143,7 +143,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                                      event: MSIDTelemetryAPIEvent?,
                                      context: MSALNativeAuthRequestContext) async -> ResetPasswordStartControllerResponse {
 
-        MSALLogger.log(level: .verbose, context: context, format: "Finished resetpassword/start request")
+        MSALLogger.log(level: .info, context: context, format: "Finished resetpassword/start request")
 
         switch response {
         case .success(let continuationToken):
@@ -489,14 +489,14 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         event: MSIDTelemetryAPIEvent?,
         context: MSALNativeAuthRequestContext
     ) async -> ResetPasswordSubmitPasswordControllerResponse {
-        MSALLogger.log(level: .verbose, context: context, format: "Performing poll completion request")
+        MSALLogger.log(level: .info, context: context, format: "Performing poll completion request")
 
         let pollCompletionResponse = await performPollCompletionRequest(
             continuationToken: continuationToken,
             context: context
         )
 
-        MSALLogger.log(level: .verbose, context: context, format: "Handling poll completion response")
+        MSALLogger.log(level: .info, context: context, format: "Handling poll completion response")
 
         return await handlePollCompletionResponse(
             pollCompletionResponse,

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -77,7 +77,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
     func signIn(params: MSALNativeAuthSignInParameters) async -> SignInControllerResponse {
         let eventId: MSALNativeAuthTelemetryApiId =
         params.password == nil ? .telemetryApiIdSignInWithCodeStart : .telemetryApiIdSignInWithPasswordStart
-        MSALLogger.log(level: .verbose, context: params.context, format: "SignIn started")
+        MSALLogger.log(level: .info, context: params.context, format: "SignIn started")
         let telemetryInfo = TelemetryInfo(
             event: makeAndStartTelemetryEvent(id: eventId, context: params.context),
             context: params.context
@@ -103,7 +103,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         scopes: [String]?,
         context: MSALNativeAuthRequestContext
     ) async -> SignInAfterPreviousFlowControllerResponse {
-        MSALLogger.log(level: .verbose, context: context, format: "SignIn after previous flow started")
+        MSALLogger.log(level: .info, context: context, format: "SignIn after previous flow started")
         let telemetryInfo = TelemetryInfo(
             event: makeAndStartTelemetryEvent(id: .telemetryApiIdSignInAfterSignUp, context: context),
             context: context
@@ -469,7 +469,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             let tokenResult = try cacheTokenResponse(tokenResponse, context: context, msidConfiguration: config)
 
             if let userAccountResult = factory.makeUserAccountResult(tokenResult: tokenResult, context: context) {
-                MSALLogger.log(level: .verbose, context: context, format: "SignIn completed successfully")
+                MSALLogger.log(level: .info, context: context, format: "SignIn completed successfully")
                 telemetryInfo.event?.setUserInformation(tokenResult.account)
                 stopTelemetryEvent(telemetryInfo)
                 onSuccess(userAccountResult)

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -489,12 +489,12 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             )
             return .init(.error(error: error, newState: state), correlationId: context.correlationId())
         case .credentialRequired(let newContinuationToken, _):
-            MSALLogger.log(level: .verbose, context: context, format: "credential_required received in signup/continue request")
+            MSALLogger.log(level: .info, context: context, format: "credential_required received in signup/continue request")
 
             let result = await performAndValidateChallengeRequest(continuationToken: newContinuationToken, context: context)
             return handlePerformChallengeAfterContinueRequest(result, username: username, event: event, context: context)
         case .attributesRequired(let newContinuationToken, let attributes, _):
-            MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
+            MSALLogger.log(level: .info, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
 
             let state = SignUpAttributesRequiredState(controller: self,
                                                       username: username,
@@ -561,7 +561,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
 
             return .init(.error(error: error, newState: state), correlationId: context.correlationId())
         case .attributesRequired(let newContinuationToken, let attributes, _):
-            MSALLogger.log(level: .verbose, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
+            MSALLogger.log(level: .info, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
 
             let state = SignUpAttributesRequiredState(controller: self,
                                                       username: username,

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
@@ -140,7 +140,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
 
     private func handleChallengeError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordChallengeValidatedResponse {
         guard let apiError = error as? MSALNativeAuthResetPasswordChallengeResponseError else {
-            MSALLogger.log(level: .info, context: context, format: "resetpassword/challenge: Unable to decode error response: \(error)")
+            MSALLogger.log(level: .error, context: context, format: "resetpassword/challenge: Unable to decode error response: \(error)")
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
         if apiError.error == .unknown {

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
@@ -28,7 +28,7 @@ extension SignInCodeRequiredState {
 
     func submitCodeInternal(code: String) async -> MSALNativeAuthSignInControlling.SignInSubmitCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
-        MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, code submitted")
+        MSALLogger.log(level: .info, context: context, format: "SignIn flow, code submitted")
         guard inputValidator.isInputValid(code) else {
             MSALLogger.log(level: .error, context: context, format: "SignIn flow, invalid code")
             return .init(.error(error: VerifyCodeError(
@@ -42,7 +42,7 @@ extension SignInCodeRequiredState {
 
     func resendCodeInternal() async -> MSALNativeAuthSignInControlling.SignInResendCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
-        MSALLogger.log(level: .verbose, context: context, format: "SignIn flow, resend code requested")
+        MSALLogger.log(level: .info, context: context, format: "SignIn flow, resend code requested")
 
         return await controller.resendCode(continuationToken: continuationToken, context: context, scopes: scopes)
     }


### PR DESCRIPTION
## Proposed changes

This PR unifies the logging level across all the NativeAuth classes using the MSAL Obj logging criteria. As some of these decisions can be a bit subjective, opinionated comments are more than welcome.

Main changes:

- For the logs regarding the flow (such as "Performing resetpassword/challenge request"),  we are now using `.info` level, in a similar way MSAL Objc does (for example, see: `MSIDLocalInteractiveController.m`)
- For the errors that don't block the user, like those regarding the cache, we are now using `.warning` level, in a similar way as MSAL Obj does (for example, see: `MSALAccountsProvider.m`)

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)