### PR TITLE
Run native auth E2E tests in automation pipeline

### DIFF
--- a/MSAL/NativeAuthEndToEndTestPlan.xctestplan
+++ b/MSAL/NativeAuthEndToEndTestPlan.xctestplan
@@ -73,14 +73,6 @@
         "identifier" : "28D1D56B29BF62E900CE75F4",
         "name" : "MSAL iOS Native Auth Integration Tests"
       }
-    },
-    {
-      "parallelizable" : true,
-      "target" : {
-        "containerPath" : "container:MSAL.xcodeproj",
-        "identifier" : "28CED2E72C21E0F9004320D1",
-        "name" : "MSAL iOS Native Auth E2E Tests"
-      }
     }
   ],
   "version" : 1

--- a/azure_pipelines/automation.yml
+++ b/azure_pipelines/automation.yml
@@ -79,6 +79,19 @@ jobs:
         issue_body = '''@AzureAD/appleidentity \nAutomation failed for [$(repositoryName)]({0}) ran against commit : {1} \n Pipeline URL : [{2}]({2})'''.format('$(Build.Repository.Uri)', git_commit, pipeline_uri) 
         github.create_issue(github_org, repo, issue_title, issue_body, labels=['automation failure'])
 
+- job: e2e_test_native_auth
+  displayName: 'Run MSAL E2E tests for native auth'
+  timeoutInMinutes: 30
+  cancelTimeoutInMinutes: 5
+  workspace:
+    clean: all
+
+  steps:
+  - template: templates/tests-with-conf-file.yml
+    parameters:
+      schema: 'MSAL iOS Native Auth E2E Tests'
+      build: 'MSAL iOS Native Auth E2E Tests_MSAL iOS Native Auth E2E Tests'
+
 - job: cocoapods_lib_lint
   displayName: Run Cocoapods lib lint
   timeoutInMinutes: 30

--- a/azure_pipelines/templates/tests-with-conf-file.yml
+++ b/azure_pipelines/templates/tests-with-conf-file.yml
@@ -68,6 +68,6 @@ steps:
     condition: succeededOrFailed()
     inputs:
       targetPath: '$(Agent.BuildDirectory)/s/test_output/'
-      artifactName: 'TestOutputs Attempt - $(System.StageAttempt)'
+      artifactName: 'TestOutputs Attempt - $(System.StageAttempt) - $(parameters.schema)'
       publishLocation: 'pipeline'
   

--- a/azure_pipelines/templates/tests-with-conf-file.yml
+++ b/azure_pipelines/templates/tests-with-conf-file.yml
@@ -68,6 +68,6 @@ steps:
     condition: succeededOrFailed()
     inputs:
       targetPath: '$(Agent.BuildDirectory)/s/test_output/'
-      artifactName: 'TestOutputs Attempt - $(System.StageAttempt) - $(parameters.schema)'
+      artifactName: 'TestOutputs Attempt - $(System.StageAttempt) - ${{ parameters.schema }}'
       publishLocation: 'pipeline'
   


### PR DESCRIPTION
## Proposed changes

This PR contains:
- automation.yml changes to run native auth E2E tests in nightly/release pipeline
- remove e2e test bundle from integration test target

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)