### PR TITLE
Skip Native Auth E2E tests in pr-validation if label is present

### DIFF
--- a/azure_pipelines/automation.yml
+++ b/azure_pipelines/automation.yml
@@ -79,6 +79,19 @@ jobs:
         issue_body = '''@AzureAD/appleidentity \nAutomation failed for [$(repositoryName)]({0}) ran against commit : {1} \n Pipeline URL : [{2}]({2})'''.format('$(Build.Repository.Uri)', git_commit, pipeline_uri)
         github.create_issue(github_org, repo, issue_title, issue_body, labels=['automation failure'])
 
+- job: e2e_test_native_auth
+  displayName: 'Run MSAL E2E tests for native auth'
+  timeoutInMinutes: 30
+  cancelTimeoutInMinutes: 5
+  workspace:
+    clean: all
+
+  steps:
+  - template: templates/tests-with-conf-file.yml
+    parameters:
+      schema: 'MSAL iOS Native Auth E2E Tests'
+      build: 'MSAL iOS Native Auth E2E Tests_MSAL iOS Native Auth E2E Tests'
+
 - job: cocoapods_lib_lint
   displayName: Run Cocoapods lib lint
   timeoutInMinutes: 30

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -84,8 +84,42 @@ jobs:
       failTaskOnFailedTests: true
       testRunTitle: 'Test Run - $(target)'
 
+- job: fetch_pr_labels
+  displayName: 'Check for PR Label'
+  timeoutInMinutes: 5
+  pool:
+    vmImage: 'macOS-14'
+  steps:
+    - script: |
+        url="https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
+
+        echo "Fetching labels from $url"
+
+        # Temporary file to store the raw response
+        temp_file=$(mktemp)
+
+        # Store the response code and the raw response in separate variables
+        response_code=$(curl -s -w "%{http_code}" -o "$temp_file" "$url")
+        response_content=$(cat "$temp_file")
+
+        echo "Response code: $response_code"
+        echo "Raw response: $response_content"
+
+        if [[ "$response_code" -eq 200 ]]; then
+          label_names=$(echo $response_content | jq -r '.[].name' | paste -sd ', ' -)
+          echo "##vso[task.setvariable variable=PR_LABELS;isOutput=true]$label_names"
+          [ -z "$label_names" ] && echo "PR labels: <empty>" || echo "PR labels: $label_names"
+        else
+          echo "Request failed with status code: $response_code - Skipping Native Auth E2E tests as a preventive measure"
+          echo "##vso[task.setvariable variable=PR_LABELS;isOutput=true]'skip-native-auth-e2e-tests'"
+        fi
+
+      name: fetchPrLabels
+
 - job: e2e_test_native_auth
   displayName: 'Run MSAL E2E tests for native auth'
+  dependsOn: fetch_pr_labels
+  condition: and( succeeded(), not(contains(dependencies.fetch_pr_labels.outputs['fetchPrLabels.PR_LABELS'], 'skip-native-auth-e2e-tests')) )
   timeoutInMinutes: 30
   cancelTimeoutInMinutes: 5
   pool:

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -84,6 +84,21 @@ jobs:
       failTaskOnFailedTests: true
       testRunTitle: 'Test Run - $(target)'
 
+- job: e2e_test_native_auth
+  displayName: 'Run MSAL E2E tests for native auth'
+  timeoutInMinutes: 30
+  cancelTimeoutInMinutes: 5
+  pool:
+    vmImage: 'macOS-14'
+  workspace:
+    clean: all
+
+  steps:
+  - template: templates/tests-with-conf-file.yml
+    parameters:
+      schema: 'MSAL iOS Native Auth E2E Tests'
+      build: 'MSAL iOS Native Auth E2E Tests_MSAL iOS Native Auth E2E Tests'
+
 - job: 'Validate_SPM_Integration'
   displayName: Validate SPM Integration
   pool:

--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -93,7 +93,7 @@ jobs:
     - script: |
         url="https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
 
-        echo "Fetching labels from $url"
+        echo "Fetching labels from $url "
 
         # Temporary file to store the raw response
         temp_file=$(mktemp)


### PR DESCRIPTION
## Proposed changes

- Add Native Auth E2E tests back to the pr-validation.yml again.
- Add Native Auth E2E tests back to the automation.yml again.
- Add an option to skip the Native Auth E2E tests in every PR that contains the label "skip-native-auth-e2e-tests".

Note:

To determine whether or not the CI should skip the tests, it makes a request to Github and retrieves the labels of the PR (ie: https://api.github.com/repos/AzureAD/microsoft-authentication-library-for-objc/issues/2274/labels).

However, this request is not authenticated. For that, [we need to include a Github token in the request](https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28#authenticating-with-a-token-generated-by-an-app)I.

As the request is not authenticated, [Github throttles the request after 60 / hour / ip](https://stackoverflow.com/questions/33655700/github-api-fetch-issues-with-exceeds-rate-limit-prematurely), which means that for a PR that is WIP, the request to get the labels might get throttled. For that scenario, **we have decided to skip the Native Auth E2E tests if the request is throttled as a preventive measure**.

We will revisit this in the future to apply proper authentication to the request to Github (with an authenticated request the throttling limit will be increased).

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)