### PR TITLE
Add new MFARequestChallengeError and MFAGetAuthMethodsError

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -280,6 +280,12 @@
 		289747B129799C6B00838C80 /* MSALNativeAuthInputValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289747AF29799A8700838C80 /* MSALNativeAuthInputValidator.swift */; };
 		289E15592948E601006104D9 /* MSALNativeAuthCacheInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E15582948E601006104D9 /* MSALNativeAuthCacheInterface.swift */; };
 		289E156D2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E156C2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift */; };
+		289E44AC2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E44AB2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift */; };
+		289E44AD2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E44AB2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift */; };
+		289E44B62C9D7B0900F6B9D7 /* MFAGetAuthMethodsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E44B52C9D7B0900F6B9D7 /* MFAGetAuthMethodsError.swift */; };
+		289E44B72C9D7B0900F6B9D7 /* MFAGetAuthMethodsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E44B52C9D7B0900F6B9D7 /* MFAGetAuthMethodsError.swift */; };
+		289E44B92C9D843F00F6B9D7 /* MFARequestChallengeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E44B82C9D843F00F6B9D7 /* MFARequestChallengeErrorTests.swift */; };
+		289E44BA2C9D843F00F6B9D7 /* MFARequestChallengeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E44B82C9D843F00F6B9D7 /* MFARequestChallengeErrorTests.swift */; };
 		28A277C82C21F08800D95E00 /* MSAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D65A6F431E3FD30A00C69FBA /* MSAL.framework */; };
 		28A277D92C22ED5E00D95E00 /* MSALNativeAuthEmailCodeRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A277D82C22ED5E00D95E00 /* MSALNativeAuthEmailCodeRetriever.swift */; };
 		28A472EC2A276C3B003F988B /* MSALNativeAuthTokenValidatedResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A472EB2A276C3B003F988B /* MSALNativeAuthTokenValidatedResponse.swift */; };
@@ -287,7 +293,7 @@
 		28A6009B2C7898DA00455666 /* MFADelegatesSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A6009A2C7898DA00455666 /* MFADelegatesSpies.swift */; };
 		28A6009D2C78A26D00455666 /* MFAGetAuthMethodsDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A6009C2C78A26D00455666 /* MFAGetAuthMethodsDelegateDispatcherTests.swift */; };
 		28A6009F2C78A27C00455666 /* MFASubmitChallengeDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A6009E2C78A27C00455666 /* MFASubmitChallengeDelegateDispatcherTests.swift */; };
-		28A600A12C78BA8900455666 /* MFAErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A02C78BA8900455666 /* MFAErrorTests.swift */; };
+		28A600A12C78BA8900455666 /* MFAGetAuthMethodsErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A02C78BA8900455666 /* MFAGetAuthMethodsErrorTests.swift */; };
 		28A600A32C78BA9C00455666 /* MFASubmitChallengeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A22C78BA9C00455666 /* MFASubmitChallengeErrorTests.swift */; };
 		28A600A62C78BDC100455666 /* AwaitingMFAStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A52C78BDC100455666 /* AwaitingMFAStateTests.swift */; };
 		28A600A82C78BDD200455666 /* MFARequiredStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A72C78BDD200455666 /* MFARequiredStateTests.swift */; };
@@ -305,7 +311,6 @@
 		28D1D59C29C2266500CE75F4 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D1D59B29C2266500CE75F4 /* Model.swift */; };
 		28D1D59E29C2392000CE75F4 /* MockAPIHandlerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D1D59D29C2392000CE75F4 /* MockAPIHandlerTest.swift */; };
 		28D5B05D2A028D2B0066E32B /* MSALNativeAuthControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D5B05C2A028D2B0066E32B /* MSALNativeAuthControllerFactory.swift */; };
-		28D811E32C735D83002BE1AA /* MFAError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D811E22C735D83002BE1AA /* MFAError.swift */; };
 		28D811E52C735D98002BE1AA /* MFASubmitChallengeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D811E42C735D98002BE1AA /* MFASubmitChallengeError.swift */; };
 		28D811E72C75FB10002BE1AA /* MFAStates+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D811E62C75FB10002BE1AA /* MFAStates+Internal.swift */; };
 		28D811E92C75FFC3002BE1AA /* MFADelegateDispatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D811E82C75FFC3002BE1AA /* MFADelegateDispatchers.swift */; };
@@ -338,7 +343,6 @@
 		28EE65142C8B0E5500015F90 /* MSALAuthMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B28B912C6F611F0030D5C5 /* MSALAuthMethod.swift */; };
 		28EE65152C8B0E6B00015F90 /* MFADelegates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B28B8B2C6F4B570030D5C5 /* MFADelegates.swift */; };
 		28EE65162C8B0E7600015F90 /* MFADelegateDispatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D811E82C75FFC3002BE1AA /* MFADelegateDispatchers.swift */; };
-		28EE65172C8B0E8200015F90 /* MFAError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D811E22C735D83002BE1AA /* MFAError.swift */; };
 		28EE65182C8B0FB200015F90 /* MFASubmitChallengeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D811E42C735D98002BE1AA /* MFASubmitChallengeError.swift */; };
 		28EE65192C8B0FBA00015F90 /* MFAStates+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D811E62C75FB10002BE1AA /* MFAStates+Internal.swift */; };
 		28EE651A2C8B0FC200015F90 /* MFAStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B28B822C6F46E50030D5C5 /* MFAStates.swift */; };
@@ -348,7 +352,7 @@
 		28EE651E2C8B103B00015F90 /* MFAGetAuthMethodsDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A6009C2C78A26D00455666 /* MFAGetAuthMethodsDelegateDispatcherTests.swift */; };
 		28EE651F2C8B107100015F90 /* MFASendChallengeDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600942C78843300455666 /* MFASendChallengeDelegateDispatcherTests.swift */; };
 		28EE65202C8B107D00015F90 /* MFASubmitChallengeDelegateDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A6009E2C78A27C00455666 /* MFASubmitChallengeDelegateDispatcherTests.swift */; };
