### PR TITLE
Run build script phase only when needed

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -5250,6 +5250,7 @@
 		};
 		B286864824037DCB004E83FC /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5267,6 +5268,7 @@
 		};
 		B286864F24037DE7004E83FC /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5288,8 +5290,10 @@
 			files = (
 			);
 			inputPaths = (
+				"~/aadtests/conf.json",
 			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/scriptOutput.data",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -5301,8 +5305,10 @@
 			files = (
 			);
 			inputPaths = (
+				"~/aadtests/conf.json",
 			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/scriptOutput.data",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
## Proposed changes

Run build script phase only when needed. This PR solve the following warning:
<img width="748" alt="Screenshot 2024-06-21 at 16 48 38" src="https://github.com/AzureAD/microsoft-authentication-library-for-objc/assets/105228698/cccd6c6e-8854-4341-aec6-5b3a425e434a">
I'm using this as a reference:
https://developer.apple.com/documentation/Xcode/improving-the-speed-of-incremental-builds#Declare-inputs-and-outputs-for-custom-scripts-and-build-rules
## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

