### PR TITLE
[macOS SDK] Update to specify macOS minimum version is 10.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ For more information on common usage patterns, error handling and debugging, log
 
 **iOS** - MSAL supports iOS 14 and above.
 
-**macOS** - MSAL supports macOS (OSX) 10.13 and above.
+**macOS** - MSAL supports macOS (OSX) 10.15 and above.
 
 ## Community help and support
 


### PR DESCRIPTION
## Proposed changes

Updated readme to specify macOS minimum version is 10.15

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [x] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

