### PR TITLE
Mask Native Auth logs subject to PII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Update common core submodule with changes related to upgrade registration.
 * Add a new flag MSALThrottlingCacheHitKey for error returned from client's throttling #2257
 * Update common core submodule with device register action with token protection hint.
+* Native Auth logs are appropriately masked to ensure sensitive information is protected. 
 
 ## [1.4.1]:
 * Update Native Auth logging levels for improved clarity and consistency. #2184

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthBaseController.swift
@@ -133,7 +133,7 @@ class MSALNativeAuthBaseController {
         case .success:
             stopTelemetryEvent(event, context: context, error: controllerError)
         case .failure(let error):
-            MSALLogger.log(level: .error, context: context, format: "Error \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error, context: context, format: "Error \(MSALLogMask.maskPII(error.errorDescription))")
             stopTelemetryEvent(event, context: context, error: error)
         }
     }

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
@@ -170,7 +170,7 @@ extension MSALNativeAuthTokenController {
             // If there is an account existing already in the cache, we remove it
             try clearAccount(msidConfiguration: msidConfiguration, context: context)
         } catch {
-            MSALLogger.log(level: .warning, context: context, format: "Error clearing account \(error) (ignoring)")
+            MSALLogger.logPII(level: .warning, context: context, format: "Error clearing account \(MSALLogMask.maskPII(error)) (ignoring)")
         }
         do {
             let result = try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse,
@@ -178,7 +178,7 @@ extension MSALNativeAuthTokenController {
                                                                            context: context)
             return result
         } catch {
-            MSALLogger.log(level: .warning, context: context, format: "Error caching response: \(error) (ignoring)")
+            MSALLogger.logPII(level: .warning, context: context, format: "Error caching response: \(MSALLogMask.maskPII(error)) (ignoring)")
         }
         return nil
     }

--- a/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
+++ b/MSAL/src/native_auth/controllers/MSALNativeAuthTokenController.swift
@@ -170,7 +170,7 @@ extension MSALNativeAuthTokenController {
             // If there is an account existing already in the cache, we remove it
             try clearAccount(msidConfiguration: msidConfiguration, context: context)
         } catch {
-            MSALLogger.logPII(level: .warning, context: context, format: "Error clearing account \(MSALLogMask.maskPII(error)) (ignoring)")
+            MSALLogger.logPII(level: .warning, context: context, format: "Error clearing account \(MSALLogMask.maskEUII(error)) (ignoring)")
         }
         do {
             let result = try cacheAccessor.validateAndSaveTokensAndAccount(tokenResponse: tokenResponse,
@@ -178,7 +178,7 @@ extension MSALNativeAuthTokenController {
                                                                            context: context)
             return result
         } catch {
-            MSALLogger.logPII(level: .warning, context: context, format: "Error caching response: \(MSALLogMask.maskPII(error)) (ignoring)")
+            MSALLogger.logPII(level: .warning, context: context, format: "Error caching response: \(MSALLogMask.maskEUII(error)) (ignoring)")
         }
         return nil
     }

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -94,7 +94,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
             MSALLogger.logPII(
                 level: .error,
                 context: nil,
-                format: "Error retrieving accounts \(MSALLogMask.maskPII(error))")
+                format: "Error retrieving accounts \(MSALLogMask.maskEUII(error))")
         }
         return []
     }

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -91,10 +91,10 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
             let config = factory.makeMSIDConfiguration(scopes: [])
             return try cacheAccessor.getAllAccounts(configuration: config)
         } catch {
-            MSALLogger.log(
+            MSALLogger.logPII(
                 level: .error,
                 context: nil,
-                format: "Error retrieving accounts \(error)")
+                format: "Error retrieving accounts \(MSALLogMask.maskPII(error))")
         }
         return []
     }

--- a/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
+++ b/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
@@ -59,10 +59,10 @@ final class MSALNativeAuthResultFactory: MSALNativeAuthResultBuildable {
                     format: "Initialising account without claims")
             }
         } catch {
-            MSALLogger.log(
+            MSALLogger.logPII(
                 level: .warning,
                 context: context,
-                format: "Claims for account could not be created - \(error)" )
+                format: "Claims for account could not be created - \(MSALLogMask.maskEUII(error))" )
         }
         return MSALAccount.init(msidAccount: tokenResult.account,
                                 createTenantProfile: false,

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -156,16 +156,16 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 correlationId: context.correlationId()
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Redirect error in resetpassword/start request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Redirect error in resetpassword/start request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         case .error(let validatedError):
             let error = validatedError.toResetPasswordStartPublicError(context: context)
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error in resetpassword/start request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error in resetpassword/start request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = ResetPasswordStartError(
@@ -176,9 +176,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 errorUri: apiError?.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in resetpassword/start request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in resetpassword/start request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         }
     }
