### PR TITLE
Add E2E tests for email OTP MFA feature

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -241,6 +241,10 @@
 		23FB5C1E22542B99002BF1EB /* MSALJsonDeserializable.h in Headers */ = {isa = PBXBuildFile; fileRef = 23FB5C1C22542B99002BF1EB /* MSALJsonDeserializable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		280095EB2C32CAFC00F1653E /* ClientIdType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 280095EA2C32CAFC00F1653E /* ClientIdType.swift */; };
 		2809E8352C3C37B7009F14D7 /* MSALNativeAuthEndToEndPasswordTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2809E8342C3C37B7009F14D7 /* MSALNativeAuthEndToEndPasswordTestCase.swift */; };
+		28188F622C8F48BD00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28188F5F2C8F482D00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift */; };
+		28188F632C8F48BD00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28188F5F2C8F482D00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift */; };
+		28188F652C8F4C1100CFDD05 /* MFADelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28188F642C8F4C1100CFDD05 /* MFADelegateSpies.swift */; };
+		28188F662C8F4C1100CFDD05 /* MFADelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28188F642C8F4C1100CFDD05 /* MFADelegateSpies.swift */; };
 		281A0E0C2C21E1F000CB30CB /* MSALNativeAuthSignUpUsernameEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E272C4EA2A4447520013B805 /* MSALNativeAuthSignUpUsernameEndToEndTests.swift */; };
 		281A0E142C21E1F200CB30CB /* MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26E391A2A4C2BE200063C07 /* MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift */; };
 		281A0E152C21E1F500CB30CB /* SignUpDelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26E39232A4C2D7400063C07 /* SignUpDelegateSpies.swift */; };
