### PR TITLE
Fix common core submodule check pipeline

### DIFF
--- a/build.py
+++ b/build.py
@@ -107,30 +107,6 @@ target_specifiers = [
         "platform" : "visionOS",
         "target" : "visionOSFramework"
     },
-    {
-        "name" : "iOS Test App",
-        "scheme" : "MSAL Test App (iOS)",
-        "operations" : [ "build" ],
-        "platform" : "visionOS",
-        "target" : "visionOSTestApp"
-
-    },
-    {
-        "name" : "Sample iOS App",
-        "scheme" : "SampleAppiOS",
-        "workspace" : "Samples/ios/SampleApp.xcworkspace",
-        "operations" : [ "build" ],
-        "platform" : "visionOS",
-        "target" : "visionOSSampleApp"
-    },
-    {
-        "name" : "Sample iOS App-iOS",
-        "scheme" : "SampleAppiOS-Swift",
-        "workspace" : "Samples/ios/SampleApp.xcworkspace",
-        "operations" : [ "build" ],
-        "platform" : "visionOS",
-        "target" : "visionOSSampleAppSwift"
-    },
 ]
 
 def print_operation_start(name, operation) :


### PR DESCRIPTION
## Proposed changes

The "[MSAL] Common core submodule update check" pipeline fails due to not being able to build the test/sample apps on visionOS. Its better to remove the visionOS configs for the sample apps because they are not updated for visionOS yet. They are also already not used in the PR validation pipeline yaml.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