-		28EE65212C8B108A00015F90 /* MFAErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A02C78BA8900455666 /* MFAErrorTests.swift */; };
+		28EE65212C8B108A00015F90 /* MFAGetAuthMethodsErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A02C78BA8900455666 /* MFAGetAuthMethodsErrorTests.swift */; };
 		28EE65222C8B109300015F90 /* MFASubmitChallengeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A22C78BA9C00455666 /* MFASubmitChallengeErrorTests.swift */; };
 		28EE65232C8B109D00015F90 /* AwaitingMFAStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A52C78BDC100455666 /* AwaitingMFAStateTests.swift */; };
 		28EE65242C8B10AA00015F90 /* MFARequiredStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A72C78BDD200455666 /* MFARequiredStateTests.swift */; };
@@ -1787,13 +1791,6 @@
 			remoteGlobalIDString = D626FF681FBA6EDF00EE4487;
 			remoteInfo = "IdentityCoreTests Mac";
 		};
-		D6BFE3DA1EB42D3200F2B7E8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D6DFF39A1E2579360012891A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 962E37A61E720C5D00DE71FE;
-			remoteInfo = "MSAL Test Automation (iOS)";
-		};
 		DE1BD0D42C3C275200B0888E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D6DFF39A1E2579360012891A /* Project object */;
@@ -2018,13 +2015,16 @@
 		289747AF29799A8700838C80 /* MSALNativeAuthInputValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInputValidator.swift; sourceTree = "<group>"; };
 		289E15582948E601006104D9 /* MSALNativeAuthCacheInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCacheInterface.swift; sourceTree = "<group>"; };
 		289E156C2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCacheAccessor.swift; sourceTree = "<group>"; };
+		289E44AB2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFARequestChallengeError.swift; sourceTree = "<group>"; };
+		289E44B52C9D7B0900F6B9D7 /* MFAGetAuthMethodsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAGetAuthMethodsError.swift; sourceTree = "<group>"; };
+		289E44B82C9D843F00F6B9D7 /* MFARequestChallengeErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFARequestChallengeErrorTests.swift; sourceTree = "<group>"; };
 		28A277D82C22ED5E00D95E00 /* MSALNativeAuthEmailCodeRetriever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthEmailCodeRetriever.swift; sourceTree = "<group>"; };
 		28A472EB2A276C3B003F988B /* MSALNativeAuthTokenValidatedResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenValidatedResponse.swift; sourceTree = "<group>"; };
 		28A600942C78843300455666 /* MFASendChallengeDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFASendChallengeDelegateDispatcherTests.swift; sourceTree = "<group>"; };
 		28A6009A2C7898DA00455666 /* MFADelegatesSpies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFADelegatesSpies.swift; sourceTree = "<group>"; };
 		28A6009C2C78A26D00455666 /* MFAGetAuthMethodsDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAGetAuthMethodsDelegateDispatcherTests.swift; sourceTree = "<group>"; };
 		28A6009E2C78A27C00455666 /* MFASubmitChallengeDelegateDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFASubmitChallengeDelegateDispatcherTests.swift; sourceTree = "<group>"; };
-		28A600A02C78BA8900455666 /* MFAErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAErrorTests.swift; sourceTree = "<group>"; };
+		28A600A02C78BA8900455666 /* MFAGetAuthMethodsErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAGetAuthMethodsErrorTests.swift; sourceTree = "<group>"; };
 		28A600A22C78BA9C00455666 /* MFASubmitChallengeErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFASubmitChallengeErrorTests.swift; sourceTree = "<group>"; };
 		28A600A52C78BDC100455666 /* AwaitingMFAStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AwaitingMFAStateTests.swift; sourceTree = "<group>"; };
 		28A600A72C78BDD200455666 /* MFARequiredStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFARequiredStateTests.swift; sourceTree = "<group>"; };
@@ -2043,7 +2043,6 @@
 		28D1D59B29C2266500CE75F4 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
 		28D1D59D29C2392000CE75F4 /* MockAPIHandlerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAPIHandlerTest.swift; sourceTree = "<group>"; };
 		28D5B05C2A028D2B0066E32B /* MSALNativeAuthControllerFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthControllerFactory.swift; sourceTree = "<group>"; };
-		28D811E22C735D83002BE1AA /* MFAError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAError.swift; sourceTree = "<group>"; };
 		28D811E42C735D98002BE1AA /* MFASubmitChallengeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFASubmitChallengeError.swift; sourceTree = "<group>"; };
 		28D811E62C75FB10002BE1AA /* MFAStates+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MFAStates+Internal.swift"; sourceTree = "<group>"; };
 		28D811E82C75FFC3002BE1AA /* MFADelegateDispatchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFADelegateDispatchers.swift; sourceTree = "<group>"; };
@@ -3157,8 +3156,9 @@
 				DE9245142A3875D700C0389F /* RetrieveAccessTokenError.swift */,
 				28FDC4A82A38C0D000E38BE1 /* SignInAfterSignUpError.swift */,
 				E224F7482B18F2FE000A7B2E /* SignInAfterResetPasswordError.swift */,
-				28D811E22C735D83002BE1AA /* MFAError.swift */,
 				28D811E42C735D98002BE1AA /* MFASubmitChallengeError.swift */,
+				289E44AB2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift */,
+				289E44B52C9D7B0900F6B9D7 /* MFAGetAuthMethodsError.swift */,
 			);
 			path = error;
 			sourceTree = "<group>";
