### PR TITLE
Update E2E tests for sign-in with code to use lab tenant

### DIFF
--- a/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
@@ -86,7 +86,11 @@ class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
     func retrieveCodeFor(email: String) async -> String? {
         return await codeRetriever.retrieveEmailOTPCode(email: email)
     }
-    
+
+    func retrieveUsernameForSignInCode() -> String? {
+        return MSALNativeAuthEndToEndBaseTestCase.nativeAuthConfFileContent?[Constants.signInEmailCodeUsernameKey]
+    }
+
     func retrieveUsernameForSignInUsernameAndPassword() -> String? {
         return MSALNativeAuthEndToEndBaseTestCase.nativeAuthConfFileContent?[Constants.signInEmailPasswordUsernameKey]
     }

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
@@ -26,6 +26,8 @@ import Foundation
 import XCTest
 
 final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuthEndToEndPasswordTestCase {
+
+    // Hero Scenario 1.2.2. Sign in - User is not registered with given email
     func test_signInUsingPasswordWithUnknownUsernameResultsInError() async throws {
         guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")
@@ -44,6 +46,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         XCTAssertTrue(signInDelegateSpy.error!.isUserNotFound)
     }
 
+    // Hero Scenario 1.2.3. Sign in - Password is incorrect
     func test_signInWithKnownUsernameInvalidPasswordResultsInError() async throws {
         guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword() else {
             XCTFail("Missing information")
@@ -61,7 +64,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         XCTAssertTrue(signInDelegateSpy.error!.isInvalidCredentials)
     }
 
-    // Hero Scenario 2.2.1. Sign in – Email and Password on SINGLE screen (Email & Password)
+    // Hero Scenario 1.2.1. Sign in - Use email and password to get token
     func test_signInUsingPasswordWithKnownUsernameResultsInSuccess() async throws {
         guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword(), let password = await retrievePasswordForSignInUsername() else {
             XCTFail("Missing information")
@@ -80,6 +83,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         XCTAssertEqual(signInDelegateSpy.result?.account.username, username)
     }
     
+    // Sign in - Password is incorrect (sent over delegate.newStatePasswordRequired)
     func test_signInAndSendingIncorrectPasswordResultsInError() async throws {
         guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword() else {
             XCTFail("Missing information")
@@ -95,7 +99,11 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
         await fulfillment(of: [signInExpectation])
 
-        XCTAssertTrue(signInDelegateSpy.onSignInPasswordRequiredCalled)
+        guard signInDelegateSpy.onSignInPasswordRequiredCalled else {
+            XCTFail("onSignInPasswordRequired not called")
+            return
+        }
+
         XCTAssertNotNil(signInDelegateSpy.newStatePasswordRequired)
 
         // Now submit the password..


### PR DESCRIPTION
## Proposed changes

- Add references to Acceptance Criteria docs in all sign-in tests.
- Convert remaining sign-in with code E2E tests to use lab tenant.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)