### PR TITLE
Support extra query parameters in logout endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [TBD]:
+## [1.5.1]:
 * Parse and add STS error codes in token error result (#2319)
 * VisionOS support added (#2139)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [TBD]:
+* Support extra query parameters on logout endpoint (#2339)
+
 ## [1.5.1]:
 * Parse and add STS error codes in token error result (#2319)
 * VisionOS support added (#2139)

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MSAL"
-  s.version      = "1.5.0"
+  s.version      = "1.5.1"
   s.summary      = "Microsoft Authentication Library (MSAL) for iOS"
   s.description  = <<-DESC
                    The MSAL library for iOS gives your app the ability to begin using the Microsoft Cloud by supporting Microsoft Azure Active Directory and Microsoft Accounts in a converged experience using industry standard OAuth2 and OpenID Connect. The library also supports Microsoft Azure B2C for those using our hosted identity management service.

--- a/MSAL/resources/ios/Info.plist
+++ b/MSAL/resources/ios/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.5.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MSAL/resources/mac/Info.plist
+++ b/MSAL/resources/mac/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.5.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1458,6 +1458,10 @@
     msidParams.platformSequence = [NSString msidUpdatePlatformSequenceParamWithSrcName:[MSIDVersion platformName]
                                                                             srcVersion:[MSIDVersion sdkVersion]
                                                                               sequence:nil];
+    
+    // Extra parameters to be added to the /authorize endpoint.
+    msidParams.extraURLQueryParameters = signoutParameters.extraQueryParameters;
+    
     NSError *localError;
     BOOL localRemovalResult = [self removeAccountImpl:account wipeAccount:signoutParameters.wipeAccount error:&localError];
     

--- a/MSAL/src/MSAL_Internal.h
+++ b/MSAL/src/MSAL_Internal.h
@@ -27,7 +27,7 @@
 
 #define MSAL_VER_HIGH       1
 #define MSAL_VER_LOW        5
-#define MSAL_VER_PATCH      0
+#define MSAL_VER_PATCH      1
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/MSAL/src/public/MSALSignoutParameters.h
+++ b/MSAL/src/public/MSALSignoutParameters.h
@@ -69,6 +69,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL wipeCacheForAllAccounts;
 
 /**
+ Key-value pairs to pass to the logout endpoint. This should not be url-encoded value.
+ */
+@property (nonatomic, nullable) NSDictionary <NSString *, NSString *> *extraQueryParameters;
+
+/**
  Initialize MSALSignoutParameters with web parameters.
  
  @param webviewParameters   User Interface configuration that MSAL uses when getting a token interactively or authorizing an end user.

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -3565,6 +3565,7 @@
     MSALWebviewParameters *webParams = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:[self.class sharedViewControllerStub]];
     MSALSignoutParameters *parameters = [[MSALSignoutParameters alloc] initWithWebviewParameters:webParams];
     parameters.signoutFromBrowser = YES;
+    parameters.extraQueryParameters = @{@"key1": @"value1"};
     MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     
     XCTAssertEqual([application allAccounts:nil].count, 1);
@@ -3581,6 +3582,7 @@
         
         XCTAssertEqualObjects(params.accountIdentifier.displayableId, @"fakeuser@contoso.com");
         XCTAssertEqualObjects(params.accountIdentifier.homeAccountId, @"myuid.utid");
+        XCTAssertEqualObjects(params.extraURLQueryParameters[@"key1"], @"value1");
         
         XCTAssertEqualObjects(params.authority.url.absoluteString, @"https://login.microsoftonline.com/common");
         XCTAssertEqualObjects(params.clientId, UNIT_TEST_CLIENT_ID);


### PR DESCRIPTION
## Proposed changes

Signout from browser was previously not allowing developers to pass extra parameters.
If developer wants to pass a slice or logout_hint parameter, they won't be able to.
Adding support for the same
Common core PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1423 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

