### PR TITLE
Fix pipeline issue once Swift code is added to Mac target

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -7460,6 +7460,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LLVM_LTO = YES_THIN;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.1.24;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -7481,6 +7482,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LLVM_LTO = YES_THIN;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.1.24;
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
## Proposed changes

Currently the setting for `Link-Time Optimisation` is set to No. 

This setting means - "The compiler will perform optimisations at the compile stage only, resulting in faster builds but potentially less optimised final binaries."

When adding Swift to the `MSAL,framework` macOS target, for `x86_64` architectures, under specific circumstances where the `MSAL.framework` is linked multiple times, the XCode compiler doesn't build the code properly, unless DerivedData is cleared.

Changing the setting to `Incremental` modifies XCode's behaviour and allows proper compilation and linking. The "Incremental LTO can provide many of the same benefits as monolithic LTO, but with reduced build times and resource usage. It’s a good choice for optimizing builds without the overhead of full LTO."

More info on the setting [here](https://developer.apple.com/documentation/xcode/build-settings-reference#Link-Time-Optimization)

This issue is fixed in XCode 16 and the setting can be reverted when this version of Xcode will be used in the pipeline.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

