### PR TITLE
[iOS SDK] Change SPM script to use major version

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,7 @@ CHANGELOG.md @AzureAD/AppleIdentityTeam @AzureAD/MSAL-ObjC-CIAM
 /MSAL/MSAL.xcodeproj/xcshareddata/xcschemes/MSAL\ iOS\ Native\ Auth\ E2E\ Tests.xcscheme @AzureAD/MSAL-ObjC-CIAM
 /MSAL/MSAL.xcodeproj/xcshareddata/xcschemes/MSAL\ Mac\ Native\ Auth\ E2E\ Tests.xcscheme @AzureAD/MSAL-ObjC-CIAM
 /Package.swift @AzureAD/MSAL-ObjC-CIAM
+/spm-integration-test.sh @AzureAD/MSAL-ObjC-CIAM
 # For more details about inheritance patterns, or to assign different
 # owners for individual file extensions, see:
 # https://help.github.com/articles/about-codeowners/

--- a/spm-integration-test.sh
+++ b/spm-integration-test.sh
@@ -48,7 +48,7 @@ cd "$SAMPLE_APP_TEMP_DIR"
 git clone https://github.com/Azure-Samples/ms-identity-ciam-native-auth-ios-sample.git
 cd ms-identity-ciam-native-auth-ios-sample
 
-sed -i '' 's#kind = upToNextMinorVersion;#kind = branch;#' NativeAuthSampleApp.xcodeproj/project.pbxproj
+sed -i '' 's#kind = upToNextMajorVersion;#kind = branch;#' NativeAuthSampleApp.xcodeproj/project.pbxproj
 sed -i '' "s#minimumVersion = [0-9.]*;#branch = $BRANCH_NAME;#" NativeAuthSampleApp.xcodeproj/project.pbxproj
 
 rm -f NativeAuthSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved


### PR DESCRIPTION
## Proposed changes

Change SPM script to use major version to match NativeAuthSampleApp project settings

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