@@ -4822,8 +4822,9 @@
 				E2CE911B2B0BA48D0009AEDD /* RetrieveAccessTokenErrorTests.swift */,
 				E2CE911D2B0BA4A60009AEDD /* SignInAfterSignUpErrorTests.swift */,
 				E2C190762B20DF4300095534 /* SignInAfterResetPasswordErrorTests.swift */,
-				28A600A02C78BA8900455666 /* MFAErrorTests.swift */,
+				28A600A02C78BA8900455666 /* MFAGetAuthMethodsErrorTests.swift */,
 				28A600A22C78BA9C00455666 /* MFASubmitChallengeErrorTests.swift */,
+				289E44B82C9D843F00F6B9D7 /* MFARequestChallengeErrorTests.swift */,
 			);
 			path = error;
 			sourceTree = "<group>";
@@ -6502,6 +6503,7 @@
 				DE8BE7DC2A1F6BD2009642A5 /* MSALNativeAuthUserAccountResult.swift in Sources */,
 				E224F73E2B18F11F000A7B2E /* SignInAfterResetPasswordState.swift in Sources */,
 				287708252A178DC500E371ED /* MSALNativeAuthSignInInitiateValidatedResponse.swift in Sources */,
+				289E44AC2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift in Sources */,
 				DEE34F89D170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionStatus.swift in Sources */,
 				9BE7E3D52A1CF51500CC3A62 /* MSALNativeAuthResetPasswordValidatedResponses.swift in Sources */,
 				287F65182983F77D00ED90BD /* MSALNativeAuthRequestParametersKey.swift in Sources */,
@@ -6623,6 +6625,7 @@
 				E2F890052B755355001FBC7C /* MSALNativeAuthUnknownCaseProtocol.swift in Sources */,
 				E2EFAD092A69A34300D6C3DE /* CodeRequiredGenericResult.swift in Sources */,
 				E2EFAD0C2A69B45100D6C3DE /* SignUpResults.swift in Sources */,
+				289E44B62C9D7B0900F6B9D7 /* MFAGetAuthMethodsError.swift in Sources */,
 				DE0D65AC29CC6A5A005798B1 /* MSALNativeAuthSignInInitiateResponse.swift in Sources */,
 				B266391C22B4B84600FEB673 /* NSString+MSALAccountIdenfiers.m in Sources */,
 				DEE34F87D170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionResponse.swift in Sources */,
@@ -6645,7 +6648,6 @@
 				E2F626B02A78130700C4A303 /* SignInAfterPreviousFlowBaseState+Internal.swift in Sources */,
 				E22427DE2B05981A0006C55E /* SignInAfterSignUpDelegateDispatcher.swift in Sources */,
 				E22427DB2B0594670006C55E /* CredentialsDelegateDispatcher.swift in Sources */,
-				28D811E32C735D83002BE1AA /* MFAError.swift in Sources */,
 				28D811ED2C760303002BE1AA /* MSALNativeAuthMFAControlling.swift in Sources */,
 				B26756C622921C42000F01D7 /* MSALAADOauth2Provider.m in Sources */,
 				DEE34F12D170B71C00BC302A /* MSALNativeAuthResetPasswordStartRequestParameters.swift in Sources */,
@@ -6814,7 +6816,6 @@
 				B27CCDF5229F9F4700CAD565 /* MSALAccountEnumerationParameters.m in Sources */,
 				DE8DC4902C6621A600534E8F /* ResetPasswordDelegates.swift in Sources */,
 				DE8DC4822C6621A100534E8F /* SignInAfterResetPasswordError.swift in Sources */,
-				28EE65172C8B0E8200015F90 /* MFAError.swift in Sources */,
 				DE8DC4D32C6621C900534E8F /* MSALNativeAuthESTSApiErrorCodes.swift in Sources */,
 				DE8DC4732C66219E00534E8F /* CredentialsDelegateDispatcher.swift in Sources */,
 				DE8DC4AA2C6621B100534E8F /* MSALNativeAuthResponseCorrelatable.swift in Sources */,
@@ -6861,6 +6862,7 @@
 				DE8DC4662C66219600534E8F /* MSALNativeAuthResultFactory.swift in Sources */,
 				DE8DC4842C6621A300534E8F /* SignInStates+Internal.swift in Sources */,
 				DE8DC49F2C6621AE00534E8F /* MSALNativeAuthResetPasswordStartRequestProviderParameters.swift in Sources */,
+				289E44AD2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift in Sources */,
 				DE8DC4B02C6621B600534E8F /* MSALNativeAuthSignInInitiateRequestParameters.swift in Sources */,
 				B2C17B0B1FC8DB2E0070A514 /* MSIDVersion.m in Sources */,
 				DE8DC4BF2C6621C100534E8F /* MSALNativeAuthResetPasswordResponseValidator.swift in Sources */,
@@ -6885,6 +6887,7 @@
 				B253151C23DD607600432133 /* MSALDeviceInformation.m in Sources */,
 				DE8DC4BB2C6621BD00534E8F /* MSALNativeAuthSignInChallengeValidatedResponse.swift in Sources */,
 				94E876CE1E492D6000FB96ED /* MSALAuthority.m in Sources */,
+				289E44B72C9D7B0900F6B9D7 /* MFAGetAuthMethodsError.swift in Sources */,
 				DE8DC4DB2C6621CC00534E8F /* MSALNativeAuthSignUpStartResponseError.swift in Sources */,
 				DE8DC4E52C6621D000534E8F /* MSALNativeAuthResetPasswordContinueResponseError.swift in Sources */,
 				DE8DC4B12C6621B800534E8F /* MSALNativeAuthResetPasswordContinueRequestParameters.swift in Sources */,