@@ -1968,6 +1972,8 @@
 		23FB5C1C22542B99002BF1EB /* MSALJsonDeserializable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALJsonDeserializable.h; sourceTree = "<group>"; };
 		280095EA2C32CAFC00F1653E /* ClientIdType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientIdType.swift; sourceTree = "<group>"; };
 		2809E8342C3C37B7009F14D7 /* MSALNativeAuthEndToEndPasswordTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthEndToEndPasswordTestCase.swift; sourceTree = "<group>"; };
+		28188F5F2C8F482D00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInWithMFAEndToEndTests.swift; sourceTree = "<group>"; };
+		28188F642C8F4C1100CFDD05 /* MFADelegateSpies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFADelegateSpies.swift; sourceTree = "<group>"; };
 		282693272A0974740037B93A /* MSALNativeAuthTokenRequestParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenRequestParameters.swift; sourceTree = "<group>"; };
 		2826933A2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInParameters.swift; sourceTree = "<group>"; };
 		285D0D682B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenResult.swift; sourceTree = "<group>"; };
@@ -2828,6 +2834,15 @@
 			path = controllers;
 			sourceTree = "<group>";
 		};
+		28188F572C8F480300CFDD05 /* mfa */ = {
+			isa = PBXGroup;
+			children = (
+				28188F5F2C8F482D00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift */,
+				28188F642C8F4C1100CFDD05 /* MFADelegateSpies.swift */,
+			);
+			path = mfa;
+			sourceTree = "<group>";
+		};
 		282693392A0B98490037B93A /* sign_in */ = {
 			isa = PBXGroup;
 			children = (
@@ -3297,6 +3312,7 @@
 		9B5D6D042A3CA0C600521576 /* end_to_end */ = {
 			isa = PBXGroup;
 			children = (
+				28188F572C8F480300CFDD05 /* mfa */,
 				28A277D02C22ED2A00D95E00 /* otp_code_retriever */,
 				E272C4E92A4447520013B805 /* sign_up */,
 				9B235DA22A3D15E400657331 /* sign_in */,
@@ -6175,9 +6191,11 @@
 				28A277D92C22ED5E00D95E00 /* MSALNativeAuthEmailCodeRetriever.swift in Sources */,
 				E24CE9CC2C57F1160069E2E4 /* AttributesStub.swift in Sources */,
 				281A0E1B2C21E20600CB30CB /* MSALNativeAuthEndToEndBaseTestCase.swift in Sources */,
+				28188F652C8F4C1100CFDD05 /* MFADelegateSpies.swift in Sources */,
 				281A0E192C21E20000CB30CB /* MSALNativeAuthResetPasswordEndToEndTests.swift in Sources */,
 				281A0E0C2C21E1F000CB30CB /* MSALNativeAuthSignUpUsernameEndToEndTests.swift in Sources */,
 				281A0E152C21E1F500CB30CB /* SignUpDelegateSpies.swift in Sources */,
+				28188F622C8F48BD00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift in Sources */,
 				281A0E172C21E1FB00CB30CB /* MSALNativeAuthSignInUsernameEndToEndTests.swift in Sources */,
 				281A0E1C2C21E3A400CB30CB /* MSALNativeAuthSignOutEndToEndTests.swift in Sources */,
 				281A0E162C21E1F800CB30CB /* MSALNativeAuthSignInUsernameAndPasswordEndToEndTests.swift in Sources */,
@@ -7192,9 +7210,11 @@
 				DE1BD1072C3C284C00B0888E /* MSALNativeAuthResetPasswordEndToEndTests.swift in Sources */,
 				DE9EB8622C5CE44B00328AA4 /* AttributesStub.swift in Sources */,
 				DE1BD1012C3C283C00B0888E /* MSALNativeAuthSignUpUsernameEndToEndTests.swift in Sources */,
+				28188F662C8F4C1100CFDD05 /* MFADelegateSpies.swift in Sources */,
 				DE1BD1032C3C284100B0888E /* SignUpDelegateSpies.swift in Sources */,
 				DE1BD1092C3C285D00B0888E /* MSALNativeAuthSignOutEndToEndTests.swift in Sources */,
 				DE1BD1052C3C284700B0888E /* MSALNativeAuthSignInUsernameEndToEndTests.swift in Sources */,
+				28188F632C8F48BD00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift in Sources */,
 				DE1BD1002C3C283900B0888E /* MSALNativeAuthEmailCodeRetriever.swift in Sources */,
 				DE1BD1042C3C284400B0888E /* MSALNativeAuthSignInUsernameAndPasswordEndToEndTests.swift in Sources */,
 				DE1BD1022C3C283F00B0888E /* MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift in Sources */,

--- a/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
@@ -34,6 +34,7 @@ class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
         static let clientIdEmailCodeAttributesKey = "email_code_attributes_client_id"
         static let tenantSubdomainKey = "tenant_subdomain"
         static let signInEmailPasswordUsernameKey = "sign_in_email_password_username"
+        static let signInEmailPasswordMFAUsernameKey = "sign_in_email_password_mfa_username"
         static let signInEmailCodeUsernameKey = "sign_in_email_code_username"
         static let resetPasswordUsernameKey = "reset_password_username"
     }
@@ -93,6 +94,10 @@ class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
 
     func retrieveUsernameForSignInUsernameAndPassword() -> String? {
         return MSALNativeAuthEndToEndBaseTestCase.nativeAuthConfFileContent?[Constants.signInEmailPasswordUsernameKey]
+    }
+    
+    func retrieveUsernameForSignInUsernamePasswordAndMFA() -> String? {
+        return MSALNativeAuthEndToEndBaseTestCase.nativeAuthConfFileContent?[Constants.signInEmailPasswordMFAUsernameKey]
     }
     
     func retrieveUsernameForResetPassword() -> String? {

--- a/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
@@ -35,6 +35,7 @@ class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
         static let tenantSubdomainKey = "tenant_subdomain"
         static let signInEmailPasswordUsernameKey = "sign_in_email_password_username"
         static let signInEmailPasswordMFAUsernameKey = "sign_in_email_password_mfa_username"
+        static let signInEmailPasswordMFANoDefaultAuthMethodUsernameKey = "sign_in_email_password_mfa_no_default_username"
         static let signInEmailCodeUsernameKey = "sign_in_email_code_username"
         static let resetPasswordUsernameKey = "reset_password_username"
     }
@@ -98,6 +99,10 @@ class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
     
     func retrieveUsernameForSignInUsernamePasswordAndMFA() -> String? {
         return MSALNativeAuthEndToEndBaseTestCase.nativeAuthConfFileContent?[Constants.signInEmailPasswordMFAUsernameKey]
+    }
+    
+    func retrieveUsernameForSignInUsernamePasswordAndMFANoDefaultAuthMethod() -> String? {
+        return MSALNativeAuthEndToEndBaseTestCase.nativeAuthConfFileContent?[Constants.signInEmailPasswordMFANoDefaultAuthMethodUsernameKey]
     }
     
     func retrieveUsernameForResetPassword() -> String? {

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MFADelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MFADelegateSpies.swift
@@ -87,6 +87,7 @@ final class MFASubmitChallengeDelegateSpy: MFASubmitChallengeDelegate {
     
     func onMFASubmitChallengeError(error: MSAL.MFASubmitChallengeError, newState: MSAL.MFARequiredState?) {
         onMFASubmitChallengeErrorCalled = true
+        self.newStateMFARequiredState = newState
         self.error = error
 
         expectation.fulfill()

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MFADelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MFADelegateSpies.swift
@@ -76,7 +76,7 @@ final class MFASubmitChallengeDelegateSpy: MFASubmitChallengeDelegate {
     
     private let expectation: XCTestExpectation
     private(set) var onSignInCompletedCalled = false
-    private(set) var onMFASubmitChallengeError = false
+    private(set) var onMFASubmitChallengeErrorCalled = false
     private(set) var error: MSAL.MFASubmitChallengeError?
     private(set) var result: MSAL.MSALNativeAuthUserAccountResult?
     private(set) var newStateMFARequiredState: MSAL.MFARequiredState?
@@ -86,7 +86,7 @@ final class MFASubmitChallengeDelegateSpy: MFASubmitChallengeDelegate {
     }
     
     func onMFASubmitChallengeError(error: MSAL.MFASubmitChallengeError, newState: MSAL.MFARequiredState?) {
-        onMFASubmitChallengeError = true
+        onMFASubmitChallengeErrorCalled = true
         self.error = error
 
         expectation.fulfill()
@@ -96,6 +96,35 @@ final class MFASubmitChallengeDelegateSpy: MFASubmitChallengeDelegate {
         onSignInCompletedCalled = true
         self.result = result
 
+        expectation.fulfill()
+    }
+}
+
+final class MFAGetAuthMethodsDelegateSpy: MFAGetAuthMethodsDelegate {
+    
+    private let expectation: XCTestExpectation
+    private(set) var onSelectionRequiredCalled = false
+    private(set) var onMFAGetAuthMethodsErrorCalled = false
+    private(set) var authMethods: [MSALAuthMethod]?
+    private(set) var error: MSAL.MFAError?
+    private(set) var newStateMFARequired: MSAL.MFARequiredState?
+    
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+    
+    func onMFAGetAuthMethodsError(error: MSAL.MFAError, newState: MSAL.MFARequiredState?) {
+        onMFAGetAuthMethodsErrorCalled = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+    
+    func onMFAGetAuthMethodsSelectionRequired(authMethods: [MSALAuthMethod], newState: MFARequiredState) {
+        onSelectionRequiredCalled = true
+        self.newStateMFARequired = newState
+        self.authMethods = authMethods
+        
         expectation.fulfill()
     }
 }

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MFADelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MFADelegateSpies.swift
@@ -1,0 +1,101 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import Foundation
+import XCTest
+import MSAL
+
+class MFARequestChallengeDelegateSpy: MFARequestChallengeDelegate {
+    
+    private let expectation: XCTestExpectation
+    private(set) var onMFARequestChallengeError = false
+    private(set) var error: MSAL.MFAError?
+    
+    private(set) var onVerificationRequiredCalled = false
+    private(set) var newStateMFARequired: MSAL.MFARequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSAL.MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+    
+    private(set) var onSelectionRequiredCalled = false
+    private(set) var authMethods: [MSALAuthMethod]?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+    
+    func onMFARequestChallengeError(error: MSAL.MFAError, newState: MSAL.MFARequiredState?) {
+        onMFARequestChallengeError = true
+        self.newStateMFARequired = newState
+        self.error = error
+
+        expectation.fulfill()
+    }
+    
+    func onMFARequestChallengeSelectionRequired(authMethods: [MSALAuthMethod], newState: MFARequiredState) {
+        onSelectionRequiredCalled = true
+        self.newStateMFARequired = newState
+        self.authMethods = authMethods
+        
+        expectation.fulfill()
+    }
+    
+    func onMFARequestChallengeVerificationRequired(newState: MFARequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        onVerificationRequiredCalled = true
+        self.newStateMFARequired = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        expectation.fulfill()
+    }
+}
+
+final class MFASubmitChallengeDelegateSpy: MFASubmitChallengeDelegate {
+    
+    private let expectation: XCTestExpectation
+    private(set) var onSignInCompletedCalled = false
+    private(set) var onMFASubmitChallengeError = false
+    private(set) var error: MSAL.MFASubmitChallengeError?
+    private(set) var result: MSAL.MSALNativeAuthUserAccountResult?
+    private(set) var newStateMFARequiredState: MSAL.MFARequiredState?
+    
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+    
+    func onMFASubmitChallengeError(error: MSAL.MFASubmitChallengeError, newState: MSAL.MFARequiredState?) {
+        onMFASubmitChallengeError = true
+        self.error = error
+
+        expectation.fulfill()
+    }
+    
+    func onSignInCompleted(result: MSALNativeAuthUserAccountResult) {
+        onSignInCompletedCalled = true
+        self.result = result
+
+        expectation.fulfill()
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
@@ -1,0 +1,82 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import Foundation
+import XCTest
+
+final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPasswordTestCase {
+
+    func test_signInUsingPasswordWithMFA_completeSuccessfully() async throws {
+        guard let sut = initialisePublicClientApplication(), 
+                let username = retrieveUsernameForSignInUsernamePasswordAndMFA(),
+                let password = await retrievePasswordForSignInUsername()
+        else {
+            XCTFail("Missing information")
+            return
+        }
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+        
+        guard signInDelegateSpy.onSignInAwaitingMFACalled, let awaitingMFAState = signInDelegateSpy.newStateAwaitingMFA else {
+            XCTFail("Awaiting MFA not called")
+            return
+        }
+        
+        // Request to send challenge to the default strong auth method
+        let mfaExpectation = expectation(description: "mfa")
+        let mfaDelegateSpy = MFARequestChallengeDelegateSpy(expectation: mfaExpectation)
+        
+        awaitingMFAState.requestChallenge(delegate: mfaDelegateSpy)
+        
+        await fulfillment(of: [signInExpectation])
+        
+        guard mfaDelegateSpy.onVerificationRequiredCalled, let mfaRequiredState = mfaDelegateSpy.newStateMFARequired else {
+            XCTFail("Challenge not sent to MFA method")
+            return
+        }
+
+        // Now submit the email OTP code
+        guard let code = await retrieveCodeFor(email: username) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+
+        let submitChallengeExpectation = expectation(description: "submitChallenge")
+        let mfaSubmitChallengeDelegateSpy = MFASubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
+
+        mfaRequiredState.submitChallenge(challenge: code, delegate: mfaSubmitChallengeDelegateSpy)
+
+        await fulfillment(of: [submitChallengeExpectation])
+
+        XCTAssertTrue(mfaSubmitChallengeDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result)
+        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result?.idToken)
+        XCTAssertEqual(mfaSubmitChallengeDelegateSpy.result?.account.username, username)
+    }
+
+}

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
@@ -82,7 +82,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         }
 
         // Now retrieve and submit the email OTP code
-        await retrieveAndSubmitCode(state: mfaRequiredState, username: username)
+        await completeSignInWithMFAFlow(state: mfaRequiredState, username: username)
     }
     
     func test_signInUsingPasswordWithMFAGetAuthMethods_thenCompleteSuccessfully() async throws {
@@ -138,7 +138,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         }
         
         // Now retrieve and submit the email OTP code
-        await retrieveAndSubmitCode(state: mfaRequiredState, username: username)
+        await completeSignInWithMFAFlow(state: mfaRequiredState, username: username)
     }
     
     func test_signInUsingPasswordWithMFANoDefaultAuthMethod_completeSuccessfully() async throws {
@@ -180,13 +180,13 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         }
         
         // Now retrieve and submit the email OTP code
-        await retrieveAndSubmitCode(state: mfaRequiredState, username: username)
+        await completeSignInWithMFAFlow(state: mfaRequiredState, username: username)
     }
     
     // MARK: private methods
     
     private func signInUsernameAndPassword(username: String, password: String) async -> AwaitingMFAState? {
-        guard let sut = initialisePublicClientApplication()
+        guard let application = initialisePublicClientApplication()
         else {
             XCTFail("Missing information")
             return nil
@@ -194,7 +194,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         let signInExpectation = expectation(description: "signing in")
         let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
 
-        sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
+        application.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
 
         await fulfillment(of: [signInExpectation])
         
@@ -205,7 +205,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         return awaitingMFAState
     }
     
-    private func retrieveAndSubmitCode(state: MFARequiredState, username: String) async {
+    private func completeSignInWithMFAFlow(state: MFARequiredState, username: String) async {
         guard let code = await retrieveCodeFor(email: username) else {
             XCTFail("OTP code could not be retrieved")
             return

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
@@ -55,7 +55,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         let submitWrongChallengeExpectation = expectation(description: "submitChallenge")
         let mfaSubmitWrongChallengeDelegateSpy = MFASubmitChallengeDelegateSpy(expectation: submitWrongChallengeExpectation)
 
-        mfaRequiredState.submitChallenge(challenge: "000000", delegate: mfaSubmitWrongChallengeDelegateSpy)
+        mfaRequiredState.submitChallenge(challenge: "wrong_code", delegate: mfaSubmitWrongChallengeDelegateSpy)
 
         await fulfillment(of: [submitWrongChallengeExpectation])
 

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
@@ -29,7 +29,7 @@ import MSAL
 final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPasswordTestCase {
 
     func test_signInUsingPasswordWithMFASubmitWrongChallengeResendChallengeThen_completeSuccessfully() async throws {
-        XCTSkip("Missing username for MFA user")
+        throw XCTSkip("Missing username for MFA user")
         guard let username = retrieveUsernameForSignInUsernamePasswordAndMFA(), 
                 let password = await retrievePasswordForSignInUsername(),
                 let awaitingMFAState = await signInUsernameAndPassword(username: username, password: password)
@@ -101,7 +101,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
     }
     
     func test_signInUsingPasswordWithMFAGetAuthMethods_thenCompleteSuccessfully() async throws {
-        XCTSkip("Missing username for MFA user")
+        throw XCTSkip("Missing username for MFA user")
         guard let sut = initialisePublicClientApplication(),
               let username = retrieveUsernameForSignInUsernamePasswordAndMFA(),
               let password = await retrievePasswordForSignInUsername(),
@@ -173,7 +173,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
     }
     
     func test_signInUsingPasswordWithMFANoDefaultAuthMethod_completeSuccessfully() async throws {
-        XCTSkip("Missing username for MFA user with no default auth method")
+        throw XCTSkip("Missing username for MFA user with no default auth method")
         guard let username = retrieveUsernameForSignInUsernamePasswordAndMFANoDefaultAuthMethod(),
                 let password = await retrievePasswordForSignInUsername(),
                 let awaitingMFAState = await signInUsernameAndPassword(username: username, password: password)

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
@@ -82,28 +82,12 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         }
 
         // Now retrieve and submit the email OTP code
-        guard let code = await retrieveCodeFor(email: username) else {
-            XCTFail("OTP code could not be retrieved")
-            return
-        }
-
-        let submitChallengeExpectation = expectation(description: "submitChallenge")
-        let mfaSubmitChallengeDelegateSpy = MFASubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
-
-        mfaRequiredState.submitChallenge(challenge: code, delegate: mfaSubmitChallengeDelegateSpy)
-
-        await fulfillment(of: [submitChallengeExpectation])
-
-        XCTAssertTrue(mfaSubmitChallengeDelegateSpy.onSignInCompletedCalled)
-        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result)
-        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result?.idToken)
-        XCTAssertEqual(mfaSubmitChallengeDelegateSpy.result?.account.username, username)
+        await retrieveAndSubmitCode(state: mfaRequiredState, username: username)
     }
     
     func test_signInUsingPasswordWithMFAGetAuthMethods_thenCompleteSuccessfully() async throws {
         throw XCTSkip("Missing username for MFA user")
-        guard let sut = initialisePublicClientApplication(),
-              let username = retrieveUsernameForSignInUsernamePasswordAndMFA(),
+        guard let username = retrieveUsernameForSignInUsernamePasswordAndMFA(),
               let password = await retrievePasswordForSignInUsername(),
               let awaitingMFAState = await signInUsernameAndPassword(username: username, password: password)
         else {
@@ -153,23 +137,8 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
             return
         }
         
-        // Now submit the email OTP code
-        guard let code = await retrieveCodeFor(email: username) else {
-            XCTFail("OTP code could not be retrieved")
-            return
-        }
-
-        let submitChallengeExpectation = expectation(description: "submitChallenge")
-        let mfaSubmitChallengeDelegateSpy = MFASubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
-
-        mfaRequiredState.submitChallenge(challenge: code, delegate: mfaSubmitChallengeDelegateSpy)
-
-        await fulfillment(of: [submitChallengeExpectation])
-
-        XCTAssertTrue(mfaSubmitChallengeDelegateSpy.onSignInCompletedCalled)
-        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result)
-        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result?.idToken)
-        XCTAssertEqual(mfaSubmitChallengeDelegateSpy.result?.account.username, username)
+        // Now retrieve and submit the email OTP code
+        await retrieveAndSubmitCode(state: mfaRequiredState, username: username)
     }
     
     func test_signInUsingPasswordWithMFANoDefaultAuthMethod_completeSuccessfully() async throws {
@@ -210,23 +179,8 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
             return
         }
         
-        // Now submit the email OTP code
-        guard let code = await retrieveCodeFor(email: username) else {
-            XCTFail("OTP code could not be retrieved")
-            return
-        }
-
-        let submitChallengeExpectation = expectation(description: "submitChallenge")
-        let mfaSubmitChallengeDelegateSpy = MFASubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
-
-        mfaRequiredState.submitChallenge(challenge: code, delegate: mfaSubmitChallengeDelegateSpy)
-
-        await fulfillment(of: [submitChallengeExpectation])
-
-        XCTAssertTrue(mfaSubmitChallengeDelegateSpy.onSignInCompletedCalled)
-        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result)
-        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result?.idToken)
-        XCTAssertEqual(mfaSubmitChallengeDelegateSpy.result?.account.username, username)
+        // Now retrieve and submit the email OTP code
+        await retrieveAndSubmitCode(state: mfaRequiredState, username: username)
     }
     
     // MARK: private methods
@@ -249,5 +203,24 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
             return nil
         }
         return awaitingMFAState
+    }
+    
+    private func retrieveAndSubmitCode(state: MFARequiredState, username: String) async {
+        guard let code = await retrieveCodeFor(email: username) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+
+        let submitChallengeExpectation = expectation(description: "submitChallenge")
+        let mfaSubmitChallengeDelegateSpy = MFASubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
+
+        state.submitChallenge(challenge: code, delegate: mfaSubmitChallengeDelegateSpy)
+
+        await fulfillment(of: [submitChallengeExpectation])
+
+        XCTAssertTrue(mfaSubmitChallengeDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result)
+        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result?.idToken)
+        XCTAssertEqual(mfaSubmitChallengeDelegateSpy.result?.account.username, username)
     }
 }

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
@@ -24,26 +24,17 @@
 
 import Foundation
 import XCTest