@@ -231,9 +231,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         case .error(let apiError):
             let error = apiError.toResetPasswordStartPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error in resetpassword/challenge request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         case .redirect:
             let error = ResetPasswordStartError(
@@ -242,9 +242,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 correlationId: context.correlationId()
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Redirect error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Redirect error in resetpassword/challenge request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = ResetPasswordStartError(
@@ -255,9 +255,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 errorUri: apiError?.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in resetpassword/challenge request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in resetpassword/challenge request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         }
     }
@@ -287,16 +287,16 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         case .error(let apiError):
             let error = apiError.toResendCodePublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error in resetpassword/challenge request (resend code) \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error in resetpassword/challenge request (resend code) \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .redirect:
             let error = ResendCodeError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error in resetpassword/challenge request (resend code) \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error in resetpassword/challenge request (resend code) \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = ResendCodeError(
@@ -306,9 +306,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
                 errorUri: apiError?.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error in resetpassword/challenge request (resend code) \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error in resetpassword/challenge request (resend code) \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         }
     }
@@ -356,9 +356,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         case .error(let apiError):
             let error = apiError.toVerifyCodePublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error in resetpassword/continue request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error in resetpassword/continue request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = VerifyCodeError(
@@ -370,9 +370,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             )
             self.stopTelemetryEvent(event, context: context, error: error)
 
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error calling resetpassword/continue \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error calling resetpassword/continue \(MSALLogMask.maskPII(error.errorDescription))")
 
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .invalidOOB(let apiError):
@@ -385,9 +385,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             )
             self.stopTelemetryEvent(event, context: context, error: error)
 
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Invalid code error calling resetpassword/continue \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Invalid code error calling resetpassword/continue \(MSALLogMask.maskPII(error.errorDescription))")
 
             let state = ResetPasswordCodeRequiredState(
                 controller: self,
@@ -442,9 +442,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             self.stopTelemetryEvent(event, context: context, error: error)
 
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Password error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Password error calling resetpassword/submit \(MSALLogMask.maskPII(error.errorDescription))")
             let newState = ResetPasswordRequiredState(
                 controller: self,
                 username: username,
@@ -456,9 +456,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             self.stopTelemetryEvent(event, context: context, error: error)
 
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error calling resetpassword/submit \(MSALLogMask.maskPII(error.errorDescription))")
 
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
@@ -471,9 +471,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             )
             self.stopTelemetryEvent(event, context: context, error: error)
 
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error calling resetpassword/submit \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error calling resetpassword/submit \(MSALLogMask.maskPII(error.errorDescription))")
 
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         }
@@ -585,9 +585,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             self.stopTelemetryEvent(event, context: context, error: error)
 
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Password error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Password error calling resetpassword/poll_completion \(MSALLogMask.maskPII(error.errorDescription))")
             let newState = ResetPasswordRequiredState(
                 controller: self,
                 username: username,
@@ -599,9 +599,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             self.stopTelemetryEvent(event, context: context, error: error)
 
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error calling resetpassword/poll_completion \(MSALLogMask.maskPII(error.errorDescription))")
 
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
@@ -614,9 +614,9 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
             )
             self.stopTelemetryEvent(event, context: context, error: error)
 
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error calling resetpassword/poll_completion \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error calling resetpassword/poll_completion \(MSALLogMask.maskPII(error.errorDescription))")
 
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         }

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -204,7 +204,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                         MSALLogger.logPII(
                             level: .error,
                             context: context,
-                            format: "SignIn submit code, token request failed with error \(MSALLogMask.maskPII(error))"
+                            format: "SignIn submit code, token request failed with error \(MSALLogMask.maskPII(error.errorDescription))"
                         )
                         guard let self = self else { return }
                         continuation.resume(returning: self.processSubmitCodeFailure(
@@ -279,7 +279,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                         MSALLogger.logPII(
                             level: .error,
                             context: context,
-                            format: "SignIn submit password, token request failed with error \(MSALLogMask.maskPII(error))"
+                            format: "SignIn submit password, token request failed with error \(MSALLogMask.maskPII(error.errorDescription))"
                         )
                         guard let self = self else { return }
                         continuation.resume(returning: self.processSubmitPasswordFailure(
@@ -322,7 +322,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             MSALLogger.logPII(
                 level: .error,
                 context: context,
-                format: "SignIn ResendCode: received challenge error response: \(MSALLogMask.maskPII(challengeError))"
+                format: "SignIn ResendCode: received challenge error response: \(MSALLogMask.maskPII(error.errorDescription))"
             )
             stopTelemetryEvent(event, context: context, error: error)
             return .init(.error(

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -201,7 +201,11 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                         }))
                     },
                     onError: { [weak self] error in
-                        MSALLogger.log(level: .error, context: context, format: "SignIn submit code, token request failed with error \(error)")
+                        MSALLogger.logPII(
+                            level: .error,
+                            context: context,
+                            format: "SignIn submit code, token request failed with error \(MSALLogMask.maskPII(error))"
+                        )
                         guard let self = self else { return }
                         continuation.resume(returning: self.processSubmitCodeFailure(
                             errorType: .generalError(nil),
@@ -272,7 +276,11 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                         }))
                     },
                     onError: { [weak self] error in
-                        MSALLogger.log(level: .error, context: context, format: "SignIn submit password, token request failed with error \(error)")
+                        MSALLogger.logPII(
+                            level: .error,
+                            context: context,
+                            format: "SignIn submit password, token request failed with error \(MSALLogMask.maskPII(error))"
+                        )
                         guard let self = self else { return }
                         continuation.resume(returning: self.processSubmitPasswordFailure(
                             errorType: .generalError(nil),
@@ -311,7 +319,11 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .error(let challengeError):
             let error = challengeError.convertToResendCodeError(correlationId: context.correlationId())
-            MSALLogger.log(level: .error, context: context, format: "SignIn ResendCode: received challenge error response: \(challengeError)")
+            MSALLogger.logPII(
+                level: .error,
+                context: context,
+                format: "SignIn ResendCode: received challenge error response: \(MSALLogMask.maskPII(challengeError))"
+            )
             stopTelemetryEvent(event, context: context, error: error)
             return .init(.error(
                 error: error,
@@ -351,10 +363,10 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         continuationToken: String,
         context: MSALNativeAuthRequestContext
     ) -> SignInSubmitCodeControllerResponse {
-        MSALLogger.log(
+        MSALLogger.logPII(
             level: .error,
             context: context,
-            format: "SignIn completed with errorType: \(errorType)")
+            format: "SignIn completed with errorType: \(MSALLogMask.maskPII(errorType))")
         stopTelemetryEvent(telemetryInfo, error: errorType)
         let state = SignInCodeRequiredState(
             scopes: scopes,
@@ -375,10 +387,10 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         continuationToken: String,
         scopes: [String]
     ) -> SignInSubmitPasswordControllerResponse {
-        MSALLogger.log(
+        MSALLogger.logPII(
             level: .error,
             context: telemetryInfo.context,
-            format: "SignIn with username and password completed with errorType: \(errorType)")
+            format: "SignIn with username and password completed with errorType: \(MSALLogMask.maskPII(errorType))")
         stopTelemetryEvent(telemetryInfo, error: errorType)
         let state = SignInPasswordRequiredState(
             scopes: scopes,
@@ -423,7 +435,11 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             )
             return .success(challengeValidatedResponse)
         case .error(let error):
-            MSALLogger.log(level: .error, context: telemetryInfo.context, format: "SignIn: an error occurred after calling /initiate API: \(error)")
+            MSALLogger.logPII(
+                level: .error,
+                context: telemetryInfo.context,
+                format: "SignIn: an error occurred after calling /initiate API: \(MSALLogMask.maskPII(error))"
+            )
             stopTelemetryEvent(telemetryInfo, error: error)
             return .failure(error)
         }
@@ -449,9 +465,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             )
         case .error(let errorType):
             let error = errorType.convertToSignInPasswordStartError(correlationId: telemetryInfo.context.correlationId())
-            MSALLogger.log(level: .error,
+            MSALLogger.logPII(level: .error,
                            context: telemetryInfo.context,
-                           format: "SignIn completed with errorType: \(error.errorDescription ?? "No error description")")
+                           format: "SignIn completed with errorType: \(MSALLogMask.maskPII(error.errorDescription))")
             stopTelemetryEvent(telemetryInfo, error: error)
             onError(error)
         }
@@ -481,7 +497,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             }
         } catch {
             let errorType = MSALNativeAuthTokenValidatedErrorType.generalError(nil)
-            MSALLogger.log(level: .error, context: telemetryInfo.context, format: "SignIn completed with error \(error)")
+            MSALLogger.logPII(level: .error, context: telemetryInfo.context, format: "SignIn completed with error \(MSALLogMask.maskPII(error))")
             stopTelemetryEvent(telemetryInfo, error: errorType)
             onError(errorType.convertToSignInPasswordStartError(correlationId: telemetryInfo.context.correlationId()))
         }
@@ -571,9 +587,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 })
         case .error(let challengeError):
             let error = challengeError.convertToSignInStartError(correlationId: telemetryInfo.context.correlationId())