@@ -6947,7 +6950,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				23A169B52073325500B051F3 /* MSALPublicClientApplicationTests.m in Sources */,
-				28A600A12C78BA8900455666 /* MFAErrorTests.swift in Sources */,
+				28A600A12C78BA8900455666 /* MFAGetAuthMethodsErrorTests.swift in Sources */,
 				D61F5BC01E5913BE00912CB8 /* SFSafariViewController+TestOverrides.m in Sources */,
 				B2725ED022C04689009B454A /* MSALLegacySharedAccountFactoryTests.m in Sources */,
 				E22427EE2B06637C0006C55E /* SignUpAttributesRequiredDelegateDispatcherTests.swift in Sources */,
@@ -6999,6 +7002,7 @@
 				B2725E7F22BD88BE009B454A /* NSStringAccountIdentifiersTest.m in Sources */,
 				287F64D4297EC29400ED90BD /* MSALNativeAuthTelemetryProviderTests.swift in Sources */,
 				E22952682A1A4FCB00EDD58C /* MSALNativeAuthSignUpResponseValidatorTests.swift in Sources */,
+				289E44B92C9D843F00F6B9D7 /* MFARequestChallengeErrorTests.swift in Sources */,
 				E286E2DD2A1BAEA800666DD0 /* MSALNativeAuthSignUpControllerTests.swift in Sources */,
 				B2725EC522BF4865009B454A /* MSALMockExternalAccountHandler.m in Sources */,
 				E2C190772B20DF4300095534 /* SignInAfterResetPasswordErrorTests.swift in Sources */,
@@ -7161,7 +7165,7 @@
 				23F32F0D1FF4789200B2905E /* MSIDTestURLResponse+MSAL.m in Sources */,
 				DE8DC5602C66221A00534E8F /* MSALNativeAuthResponseCorrelatableTests.swift in Sources */,
 				DE8DC4FC2C6621E700534E8F /* MSALNativeAuthSignUpControllerTests.swift in Sources */,
-				28EE65212C8B108A00015F90 /* MFAErrorTests.swift in Sources */,
+				28EE65212C8B108A00015F90 /* MFAGetAuthMethodsErrorTests.swift in Sources */,
 				DE8DC5492C66220D00534E8F /* MSALNativeAuthResetPasswordChallengeOauth2ErrorCodeTests.swift in Sources */,
 				DE8DC52A2C6621F700534E8F /* SignUpStartErrorTests.swift in Sources */,
 				DE8DC53C2C66220700534E8F /* MSALNativeAuthTelemetryProviderTests.swift in Sources */,
@@ -7287,6 +7291,7 @@
 				DE8DC5202C6621F500534E8F /* ResetPasswordStartDelegateDispatcherTests.swift in Sources */,
 				DE8DC55C2C66221700534E8F /* MSALNativeAuthResetPasswordStartRequestParametersTest.swift in Sources */,
 				28EE651C2C8B0FF500015F90 /* MSALNativeAuthMFAControllerTests.swift in Sources */,
+				289E44BA2C9D843F00F6B9D7 /* MFARequestChallengeErrorTests.swift in Sources */,
 				DE8DC56C2C66221C00534E8F /* MSALNativeLoggingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -7464,11 +7469,6 @@
 			isa = PBXTargetDependency;
 			target = D672279E1EBD111900F3422A /* unit-test-host */;
 			targetProxy = D67227B61EBD112800F3422A /* PBXContainerItemProxy */;
-		};
-		D6BFE3DB1EB42D3200F2B7E8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 962E37A61E720C5D00DE71FE /* MSAL Test Automation (iOS) */;
-			targetProxy = D6BFE3DA1EB42D3200F2B7E8 /* PBXContainerItemProxy */;
 		};
 		DE1BD0D52C3C275200B0888E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/MSAL/src/native_auth/MSALNativeAuthLogMessage.swift
+++ b/MSAL/src/native_auth/MSALNativeAuthLogMessage.swift
@@ -25,5 +25,6 @@
 import Foundation
 
 enum MSALNativeAuthLogMessage {
-    static let privatePreviewLog = "Warning ⚠️: this API is experimental. It may be changed in the future without notice. Do not use in production applications."
+    static let privatePreviewLog = 
+    "Warning ⚠️: this API is experimental. It may be changed in the future without notice. Do not use in production applications."
 }

--- a/MSAL/src/native_auth/controllers/responses/MFAResults.swift
+++ b/MSAL/src/native_auth/controllers/responses/MFAResults.swift
@@ -27,12 +27,12 @@ import Foundation
 enum MFARequestChallengeResult {
     case verificationRequired(sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int, newState: MFARequiredState)
     case selectionRequired(authMethods: [MSALAuthMethod], newState: MFARequiredState)
-    case error(error: MFAError, newState: MFARequiredState?)
+    case error(error: MFARequestChallengeError, newState: MFARequiredState?)
 }
 
 enum MFAGetAuthMethodsResult {
     case selectionRequired(authMethods: [MSALAuthMethod], newState: MFARequiredState)
-    case error(error: MFAError, newState: MFARequiredState?)
+    case error(error: MFAGetAuthMethodsError, newState: MFARequiredState?)
 }
 
 enum MFASubmitChallengeResult {

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
@@ -102,7 +102,7 @@ enum MSALNativeAuthSignInChallengeValidatedErrorType: Error {
         }
     }
 