+import MSAL
 
 final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPasswordTestCase {
 
     func test_signInUsingPasswordWithMFA_completeSuccessfully() async throws {
-        guard let sut = initialisePublicClientApplication(), 
-                let username = retrieveUsernameForSignInUsernamePasswordAndMFA(),
-                let password = await retrievePasswordForSignInUsername()
+        XCTSkip("Missing username for MFA user")
+        guard let username = retrieveUsernameForSignInUsernamePasswordAndMFA(), 
+                let password = await retrievePasswordForSignInUsername(),
+                let awaitingMFAState = await signInUsernameAndPassword(username: username, password: password)
         else {
-            XCTFail("Missing information")
-            return
-        }
-        let signInExpectation = expectation(description: "signing in")
-        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
-
-        sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
-
-        await fulfillment(of: [signInExpectation])
-        
-        guard signInDelegateSpy.onSignInAwaitingMFACalled, let awaitingMFAState = signInDelegateSpy.newStateAwaitingMFA else {
-            XCTFail("Awaiting MFA not called")
+            XCTFail("Something went wrong")
             return
         }
         
@@ -53,7 +44,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         
         awaitingMFAState.requestChallenge(delegate: mfaDelegateSpy)
         
-        await fulfillment(of: [signInExpectation])
+        await fulfillment(of: [mfaExpectation])
         
         guard mfaDelegateSpy.onVerificationRequiredCalled, let mfaRequiredState = mfaDelegateSpy.newStateMFARequired else {
             XCTFail("Challenge not sent to MFA method")
@@ -77,6 +68,136 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result)
         XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result?.idToken)
         XCTAssertEqual(mfaSubmitChallengeDelegateSpy.result?.account.username, username)
+    }
+    
+    func test_signInUsingPasswordWithMFASendWrongChallenge_returnExpectedError() async throws {
+        XCTSkip("Missing username for MFA user")
+        guard let sut = initialisePublicClientApplication(),
+              let username = retrieveUsernameForSignInUsernamePasswordAndMFA(),
+              let password = await retrievePasswordForSignInUsername(),
+              let awaitingMFAState = await signInUsernameAndPassword(username: username, password: password)
+        else {
+            XCTFail("Something went wrong")
+            return
+        }
+        
+        // Request to send challenge to the default strong auth method
+        let mfaExpectation = expectation(description: "mfa")
+        let mfaDelegateSpy = MFARequestChallengeDelegateSpy(expectation: mfaExpectation)
+        
+        awaitingMFAState.requestChallenge(delegate: mfaDelegateSpy)
+        
+        await fulfillment(of: [mfaExpectation])
+        
+        guard mfaDelegateSpy.onVerificationRequiredCalled, let mfaRequiredState = mfaDelegateSpy.newStateMFARequired else {
+            XCTFail("Challenge not sent to MFA method")
+            return
+        }
+
+        // Now submit the wrong email OTP code
+        let submitChallengeExpectation = expectation(description: "submitChallenge")
+        let mfaSubmitChallengeDelegateSpy = MFASubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
+
+        mfaRequiredState.submitChallenge(challenge: "000000", delegate: mfaSubmitChallengeDelegateSpy)
+
+        await fulfillment(of: [submitChallengeExpectation])
+
+        XCTAssertTrue(mfaSubmitChallengeDelegateSpy.onMFASubmitChallengeErrorCalled)
+        XCTAssertEqual(mfaSubmitChallengeDelegateSpy.error?.isInvalidChallenge, true)
+    }
+    
+    func test_signInUsingPasswordWithMFAGetAuthMethods_thenCompleteSuccessfully() async throws {
+        XCTSkip("Missing username for MFA user")
+        guard let sut = initialisePublicClientApplication(),
+              let username = retrieveUsernameForSignInUsernamePasswordAndMFA(),
+              let password = await retrievePasswordForSignInUsername(),
+              let awaitingMFAState = await signInUsernameAndPassword(username: username, password: password)
+        else {
+            XCTFail("Something went wrong")
+            return
+        }
+        
+        // Request to send challenge to the default strong auth method
+        let mfaExpectation = expectation(description: "mfa")
+        let mfaDelegateSpy = MFARequestChallengeDelegateSpy(expectation: mfaExpectation)
+        
+        awaitingMFAState.requestChallenge(delegate: mfaDelegateSpy)
+        
+        await fulfillment(of: [mfaExpectation])
+        
+        guard mfaDelegateSpy.onVerificationRequiredCalled, let mfaRequiredState = mfaDelegateSpy.newStateMFARequired else {
+            XCTFail("Challenge not sent to MFA method")
+            return
+        }
+
+        // Now retrieve the list of auth methods
+        let getAuthMethodsExpectation = expectation(description: "getAuthmethods")
+        let mfaGetAuthMethodsDelegateSpy = MFAGetAuthMethodsDelegateSpy(expectation: getAuthMethodsExpectation)
+
+        mfaRequiredState.getAuthMethods(delegate: mfaGetAuthMethodsDelegateSpy)
+
+        await fulfillment(of: [getAuthMethodsExpectation])
+
+        guard let authMethod = mfaGetAuthMethodsDelegateSpy.authMethods?.first, let mfaRequiredState = mfaGetAuthMethodsDelegateSpy.newStateMFARequired else {
+            XCTFail("No MFA auth methods returned")
+            return
+        }
+        
+        XCTAssertTrue(authMethod.channelTargetType.isEmailType)
+        XCTAssertTrue(mfaGetAuthMethodsDelegateSpy.onSelectionRequiredCalled)
+        
+        // Request to send challenge to a specific strong auth method
+        
+        let mfaSendChallengeExpectation = expectation(description: "mfa")
+        let mfaSendChallengeDelegateSpy = MFARequestChallengeDelegateSpy(expectation: mfaSendChallengeExpectation)
+        mfaRequiredState.requestChallenge(authMethod: authMethod, delegate: mfaSendChallengeDelegateSpy)
+        
+        await fulfillment(of: [mfaSendChallengeExpectation])
+        
+        guard mfaSendChallengeDelegateSpy.onVerificationRequiredCalled, let mfaRequiredState = mfaSendChallengeDelegateSpy.newStateMFARequired else {
+            XCTFail("Challenge not sent to MFA method")
+            return
+        }
+        
+        // Now submit the email OTP code
+        guard let code = await retrieveCodeFor(email: username) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+
+        let submitChallengeExpectation = expectation(description: "submitChallenge")
+        let mfaSubmitChallengeDelegateSpy = MFASubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
+
+        mfaRequiredState.submitChallenge(challenge: code, delegate: mfaSubmitChallengeDelegateSpy)
+
+        await fulfillment(of: [submitChallengeExpectation])
+
+        XCTAssertTrue(mfaSubmitChallengeDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result)
+        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result?.idToken)
+        XCTAssertEqual(mfaSubmitChallengeDelegateSpy.result?.account.username, username)
+    }
+    
+    // MARK: private methods
+    
+    private func signInUsernameAndPassword(username: String, password: String) async -> AwaitingMFAState? {
+        guard let sut = initialisePublicClientApplication()
+        else {
+            XCTFail("Missing information")
+            return nil
+        }
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+        
+        guard signInDelegateSpy.onSignInAwaitingMFACalled, let awaitingMFAState = signInDelegateSpy.newStateAwaitingMFA else {
+            XCTFail("Awaiting MFA not called")
+            return nil
+        }
+        return awaitingMFAState
     }
 
 }

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/SignInDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/SignInDelegateSpies.swift
@@ -30,8 +30,10 @@ class SignInPasswordStartDelegateSpy: SignInStartDelegate {
     private let expectation: XCTestExpectation
     private(set) var onSignInPasswordErrorCalled = false
     private(set) var onSignInCompletedCalled = false
+    private(set) var onSignInAwaitingMFACalled = false
     private(set) var error: MSAL.SignInStartError?
     private(set) var result: MSAL.MSALNativeAuthUserAccountResult?
+    private(set) var newStateAwaitingMFA: MSAL.AwaitingMFAState?
 
     init(expectation: XCTestExpectation) {
         self.expectation = expectation
@@ -48,6 +50,13 @@ class SignInPasswordStartDelegateSpy: SignInStartDelegate {
         onSignInCompletedCalled = true
         self.result = result
 
+        expectation.fulfill()
+    }
+    
+    public func onSignInAwaitingMFA(newState: AwaitingMFAState) {
+        onSignInAwaitingMFACalled = true
+        
+        self.newStateAwaitingMFA = newState
         expectation.fulfill()
     }
 }

--- a/MSAL/test/testplan/MSAL iOS Native Auth E2E Tests.xctestplan
+++ b/MSAL/test/testplan/MSAL iOS Native Auth E2E Tests.xctestplan
@@ -13,6 +13,9 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "MSALNativeAuthSignInWithMFAEndToEndTests\/test_signInUsingPasswordWithMFA_completeSuccessfully()"
+      ],
       "target" : {
         "containerPath" : "container:MSAL.xcodeproj",
         "identifier" : "28CED2E72C21E0F9004320D1",

--- a/MSAL/test/testplan/MSAL iOS Native Auth E2E Tests.xctestplan
+++ b/MSAL/test/testplan/MSAL iOS Native Auth E2E Tests.xctestplan
@@ -13,9 +13,6 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-        "MSALNativeAuthSignInWithMFAEndToEndTests\/test_signInUsingPasswordWithMFA_completeSuccessfully()"
-      ],
       "target" : {
         "containerPath" : "container:MSAL.xcodeproj",
         "identifier" : "28CED2E72C21E0F9004320D1",


### PR DESCRIPTION
## Proposed changes

This PR contains the following 2 E2E tests:
- test_signInUsingPasswordWithMFASubmitWrongChallengeResendChallengeThen_completeSuccessfully
- test_signInUsingPasswordWithMFAGetAuthMethods_thenCompleteSuccessfully
- test_signInUsingPasswordWithMFANoDefaultAuthMethod_completeSuccessfully

These tests are currently disabled because the lab tenant isn't allowlisted yet.

The first test checks the following three scenarios. These scenarios could be merged in one single test speeding up the execution:
- Submit wrong challenge
- resend challenge
- submit correct challenge

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [X] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