-            MSALLogger.log(level: .error,
-                           context: telemetryInfo.context,
-                           format: "SignIn, completed with error: \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: telemetryInfo.context,
+                              format: "SignIn, completed with error: \(MSALLogMask.maskPII(error.errorDescription))")
             stopTelemetryEvent(telemetryInfo, error: error)
             return .init(.error(error), correlationId: telemetryInfo.context.correlationId())
         }

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -206,7 +206,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             stopTelemetryEvent(event, context: context, error: error)
             MSALLogger.logPII(level: .error,
                               context: context,
-                              format: "InvalidUsername in signup/start request \(MSALLogMask.maskPII(error.errorDescription))")
+                              format: "InvalidUsername in signup/start request \(MSALLogMask.maskEUII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = SignUpStartError(

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -169,10 +169,10 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             let challengeResult = await performAndValidateChallengeRequest(continuationToken: continuationToken, context: context)
             return handleSignUpChallengeResult(challengeResult, username: username, event: event, context: context)
         case .attributeValidationFailed(let apiError, let invalidAttributes):
-            MSALLogger.log(
+            MSALLogger.logPII(
                 level: .error,
                 context: context,
-                format: "attribute_validation_failed received from signup/start request for attributes: \(invalidAttributes)"
+                format: "attribute_validation_failed received from signup/start request for attributes: \(MSALLogMask.maskEUII(invalidAttributes))"
             )
             let message = String(format: MSALNativeAuthErrorMessage.attributeValidationFailedSignUpStart, invalidAttributes.description)
             let error = apiError.toSignUpStartPublicError(correlationId: context.correlationId(), message: message)
@@ -183,17 +183,17 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         case .redirect:
             let error = SignUpStartError(type: .browserRequired, correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Redirect error in signup/start request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Redirect error in signup/start request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         case .error(let apiError),
              .unauthorizedClient(let apiError):
             let error = apiError.toSignUpStartPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error in signup/start request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error in signup/start request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         case .invalidUsername(let apiError):
             let error = SignUpStartError(
@@ -204,9 +204,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 errorUri: apiError.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "InvalidUsername in signup/start request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "InvalidUsername in signup/start request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = SignUpStartError(
@@ -217,9 +217,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 errorUri: apiError?.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/start request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/start request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         }
     }
@@ -273,23 +273,23 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         case .error(let apiError):
             let error = apiError.toSignUpStartPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error in signup/challenge request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         case .redirect:
             let error = SignUpStartError(type: .browserRequired, correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Redirect error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Redirect error in signup/challenge request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         case .passwordRequired:
             let error = SignUpStartError(type: .generalError, correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/challenge request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = SignUpStartError(
@@ -300,9 +300,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 errorUri: apiError?.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/challenge request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error), correlationId: context.correlationId())
         }
     }
@@ -336,9 +336,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         case .error(let apiError):
             let error = apiError.toResendCodePublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error in signup/challenge resendCode request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error in signup/challenge resendCode request \(MSALLogMask.maskPII(error.errorDescription))")
             let newState = SignUpCodeRequiredState(
                 controller: self,
                 username: username,
@@ -349,16 +349,16 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         case .redirect:
             let error = ResendCodeError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/challenge resendCode request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/challenge resendCode request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .passwordRequired:
             let error = ResendCodeError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/challenge resendCode request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/challenge resendCode request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = ResendCodeError(
@@ -368,9 +368,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 errorUri: apiError?.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/challenge resendCode request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/challenge resendCode request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         }
     }
@@ -397,9 +397,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         case .redirect:
             let error = VerifyCodeError(type: .browserRequired, correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Redirect error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Redirect error in signup/challenge request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .error(let apiError):
             let error = VerifyCodeError(
@@ -409,16 +409,16 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 errorUri: apiError.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/challenge request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .codeRequired:
             let error = VerifyCodeError(type: .generalError, correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/challenge request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = VerifyCodeError(
@@ -429,9 +429,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 errorUri: apiError?.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/challenge request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/challenge request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         }
     }
@@ -494,7 +494,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             let result = await performAndValidateChallengeRequest(continuationToken: newContinuationToken, context: context)
             return handlePerformChallengeAfterContinueRequest(result, username: username, event: event, context: context)
         case .attributesRequired(let newContinuationToken, let attributes, _):
-            MSALLogger.log(level: .info, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
+            MSALLogger.logPII(level: .info, 
+                              context: context,
+                              format: "attributes_required received in signup/continue request: \(MSALLogMask.maskEUII(attributes))")
 
             let state = SignUpAttributesRequiredState(controller: self,
                                                       username: username,
@@ -511,9 +513,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
              .attributeValidationFailed(let apiError, _):
             let error = apiError.toVerifyCodePublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error in signup/continue request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error in signup/continue request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = VerifyCodeError(
@@ -524,9 +526,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 errorUri: apiError?.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/continue request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/continue request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         }
     }
@@ -548,10 +550,10 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         case .invalidUserInput(let apiError):
             let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(
+            MSALLogger.logPII(
                 level: .error,
                 context: context,
-                format: "invalid_user_input error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")"
+                format: "invalid_user_input error in signup/continue submitPassword request \(MSALLogMask.maskPII(error.errorDescription))"
             )
 
             let state = SignUpPasswordRequiredState(controller: self,
@@ -561,7 +563,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
 
             return .init(.error(error: error, newState: state), correlationId: context.correlationId())
         case .attributesRequired(let newContinuationToken, let attributes, _):
-            MSALLogger.log(level: .info, context: context, format: "attributes_required received in signup/continue request: \(attributes)")
+            MSALLogger.logPII(level: .info,
+                              context: context,
+                              format: "attributes_required received in signup/continue request: \(MSALLogMask.maskEUII(attributes))")
 
             let state = SignUpAttributesRequiredState(controller: self,
                                                       username: username,
@@ -579,9 +583,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
              .credentialRequired(_, let apiError):
             let error = apiError.toPasswordRequiredPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/continue submitPassword request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = PasswordRequiredError(
@@ -592,9 +596,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 errorUri: apiError?.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/continue submitPassword request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/continue submitPassword request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         }
     }
@@ -615,9 +619,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
             })
         case .attributesRequired(let newContinuationToken, let attributes, let apiError):
             let error = apiError.toAttributesRequiredPublicError(correlationId: context.correlationId())
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "attributes_required received in signup/continue submitAttributes request: \(attributes)")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "attributes_required received in signup/continue submitAttributes request: \(MSALLogMask.maskEUII(attributes))")
             let state = SignUpAttributesRequiredState(
                 controller: self,
                 username: username,
@@ -632,8 +636,8 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result, controllerError: error)
             })
         case .attributeValidationFailed(let apiError, let invalidAttributes):
