### PR TITLE
Add STS error codes to MSAL public error

### DIFF
--- a/MSAL/src/MSALError.m
+++ b/MSAL/src/MSALError.m
@@ -31,6 +31,7 @@ NSString *MSALErrorDomain = @"MSALErrorDomain";
 NSString *MSALOAuthErrorKey = @"MSALOAuthErrorKey";
 NSString *MSALOAuthSubErrorKey = @"MSALOAuthSubErrorKey";
 NSString *MSALErrorDescriptionKey = @"MSALErrorDescriptionKey";
+NSString *MSALSTSErrorCodesKey = @"MSALSTSErrorCodesKey";
 NSString *MSALInternalErrorCodeKey = @"MSALInternalErrorCodeKey";
 NSString *MSALHTTPHeadersKey = @"MSALHTTPHeadersKey";
 NSString *MSALHTTPResponseCodeKey = @"MSALHTTPResponseCodeKey";

--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -139,6 +139,7 @@ static NSSet *s_recoverableErrorCode;
                              MSIDHTTPResponseCodeKey : MSALHTTPResponseCodeKey,
                              MSIDCorrelationIdKey : MSALCorrelationIDKey,
                              MSIDErrorDescriptionKey : MSALErrorDescriptionKey,
+                             MSIDSTSErrorCodesKey : MSALSTSErrorCodesKey,
                              MSIDOAuthErrorKey: MSALOAuthErrorKey,
                              MSIDOAuthSubErrorKey: MSALOAuthSubErrorKey,
                              MSIDDeclinedScopesKey: MSALDeclinedScopesKey,
@@ -249,8 +250,12 @@ static NSSet *s_recoverableErrorCode;
     if (errorDescription) msalUserInfo[MSALErrorDescriptionKey] = errorDescription;
     if (oauthError) msalUserInfo[MSALOAuthErrorKey] = oauthError;
     if (subError) msalUserInfo[MSALOAuthSubErrorKey] = subError;
-    
-    if (underlyingError) msalUserInfo[NSUnderlyingErrorKey] = [MSALErrorConverter msalErrorFromMsidError:underlyingError];
+        
+    if (underlyingError) {
+        msalUserInfo[NSUnderlyingErrorKey] = [MSALErrorConverter msalErrorFromMsidError:underlyingError];
+        NSArray<NSNumber *>* stsErrorCodes = underlyingError.userInfo[MSIDSTSErrorCodesKey];
+        if (stsErrorCodes) msalUserInfo[MSALSTSErrorCodesKey] = stsErrorCodes;
+    }
     
     msalUserInfo[MSALInternalErrorCodeKey] = internalCode;
 

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -63,6 +63,12 @@ extern NSString *MSALOAuthSubErrorKey;
 extern NSString *MSALErrorDescriptionKey;
 
 /**
+    A list of STS-specific error codes returned by the service that can help in diagnostics. Note that error codes can change and should
+    not be relied upon for any error handling logic.
+ */
+extern NSString *MSALSTSErrorCodesKey;
+
+/**
  Internal error code returned together with MSALErrorInternal error.
  */
 extern NSString *MSALInternalErrorCodeKey;

--- a/MSAL/test/unit/MSALErrorConverterTests.m
+++ b/MSAL/test/unit/MSALErrorConverterTests.m
@@ -89,6 +89,7 @@
     NSUUID *correlationId = [NSUUID UUID];
     NSDictionary *httpHeaders = @{@"fake header key" : @"fake header value"};
     NSString *httpResponseCode = @"-99999";
+    NSArray<NSNumber *> *stsErrorCodes = @[@123];
     
     NSError *msalError = [MSALErrorConverter errorWithDomain:MSIDKeychainErrorDomain
                                                         code:errorCode
@@ -100,6 +101,7 @@
                                                     userInfo:@{MSIDHTTPHeadersKey : httpHeaders,
                                                                MSIDHTTPResponseCodeKey : httpResponseCode,
                                                                MSIDThrottlingCacheHitKey : @1,
+                                                               MSIDSTSErrorCodesKey : stsErrorCodes,
                                                                @"additional_user_info": @"unmapped_userinfo"}
                                               classifyErrors:YES
                                           msalOauth2Provider:nil
@@ -123,6 +125,7 @@
     XCTAssertNil(msalError.userInfo[MSIDHTTPResponseCodeKey]);
     XCTAssertEqualObjects(msalError.userInfo[@"additional_user_info"], @"unmapped_userinfo");
     XCTAssertTrue(msalError.userInfo[MSALThrottlingCacheHitKey]);
+    XCTAssertEqualObjects(msalError.userInfo[MSALSTSErrorCodesKey], stsErrorCodes);
 }
 
 - (void)testErrorConversion_whenUnclassifiedInternalMSALErrorPassed_shouldMapToInternal
@@ -153,6 +156,7 @@
     XCTAssertEqualObjects(msalError.userInfo[MSALOAuthErrorKey], oauthError);
     XCTAssertEqualObjects(msalError.userInfo[MSALOAuthSubErrorKey], subError);
     XCTAssertEqualObjects(msalError.userInfo[MSALInternalErrorCodeKey], @(-42400));
+    XCTAssertFalse([msalError.userInfo.allKeys containsObject: MSALSTSErrorCodesKey]);
 }
 
 - (void)testErrorConversion_whenUnclassifiedInternalMSALErrorPassed_andErrorDescriptionPassedInDictionary_shouldMapToInternal_andPreserveErrorDescription


### PR DESCRIPTION
## Proposed changes

This PR depends on this Identity core change: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1417

Add STS error codes to MSAL public NSError. STS error codes are useful to external developers to diagnose the issue. More info here: https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
