### PR TITLE
Remove native auth E2E tests from PR validation

### DIFF
--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -84,21 +84,6 @@ jobs:
       failTaskOnFailedTests: true
       testRunTitle: 'Test Run - $(target)'
 
-- job: e2e_test_native_auth
-  displayName: 'Run MSAL E2E tests for native auth'
-  timeoutInMinutes: 30
-  cancelTimeoutInMinutes: 5
-  pool:
-    vmImage: 'macOS-14'
-  workspace:
-    clean: all
-
-  steps:
-  - template: templates/tests-with-conf-file.yml
-    parameters:
-      schema: 'MSAL iOS Native Auth E2E Tests'
-      build: 'MSAL iOS Native Auth E2E Tests_MSAL iOS Native Auth E2E Tests'
-
 - job: 'Validate_SPM_Integration'
   displayName: Validate SPM Integration
   pool:


### PR DESCRIPTION
## Proposed changes

Remove temporarily native auth E2E tests from PR validation

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