-            let message = "attribute_validation_failed from signup/continue submitAttributes request. Make sure these attributes are correct: \(invalidAttributes)" // swiftlint:disable:this line_length
-            MSALLogger.log(level: .error, context: context, format: message)
+            let message = "attribute_validation_failed from signup/continue submitAttributes request. Make sure these attributes are correct: \(MSALLogMask.maskEUII(invalidAttributes))" // swiftlint:disable:this line_length
+            MSALLogger.logPII(level: .error, context: context, format: message)
 
             let errorMessage = String(format: MSALNativeAuthErrorMessage.attributeValidationFailed, invalidAttributes.description)
             let error = apiError.toAttributesRequiredPublicError(correlationId: context.correlationId(), message: errorMessage)
@@ -655,9 +659,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
              .credentialRequired(_, let apiError):
             let error = apiError.toAttributesRequiredPublicError(correlationId: context.correlationId())
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Error in signup/continue submitAttributes request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Error in signup/continue submitAttributes request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error), correlationId: context.correlationId())
         case .unexpectedError(let apiError):
             let error = AttributesRequiredError(
@@ -667,9 +671,9 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
                 errorUri: apiError?.errorURI
             )
             stopTelemetryEvent(event, context: context, error: error)
-            MSALLogger.log(level: .error,
-                           context: context,
-                           format: "Unexpected error in signup/continue submitAttributes request \(error.errorDescription ?? "No error description")")
+            MSALLogger.logPII(level: .error,
+                              context: context,
+                              format: "Unexpected error in signup/continue submitAttributes request \(MSALLogMask.maskPII(error.errorDescription))")
             return .init(.error(error: error), correlationId: context.correlationId())
         }
     }

