### PR TITLE
[iOS SDK] Removed version from automation script as it's now present in MSAL.podpsec

### DIFF
--- a/azure_pipelines/automation.yml
+++ b/azure_pipelines/automation.yml
@@ -100,9 +100,9 @@ jobs:
     maxParallel: 2
     matrix:
       STATIC_LIBRARY:
-        args: "--fail-fast --swift-version=5 --allow-warnings --use-static-frameworks"
+        args: "--fail-fast --allow-warnings --use-static-frameworks"
       DYNAMIC_LIBRARY:
-        args: "--fail-fast --swift-version=5 --allow-warnings"
+        args: "--fail-fast --allow-warnings"
   workspace:
     clean: all
   


### PR DESCRIPTION

## Proposed changes

The `swift_versions` has been set in the `MSAL.podspec` but the automation pipeline is failing because it's trying to set `--swift-version=5` which is not the same exact value.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

