### PR TITLE
MSAL automation force tap done button

### DIFF
--- a/MSAL/test/automation/tests/MSALBaseUITest.m
+++ b/MSAL/test/automation/tests/MSALBaseUITest.m
@@ -214,9 +214,21 @@ static MSIDTestConfigurationProvider *s_confProvider;
         // We take the second one and tap it
         XCUIElement *secondButton = [elementQuery elementBoundByIndex:1];
         [secondButton msidTap];
-    } else
+    } 
+    else
     {
-        [self.testApp.buttons[buttonTitle] msidTap];
+        if (webViewType == MSIDWebviewTypeSafariViewController)
+        {
+            // We take the first one and force tap it, for some reason tap doesn't work
+            XCUIElement *firstButton = [elementQuery elementBoundByIndex:0];
+            
+            __auto_type coordinate = [firstButton coordinateWithNormalizedOffset:CGVectorMake(0, 0)];
+            [coordinate tap];
+        }
+        else
+        {
+            [self.testApp.buttons[buttonTitle] msidTap];
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed changes

Force tap 'Done' button when using SafariViewController to fix flaky automation test

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