--- a/MSAL/src/native_auth/logger/MSALNativeAuthLogging.swift
+++ b/MSAL/src/native_auth/logger/MSALNativeAuthLogging.swift
@@ -148,3 +148,7 @@ extension MSALLogger: MSALLogging {
                   getVaList(args))
     }
 }
+
+/// This class is a wrapper of the objc class `MSALLogMask`. In the Swift non-public classes where `MSALLogMask` is used, it is imported using `@_implementationOnly import MSAL_Private`.
+/// But in the Swift public classes we are not using `@_implementationOnly`, as it is an internal implementation detail, so this wrapper is used instead.
+class MSALLogMaskWrapper: MSALLogMask {}

--- a/MSAL/src/native_auth/network/MSALNativeAuthCustomErrorSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthCustomErrorSerializer.swift
@@ -32,7 +32,7 @@ final class MSALNativeAuthCustomErrorSerializer<T: Decodable & Error & MSALNativ
             var customError = try JSONDecoder().decode(T.self, from: data ?? Data())
             customError.correlationId = T.retrieveCorrelationIdFromHeaders(from: httpResponse)
 
-            // the successfuly constructed "customError" needs to be thrown,
+            // the successfully constructed "customError" needs to be thrown,
             // since the previous "try" command just validates the object (error) decoding
             throw customError
         } catch is DecodingError {

--- a/MSAL/src/native_auth/network/MSALNativeAuthResponseSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthResponseSerializer.swift
@@ -40,7 +40,7 @@ final class MSALNativeAuthResponseSerializer<T: Decodable & MSALNativeAuthRespon
             response.correlationId = T.retrieveCorrelationIdFromHeaders(from: httpResponse)
             return response
         } catch {
-            MSALLogger.log(level: .error, context: context, format: "ResponseSerializer failed decoding \(error)")
+            MSALLogger.logPII(level: .error, context: context, format: "ResponseSerializer failed decoding \(MSALLogMask.maskPII(error))")
             throw MSALNativeAuthInternalError.responseSerializationError(headerCorrelationId: T.retrieveCorrelationIdFromHeaders(from: httpResponse))
         }
     }

