### PR TITLE
Email OTP MFA Network layer implementation

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 		28A277C82C21F08800D95E00 /* MSAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D65A6F431E3FD30A00C69FBA /* MSAL.framework */; };
 		28A277D92C22ED5E00D95E00 /* MSALNativeAuthEmailCodeRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A277D82C22ED5E00D95E00 /* MSALNativeAuthEmailCodeRetriever.swift */; };
 		28A472EC2A276C3B003F988B /* MSALNativeAuthTokenValidatedResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A472EB2A276C3B003F988B /* MSALNativeAuthTokenValidatedResponse.swift */; };
+		28ABE1762C5D213700F5275D /* MSALNativeAuthSignInIntrospectIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28ABE1752C5D213700F5275D /* MSALNativeAuthSignInIntrospectIntegrationTests.swift */; };
 		28B6494D2A0959EB00EF3DB7 /* MSALNativeAuthSignInResponseValidatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B6494A2A0959DC00EF3DB7 /* MSALNativeAuthSignInResponseValidatorTest.swift */; };
 		28CA6F5D29689F34004DB11D /* MSALNativeAuthCacheAccessorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28CA6F5429689F26004DB11D /* MSALNativeAuthCacheAccessorTest.swift */; };
 		28D1D57029BF62E900CE75F4 /* MSAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D65A6F431E3FD30A00C69FBA /* MSAL.framework */; };
@@ -1591,6 +1592,7 @@
 		289E156C2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCacheAccessor.swift; sourceTree = "<group>"; };
 		28A277D82C22ED5E00D95E00 /* MSALNativeAuthEmailCodeRetriever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthEmailCodeRetriever.swift; sourceTree = "<group>"; };
 		28A472EB2A276C3B003F988B /* MSALNativeAuthTokenValidatedResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenValidatedResponse.swift; sourceTree = "<group>"; };
+		28ABE1752C5D213700F5275D /* MSALNativeAuthSignInIntrospectIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInIntrospectIntegrationTests.swift; sourceTree = "<group>"; };
 		28B6494A2A0959DC00EF3DB7 /* MSALNativeAuthSignInResponseValidatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInResponseValidatorTest.swift; sourceTree = "<group>"; };
 		28CA6F5429689F26004DB11D /* MSALNativeAuthCacheAccessorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCacheAccessorTest.swift; sourceTree = "<group>"; };
 		28CED2E82C21E0F9004320D1 /* MSAL iOS Native Auth E2E Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "MSAL iOS Native Auth E2E Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3782,6 +3784,7 @@
 			children = (
 				DE0D65C529D344F1005798B1 /* MSALNativeAuthSignInInitiateIntegrationTests.swift */,
 				DE0D65CA29D5CD6D005798B1 /* MSALNativeAuthSignInChallengeIntegrationTests.swift */,
+				28ABE1752C5D213700F5275D /* MSALNativeAuthSignInIntrospectIntegrationTests.swift */,
 			);
 			path = sign_in;
 			sourceTree = "<group>";
@@ -5628,6 +5631,7 @@
 				E2BC027529D6E0C600041DBC /* MSALNativeAuthSignUpContinueIntegrationTests.swift in Sources */,
 				E23E955F29D4B9F7001DC59C /* MSALNativeAuthSignUpChallengeIntegrationTests.swift in Sources */,
 				28D1D59229C2231C00CE75F4 /* MockAPIHandler.swift in Sources */,
+				28ABE1762C5D213700F5275D /* MSALNativeAuthSignInIntrospectIntegrationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 		285F585F2C5BA71600F4EFA4 /* MSALNativeAuthInternalAuthenticationMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F585E2C5BA71600F4EFA4 /* MSALNativeAuthInternalAuthenticationMethod.swift */; };
 		285F58612C5BC1EC00F4EFA4 /* MSALNativeAuthSignInIntrospectResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F58602C5BC1EC00F4EFA4 /* MSALNativeAuthSignInIntrospectResponseError.swift */; };
 		285F58632C5BC67900F4EFA4 /* MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F58622C5BC67900F4EFA4 /* MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift */; };
+		285F58652C5BCA8900F4EFA4 /* MSALNativeAuthSignInIntrospectValidatedResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F58642C5BCA8900F4EFA4 /* MSALNativeAuthSignInIntrospectValidatedResponse.swift */; };
 		28664DDF2C382A440007D6A5 /* libIdentityAutomationTestLib iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B21FA9BC2204DC5700806B68 /* libIdentityAutomationTestLib iOS.a */; };
 		2877081F2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2877081E2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift */; };
 		287708222A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287708212A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift */; };
@@ -1573,6 +1574,7 @@
 		285F585E2C5BA71600F4EFA4 /* MSALNativeAuthInternalAuthenticationMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalAuthenticationMethod.swift; sourceTree = "<group>"; };
 		285F58602C5BC1EC00F4EFA4 /* MSALNativeAuthSignInIntrospectResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInIntrospectResponseError.swift; sourceTree = "<group>"; };
 		285F58622C5BC67900F4EFA4 /* MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift; sourceTree = "<group>"; };
+		285F58642C5BCA8900F4EFA4 /* MSALNativeAuthSignInIntrospectValidatedResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInIntrospectValidatedResponse.swift; sourceTree = "<group>"; };
 		2877081E2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInChallengeValidatedResponse.swift; sourceTree = "<group>"; };
 		287708212A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalChannelType.swift; sourceTree = "<group>"; };
 		287708242A178DC500E371ED /* MSALNativeAuthSignInInitiateValidatedResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInInitiateValidatedResponse.swift; sourceTree = "<group>"; };
@@ -2398,6 +2400,7 @@
 			children = (
 				2877081E2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift */,
 				287708242A178DC500E371ED /* MSALNativeAuthSignInInitiateValidatedResponse.swift */,
+				285F58642C5BCA8900F4EFA4 /* MSALNativeAuthSignInIntrospectValidatedResponse.swift */,
 			);
 			path = validated_response;
 			sourceTree = "<group>";
@@ -5866,6 +5869,7 @@
 				DE8EC8742A026BA0003FA561 /* MSALNativeAuthSignInRequestProvider.swift in Sources */,
 				232D616422485BA700260C42 /* MSALIndividualClaimRequestAdditionalInfo.m in Sources */,
 				287708222A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift in Sources */,
+				285F58652C5BCA8900F4EFA4 /* MSALNativeAuthSignInIntrospectValidatedResponse.swift in Sources */,
 				D61BD2BD1EBD0A010007E484 /* MSALTelemetry.m in Sources */,
 				DEE34F60D170B71C00BC302A /* MSALNativeAuthResetPasswordStartResponseError.swift in Sources */,
 				9BE7E3CB2A1CB70700CC3A62 /* MSALNativeAuthResetPasswordStartRequestProviderParameters.swift in Sources */,

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -255,6 +255,11 @@
 		2826933B2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2826933A2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift */; };
 		285D0D692B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285D0D682B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift */; };
 		285F36082A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F36072A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift */; };
+		285F58542C5BA33B00F4EFA4 /* MSALNativeAuthSignInIntrospectRequestParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F58532C5BA33B00F4EFA4 /* MSALNativeAuthSignInIntrospectRequestParameters.swift */; };
+		285F585D2C5BA4F700F4EFA4 /* MSALNativeAuthSignInIntrospectResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F585C2C5BA4F600F4EFA4 /* MSALNativeAuthSignInIntrospectResponse.swift */; };
+		285F585F2C5BA71600F4EFA4 /* MSALNativeAuthInternalAuthenticationMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F585E2C5BA71600F4EFA4 /* MSALNativeAuthInternalAuthenticationMethod.swift */; };
+		285F58612C5BC1EC00F4EFA4 /* MSALNativeAuthSignInIntrospectResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F58602C5BC1EC00F4EFA4 /* MSALNativeAuthSignInIntrospectResponseError.swift */; };
+		285F58632C5BC67900F4EFA4 /* MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F58622C5BC67900F4EFA4 /* MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift */; };
 		28664DDF2C382A440007D6A5 /* libIdentityAutomationTestLib iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B21FA9BC2204DC5700806B68 /* libIdentityAutomationTestLib iOS.a */; };
 		2877081F2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2877081E2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift */; };
 		287708222A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287708212A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift */; };
@@ -1563,6 +1568,11 @@
 		2826933A2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInParameters.swift; sourceTree = "<group>"; };
 		285D0D682B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenResult.swift; sourceTree = "<group>"; };
 		285F36072A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInControlling.swift; sourceTree = "<group>"; };
+		285F58532C5BA33B00F4EFA4 /* MSALNativeAuthSignInIntrospectRequestParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInIntrospectRequestParameters.swift; sourceTree = "<group>"; };
+		285F585C2C5BA4F600F4EFA4 /* MSALNativeAuthSignInIntrospectResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInIntrospectResponse.swift; sourceTree = "<group>"; };
+		285F585E2C5BA71600F4EFA4 /* MSALNativeAuthInternalAuthenticationMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalAuthenticationMethod.swift; sourceTree = "<group>"; };
+		285F58602C5BC1EC00F4EFA4 /* MSALNativeAuthSignInIntrospectResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInIntrospectResponseError.swift; sourceTree = "<group>"; };
+		285F58622C5BC67900F4EFA4 /* MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift; sourceTree = "<group>"; };
 		2877081E2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInChallengeValidatedResponse.swift; sourceTree = "<group>"; };
 		287708212A151A8500E371ED /* MSALNativeAuthInternalChannelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalChannelType.swift; sourceTree = "<group>"; };
 		287708242A178DC500E371ED /* MSALNativeAuthSignInInitiateValidatedResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInInitiateValidatedResponse.swift; sourceTree = "<group>"; };
@@ -3728,6 +3738,8 @@
 			children = (
 				DE0D65AB29CC6A59005798B1 /* MSALNativeAuthSignInInitiateResponse.swift */,
 				DE0D65B529CC6BBA005798B1 /* MSALNativeAuthSignInChallengeResponse.swift */,
