### PR TITLE
Use correct variable name in build script

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -5381,7 +5381,7 @@
 			files = (
 			);
 			inputPaths = (
-				"~/aadtests/conf.json",
+				"$(HOME)/aadtests/conf.json",
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/scriptOutput.data",
@@ -5396,7 +5396,7 @@
 			files = (
 			);
 			inputPaths = (
-				"~/aadtests/conf.json",
+				"$(HOME)/aadtests/conf.json",
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/scriptOutput.data",


### PR DESCRIPTION
## Proposed changes

In PR #2218 , I made updates to the build script's input files to ensure it runs only as necessary. However, I mistakenly used the wrong variable name, resulting in the conf.json file not being copied as needed during local test runs.

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