--- a/MSAL/src/native_auth/network/MSALNativeAuthUrlRequestSerializer.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthUrlRequestSerializer.swift
@@ -67,7 +67,7 @@ final class MSALNativeAuthUrlRequestSerializer: NSObject, MSIDRequestSerializati
                     MSALLogger.log(
                         level: .error,
                         context: context,
-                        format: "HTTP body request serialization failed with error: \(error.localizedDescription)"
+                        format: "HTTP body request serialization failed with error: \(MSALLogMask.maskPII(error.localizedDescription))"
                     )
                 }
             } else {

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
@@ -69,9 +69,9 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
     private func handleStartFailed(_ error: Error,
                                    with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordStartValidatedResponse {
         guard let apiError = error as? MSALNativeAuthResetPasswordStartResponseError else {
-            MSALLogger.log(level: .error,
+            MSALLogger.logPII(level: .error,
                            context: context,
-                           format: "resetpassword/start: Unable to decode error response: \(error)")
+                           format: "resetpassword/start: Unable to decode error response: \(MSALLogMask.maskPII(error))")
 
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
@@ -140,7 +140,11 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
 
     private func handleChallengeError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordChallengeValidatedResponse {
         guard let apiError = error as? MSALNativeAuthResetPasswordChallengeResponseError else {
-            MSALLogger.log(level: .error, context: context, format: "resetpassword/challenge: Unable to decode error response: \(error)")
+            MSALLogger.logPII(
+                level: .error,
+                context: context,
+                format: "resetpassword/challenge: Unable to decode error response: \(MSALLogMask.maskPII(error))"
+            )
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
         if apiError.error == .unknown {
@@ -171,7 +175,11 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
 
     private func handleContinueError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordContinueValidatedResponse {
         guard let apiError = error as? MSALNativeAuthResetPasswordContinueResponseError else {
-            MSALLogger.log(level: .error, context: context, format: "resetpassword/continue: Unable to decode error response: \(error)")
+            MSALLogger.logPII(
+                level: .error,
+                context: context,
+                format: "resetpassword/continue: Unable to decode error response: \(MSALLogMask.maskPII(error))"
+            )
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
 
@@ -212,7 +220,11 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
 
     private func handleSubmitError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthResetPasswordSubmitValidatedResponse {
         guard let apiError = error as? MSALNativeAuthResetPasswordSubmitResponseError else {
-            MSALLogger.log(level: .error, context: context, format: "resetpassword/submit: Unable to decode error response: \(error)")
+            MSALLogger.logPII(
+                level: .error,
+                context: context,
+                format: "resetpassword/submit: Unable to decode error response: \(MSALLogMask.maskPII(error))"
+            )
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
 
@@ -258,7 +270,11 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
         with context: MSIDRequestContext
     ) -> MSALNativeAuthResetPasswordPollCompletionValidatedResponse {
         guard let apiError = error as? MSALNativeAuthResetPasswordPollCompletionResponseError else {
-            MSALLogger.log(level: .error, context: context, format: "resetpassword/poll_completion: Unable to decode error response: \(error)")
+            MSALLogger.logPII(
+                level: .error,
+                context: context,
+                format: "resetpassword/poll_completion: Unable to decode error response: \(MSALLogMask.maskPII(error))"
+            )
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
 

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -101,10 +101,10 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                     let targetLabel = response.challengeTargetLabel,
                     let codeLength = response.codeLength,
                     let channelType = response.challengeChannel else {
-                MSALLogger.log(
+                MSALLogger.logPII(
                     level: .error,
                     context: context,
-                    format: "signin/challenge: Invalid response with challenge type oob, response: \(response)")
+                    format: "signin/challenge: Invalid response with challenge type oob, response: \(MSALLogMask.maskPII(response))")
                 return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)))
             }
             return .codeRequired(

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -48,10 +48,10 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
         case .failure(let signInChallengeResponseError):
             guard let signInChallengeResponseError =
                     signInChallengeResponseError as? MSALNativeAuthSignInChallengeResponseError else {
-                MSALLogger.log(
+                MSALLogger.logPII(
                     level: .error,
                     context: context,
-                    format: "signin/challenge: Unable to decode error response: \(signInChallengeResponseError)")
+                    format: "signin/challenge: Unable to decode error response: \(MSALLogMask.maskPII(signInChallengeResponseError))")
                 return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)))
             }
             return handleFailedSignInChallengeResult(error: signInChallengeResponseError)
@@ -74,10 +74,10 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
             return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)))
         case .failure(let responseError):
             guard let initiateResponseError = responseError as? MSALNativeAuthSignInInitiateResponseError else {
-                MSALLogger.log(
+                MSALLogger.logPII(
                     level: .error,
                     context: context,
-                    format: "signin/initiate: Unable to decode error response: \(responseError)")
+                    format: "signin/initiate: Unable to decode error response: \(MSALLogMask.maskPII(responseError))")
                 return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)))
             }
             return handleFailedSignInInitiateResult(error: initiateResponseError)

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -68,7 +68,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
 
     private func handleStartFailed(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpStartValidatedResponse {
         guard let apiError = error as? MSALNativeAuthSignUpStartResponseError else {
-            MSALLogger.log(level: .error, context: context, format: "signup/start: Unable to decode error response: \(error)")
+            MSALLogger.logPII(level: .error, context: context, format: "signup/start: Unable to decode error response: \(MSALLogMask.maskPII(error))")
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
 
@@ -150,7 +150,11 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
 
     private func handleChallengeError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpChallengeValidatedResponse {
         guard let apiError = error as? MSALNativeAuthSignUpChallengeResponseError else {
-            MSALLogger.log(level: .error, context: context, format: "signup/challenge: Unable to decode error response: \(error)")
+            MSALLogger.logPII(
+                level: .error,
+                context: context,
+                format: "signup/challenge: Unable to decode error response: \(MSALLogMask.maskPII(error))"
+            )
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
         if apiError.error == .unknown {
@@ -177,7 +181,11 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
 
     private func handleContinueError(_ error: Error, with context: MSIDRequestContext) -> MSALNativeAuthSignUpContinueValidatedResponse {
         guard let apiError = error as? MSALNativeAuthSignUpContinueResponseError else {
-            MSALLogger.log(level: .error, context: context, format: "signup/continue: Unable to decode error response: \(error)")
+            MSALLogger.logPII(
+                level: .error,
+                context: context,
+                format: "signup/continue: Unable to decode error response: \(MSALLogMask.maskPII(error))"
+            )
             return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
 

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -61,10 +61,10 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
         case .failure(let tokenResponseError):
             guard let tokenResponseError =
                     tokenResponseError as? MSALNativeAuthTokenResponseError else {
-                MSALLogger.log(
+                MSALLogger.logPII(
                     level: .error,
                     context: context,
-                    format: "Token: Unable to decode error response: \(tokenResponseError)")
+                    format: "Token: Unable to decode error response: \(MSALLogMask.maskPII(tokenResponseError))")
                 return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)))
             }
             return handleFailedTokenResult(context, tokenResponseError)
@@ -160,7 +160,11 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
         if let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: firstErrorCode) {
             validatedResponse = .error(errorCodesConverterFunction(knownErrorCode, apiError))
         } else {
-            MSALLogger.log(level: .error, context: context, format: "/token error - Unknown code received in error_codes: \(firstErrorCode)")
+            MSALLogger.logPII(
+                level: .error,
+                context: context,
+                format: "/token error - Unknown code received in error_codes: \(MSALLogMask.maskPII(firstErrorCode))"
+            )
             validatedResponse = useInvalidRequestAsDefaultResult ? .error(.invalidRequest(apiError)) : .error(.generalError(apiError))
         }
 
@@ -170,12 +174,12 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
             let errorMessage: String
 
             if let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: errorCode) {
-                errorMessage = "/token error - ESTS error received in error_codes: \(knownErrorCode) (ignoring)"
+                errorMessage = "/token error - ESTS error received in error_codes: \(MSALLogMask.maskPII(knownErrorCode)) (ignoring)"
             } else {
-                errorMessage = "/token error - Unknown ESTS received in error_codes with code: \(errorCode) (ignoring)"
+                errorMessage = "/token error - Unknown ESTS received in error_codes with code: \(MSALLogMask.maskPII(errorCode)) (ignoring)"
             }
 
-            MSALLogger.log(level: .verbose, context: context, format: errorMessage)
+            MSALLogger.logPII(level: .verbose, context: context, format: errorMessage)
         }
 
         return validatedResponse

--- a/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
@@ -97,7 +97,7 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
                 errorUri: apiError.errorURI
             )
         case .expiredRefreshToken(let apiError):
-            MSALLogger.log(level: .error, context: nil, format: "Error not treated - \(self))")
+            MSALLogger.logPII(level: .error, context: nil, format: "Error not treated - \(MSALLogMask.maskPII(self))")
             return SignInStartError(
                 type: .generalError,
                 message: apiError.errorDescription,
@@ -154,7 +154,7 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
         case .userNotFound(let apiError),
              .invalidPassword(let apiError),
              .invalidOOBCode(let apiError):
-            MSALLogger.log(level: .error, context: nil, format: "Error not treated - \(self))")
+            MSALLogger.logPII(level: .error, context: nil, format: "Error not treated - \(MSALLogMask.maskPII(self))")
             return RetrieveAccessTokenError(
                 type: .generalError,
                 message: apiError.errorDescription,

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -68,7 +68,7 @@ import Foundation
             MSALLogger.logPII(
                 level: .error,
                 context: context,
-                format: "Clearing MSAL token cache for the current account failed with error %@: \(MSALLogMaskWrapper.maskPII(error))"
+                format: "Clearing MSAL token cache for the current account failed with error %@: \(MSALLogMaskWrapper.maskEUII(error))"
             )
         }
     }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -65,10 +65,10 @@ import Foundation
                 context: context
             )
         } catch {
-            MSALLogger.log(
+            MSALLogger.logPII(
                 level: .error,
                 context: context,
-                format: "Clearing MSAL token cache for the current account failed with error %@: \(error)"
+                format: "Clearing MSAL token cache for the current account failed with error %@: \(MSALLogMaskWrapper.maskPII(error))"
             )
         }
     }