-    func convertToMFARequestChallengeError(correlationId: UUID) -> MFAError {
+    func convertToMFARequestChallengeError(correlationId: UUID) -> MFARequestChallengeError {
         switch self {
         case .redirect:
             return .init(type: .browserRequired, correlationId: correlationId)

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInIntrospectValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInIntrospectValidatedResponse.swift
@@ -35,7 +35,7 @@ enum MSALNativeAuthSignInIntrospectValidatedErrorType: Error {
     case invalidRequest(MSALNativeAuthSignInIntrospectResponseError)
     case unexpectedError(MSALNativeAuthSignInIntrospectResponseError?)
 
-    func convertToMFARequestChallengeError(correlationId: UUID) -> MFAError {
+    func convertToMFAGetAuthMethodsError(correlationId: UUID) -> MFAGetAuthMethodsError {
         switch self {
         case .redirect:
             return .init(type: .browserRequired, correlationId: correlationId)

--- a/MSAL/src/native_auth/public/state_machine/delegate/MFADelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/MFADelegates.swift
@@ -32,7 +32,7 @@ public protocol MFARequestChallengeDelegate {
     /// - Parameters:
     ///     - error: An error object indicating why the operation failed.
     ///     - newState: An object representing the new state of the flow with follow on methods.
-    @MainActor func onMFARequestChallengeError(error: MFAError, newState: MFARequiredState?)
+    @MainActor func onMFARequestChallengeError(error: MFARequestChallengeError, newState: MFARequiredState?)
 
     /// Notifies the delegate that a verification is required from the user to continue.
     /// - Note: If a flow requires this optional method and it is not implemented, then ``onMFARequestChallengeError(error:)`` will be called.
@@ -64,7 +64,7 @@ public protocol MFAGetAuthMethodsDelegate {
     /// - Parameters:
     ///     - error: An error object indicating why the operation failed.
     ///     - newState: An object representing the new state of the flow with follow on methods.
-    @MainActor func onMFAGetAuthMethodsError(error: MFAError, newState: MFARequiredState?)
+    @MainActor func onMFAGetAuthMethodsError(error: MFAGetAuthMethodsError, newState: MFARequiredState?)
 
     /// Notifies the delegate that the list of authentication methods is now available.
     /// - Note: If a flow requires this optional method and it is not implemented, then ``onMFAGetAuthMethodsError(error:)`` will be called.

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/MFADelegateDispatchers.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/MFADelegateDispatchers.swift
@@ -41,7 +41,7 @@ final class MFARequestChallengeDelegateDispatcher: DelegateDispatcher<MFARequest
                 codeLength
             )
         } else {
-            let error = MFAError(
+            let error = MFARequestChallengeError(
                 type: .generalError,
                 message: requiredErrorMessage(for: "onMFARequestChallengeVerificationRequired"),
                 correlationId: correlationId
@@ -56,7 +56,7 @@ final class MFARequestChallengeDelegateDispatcher: DelegateDispatcher<MFARequest
             telemetryUpdate?(.success(()))
             await onSelectionRequired(authMethods, newState)
         } else {
-            let error = MFAError(
+            let error = MFARequestChallengeError(
                 type: .generalError,
                 message: requiredErrorMessage(for: "onMFARequestChallengeSelectionRequired"),
                 correlationId: correlationId
@@ -74,7 +74,7 @@ final class MFAGetAuthMethodsDelegateDispatcher: DelegateDispatcher<MFAGetAuthMe
             telemetryUpdate?(.success(()))
             await onSelectionRequired(authMethods, newState)
         } else {
-            let error = MFAError(
+            let error = MFAGetAuthMethodsError(
                 type: .generalError,
                 message: requiredErrorMessage(for: "onMFAGetAuthMethodsSelectionRequired"),
                 correlationId: correlationId

--- a/MSAL/src/native_auth/public/state_machine/error/MFAGetAuthMethodsError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/MFAGetAuthMethodsError.swift
@@ -24,9 +24,9 @@
 
 import Foundation
 
-/// Class that defines the structure and type of a MFAError
+/// Class that defines the structure and type of a MFAGetAuthMethodsError
 @objcMembers
-public class MFAError: MSALNativeAuthError {
+public class MFAGetAuthMethodsError: MSALNativeAuthError {
     enum ErrorType: CaseIterable {
         case browserRequired
         case generalError
@@ -56,5 +56,22 @@ public class MFAError: MSALNativeAuthError {
     /// Returns `true` if a browser is required to continue the operation.
     public var isBrowserRequired: Bool {
         return type == .browserRequired
+    }
+
+    func toMFARequestChallengeError() -> MFARequestChallengeError {
+        var requestChallengeType = MFARequestChallengeError.ErrorType.browserRequired
+        switch type {
+        case .browserRequired:
+            requestChallengeType = .browserRequired
+        case .generalError:
+            requestChallengeType = .generalError
+        }
+        return MFARequestChallengeError(
+            type: requestChallengeType,
+            message: errorDescription,
+            correlationId: correlationId,
+            errorCodes: errorCodes,
+            errorUri: errorUri
+        )
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/MFARequestChallengeError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/MFARequestChallengeError.swift
@@ -22,43 +22,39 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-import XCTest
-@testable import MSAL
+import Foundation
 
-final class MFASubmitChallengeErrorTests: XCTestCase {
-
-    private var sut: MFASubmitChallengeError!
-
-    func test_totalCases() {
-        XCTAssertEqual(MFASubmitChallengeError.ErrorType.allCases.count, 2)
+/// Class that defines the structure and type of a MFARequestChallengeError
+@objcMembers
+public class MFARequestChallengeError: MSALNativeAuthError {
+    enum ErrorType: CaseIterable {
+        case browserRequired
+        case generalError
     }
 
-    func test_customErrorDescription() {
-        let expectedMessage = "Custom error message"
-        sut = .init(type: .generalError, message: expectedMessage, correlationId: .init())
-        XCTAssertEqual(sut.errorDescription, expectedMessage)
+    let type: ErrorType
+
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = [], errorUri: String? = nil) {
+        self.type = type
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes, errorUri: errorUri)
     }
 
-    func test_defaultErrorDescription() {
-        let sut: [MFASubmitChallengeError] = [
-            .init(type: .invalidChallenge, correlationId: .init()),
-            .init(type: .generalError, correlationId: .init())
-        ]
+    /// Describes why an error occurred and provides more information about the error.
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
 
-        let expectedDescriptions = [
-            MSALNativeAuthErrorMessage.invalidChallenge,
-            MSALNativeAuthErrorMessage.generalError
-        ]
-
-        let errorDescriptions = sut.map { $0.errorDescription }
-
-        zip(errorDescriptions, expectedDescriptions).forEach {
-            XCTAssertEqual($0, $1)
+        switch type {
+        case .browserRequired:
+            return MSALNativeAuthErrorMessage.browserRequired
+        case .generalError:
+            return MSALNativeAuthErrorMessage.generalError
         }
     }
 
-    func test_isInvalidChallenge() {
-        sut = .init(type: .invalidChallenge, correlationId: .init())
-        XCTAssertTrue(sut.isInvalidChallenge)
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
     }
 }

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MFADelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MFADelegateSpies.swift
@@ -30,7 +30,7 @@ class MFARequestChallengeDelegateSpy: MFARequestChallengeDelegate {
     
     private let expectation: XCTestExpectation
     private(set) var onMFARequestChallengeError = false
-    private(set) var error: MSAL.MFAError?
+    private(set) var error: MSAL.MFARequestChallengeError?
     
     private(set) var onVerificationRequiredCalled = false
     private(set) var newStateMFARequired: MSAL.MFARequiredState?
@@ -45,7 +45,7 @@ class MFARequestChallengeDelegateSpy: MFARequestChallengeDelegate {
         self.expectation = expectation
     }
     
-    func onMFARequestChallengeError(error: MSAL.MFAError, newState: MSAL.MFARequiredState?) {
+    func onMFARequestChallengeError(error: MSAL.MFARequestChallengeError, newState: MSAL.MFARequiredState?) {
         onMFARequestChallengeError = true
         self.newStateMFARequired = newState
         self.error = error
@@ -107,14 +107,14 @@ final class MFAGetAuthMethodsDelegateSpy: MFAGetAuthMethodsDelegate {
     private(set) var onSelectionRequiredCalled = false
     private(set) var onMFAGetAuthMethodsErrorCalled = false
     private(set) var authMethods: [MSALAuthMethod]?
-    private(set) var error: MSAL.MFAError?
+    private(set) var error: MSAL.MFAGetAuthMethodsError?
     private(set) var newStateMFARequired: MSAL.MFARequiredState?
     
     init(expectation: XCTestExpectation) {
         self.expectation = expectation
     }
     
-    func onMFAGetAuthMethodsError(error: MSAL.MFAError, newState: MSAL.MFARequiredState?) {
+    func onMFAGetAuthMethodsError(error: MSAL.MFAGetAuthMethodsError, newState: MSAL.MFARequiredState?) {
         onMFAGetAuthMethodsErrorCalled = true
         self.error = error
 

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthMFAControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthMFAControllerTests.swift
@@ -361,7 +361,7 @@ class MSALNativeAuthMFAControllerTests: MSALNativeAuthSignInControllerTests {
     
     // MARK: Private methods
     
-    private func checkGetAuthMethodsWithIntrospectValidatorError(validatedError: MSALNativeAuthSignInIntrospectValidatedErrorType, expectedType: MFAError.ErrorType) async {
+    private func checkGetAuthMethodsWithIntrospectValidatorError(validatedError: MSALNativeAuthSignInIntrospectValidatedErrorType, expectedType: MFAGetAuthMethodsError.ErrorType) async {
         let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         
         signInRequestProviderMock.expectedContext = expectedContext

--- a/MSAL/test/unit/native_auth/mock/delegate/MFADelegatesSpies.swift
+++ b/MSAL/test/unit/native_auth/mock/delegate/MFADelegatesSpies.swift
@@ -28,19 +28,19 @@ import XCTest
 open class MFARequestChallengeDelegateSpy: MFARequestChallengeDelegate {
     
     let expectation: XCTestExpectation
-    var expectedError: MFAError?
+    var expectedError: MFARequestChallengeError?
     private(set) var newSentTo: String?
     private(set) var newChannelTargetType: MSALNativeAuthChannelType?
     private(set) var newCodeLength: Int?
     private(set) var newMFARequiredState: MFARequiredState?
     private(set) var newAuthMethods: [MSALAuthMethod]?
     
-    init(expectation: XCTestExpectation, expectedError: MFAError? = nil) {
+    init(expectation: XCTestExpectation, expectedError: MFARequestChallengeError? = nil) {
         self.expectation = expectation
         self.expectedError = expectedError
     }
     
-    public func onMFARequestChallengeError(error: MSAL.MFAError, newState: MSAL.MFARequiredState?) {
+    public func onMFARequestChallengeError(error: MSAL.MFARequestChallengeError, newState: MSAL.MFARequiredState?) {
         if let expectedError = expectedError {
             XCTAssertTrue(Thread.isMainThread)
             checkErrors(error: error, expectedError: expectedError)
@@ -73,14 +73,14 @@ open class MFARequestChallengeDelegateSpy: MFARequestChallengeDelegate {
 open class MFARequestChallengeNotImplementedDelegateSpy: MFARequestChallengeDelegate {
     
     let expectation: XCTestExpectation
-    let expectedError: MFAError
+    let expectedError: MFARequestChallengeError
 
-    init(expectation: XCTestExpectation, expectedError: MFAError) {
+    init(expectation: XCTestExpectation, expectedError: MFARequestChallengeError) {
         self.expectation = expectation
         self.expectedError = expectedError
     }
     
-    public func onMFARequestChallengeError(error: MSAL.MFAError, newState: MSAL.MFARequiredState?) {
+    public func onMFARequestChallengeError(error: MSAL.MFARequestChallengeError, newState: MSAL.MFARequiredState?) {
         XCTAssertTrue(Thread.isMainThread)
         XCTAssertNil(newState)
         checkErrors(error: error, expectedError: expectedError)
@@ -91,16 +91,16 @@ open class MFARequestChallengeNotImplementedDelegateSpy: MFARequestChallengeDele
 open class MFAGetAuthMethodsDelegateSpy: MFAGetAuthMethodsDelegate {
     
     let expectation: XCTestExpectation
-    var expectedError: MFAError?
+    var expectedError: MFAGetAuthMethodsError?
     private(set) var newMFARequiredState: MFARequiredState?
     private(set) var newAuthMethods: [MSALAuthMethod]?
     
-    init(expectation: XCTestExpectation, expectedError: MFAError? = nil) {
+    init(expectation: XCTestExpectation, expectedError: MFAGetAuthMethodsError? = nil) {
         self.expectation = expectation
         self.expectedError = expectedError
     }
     
-    public func onMFAGetAuthMethodsError(error: MSAL.MFAError, newState: MSAL.MFARequiredState?) {
+    public func onMFAGetAuthMethodsError(error: MSAL.MFAGetAuthMethodsError, newState: MSAL.MFARequiredState?) {
         if let expectedError = expectedError {
             XCTAssertTrue(Thread.isMainThread)
             checkErrors(error: error, expectedError: expectedError)
@@ -124,14 +124,14 @@ open class MFAGetAuthMethodsDelegateSpy: MFAGetAuthMethodsDelegate {
 open class MFAGetAuthMethodsNotImplementedDelegateSpy: MFAGetAuthMethodsDelegate {
     
     let expectation: XCTestExpectation
-    let expectedError: MFAError
+    let expectedError: MFAGetAuthMethodsError
 
-    init(expectation: XCTestExpectation, expectedError: MFAError) {
+    init(expectation: XCTestExpectation, expectedError: MFAGetAuthMethodsError) {
         self.expectation = expectation
         self.expectedError = expectedError
     }
     
-    public func onMFAGetAuthMethodsError(error: MSAL.MFAError, newState: MSAL.MFARequiredState?) {
+    public func onMFAGetAuthMethodsError(error: MSAL.MFAGetAuthMethodsError, newState: MSAL.MFARequiredState?) {
         XCTAssertTrue(Thread.isMainThread)
         XCTAssertNil(newState)
         checkErrors(error: error, expectedError: expectedError)

--- a/MSAL/test/unit/native_auth/public/delegate/mfa/MFAGetAuthMethodsDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/mfa/MFAGetAuthMethodsDelegateDispatcherTests.swift
@@ -60,7 +60,7 @@ final class MFAGetAuthMethodsDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSelection_whenDelegateOptionalMethodNotImplemented() async {
-        let expectedError = MFAError(
+        let expectedError = MFAGetAuthMethodsError(
             type: .generalError,
             message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onMFAGetAuthMethodsSelectionRequired"),
             correlationId: correlationId
@@ -68,7 +68,7 @@ final class MFAGetAuthMethodsDelegateDispatcherTests: XCTestCase {
         let delegate = MFAGetAuthMethodsNotImplementedDelegateSpy(expectation: delegateExp, expectedError: expectedError)
 
         sut = .init(delegate: delegate, telemetryUpdate: { result in
-            guard case let .failure(error) = result, let customError = error as? MFAError else {
+            guard case let .failure(error) = result, let customError = error as? MFAGetAuthMethodsError else {
                 return XCTFail("wrong result")
             }
 
@@ -83,7 +83,7 @@ final class MFAGetAuthMethodsDelegateDispatcherTests: XCTestCase {
         await fulfillment(of: [telemetryExp, delegateExp], timeout: 1)
         checkError(delegate.expectedError)
 
-        func checkError(_ error: MFAError?) {
+        func checkError(_ error: MFAGetAuthMethodsError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
             XCTAssertEqual(error?.correlationId, expectedError.correlationId)

--- a/MSAL/test/unit/native_auth/public/delegate/mfa/MFASendChallengeDelegateDispatcherTests.swift
+++ b/MSAL/test/unit/native_auth/public/delegate/mfa/MFASendChallengeDelegateDispatcherTests.swift
@@ -70,7 +70,7 @@ final class MFARequestChallengeDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchVerificationRequired_whenDelegateOptionalMethodNotImplemented() async {
-        let expectedError = MFAError(
+        let expectedError = MFARequestChallengeError(
             type: .generalError,
             message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onMFARequestChallengeVerificationRequired"),
             correlationId: correlationId
@@ -78,7 +78,7 @@ final class MFARequestChallengeDelegateDispatcherTests: XCTestCase {
         let delegate = MFARequestChallengeNotImplementedDelegateSpy(expectation: delegateExp, expectedError: expectedError)
 
         sut = .init(delegate: delegate, telemetryUpdate: { result in
-            guard case let .failure(error) = result, let customError = error as? MFAError else {
+            guard case let .failure(error) = result, let customError = error as? MFARequestChallengeError else {
                 return XCTFail("wrong result")
             }
 
@@ -97,7 +97,7 @@ final class MFARequestChallengeDelegateDispatcherTests: XCTestCase {
         await fulfillment(of: [telemetryExp, delegateExp], timeout: 1)
         checkError(delegate.expectedError)
 
-        func checkError(_ error: MFAError?) {
+        func checkError(_ error: MFARequestChallengeError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
             XCTAssertEqual(error?.correlationId, expectedError.correlationId)
@@ -126,7 +126,7 @@ final class MFARequestChallengeDelegateDispatcherTests: XCTestCase {
     }
 
     func test_dispatchSelection_whenDelegateOptionalMethodNotImplemented() async {
-        let expectedError = MFAError(
+        let expectedError = MFARequestChallengeError(
             type: .generalError,
             message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onMFARequestChallengeSelectionRequired"),
             correlationId: correlationId
@@ -135,7 +135,7 @@ final class MFARequestChallengeDelegateDispatcherTests: XCTestCase {
 
 
         sut = .init(delegate: delegate, telemetryUpdate: { result in
-            guard case let .failure(error) = result, let customError = error as? MFAError else {
+            guard case let .failure(error) = result, let customError = error as? MFARequestChallengeError else {
                 return XCTFail("wrong result")
             }
 
@@ -150,7 +150,7 @@ final class MFARequestChallengeDelegateDispatcherTests: XCTestCase {
         await fulfillment(of: [telemetryExp, delegateExp], timeout: 1)
         checkError(delegate.expectedError)
 
-        func checkError(_ error: MFAError?) {
+        func checkError(_ error: MFARequestChallengeError?) {
             XCTAssertEqual(error?.type, expectedError.type)
             XCTAssertEqual(error?.errorDescription, expectedError.errorDescription)
             XCTAssertEqual(error?.correlationId, expectedError.correlationId)

--- a/MSAL/test/unit/native_auth/public/error/MFAGetAuthMethodsErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/MFAGetAuthMethodsErrorTests.swift
@@ -25,12 +25,12 @@
 import XCTest
 @testable import MSAL
 
-final class MFASubmitChallengeErrorTests: XCTestCase {
+final class MFAGetAuthMethodsErrorTests: XCTestCase {
 
-    private var sut: MFASubmitChallengeError!
+    private var sut: MFAGetAuthMethodsError!
 
     func test_totalCases() {
-        XCTAssertEqual(MFASubmitChallengeError.ErrorType.allCases.count, 2)
+        XCTAssertEqual(MFAGetAuthMethodsError.ErrorType.allCases.count, 2)
     }
 
     func test_customErrorDescription() {
@@ -40,13 +40,13 @@ final class MFASubmitChallengeErrorTests: XCTestCase {
     }
 
     func test_defaultErrorDescription() {
-        let sut: [MFASubmitChallengeError] = [
-            .init(type: .invalidChallenge, correlationId: .init()),
+        let sut: [MFAGetAuthMethodsError] = [
+            .init(type: .browserRequired, correlationId: .init()),
             .init(type: .generalError, correlationId: .init())
         ]
 
         let expectedDescriptions = [
-            MSALNativeAuthErrorMessage.invalidChallenge,
+            MSALNativeAuthErrorMessage.browserRequired,
             MSALNativeAuthErrorMessage.generalError
         ]
 
@@ -57,8 +57,8 @@ final class MFASubmitChallengeErrorTests: XCTestCase {
         }
     }
 
-    func test_isInvalidChallenge() {
-        sut = .init(type: .invalidChallenge, correlationId: .init())
-        XCTAssertTrue(sut.isInvalidChallenge)
+    func test_isBrowserRequired() {
+        sut = .init(type: .browserRequired, correlationId: .init())
+        XCTAssertTrue(sut.isBrowserRequired)
     }
 }

--- a/MSAL/test/unit/native_auth/public/error/MFARequestChallengeErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/MFARequestChallengeErrorTests.swift
@@ -25,12 +25,12 @@
 import XCTest
 @testable import MSAL
 
-final class MFAErrorTests: XCTestCase {
+final class MFARequestChallengeErrorTests: XCTestCase {
 
-    private var sut: MFAError!
+    private var sut: MFARequestChallengeError!
 
     func test_totalCases() {
-        XCTAssertEqual(MFAError.ErrorType.allCases.count, 2)
+        XCTAssertEqual(MFARequestChallengeError.ErrorType.allCases.count, 2)
     }
 
     func test_customErrorDescription() {
@@ -40,7 +40,7 @@ final class MFAErrorTests: XCTestCase {
     }
 
     func test_defaultErrorDescription() {
-        let sut: [MFAError] = [
+        let sut: [MFAGetAuthMethodsError] = [
             .init(type: .browserRequired, correlationId: .init()),
             .init(type: .generalError, correlationId: .init())
         ]

--- a/MSAL/test/unit/native_auth/public/state_machine/mfa/AwaitingMFAStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/mfa/AwaitingMFAStateTests.swift
@@ -45,7 +45,7 @@ final class AwaitingMFAStateTests: XCTestCase {
     func test_requestChallenge_delegate_withError_shouldReturnCorrectError() {
         let exp = expectation(description: "mfa state")
 
-        let expectedError = MFAError(type: .generalError, message: "test error", correlationId: correlationId)
+        let expectedError = MFARequestChallengeError(type: .generalError, message: "test error", correlationId: correlationId)
         let expectedState = MFARequiredState(controller: controller, scopes: [], continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: MFARequestChallengeResult = .error(

--- a/MSAL/test/unit/native_auth/public/state_machine/mfa/MFARequiredStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/mfa/MFARequiredStateTests.swift
@@ -98,7 +98,7 @@ final class MFARequiredStateTests: XCTestCase {
     func test_getAuthMethods_delegate_withError_shouldReturnCorrectError() {
         let exp = expectation(description: "mfa state")
 
-        let expectedError = MFAError(type: .generalError, message: "test error", correlationId: correlationId)
+        let expectedError = MFAGetAuthMethodsError(type: .generalError, message: "test error", correlationId: correlationId)
         let expectedState = MFARequiredState(controller: controller, scopes: [], continuationToken: "continuationToken", correlationId: correlationId)
 
         let expectedResult: MFAGetAuthMethodsResult = .error(


### PR DESCRIPTION
## Proposed changes

Introduce new error types: MFARequestChallengeError and MFAGetAuthMethodsError. This update enables the future addition of specific errors for each MFA-related action.

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
