### PR TITLE
[macOS SDK] Increase SPM version for macOS to 10.15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "MSAL",
   platforms: [
-        .macOS(.v10_13),.iOS(.v14)
+        .macOS(.v10_15),.iOS(.v14)
   ],
   products: [
       .library(


### PR DESCRIPTION
## Proposed changes

The version required for macOS in `Package.swift` should be same as the one in the project - 10.15 

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

