### PR TITLE
Add XCPretty to test-with-conf file

### DIFF
--- a/azure_pipelines/templates/tests-with-conf-file.yml
+++ b/azure_pipelines/templates/tests-with-conf-file.yml
@@ -63,8 +63,8 @@ steps:
             -destination '${{ parameters.destination }}' \
             -retry-tests-on-failure \
             -parallel-testing-enabled NO \
-            -resultBundlePath '$(Agent.BuildDirectory)/s/test_output/report.xcresult'      
-
+            -resultBundlePath '$(Agent.BuildDirectory)/s/test_output/report.xcresult'
+            | xcpretty -c
   # https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#q-can-i-delete-pipeline-artifacts-when-re-running-failed-jobs
   - task: PublishPipelineArtifact@1
     condition: succeededOrFailed()


### PR DESCRIPTION
## Proposed changes

Add XCPretty to `xcodebuild test-without-building` command in template tests-with-conf-file.yml

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