+				285F585C2C5BA4F600F4EFA4 /* MSALNativeAuthSignInIntrospectResponse.swift */,
+				285F585E2C5BA71600F4EFA4 /* MSALNativeAuthInternalAuthenticationMethod.swift */,
 			);
 			path = sign_in;
 			sourceTree = "<group>";
@@ -3756,6 +3768,8 @@
 				DEDB29A429DDA9DC008DA85B /* MSALNativeAuthSignInInitiateResponseError.swift */,
 				DEDB29A629DDAEB3008DA85B /* MSALNativeAuthSignInChallengeOauth2ErrorCode.swift */,
 				DEDB29AA29DDAF52008DA85B /* MSALNativeAuthSignInChallengeResponseError.swift */,
+				285F58602C5BC1EC00F4EFA4 /* MSALNativeAuthSignInIntrospectResponseError.swift */,
+				285F58622C5BC67900F4EFA4 /* MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift */,
 			);
 			path = sign_in;
 			sourceTree = "<group>";
@@ -4133,6 +4147,7 @@
 			children = (
 				DE0D656729BF72F6005798B1 /* MSALNativeAuthSignInInitiateRequestParameters.swift */,
 				DE0D657429BF73CB005798B1 /* MSALNativeAuthSignInChallengeRequestParameters.swift */,
+				285F58532C5BA33B00F4EFA4 /* MSALNativeAuthSignInIntrospectRequestParameters.swift */,
 			);
 			path = sign_in;
 			sourceTree = "<group>";
@@ -5770,9 +5785,11 @@
 				04D32CAE1FD615B3000B123E /* MSALErrorConverter.m in Sources */,
 				B26756D222921C6D000F01D7 /* MSALADFSOauth2Provider.m in Sources */,
 				E26097C32948FC4D0060DD7C /* MSALNativeAuthLogging.swift in Sources */,
+				285F585F2C5BA71600F4EFA4 /* MSALNativeAuthInternalAuthenticationMethod.swift in Sources */,
 				232D614C2248484C00260C42 /* MSALClaimsRequest.m in Sources */,
 				B203459621AF77FB00B221AA /* MSALRedirectUri.m in Sources */,
 				E2025CC92B2A182200E32871 /* MSALNativeAuthSubErrorCode.swift in Sources */,
+				285F585D2C5BA4F700F4EFA4 /* MSALNativeAuthSignInIntrospectResponse.swift in Sources */,
 				DEE34F7BD170B71C00BC302A /* MSALNativeAuthResetPasswordContinueOauth2ErrorCode.swift in Sources */,
 				DEE34F7FD170B71C00BC302A /* MSALNativeAuthResetPasswordSubmitResponse.swift in Sources */,
 				E284F5D929F28B4200DBED7D /* MSALNativeAuthSignUpController.swift in Sources */,
@@ -5866,6 +5883,7 @@
 				289E156D2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift in Sources */,
 				E2C61FE729DED73700F15203 /* MSALNativeAuthSignUpChallengeResponseError.swift in Sources */,
 				289747B129799C6B00838C80 /* MSALNativeAuthInputValidator.swift in Sources */,
+				285F58632C5BC67900F4EFA4 /* MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift in Sources */,
 				DEE34F7AD170B71C00BC302A /* MSALNativeAuthResetPasswordContinueResponseError.swift in Sources */,
 				28E4D9032A30ABA200280921 /* ResendCodeError.swift in Sources */,
 				E2F6269D2A780DDE00C4A303 /* MSALNativeAuthPublicClientApplication+Internal.swift in Sources */,
@@ -5897,6 +5915,7 @@
 				B2C17B0A1FC8DB2E0070A514 /* MSIDVersion.m in Sources */,
 				E2DC31C829B0FDB100051CE7 /* MSALNativeAuthAuthorityProvider.swift in Sources */,
 				28DCD0AE29D737E600C4601E /* VerifyCodeError.swift in Sources */,
+				285F58612C5BC1EC00F4EFA4 /* MSALNativeAuthSignInIntrospectResponseError.swift in Sources */,
 				E22427C82B0526660006C55E /* SignUpDelegateDispatchers.swift in Sources */,
 				E224F7472B18F29F000A7B2E /* SignInAfterResetPasswordDelegate.swift in Sources */,
 				E2F626B02A78130700C4A303 /* SignInAfterPreviousFlowBaseState+Internal.swift in Sources */,
@@ -5943,6 +5962,7 @@
 				232D68D8223DB8C200594BBD /* MSALSilentTokenParameters.m in Sources */,
 				DE729ECD2A1793A100A761D9 /* MSALNativeAuthChannelType.swift in Sources */,
 				E2EFAD162A70300B00D6C3DE /* MSALNativeAuthControllerTelemetryWrapper.swift in Sources */,
