### PR TITLE
Converted "test_signOutAfterSignInPasswordSuccess" to use lab tenant

### DIFF
--- a/MSAL/test/integration/native_auth/end_to_end/sign_out/MSALNativeAuthSignOutEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_out/MSALNativeAuthSignOutEndToEndTests.swift
@@ -50,6 +50,7 @@ final class MSALNativeAuthSignOutEndToEndTests: MSALNativeAuthEndToEndPasswordTe
         // Sign out
 
         var userAccountResult = sut.getNativeAuthUserAccount()
+        XCTAssertNotNil(userAccountResult)
         userAccountResult?.signOut()
 
         userAccountResult = sut.getNativeAuthUserAccount()


### PR DESCRIPTION
- Converted "test_signOutAfterSignInPasswordSuccess" to use lab tenant
- Removed "test_signOutAfterSignInOTPSuccess"


## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


