### PR TITLE
MSAL - Fix visionOS related errors during build pipeline

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -9009,6 +9009,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
 				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 1.2;
 			};
 			name = Debug;
 		};
@@ -9024,6 +9025,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
 				TARGETED_DEVICE_FAMILY = "1,2,7";
+				XROS_DEPLOYMENT_TARGET = 1.2;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## Proposed changes

Related to IdentityCore: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1430 

Add specific minimum version to match downloaded visionOS simulator's version to fix this issue on [MSAL] Common core submodule update check pipeline:
![image](https://github.com/user-attachments/assets/1eec8179-4ee0-463a-9cef-3fd1d1fd036e)

for example: https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1371147&view=logs&j=ca125a0f-805b-582c-c197-3584139e4584&t=e20b3035-7539-51e8-aba3-a8fc9c962b85

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