### PR DESCRIPTION
## Proposed changes

In this PR the Native Auth logs have been reviewed and updated, by using `MSALLogger.logPII()` in conjunction with `MSALLogMask` and its different types of masking options.

In general, this is the logic I have followed:

- All of the API errors are masked.
- None of the request errors have been masked (because I don't think they are not leaking any PII).
- The cache-related errors have been masked.

Important note 1:

In the controllers, when we log the errorDescription, we had in all of them: "\(error.errorDescription ?? "No error description")". I have removed the "no error description" part, so now if there isn't an error description, it uses the error description that we provide in the public errors (for example, see from `SignUpStartError` the `errorDescription` property). 

Before we were not using those descriptions, IMO they are richer than simply returning "no error description". But let me know if you don't agree with this change, I can revert it.

Important note 2:

I have made the decision of **not** to mask the following logs, and I would like to highlight them so everybody is aware.

- `MSALNativeAuthUrlRequestSerializer` class, line 70: when there is an error serializing a request.
- `MSALNativeAuthRequestConfigurator` class, line 265: when there is a problem creating the endpoint url.
- `MSALNativeAuthRequestContext` class, line 78: when there is a mismatch of the correlation id set in the SDK and the correlation id received in the response. Since all of the logs show the correlation id, I think it's not needed to mask them.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)