+				285F58542C5BA33B00F4EFA4 /* MSALNativeAuthSignInIntrospectRequestParameters.swift in Sources */,
 				28DE70D629FAC16700EB75AA /* MSALNativeAuthSignInResponseValidator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -620,11 +620,13 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
 
     private func createChallengeRequest(
         continuationToken: String,
-        context: MSALNativeAuthRequestContext
+        context: MSALNativeAuthRequestContext,
+        mfaAuthMethodId: String? = nil
     ) -> MSIDHttpRequest? {
         do {
             let params = MSALNativeAuthSignInChallengeRequestParameters(
                 context: context,
+                mfaAuthMethodId: mfaAuthMethodId, 
                 continuationToken: continuationToken
             )
             return try signInRequestProvider.challenge(parameters: params, context: context)

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -427,7 +427,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         }
 
         let initiateResponse: Result<MSALNativeAuthSignInInitiateResponse, Error> = await performRequest(request, context: telemetryInfo.context)
-        let validatedResponse = signInResponseValidator.validate(context: telemetryInfo.context, result: initiateResponse)
+        let validatedResponse = signInResponseValidator.validateInitiate(context: telemetryInfo.context, result: initiateResponse)
 
         return validatedResponse
     }
@@ -620,7 +620,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             return .error(.invalidRequest(.init(errorDescription: errorDescription)))
         }
         let challengeResponse: Result<MSALNativeAuthSignInChallengeResponse, Error> = await performRequest(challengeRequest, context: context)
-        return signInResponseValidator.validate(context: context, result: challengeResponse)
+        return signInResponseValidator.validateChallenge(context: context, result: challengeResponse)
     }
 
     private func createInitiateRequest(username: String, context: MSALNativeAuthRequestContext) -> MSIDHttpRequest? {

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -225,6 +225,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 continuationToken: continuationToken,
                 context: context
             )
+        case .strongAuthRequired(_):
+            // TODO: this will be handled in a separate PBI
+            return .init(.error(error: VerifyCodeError(type: .generalError, correlationId: UUID()), newState: nil), correlationId: UUID())
         }
     }
 
@@ -301,6 +304,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 continuationToken: continuationToken,
                 scopes: scopes
             )
+        case .strongAuthRequired(_):
+            // TODO: this will be handled in a separate PBI
+            return .init(.error(error: PasswordRequiredError(type: .generalError, correlationId: UUID()), newState: nil), correlationId: UUID())
         }
     }
 
@@ -351,6 +357,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 telemetryUpdate: { [weak self] result in
                     self?.stopTelemetryEvent(event, context: context, delegateDispatcherResult: result)
                 })
+        case .introspectRequired:
+            // TODO: this will be handled in a separate PBI
+            return .init(.error(error: ResendCodeError(correlationId: UUID()), newState: nil), correlationId: UUID())
         }
     }
 
@@ -470,6 +479,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                            format: "SignIn completed with errorType: \(MSALLogMask.maskPII(error.errorDescription))")
             stopTelemetryEvent(telemetryInfo, error: error)
             onError(error)
+        case .strongAuthRequired(_):
+            return
+            // TODO: this will be handled in a separate PBI
         }
     }
 
@@ -592,6 +604,9 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                               format: "SignIn, completed with error: \(MSALLogMask.maskPII(error.errorDescription))")
             stopTelemetryEvent(telemetryInfo, error: error)
             return .init(.error(error), correlationId: telemetryInfo.context.correlationId())
+        case .introspectRequired:
+            // TODO: this will be handled in a separate PBI
+            return .init(.error(SignInStartError(type: .generalError, correlationId: telemetryInfo.context.correlationId())), correlationId: telemetryInfo.context.correlationId())
         }
     }
 

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -606,7 +606,12 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             return .init(.error(error), correlationId: telemetryInfo.context.correlationId())
         case .introspectRequired:
             // TODO: this will be handled in a separate PBI
-            return .init(.error(SignInStartError(type: .generalError, correlationId: telemetryInfo.context.correlationId())), correlationId: telemetryInfo.context.correlationId())
+            return .init(.error(
+                SignInStartError(
+                    type: .generalError,
+                    correlationId: telemetryInfo.context.correlationId()
+                )), correlationId: telemetryInfo.context.correlationId()
+            )
         }
     }
 
@@ -641,7 +646,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         do {
             let params = MSALNativeAuthSignInChallengeRequestParameters(
                 context: context,
-                mfaAuthMethodId: mfaAuthMethodId, 
+                mfaAuthMethodId: mfaAuthMethodId,
                 continuationToken: continuationToken
             )
             return try signInRequestProvider.challenge(parameters: params, context: context)

--- a/MSAL/src/native_auth/network/MSALNativeAuthRequestConfigurator.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthRequestConfigurator.swift
@@ -36,6 +36,7 @@ enum MSALNativeAuthRequestConfiguratorType {
     enum SignIn {
         case initiate(MSALNativeAuthSignInInitiateRequestParameters)
         case challenge(MSALNativeAuthSignInChallengeRequestParameters)
+        case introspect(MSALNativeAuthSignInIntrospectRequestParameters)
     }
 
     enum ResetPassword {
@@ -130,6 +131,15 @@ class MSALNativeAuthRequestConfigurator: MSIDAADRequestConfigurator {
             let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignInChallengeResponse>()
             let telemetry = telemetryProvider.telemetryForSignIn(type: .signInChallenge)
             let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInChallengeResponseError>()
+            try configure(request: request,
+                          parameters: parameters,
+                          responseSerializer: responseSerializer,
+                          telemetry: telemetry,
+                          errorHandler: errorHandler)
+        case .introspect(let parameters):
+            let responseSerializer = MSALNativeAuthResponseSerializer<MSALNativeAuthSignInIntrospectResponse>()
+            let telemetry = telemetryProvider.telemetryForSignIn(type: .signInIntrospect)
+            let errorHandler = MSALNativeAuthResponseErrorHandler<MSALNativeAuthSignInIntrospectResponseError>()
             try configure(request: request,
                           parameters: parameters,
                           responseSerializer: responseSerializer,

--- a/MSAL/src/native_auth/network/MSALNativeAuthRequestParametersKey.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthRequestParametersKey.swift
@@ -28,6 +28,7 @@ enum MSALNativeAuthRequestParametersKey: String {
     case clientId = "client_id"
     case challengeType = "challenge_type"
     case grantType = "grant_type"
+    case id = "id"
     case username
     case email
     case password

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorCodes.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorCodes.swift
@@ -26,7 +26,6 @@
 enum MSALNativeAuthESTSApiErrorCodes: Int {
     case userNotFound = 50034
     case invalidCredentials = 50126
-    case strongAuthRequired = 50076
     case userNotHaveAPassword = 500222
     case invalidRequestParameter = 90100
 }

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
@@ -26,7 +26,6 @@
 enum MSALNativeAuthErrorMessage {
     static let invalidScope = "Invalid scope"
     static let delegateNotImplemented = "MSALNativeAuth has called the delegate method %@ that has not been implemented"
-    static let unsupportedMFA = "MFA currently not supported. Use the browser instead"
     static let browserRequired = "Browser required. Use acquireTokenInteractively instead"
     static let userDoesNotHavePassword = "User does not have password associated with account"
     static let userNotFound = "User does not exist"

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
@@ -34,6 +34,7 @@ enum MSALNativeAuthSubErrorCode: String, Decodable, Equatable, MSALNativeAuthUnk
     case attributeValidationFailed = "attribute_validation_failed"
     case invalidOOBValue = "invalid_oob_value"
     case introspectRequired = "introspect_required"
+    case mfaRequired = "mfa_required"
     case unknown
 
     var isAnyPasswordError: Bool {
@@ -48,6 +49,7 @@ enum MSALNativeAuthSubErrorCode: String, Decodable, Equatable, MSALNativeAuthUnk
         case .attributeValidationFailed,
              .invalidOOBValue,
              .introspectRequired,
+             .mfaRequired,
              .unknown:
             return false
         }

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
@@ -33,6 +33,7 @@ enum MSALNativeAuthSubErrorCode: String, Decodable, Equatable, MSALNativeAuthUnk
     case passwordBanned = "password_banned"
     case attributeValidationFailed = "attribute_validation_failed"
     case invalidOOBValue = "invalid_oob_value"
+    case introspectRequired = "introspect_required"
     case unknown
 
     var isAnyPasswordError: Bool {
@@ -46,6 +47,7 @@ enum MSALNativeAuthSubErrorCode: String, Decodable, Equatable, MSALNativeAuthUnk
             return true
         case .attributeValidationFailed,
              .invalidOOBValue,
+             .introspectRequired,
              .unknown:
             return false
         }

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
@@ -40,8 +40,7 @@ struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
         case errorCodes = "error_codes"
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
-        // DR: check with Mario if suberror or sub_error
-        case subError = "sub_error"
+        case subError = "suberror"
         case correlationId
     }
 

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeResponseError.swift
@@ -31,6 +31,7 @@ struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
     let errorCodes: [Int]?
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
+    let subError: MSALNativeAuthSubErrorCode?
     var correlationId: UUID?
 
     enum CodingKeys: String, CodingKey {
@@ -39,6 +40,8 @@ struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
         case errorCodes = "error_codes"
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
+        // DR: check with Mario if suberror or sub_error
+        case subError = "sub_error"
         case correlationId
     }
 
@@ -48,6 +51,7 @@ struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,
         innerErrors: [MSALNativeAuthInnerError]? = nil,
+        subError: MSALNativeAuthSubErrorCode? = nil,
         correlationId: UUID? = nil
     ) {
         self.error = error
@@ -55,6 +59,7 @@ struct MSALNativeAuthSignInChallengeResponseError: MSALNativeAuthResponseError {
         self.errorCodes = errorCodes
         self.errorURI = errorURI
         self.innerErrors = innerErrors
+        self.subError = subError
         self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift
@@ -20,20 +20,12 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
-enum MSALNativeAuthEndpoint: String, CaseIterable {
-    case signUpStart = "/signup/v1.0/start"
-    case signUpChallenge = "/signup/v1.0/challenge"
-    case signUpContinue = "/signup/v1.0/continue"
-    case signInInitiate = "/oauth2/v2.0/initiate"
-    case signInChallenge = "/oauth2/v2.0/challenge"
-    case signInIntrospect = "/oauth2/v2.0/introspect"
-    case token = "/oauth2/v2.0/token"
-    case resetPasswordStart = "/resetpassword/v1.0/start"
-    case resetPasswordChallenge = "/resetpassword/v1.0/challenge"
-    case resetPasswordContinue = "/resetpassword/v1.0/continue"
-    case resetPasswordComplete = "/resetpassword/v1.0/complete"
-    case resetPasswordSubmit = "/resetpassword/v1.0/submit"
-    case resetpasswordPollCompletion = "/resetpassword/v1.0/poll_completion"
+import Foundation
+
+enum MSALNativeAuthSignInIntrospectOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
+    case invalidRequest = "invalid_request"
+    case expiredToken = "expired_token"
+    case unknown
 }

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInIntrospectResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInIntrospectResponseError.swift
@@ -20,20 +20,41 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
-enum MSALNativeAuthEndpoint: String, CaseIterable {
-    case signUpStart = "/signup/v1.0/start"
-    case signUpChallenge = "/signup/v1.0/challenge"
-    case signUpContinue = "/signup/v1.0/continue"
-    case signInInitiate = "/oauth2/v2.0/initiate"
-    case signInChallenge = "/oauth2/v2.0/challenge"
-    case signInIntrospect = "/oauth2/v2.0/introspect"
-    case token = "/oauth2/v2.0/token"
-    case resetPasswordStart = "/resetpassword/v1.0/start"
-    case resetPasswordChallenge = "/resetpassword/v1.0/challenge"
-    case resetPasswordContinue = "/resetpassword/v1.0/continue"
-    case resetPasswordComplete = "/resetpassword/v1.0/complete"
-    case resetPasswordSubmit = "/resetpassword/v1.0/submit"
-    case resetpasswordPollCompletion = "/resetpassword/v1.0/poll_completion"
+import Foundation
+
+struct MSALNativeAuthSignInIntrospectResponseError: MSALNativeAuthResponseError {
+
+    let error: MSALNativeAuthSignInIntrospectOauth2ErrorCode
+    let errorDescription: String?
+    let errorCodes: [Int]?
+    let errorURI: String?
+    let innerErrors: [MSALNativeAuthInnerError]?
+    var correlationId: UUID?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription = "error_description"
+        case errorCodes = "error_codes"
+        case errorURI = "error_uri"
+        case innerErrors = "inner_errors"
+        case correlationId
+    }
+
+    init(
+        error: MSALNativeAuthSignInIntrospectOauth2ErrorCode = .unknown,
+        errorDescription: String? = nil,
+        errorCodes: [Int]? = nil,
+        errorURI: String? = nil,
+        innerErrors: [MSALNativeAuthInnerError]? = nil,
+        correlationId: UUID? = nil
+    ) {
+        self.error = error
+        self.errorDescription = errorDescription
+        self.errorCodes = errorCodes
+        self.errorURI = errorURI
+        self.innerErrors = innerErrors
+        self.correlationId = correlationId
+    }
 }

--- a/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParameters.swift
@@ -27,6 +27,7 @@
 struct MSALNativeAuthSignInChallengeRequestParameters: MSALNativeAuthRequestable {
     let endpoint: MSALNativeAuthEndpoint = .signInChallenge
     let context: MSALNativeAuthRequestContext
+    let mfaAuthMethodId: String?
     let continuationToken: String
 
     func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
@@ -35,7 +36,8 @@ struct MSALNativeAuthSignInChallengeRequestParameters: MSALNativeAuthRequestable
         return [
             Key.clientId.rawValue: config.clientId,
             Key.continuationToken.rawValue: continuationToken,
-            Key.challengeType.rawValue: config.challengeTypesString
+            Key.challengeType.rawValue: config.challengeTypesString,
+            Key.id.rawValue: mfaAuthMethodId
         ].compactMapValues { $0 }
     }
 }

--- a/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInIntrospectRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInIntrospectRequestParameters.swift
@@ -20,20 +20,21 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
-enum MSALNativeAuthEndpoint: String, CaseIterable {
-    case signUpStart = "/signup/v1.0/start"
-    case signUpChallenge = "/signup/v1.0/challenge"
-    case signUpContinue = "/signup/v1.0/continue"
-    case signInInitiate = "/oauth2/v2.0/initiate"
-    case signInChallenge = "/oauth2/v2.0/challenge"
-    case signInIntrospect = "/oauth2/v2.0/introspect"
-    case token = "/oauth2/v2.0/token"
-    case resetPasswordStart = "/resetpassword/v1.0/start"
-    case resetPasswordChallenge = "/resetpassword/v1.0/challenge"
-    case resetPasswordContinue = "/resetpassword/v1.0/continue"
-    case resetPasswordComplete = "/resetpassword/v1.0/complete"
-    case resetPasswordSubmit = "/resetpassword/v1.0/submit"
-    case resetpasswordPollCompletion = "/resetpassword/v1.0/poll_completion"
+@_implementationOnly import MSAL_Private
+
+struct MSALNativeAuthSignInIntrospectRequestParameters: MSALNativeAuthRequestable {
+    let endpoint: MSALNativeAuthEndpoint = .signInIntrospect
+    let context: MSALNativeAuthRequestContext
+    let continuationToken: String
+
+    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+        typealias Key = MSALNativeAuthRequestParametersKey
+
+        return [
+            Key.clientId.rawValue: config.clientId,
+            Key.continuationToken.rawValue: continuationToken
+        ].compactMapValues { $0 }
+    }
 }

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthInternalAuthenticationMethod.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthInternalAuthenticationMethod.swift
@@ -20,20 +20,14 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
-enum MSALNativeAuthEndpoint: String, CaseIterable {
-    case signUpStart = "/signup/v1.0/start"
-    case signUpChallenge = "/signup/v1.0/challenge"
-    case signUpContinue = "/signup/v1.0/continue"
-    case signInInitiate = "/oauth2/v2.0/initiate"
-    case signInChallenge = "/oauth2/v2.0/challenge"
-    case signInIntrospect = "/oauth2/v2.0/introspect"
-    case token = "/oauth2/v2.0/token"
-    case resetPasswordStart = "/resetpassword/v1.0/start"
-    case resetPasswordChallenge = "/resetpassword/v1.0/challenge"
-    case resetPasswordContinue = "/resetpassword/v1.0/continue"
-    case resetPasswordComplete = "/resetpassword/v1.0/complete"
-    case resetPasswordSubmit = "/resetpassword/v1.0/submit"
-    case resetpasswordPollCompletion = "/resetpassword/v1.0/poll_completion"
+import Foundation
+
+struct MSALNativeAuthInternalAuthenticationMethod: Decodable {
+    // MARK: - Variables
+    let id: String?
+    let challengeType: MSALNativeAuthInternalChallengeType?
+    let challengeChannel: MSALNativeAuthInternalChannelType?
+    let loginHint: String?
 }

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthInternalAuthenticationMethod.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthInternalAuthenticationMethod.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-struct MSALNativeAuthInternalAuthenticationMethod: Decodable {
+struct MSALNativeAuthInternalAuthenticationMethod: Decodable, Equatable {
     // MARK: - Variables
     let id: String
     let challengeType: MSALNativeAuthInternalChallengeType

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInIntrospectResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInIntrospectResponse.swift
@@ -22,7 +22,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-
 import Foundation
 
 struct MSALNativeAuthSignInIntrospectResponse: Decodable, MSALNativeAuthResponseCorrelatable {

--- a/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInIntrospectResponse.swift
+++ b/MSAL/src/native_auth/network/responses/sign_in/MSALNativeAuthSignInIntrospectResponse.swift
@@ -20,20 +20,16 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
-enum MSALNativeAuthEndpoint: String, CaseIterable {
-    case signUpStart = "/signup/v1.0/start"
-    case signUpChallenge = "/signup/v1.0/challenge"
-    case signUpContinue = "/signup/v1.0/continue"
-    case signInInitiate = "/oauth2/v2.0/initiate"
-    case signInChallenge = "/oauth2/v2.0/challenge"
-    case signInIntrospect = "/oauth2/v2.0/introspect"
-    case token = "/oauth2/v2.0/token"
-    case resetPasswordStart = "/resetpassword/v1.0/start"
-    case resetPasswordChallenge = "/resetpassword/v1.0/challenge"
-    case resetPasswordContinue = "/resetpassword/v1.0/continue"
-    case resetPasswordComplete = "/resetpassword/v1.0/complete"
-    case resetPasswordSubmit = "/resetpassword/v1.0/submit"
-    case resetpasswordPollCompletion = "/resetpassword/v1.0/poll_completion"
+
+import Foundation
+
+struct MSALNativeAuthSignInIntrospectResponse: Decodable, MSALNativeAuthResponseCorrelatable {
+
+    // MARK: - Variables
+    let continuationToken: String?
+    let methods: [MSALNativeAuthInternalAuthenticationMethod]?
+    let challengeType: MSALNativeAuthInternalChallengeType?
+    var correlationId: UUID?
 }

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -174,7 +174,11 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
         error: MSALNativeAuthSignInChallengeResponseError) -> MSALNativeAuthSignInChallengeValidatedResponse {
             switch error.error {
             case .invalidRequest:
-                return .error(.invalidRequest(error))
+                if error.subError == .introspectRequired {
+                    return .introspectRequired
+                } else {
+                    return .error(.invalidRequest(error))
+                }
             case .unauthorizedClient:
                 return .error(.unauthorizedClient(error))
             case .invalidGrant:

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -25,17 +25,17 @@
 @_implementationOnly import MSAL_Private
 
 protocol MSALNativeAuthSignInResponseValidating {
-    func validate(
+    func validateInitiate(
         context: MSIDRequestContext,
         result: Result<MSALNativeAuthSignInInitiateResponse, Error>
     ) -> MSALNativeAuthSignInInitiateValidatedResponse
 
-    func validate(
+    func validateChallenge(
         context: MSIDRequestContext,
         result: Result<MSALNativeAuthSignInChallengeResponse, Error>
     ) -> MSALNativeAuthSignInChallengeValidatedResponse
 
-    func validate(
+    func validateIntrospect(
         context: MSIDRequestContext,
         result: Result<MSALNativeAuthSignInIntrospectResponse, Error>
     ) -> MSALNativeAuthSignInIntrospectValidatedResponse
@@ -43,7 +43,7 @@ protocol MSALNativeAuthSignInResponseValidating {
 
 final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseValidating {
 
-    func validate(
+    func validateChallenge(
         context: MSIDRequestContext,
         result: Result<MSALNativeAuthSignInChallengeResponse, Error>
     ) -> MSALNativeAuthSignInChallengeValidatedResponse {
@@ -63,7 +63,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
         }
     }
 
-    func validate(
+    func validateInitiate(
         context: MSIDRequestContext,
         result: Result<MSALNativeAuthSignInInitiateResponse, Error>
     ) -> MSALNativeAuthSignInInitiateValidatedResponse {
@@ -89,7 +89,7 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
         }
     }
 
-    func validate(
+    func validateIntrospect(
         context: any MSIDRequestContext,
         result: Result<MSALNativeAuthSignInIntrospectResponse, any Error>
     ) -> MSALNativeAuthSignInIntrospectValidatedResponse {

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
@@ -27,6 +27,7 @@ import Foundation
 enum MSALNativeAuthSignInChallengeValidatedResponse {
     case codeRequired(continuationToken: String, sentTo: String, channelType: MSALNativeAuthChannelType, codeLength: Int)
     case passwordRequired(continuationToken: String)
+    case introspectRequired
     case error(MSALNativeAuthSignInChallengeValidatedErrorType)
 }
 

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInIntrospectValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInIntrospectValidatedResponse.swift
@@ -24,10 +24,14 @@
 
 import Foundation
 
-struct MSALNativeAuthInternalAuthenticationMethod: Decodable {
-    // MARK: - Variables
-    let id: String
-    let challengeType: MSALNativeAuthInternalChallengeType
-    let challengeChannel: MSALNativeAuthInternalChannelType
-    let loginHint: String
+enum MSALNativeAuthSignInIntrospectValidatedResponse {
+    case authMethodsRetrieved(continuationToken: String, authMethods: [MSALNativeAuthInternalAuthenticationMethod])
+    case error(MSALNativeAuthSignInIntrospectValidatedErrorType)
+}
+
+enum MSALNativeAuthSignInIntrospectValidatedErrorType: Error {
+    case redirect
+    case expiredToken(MSALNativeAuthSignInIntrospectResponseError)
+    case invalidRequest(MSALNativeAuthSignInIntrospectResponseError)
+    case unexpectedError(MSALNativeAuthSignInIntrospectResponseError?)
 }

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -255,7 +255,8 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
                 return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
             }
         case .unknown,
-            .introspectRequired:
+            .introspectRequired,
+            .mfaRequired:
             return .unexpectedError(apiError)
         }
     }

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -254,7 +254,8 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
                 )
                 return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
             }
-        case .unknown:
+        case .unknown,
+            .introspectRequired:
             return .unexpectedError(apiError)
         }
     }

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -103,7 +103,16 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
                 if responseError.subError == .invalidOOBValue {
                     return .error(.invalidOOBCode(responseError))
                 } else if responseError.subError == .mfaRequired {
-                    return .strongAuthRequired(responseError)
+                    guard let continuationToken = responseError.continuationToken else {
+                        MSALLogger.log(
+                            level: .error,
+                            context: context,
+                            format: "Token: MFA required response, expected continuation token not empty")
+                        return .error(.generalError(
+                            MSALNativeAuthTokenResponseError(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)
+                        ))
+                    }
+                    return .strongAuthRequired(continuationToken: continuationToken)
                 } else {
                     return handleInvalidGrantErrorCodes(apiError: responseError, context: context)
                 }

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -102,6 +102,8 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
             case .invalidGrant:
                 if responseError.subError == .invalidOOBValue {
                     return .error(.invalidOOBCode(responseError))
+                } else if responseError.subError == .mfaRequired {
+                    return .strongAuthRequired(responseError)
                 } else {
                     return handleInvalidGrantErrorCodes(apiError: responseError, context: context)
                 }
@@ -194,8 +196,6 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
             return .userNotFound(apiError)
         case .invalidCredentials:
             return .invalidPassword(apiError)
-        case .strongAuthRequired:
-            return .strongAuthRequired(apiError)
         case .userNotHaveAPassword,
              .invalidRequestParameter:
             return .generalError(apiError)
@@ -209,7 +209,6 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
         switch errorCode {
         case .userNotFound,
             .invalidCredentials,
-            .strongAuthRequired,
             .userNotHaveAPassword,
             .invalidRequestParameter:
             return .invalidRequest(apiError)

--- a/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
@@ -26,7 +26,7 @@
 
 enum MSALNativeAuthTokenValidatedResponse {
     case success(MSIDTokenResponse)
-    case strongAuthRequired(MSALNativeAuthTokenResponseError)
+    case strongAuthRequired(continuationToken: String)
     case error(MSALNativeAuthTokenValidatedErrorType)
 }
 

--- a/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/validated_response/MSALNativeAuthTokenValidatedResponse.swift
@@ -26,6 +26,7 @@
 
 enum MSALNativeAuthTokenValidatedResponse {
     case success(MSIDTokenResponse)
+    case strongAuthRequired(MSALNativeAuthTokenResponseError)
     case error(MSALNativeAuthTokenValidatedErrorType)
 }
 
@@ -40,7 +41,6 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
     case invalidPassword(MSALNativeAuthTokenResponseError)
     case invalidOOBCode(MSALNativeAuthTokenResponseError)
     case unsupportedChallengeType(MSALNativeAuthTokenResponseError)
-    case strongAuthRequired(MSALNativeAuthTokenResponseError)
     case invalidScope(MSALNativeAuthTokenResponseError)
     case authorizationPending(MSALNativeAuthTokenResponseError)
     case slowDown(MSALNativeAuthTokenResponseError)
@@ -83,14 +83,6 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
         case .invalidPassword(let apiError):
             return SignInStartError(
                 type: .invalidCredentials,
-                message: apiError.errorDescription,
-                correlationId: correlationId,
-                errorCodes: apiError.errorCodes ?? [],
-                errorUri: apiError.errorURI
-            )
-        case .strongAuthRequired(let apiError):
-            return SignInStartError(
-                type: .browserRequired,
                 message: apiError.errorDescription,
                 correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],
@@ -143,14 +135,6 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
                 errorCodes: apiError.errorCodes ?? [],
                 errorUri: apiError.errorURI
             )
-        case .strongAuthRequired(let apiError):
-            return RetrieveAccessTokenError(
-                type: .browserRequired,
-                message: apiError.errorDescription,
-                correlationId: correlationId,
-                errorCodes: apiError.errorCodes ?? [],
-                errorUri: apiError.errorURI
-            )
         case .userNotFound(let apiError),
              .invalidPassword(let apiError),
              .invalidOOBCode(let apiError):
@@ -170,14 +154,6 @@ enum MSALNativeAuthTokenValidatedErrorType: Error {
         case .invalidOOBCode(let apiError):
             return VerifyCodeError(
                 type: .invalidCode,
-                message: apiError.errorDescription,
-                correlationId: correlationId,
-                errorCodes: apiError.errorCodes ?? [],
-                errorUri: apiError.errorURI
-            )
-        case .strongAuthRequired(let apiError):
-            return VerifyCodeError(
-                type: .browserRequired,
                 message: apiError.errorDescription,
                 correlationId: correlationId,
                 errorCodes: apiError.errorCodes ?? [],

--- a/MSAL/src/native_auth/network/sign_in/MSALNativeAuthSignInRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_in/MSALNativeAuthSignInRequestProvider.swift
@@ -34,6 +34,11 @@ protocol MSALNativeAuthSignInRequestProviding {
         parameters: MSALNativeAuthSignInChallengeRequestParameters,
         context: MSIDRequestContext
     ) throws -> MSIDHttpRequest
+    
+    func introspect(
+        parameters: MSALNativeAuthSignInIntrospectRequestParameters,
+        context: MSIDRequestContext
+    ) throws -> MSIDHttpRequest
 }
 
 final class MSALNativeAuthSignInRequestProvider: MSALNativeAuthSignInRequestProviding {
@@ -76,6 +81,20 @@ final class MSALNativeAuthSignInRequestProvider: MSALNativeAuthSignInRequestProv
 
         let request = MSIDHttpRequest()
         try requestConfigurator.configure(configuratorType: .signIn(.challenge(parameters)),
+                                      request: request,
+                                      telemetryProvider: telemetryProvider)
+        return request
+    }
+    
+    // MARK: - SignIn Introspect
+    
+    func introspect(
+        parameters: MSALNativeAuthSignInIntrospectRequestParameters,
+        context: any MSIDRequestContext
+    ) throws -> MSIDHttpRequest {
+        
+        let request = MSIDHttpRequest()
+        try requestConfigurator.configure(configuratorType: .signIn(.introspect(parameters)),
                                       request: request,
                                       telemetryProvider: telemetryProvider)
         return request

--- a/MSAL/src/native_auth/network/sign_in/MSALNativeAuthSignInRequestProvider.swift
+++ b/MSAL/src/native_auth/network/sign_in/MSALNativeAuthSignInRequestProvider.swift
@@ -34,7 +34,7 @@ protocol MSALNativeAuthSignInRequestProviding {
         parameters: MSALNativeAuthSignInChallengeRequestParameters,
         context: MSIDRequestContext
     ) throws -> MSIDHttpRequest
-    
+
     func introspect(
         parameters: MSALNativeAuthSignInIntrospectRequestParameters,
         context: MSIDRequestContext
@@ -85,14 +85,14 @@ final class MSALNativeAuthSignInRequestProvider: MSALNativeAuthSignInRequestProv
                                       telemetryProvider: telemetryProvider)
         return request
     }
-    
+
     // MARK: - SignIn Introspect
-    
+
     func introspect(
         parameters: MSALNativeAuthSignInIntrospectRequestParameters,
         context: any MSIDRequestContext
     ) throws -> MSIDHttpRequest {
-        
+
         let request = MSIDHttpRequest()
         try requestConfigurator.configure(configuratorType: .signIn(.introspect(parameters)),
                                       request: request,

--- a/MSAL/src/native_auth/telemetry/MSALNativeAuthOperationTypes.swift
+++ b/MSAL/src/native_auth/telemetry/MSALNativeAuthOperationTypes.swift
@@ -41,6 +41,7 @@ enum MSALNativeAuthSignInType: MSALNativeAuthOperationType {
     case signInWithMFA = 1
     case signInInitiate = 2
     case signInChallenge = 3
+    case signInIntrospect = 4
 }
 
 enum MSALNativeAuthTokenType: MSALNativeAuthOperationType {

--- a/MSAL/test/integration/native_auth/common/Model.swift
+++ b/MSAL/test/integration/native_auth/common/Model.swift
@@ -33,6 +33,7 @@ enum MockAPIError: Error {
 enum MockAPIEndpoint: String {
     case signInInitiate = "SignInInitiate"
     case signInChallenge = "SignInChallenge"
+    case signInIntrospect = "SignInIntrospect"
     case signInToken = "SignInToken"
     case signUpStart = "SignUpStart"
     case signUpChallenge = "SignUpChallenge"
@@ -77,6 +78,9 @@ enum MockAPIResponse: String {
     case verificationRequired = "VerificationRequired"
     case attributeValidationFailed = "AttributeValidationFailed"
     case invalidContinuationToken = "InvalidContinuationToken"
+    case signInIntrospectSuccess = "SignInIntrospectSuccess"
+    case mfaRequired = "MFARequired"
+    case introspectRequired = "IntrospectRequired"
     case ssprStartSuccess = "SSPRStartSuccess"
     case ssprContinueSuccess = "SSPRContinueSuccess"
     case ssprSubmitSuccess = "SSPRSubmitSuccess"

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
@@ -40,6 +40,7 @@ class MSALNativeAuthSignInChallengeIntegrationTests: MSALNativeAuthIntegrationBa
         sut = try provider.challenge(
             parameters: .init(
                 context: context,
+                mfaAuthMethodId: nil,
                 continuationToken: "Test Credential Token"
             ),
             context: context

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
@@ -83,6 +83,15 @@ class MSALNativeAuthSignInChallengeIntegrationTests: MSALNativeAuthIntegrationBa
             expectedError: Error(error: .unauthorizedClient, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
         )
     }
+    
+    func test_failRequest_introspectRequired() async throws {
+        let errorResponse = try await perform_testFail(
+            endpoint: .signInChallenge,
+            response: .introspectRequired,
+            expectedError: Error(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, subError: .introspectRequired)
+        )
+        XCTAssertEqual(errorResponse.subError, .introspectRequired)
+    }
 
     func test_failRequest_invalidContinuationToken() async throws {
         try await perform_testFail(

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInIntrospectIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInIntrospectIntegrationTests.swift
@@ -1,0 +1,78 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthSignInIntrospectIntegrationTests: MSALNativeAuthIntegrationBaseTests {
+    private typealias Error = MSALNativeAuthSignInIntrospectResponseError
+    private var provider: MSALNativeAuthSignInRequestProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        provider = MSALNativeAuthSignInRequestProvider(requestConfigurator: MSALNativeAuthRequestConfigurator(config: config))
+
+        let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+
+        sut = try provider.introspect(
+            parameters: .init(
+                context: context,
+                continuationToken: "Test Credential Token"
+            ),
+            context: context
+        )
+    }
+    
+    func test_succeedRequest_challengeTypeRedirect() async throws {
+        try await mockResponse(.challengeTypeRedirect, endpoint: .signInIntrospect)
+        let response: MSALNativeAuthSignInIntrospectResponse? = try await performTestSucceed()
+
+        XCTAssertNil(response?.continuationToken)
+        XCTAssertEqual(response?.challengeType, .redirect)
+    }
+
+    func test_succeedRequest_successfulResult() async throws {
+        try await mockResponse(.signInIntrospectSuccess, endpoint: .signInIntrospect)
+        let response: MSALNativeAuthSignInIntrospectResponse? = try await performTestSucceed()
+
+        XCTAssertNil(response?.continuationToken)
+        guard let firstMethod = response?.methods?.first else {
+            return XCTFail("No authentication method returned")
+        }
+        XCTAssertEqual(firstMethod.id, "1")
+        XCTAssertEqual(firstMethod.challengeChannel, .email)
+        XCTAssertEqual(firstMethod.challengeType, .oob)
+        XCTAssertEqual(firstMethod.loginHint, "us*********com")
+    }
+
+    func test_failRequest_invalidRequest() async throws {
+        try await perform_testFail(
+            endpoint: .signInIntrospect,
+            response: .invalidRequest,
+            expectedError: Error(error: .invalidRequest, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        )
+    }
+}

--- a/MSAL/test/integration/native_auth/requests/token/MSALNativeAuthTokenIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/token/MSALNativeAuthTokenIntegrationTests.swift
@@ -106,6 +106,15 @@ class MSALNativeAuthTokenIntegrationTests: MSALNativeAuthIntegrationBaseTests {
             expectedError: Error(error: .invalidRequest, errorDescription: nil, errorCodes: [55000], errorURI: nil, innerErrors: nil)
         )
     }
+    
+    func test_failRequest_mfaRequired() async throws {
+        let errorResponse = try await perform_testFail(
+            endpoint: .signInToken,
+            response: .mfaRequired,
+            expectedError: Error(error: .invalidGrant, subError: .mfaRequired,  errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil)
+        )
+        XCTAssertEqual(errorResponse.subError, .mfaRequired)
+    }
 
     func test_failRequest_invalidPassword() async throws {
         try await perform_testFail(

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -123,7 +123,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = continuationToken
+        signInRequestProviderMock.expectedContinuationToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -152,7 +152,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = continuationToken
+        signInRequestProviderMock.expectedContinuationToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.password, scope: expectedScopes, password: expectedPassword, oobCode: nil, includeChallengeType: true, refreshToken: nil)
@@ -181,7 +181,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = continuationToken
+        signInRequestProviderMock.expectedContinuationToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -218,7 +218,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = continuationToken
+        signInRequestProviderMock.expectedContinuationToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
@@ -286,38 +286,6 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .invalidCredentials, correlationId: defaultUUID), validatorError: .invalidPassword(signInTokenApiErrorStub))
         await checkDelegateErrorWithValidatorError(delegateError: SignInStartError(type: .generalError, message: "Error message", correlationId: defaultUUID), validatorError: .unexpectedError(.init(errorDescription: "Error message")))
     }
-    
-    func test_whenCredentialsAreRequired_browserRequiredErrorIsReturned() async {
-        let expectedUsername = "username"
-        let expectedPassword = "password"
-        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let continuationToken = "continuationToken"
-
-        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
-        signInResponseValidatorMock.challengeValidatedResponse = .passwordRequired(continuationToken: continuationToken)
-
-        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = continuationToken
-        signInRequestProviderMock.expectedContext = expectedContext
-
-        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
-        tokenRequestProviderMock.expectedCredentialToken = continuationToken
-
-        let expectation = expectation(description: "SignInController")
-
-        let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: .init(type: .browserRequired, message: MSALNativeAuthErrorMessage.unsupportedMFA, correlationId: defaultUUID))
-
-        tokenResponseValidatorMock.tokenValidatedResponse = .error(.strongAuthRequired(.init(error: .unauthorizedClient, subError: nil, errorDescription: MSALNativeAuthErrorMessage.unsupportedMFA, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: nil)))
-
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
-
-        helper.onSignInPasswordError(result)
-
-        await fulfillment(of: [expectation], timeout: 1)
-        checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)
-    }
 
     func test_whenSignInUsingPassword_apiReturnsChallengeTypeOOB_codeRequiredShouldBeCalled() async {
         let expectedUsername = "username"
@@ -336,7 +304,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = continuationToken
+        signInRequestProviderMock.expectedContinuationToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation)
@@ -370,7 +338,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = continuationToken
+        signInRequestProviderMock.expectedContinuationToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation)
@@ -402,7 +370,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = continuationToken
+        signInRequestProviderMock.expectedContinuationToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedSentTo: sentTo, expectedChannelTargetType: channelTargetType, expectedCodeLength: codeLength)
@@ -657,7 +625,6 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, message: "User does not exist", correlationId: defaultUUID), validatorError: .userNotFound(signInTokenApiErrorStub))
         await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidOOBCode(signInTokenApiErrorStub))
         await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .unsupportedChallengeType(signInTokenApiErrorStub))
-        await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .browserRequired, correlationId: defaultUUID), validatorError: .strongAuthRequired(signInTokenApiErrorStub))
         await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .invalidScope(signInTokenApiErrorStub))
         await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .authorizationPending(signInTokenApiErrorStub))
         await checkSubmitPasswordPublicErrorWithTokenValidatorError(publicError: PasswordRequiredError(type: .generalError, correlationId: defaultUUID), validatorError: .slowDown(signInTokenApiErrorStub))
@@ -691,7 +658,6 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .userNotFound(signInTokenApiErrorStub))
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .invalidCode, validatorError: .invalidOOBCode(signInTokenApiErrorStub))
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .unsupportedChallengeType(signInTokenApiErrorStub))
-        checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .browserRequired, validatorError: .strongAuthRequired(signInTokenApiErrorStub))
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .invalidScope(signInTokenApiErrorStub))
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .authorizationPending(signInTokenApiErrorStub))
         checkSubmitCodeDelegateErrorWithTokenValidatorError(delegateError: .generalError, validatorError: .slowDown(signInTokenApiErrorStub))
@@ -710,7 +676,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = continuationToken
+        signInRequestProviderMock.expectedContinuationToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         let helper = SignInResendCodeTestsValidatorHelper(expectation: expectation, expectedSentTo: sentTo, expectedChannelTargetType: channelTargetType, expectedCodeLength: codeLength)
@@ -973,7 +939,7 @@ final class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInRequestProviderMock.mockInitiateRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInRequestProviderMock.mockChallengeRequestFunc((MSALNativeAuthHTTPRequestMock.prepareMockRequest()))
         signInRequestProviderMock.expectedUsername = expectedUsername
-        signInRequestProviderMock.expectedCredentialToken = continuationToken
+        signInRequestProviderMock.expectedContinuationToken = continuationToken
         signInRequestProviderMock.expectedContext = expectedContext
 
         let expectation = expectation(description: "SignInController")

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
@@ -137,11 +137,11 @@ class MSALNativeAuthSignInResponseValidatorMock: MSALNativeAuthSignInResponseVal
     }
     
     private func checkConfAndContext(_ context: MSIDRequestContext, config: MSIDConfiguration? = nil) {
-        if let expectedRequestContext = expectedRequestContext {
+        if let expectedRequestContext {
             XCTAssertEqual(expectedRequestContext.correlationId(), context.correlationId())
             XCTAssertEqual(expectedRequestContext.telemetryRequestId(), context.telemetryRequestId())
         }
-        if let expectedConfiguration = expectedConfiguration {
+        if let expectedConfiguration {
             XCTAssertEqual(expectedConfiguration, config)
         }
     }
@@ -175,11 +175,11 @@ class MSALNativeAuthTokenResponseValidatorMock: MSALNativeAuthTokenResponseValid
     }
 
     private func checkConfAndContext(_ context: MSIDRequestContext, config: MSIDConfiguration? = nil) {
-        if let expectedRequestContext = expectedRequestContext {
+        if let expectedRequestContext {
             XCTAssertEqual(expectedRequestContext.correlationId(), context.correlationId())
             XCTAssertEqual(expectedRequestContext.telemetryRequestId(), context.telemetryRequestId())
         }
-        if let expectedConfiguration = expectedConfiguration {
+        if let expectedConfiguration {
             XCTAssertEqual(expectedConfiguration, config)
         }
     }
@@ -205,11 +205,11 @@ class MSALNativeAuthSignInRequestProviderMock: MSALNativeAuthSignInRequestProvid
     
     func inititate(parameters: MSAL.MSALNativeAuthSignInInitiateRequestParameters, context: MSIDRequestContext) throws -> MSIDHttpRequest {
         checkContext(context)
-        if let expectedUsername = expectedUsername {
+        if let expectedUsername {
             XCTAssertEqual(expectedUsername, parameters.username)
         }
-        if let request = requestInitiate {
-            return request
+        if let requestInitiate {
+            return requestInitiate
         } else if throwingInitError != nil {
             throw throwingInitError!
         } else {
@@ -224,11 +224,11 @@ class MSALNativeAuthSignInRequestProviderMock: MSALNativeAuthSignInRequestProvid
     
     func challenge(parameters: MSAL.MSALNativeAuthSignInChallengeRequestParameters, context: MSIDRequestContext) throws -> MSIDHttpRequest {
         checkContext(context)
-        if let expectedCredentialToken = expectedContinuationToken {
-            XCTAssertEqual(expectedCredentialToken, parameters.continuationToken)
+        if let expectedContinuationToken {
+            XCTAssertEqual(expectedContinuationToken, parameters.continuationToken)
         }
-        if let request = requestChallenge {
-            return request
+        if let requestChallenge {
+            return requestChallenge
         } else if throwingChallengeError != nil {
             throw throwingChallengeError!
         } else {
@@ -238,11 +238,11 @@ class MSALNativeAuthSignInRequestProviderMock: MSALNativeAuthSignInRequestProvid
     
     func introspect(parameters: MSAL.MSALNativeAuthSignInIntrospectRequestParameters, context: any MSIDRequestContext) throws -> MSIDHttpRequest {
         checkContext(context)
-        if let expectedCredentialToken = expectedContinuationToken {
-            XCTAssertEqual(expectedCredentialToken, parameters.continuationToken)
+        if let expectedContinuationToken {
+            XCTAssertEqual(expectedContinuationToken, parameters.continuationToken)
         }
-        if let request = requestIntrospect {
-            return request
+        if let requestIntrospect {
+            return requestIntrospect
         } else if throwingIntrospectError != nil {
             throw throwingIntrospectError!
         } else {
@@ -251,7 +251,7 @@ class MSALNativeAuthSignInRequestProviderMock: MSALNativeAuthSignInRequestProvid
     }
     
     fileprivate func checkContext(_ context: MSIDRequestContext) {
-        if let expectedContext = expectedContext {
+        if let expectedContext {
             XCTAssertEqual(expectedContext.correlationId(), context.correlationId())
         }
     }
@@ -275,7 +275,7 @@ class MSALNativeAuthTokenRequestProviderMock: MSALNativeAuthTokenRequestProvidin
     
     func signInWithPassword(parameters: MSAL.MSALNativeAuthTokenRequestParameters, context: MSIDRequestContext) throws -> MSIDHttpRequest {
         checkContext(context)
-        if let expectedTokenParams = expectedTokenParams {
+        if let expectedTokenParams {
             XCTAssertEqual(expectedTokenParams.username, parameters.username)
             XCTAssertEqual(expectedTokenParams.continuationToken, parameters.continuationToken)
             XCTAssertEqual(expectedTokenParams.continuationToken, parameters.continuationToken)
@@ -285,8 +285,8 @@ class MSALNativeAuthTokenRequestProviderMock: MSALNativeAuthTokenRequestProvidin
             XCTAssertEqual(expectedTokenParams.oobCode, parameters.oobCode)
             XCTAssertEqual(expectedTokenParams.context.correlationId(), parameters.context.correlationId())
         }
-        if let request = requestToken {
-            return request
+        if let requestToken {
+            return requestToken
         } else if throwingTokenError != nil {
             throw throwingTokenError!
         } else {
@@ -301,7 +301,7 @@ class MSALNativeAuthTokenRequestProviderMock: MSALNativeAuthTokenRequestProvidin
     
     func refreshToken(parameters: MSAL.MSALNativeAuthTokenRequestParameters, context: MSIDRequestContext) throws -> MSIDHttpRequest {
         checkContext(context)
-        if let expectedTokenParams = expectedTokenParams {
+        if let expectedTokenParams {
             XCTAssertEqual(expectedTokenParams.username, parameters.username)
             XCTAssertEqual(expectedTokenParams.continuationToken, parameters.continuationToken)
             XCTAssertEqual(expectedTokenParams.continuationToken, parameters.continuationToken)
@@ -311,8 +311,8 @@ class MSALNativeAuthTokenRequestProviderMock: MSALNativeAuthTokenRequestProvidin
             XCTAssertEqual(expectedTokenParams.oobCode, parameters.oobCode)
             XCTAssertEqual(expectedTokenParams.context.correlationId(), parameters.context.correlationId())
         }
-        if let request = requestRefreshToken {
-            return request
+        if let requestRefreshToken {
+            return requestRefreshToken
         } else if throwingRefreshTokenError != nil {
             throw throwingRefreshTokenError!
         } else {
@@ -321,7 +321,7 @@ class MSALNativeAuthTokenRequestProviderMock: MSALNativeAuthTokenRequestProvidin
     }
 
     fileprivate func checkContext(_ context: MSIDRequestContext) {
-        if let expectedContext = expectedContext {
+        if let expectedContext {
             XCTAssertEqual(expectedContext.correlationId(), context.correlationId())
         }
     }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthNetworkMocks.swift
@@ -94,7 +94,7 @@ class MSALNativeAuthSignInResponseValidatorMock: MSALNativeAuthSignInResponseVal
     ))
 
     
-    func validate(context: MSIDRequestContext, result: Result<MSAL.MSALNativeAuthSignInChallengeResponse, Error>) -> MSAL.MSALNativeAuthSignInChallengeValidatedResponse {
+    func validateChallenge(context: MSIDRequestContext, result: Result<MSAL.MSALNativeAuthSignInChallengeResponse, Error>) -> MSAL.MSALNativeAuthSignInChallengeValidatedResponse {
         checkConfAndContext(context)
         if case .success(let successChallengeResponse) = result, let expectedChallengeResponse = expectedChallengeResponse {
             XCTAssertEqual(successChallengeResponse.challengeType, expectedChallengeResponse.challengeType)
@@ -110,7 +110,7 @@ class MSALNativeAuthSignInResponseValidatorMock: MSALNativeAuthSignInResponseVal
         return challengeValidatedResponse
     }
     
-    func validate(context: MSIDRequestContext, result: Result<MSAL.MSALNativeAuthSignInInitiateResponse, Error>) -> MSAL.MSALNativeAuthSignInInitiateValidatedResponse {
+    func validateInitiate(context: MSIDRequestContext, result: Result<MSAL.MSALNativeAuthSignInInitiateResponse, Error>) -> MSAL.MSALNativeAuthSignInInitiateValidatedResponse {
         checkConfAndContext(context)
         if case .success(let successInitiateResponse) = result, let expectedInitiateResponse = expectedInitiateResponse {
             XCTAssertEqual(successInitiateResponse.challengeType, expectedInitiateResponse.challengeType)
@@ -123,7 +123,7 @@ class MSALNativeAuthSignInResponseValidatorMock: MSALNativeAuthSignInResponseVal
         return initiateValidatedResponse
     }
     
-    func validate(context: any MSIDRequestContext, result: Result<MSAL.MSALNativeAuthSignInIntrospectResponse, any Error>) -> MSAL.MSALNativeAuthSignInIntrospectValidatedResponse {
+    func validateIntrospect(context: any MSIDRequestContext, result: Result<MSAL.MSALNativeAuthSignInIntrospectResponse, any Error>) -> MSAL.MSALNativeAuthSignInIntrospectValidatedResponse {
         checkConfAndContext(context)
         if case .success(let successIntrospectResponse) = result, let expectedIntrospectResponse = expectedIntrospectResponse {
             XCTAssertEqual(successIntrospectResponse.challengeType, expectedInitiateResponse?.challengeType)

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthEndpointTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthEndpointTests.swift
@@ -30,7 +30,7 @@ final class MSALNativeAuthEndpointTests: XCTestCase {
     private typealias sut = MSALNativeAuthEndpoint
 
     func test_allEndpoints_are_tested() {
-        XCTAssertEqual(sut.allCases.count, 12)
+        XCTAssertEqual(sut.allCases.count, 13)
     }
 
     func test_signUp_start() {
@@ -51,6 +51,10 @@ final class MSALNativeAuthEndpointTests: XCTestCase {
 
     func test_signInChallenge_endpoint() {
         XCTAssertEqual(sut.signInChallenge.rawValue, "/oauth2/v2.0/challenge")
+    }
+    
+    func test_signInIntrospect_endpoint() {
+        XCTAssertEqual(sut.signInIntrospect.rawValue, "/oauth2/v2.0/introspect")
     }
 
     func test_token_endpoint() {

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
@@ -70,7 +70,8 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
         )
 
         let request = MSIDHttpRequest()
-        let params = MSALNativeAuthSignInChallengeRequestParameters(context: context,
+        let params = MSALNativeAuthSignInChallengeRequestParameters(context: context, 
+                                                                    mfaAuthMethodId: nil,
                                                                     continuationToken: "Test Credential Token")
         let sut = MSALNativeAuthRequestConfigurator(config: config)
         try sut.configure(configuratorType: .signIn(.challenge(params)),

--- a/MSAL/test/unit/native_auth/network/errors/MSALNativeAuthSubErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/MSALNativeAuthSubErrorCodeTests.swift
@@ -29,7 +29,7 @@ final class MSALNativeAuthSubErrorCodeTests: XCTestCase {
     private typealias sut = MSALNativeAuthSubErrorCode
 
     func test_allCases() {
-        XCTAssertEqual(sut.allCases.count, 9)
+        XCTAssertEqual(sut.allCases.count, 11)
     }
 
     func test_passwordTooWeak() {
@@ -62,5 +62,13 @@ final class MSALNativeAuthSubErrorCodeTests: XCTestCase {
 
     func test_invalidOOBValue() {
         XCTAssertEqual(sut.invalidOOBValue.rawValue, "invalid_oob_value")
+    }
+    
+    func test_introspectRequiredValue() {
+        XCTAssertEqual(sut.introspectRequired.rawValue, "introspect_required")
+    }
+    
+    func test_mfaRequiredValue() {
+        XCTAssertEqual(sut.mfaRequired.rawValue, "mfa_required")
     }
 }

--- a/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParametersTest.swift
@@ -39,6 +39,7 @@ final class MSALNativeAuthSignInChallengeRequestParametersTest: XCTestCase {
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], redirectUri: nil))
         let parameters = MSALNativeAuthSignInChallengeRequestParameters(context: MSALNativeAuthRequestContextMock(),
+                                                                        mfaAuthMethodId: nil,
                                                                         continuationToken: "Test Credential Token")
         var resultUrl: URL? = nil
         XCTAssertNoThrow(resultUrl = try parameters.makeEndpointUrl(config: config))
@@ -48,7 +49,8 @@ final class MSALNativeAuthSignInChallengeRequestParametersTest: XCTestCase {
     func test_otpParameters_shouldCreateCorrectBodyRequest() throws {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.otp], redirectUri: nil))
         let params = MSALNativeAuthSignInChallengeRequestParameters(
-            context: context,
+            context: context, 
+            mfaAuthMethodId: nil,
             continuationToken: "Test Credential Token"
         )
 
@@ -67,6 +69,7 @@ final class MSALNativeAuthSignInChallengeRequestParametersTest: XCTestCase {
         XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .redirect], redirectUri: nil))
         let params = MSALNativeAuthSignInChallengeRequestParameters(
             context: context,
+            mfaAuthMethodId: nil,
             continuationToken: "Test Credential Token"
         )
 

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
@@ -46,7 +46,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     func test_whenChallengeTypeRedirect_validationShouldReturnRedirectError() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: nil, challengeType: .redirect, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
-        let result = sut.validate(context: context, result: .success(challengeResponse))
+        let result = sut.validateChallenge(context: context, result: .success(challengeResponse))
         if case .error(.redirect) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
@@ -56,7 +56,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let continuationToken = "continuationToken"
         let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
-        let result = sut.validate(context: context, result: .success(challengeResponse))
+        let result = sut.validateChallenge(context: context, result: .success(challengeResponse))
         if case .passwordRequired(continuationToken: continuationToken) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
@@ -65,7 +65,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     func test_whenChallengeTypePasswordAndNoCredentialToken_validationShouldFail() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: nil, challengeType: .password, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: nil, codeLength: nil, interval: nil)
-        let result = sut.validate(context: context, result: .success(challengeResponse))
+        let result = sut.validateChallenge(context: context, result: .success(challengeResponse))
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
@@ -78,7 +78,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let codeLength = 4
         let channelType = MSALNativeAuthInternalChannelType.email
         let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
-        let result = sut.validate(context: context, result: .success(challengeResponse))
+        let result = sut.validateChallenge(context: context, result: .success(challengeResponse))
         if case .codeRequired(continuationToken: continuationToken, sentTo: targetLabel, channelType: .email, codeLength: codeLength) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
@@ -91,22 +91,22 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let codeLength = 4
         let channelType = MSALNativeAuthInternalChannelType.email
         let missingCredentialToken = MSALNativeAuthSignInChallengeResponse(continuationToken: nil, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: codeLength, interval: nil)
-        var result = sut.validate(context: context, result: .success(missingCredentialToken))
+        var result = sut.validateChallenge(context: context, result: .success(missingCredentialToken))
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
         let missingTargetLabel = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: nil, challengeChannel: channelType, codeLength: codeLength, interval: nil)
-        result = sut.validate(context: context, result: .success(missingTargetLabel))
+        result = sut.validateChallenge(context: context, result: .success(missingTargetLabel))
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
         let missingChannelType = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: nil, codeLength: codeLength, interval: nil)
-        result = sut.validate(context: context, result: .success(missingChannelType))
+        result = sut.validateChallenge(context: context, result: .success(missingChannelType))
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
         let missingCodeLength = MSALNativeAuthSignInChallengeResponse(continuationToken: continuationToken, challengeType: .oob, bindingMethod: nil, challengeTargetLabel: targetLabel, challengeChannel: channelType, codeLength: nil, interval: nil)
-        result = sut.validate(context: context, result: .success(missingCodeLength))
+        result = sut.validateChallenge(context: context, result: .success(missingCodeLength))
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
@@ -115,8 +115,17 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     func test_whenChallengeTypeOTP_validationShouldFail() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: "something", challengeType: .otp, bindingMethod: nil, challengeTargetLabel: "some", challengeChannel: .email, codeLength: 2, interval: nil)
-        let result = sut.validate(context: context, result: .success(challengeResponse))
+        let result = sut.validateChallenge(context: context, result: .success(challengeResponse))
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected challenge type"))) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenIntrospectRequiredError_validationNotFail() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let challengeErrorResponse = MSALNativeAuthSignInChallengeResponseError(error: .invalidRequest, subError: .introspectRequired, correlationId: defaultUUID)
+        let result = sut.validateChallenge(context: context, result: .failure(challengeErrorResponse))
+        if case .introspectRequired = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }
@@ -127,7 +136,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let continuationToken = "continuationToken"
         let initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: continuationToken, challengeType: nil)
-        let result = sut.validate(context: context, result: .success(initiateResponse))
+        let result = sut.validateInitiate(context: context, result: .success(initiateResponse))
         if case .success(continuationToken: continuationToken) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
@@ -136,7 +145,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     func test_whenInitiateResponseIsInvalid_validationShouldFail() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: nil)
-        let result = sut.validate(context: context, result: .success(initiateResponse))
+        let result = sut.validateInitiate(context: context, result: .success(initiateResponse))
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
@@ -145,7 +154,7 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     func test_whenInitiateChallengeTypeIsRedirect_validationShouldReturnRedirectError() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .redirect)
-        let result = sut.validate(context: context, result: .success(initiateResponse))
+        let result = sut.validateInitiate(context: context, result: .success(initiateResponse))
         if case .error(.redirect) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
@@ -154,17 +163,17 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     func test_whenInitiateChallengeTypeIsInvalid_validationShouldFail() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         var initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .oob)
-        var result = sut.validate(context: context, result: .success(initiateResponse))
+        var result = sut.validateInitiate(context: context, result: .success(initiateResponse))
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
         initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .otp)
-        result = sut.validate(context: context, result: .success(initiateResponse))
+        result = sut.validateInitiate(context: context, result: .success(initiateResponse))
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
         initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .password)
-        result = sut.validate(context: context, result: .success(initiateResponse))
+        result = sut.validateInitiate(context: context, result: .success(initiateResponse))
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTest.swift
@@ -192,7 +192,6 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     
     func test_whenIntrospectReturnsInvalidRequest_validationShouldReturnRightError() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let continuationToken = "continuationToken"
         let introspectErrorResponse = MSALNativeAuthSignInIntrospectResponseError(error: .invalidRequest)
         let result = sut.validateIntrospect(context: context, result: .failure(introspectErrorResponse))
         if case .error(.invalidRequest(introspectErrorResponse)) = result {} else {
@@ -202,7 +201,6 @@ final class MSALNativeAuthSignInResponseValidatorTest: MSALNativeAuthTestCase {
     
     func test_whenIntrospectReturnsExpiredToken_validationShouldReturnRightError() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let continuationToken = "continuationToken"
         let introspectErrorResponse = MSALNativeAuthSignInIntrospectResponseError(error: .expiredToken)
         let result = sut.validateIntrospect(context: context, result: .failure(introspectErrorResponse))
         if case .error(.expiredToken(introspectErrorResponse)) = result {} else {

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
@@ -146,10 +146,6 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
         guard case .userNotFound(createError(errorCodes)) = checkErrorCodes() else {
             return XCTFail("Unexpected Error")
         }
-        errorCodes = [MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue, unknownErrorCode1, unknownErrorCode2]
-        guard case .userNotFound(createError(errorCodes)) = checkErrorCodes() else {
-            return XCTFail("Unexpected Error")
-        }
         errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidCredentials.rawValue, unknownErrorCode1, unknownErrorCode2]
         guard case .invalidPassword(createError(errorCodes)) = checkErrorCodes() else {
             return XCTFail("Unexpected Error")

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
@@ -142,12 +142,12 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
         guard case .userNotFound(createError(errorCodes)) = checkErrorCodes() else {
             return XCTFail("Unexpected Error")
         }
-        errorCodes = [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue, unknownErrorCode1, unknownErrorCode2]
-        guard case .strongAuthRequired(createError(errorCodes)) = checkErrorCodes() else {
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .userNotFound(createError(errorCodes)) = checkErrorCodes() else {
             return XCTFail("Unexpected Error")
         }
-        errorCodes = [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue, unknownErrorCode1, unknownErrorCode2]
-        guard case .strongAuthRequired(createError(errorCodes)) = checkErrorCodes() else {
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue, unknownErrorCode1, unknownErrorCode2]
+        guard case .userNotFound(createError(errorCodes)) = checkErrorCodes() else {
             return XCTFail("Unexpected Error")
         }
         errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidCredentials.rawValue, unknownErrorCode1, unknownErrorCode2]
@@ -199,7 +199,7 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
         let unknownErrorCode1 = Int.max
         var errorCodes: [Int] = [unknownErrorCode1]
         checkErrorCodes()
-        errorCodes = [MSALNativeAuthESTSApiErrorCodes.strongAuthRequired.rawValue]
+        errorCodes = [MSALNativeAuthESTSApiErrorCodes.invalidRequestParameter.rawValue]
         checkErrorCodes()
         errorCodes = [MSALNativeAuthESTSApiErrorCodes.userNotFound.rawValue]
         checkErrorCodes()

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenValidatedErrorTypeTests.swift
@@ -147,16 +147,6 @@ final class MSALNativeAuthTokenValidatedErrorTypeTests: XCTestCase {
         XCTAssertEqual(error.errorUri, testErrorUri)
     }
     
-    func test_convertToSignInPasswordStartError_strongAuthRequired() {
-        let error = sut.strongAuthRequired(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
-
-        XCTAssertEqual(error.type, .browserRequired)
-        XCTAssertEqual(error.errorDescription, testDescription)
-        XCTAssertEqual(error.errorCodes, testErrorCodes)
-        XCTAssertEqual(error.correlationId, testCorrelationId)
-        XCTAssertEqual(error.errorUri, testErrorUri)
-    }
-    
     func test_convertToSignInPasswordStartError_invalidScope() {
         let error = sut.invalidScope(apiErrorStub).convertToSignInPasswordStartError(correlationId: testCorrelationId)
 


### PR DESCRIPTION
## Proposed changes

**Do not merge this PR directly on dev.**

What this PR contains:

- Handling of MFA required token response using suberror instead of error code
- Handle Challenge endpoint changes: request and response
- Handle new introspect endpoint: request and response (successful and error)
- New integration tests. Right now, those tests are failing because mock API service has not been updated yet.

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
