### PR TITLE
Add more details when reset password required error is received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Next release]:
+* Add native auth instructions to error description when reset password required is returned (#2582)
+
 ## [1.6.1]:
 * Support extra query parameters on logout endpoint (#2339)
 * Add support functions to help broker improve cross cloud experience (#2361)

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorCodes.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorCodes.swift
@@ -28,4 +28,5 @@ enum MSALNativeAuthESTSApiErrorCodes: Int {
     case invalidCredentials = 50126
     case userNotHaveAPassword = 500222
     case invalidRequestParameter = 90100
+    case resetPasswordRequired = 50142
 }

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
@@ -45,6 +45,7 @@ enum MSALNativeAuthErrorMessage {
     static let unexpectedResponseBody = "Unexpected response body received"
     static let unexpectedChallengeType = "Unexpected challenge type"
     static let refreshTokenMFARequiredError = "Multi-factor authentication is required, which can't be fulfilled as part of this flow. Please sign out and perform a new sign in operation. More information: "
+    static let passwordResetRequired = "User password change is required, which can't be fulfilled as part of this flow. Please reset the password and perform a new sign in operation. More information: "
 }
 
 // swiftlint:enable line_length

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -139,6 +139,19 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
         apiError: MSALNativeAuthTokenResponseError,
         context: MSIDRequestContext
     ) -> MSALNativeAuthTokenValidatedResponse {
+        var apiError = apiError
+        if (apiError.errorCodes?.contains(MSALNativeAuthESTSApiErrorCodes.resetPasswordRequired.rawValue) ?? false) {
+            let customErrorDescription = MSALNativeAuthErrorMessage.passwordResetRequired + (apiError.errorDescription ?? "")
+            apiError = MSALNativeAuthTokenResponseError(
+                error: apiError.error,
+                subError: apiError.subError,
+                errorDescription: customErrorDescription,
+                errorCodes: apiError.errorCodes,
+                errorURI: apiError.errorURI,
+                innerErrors: apiError.innerErrors,
+                continuationToken: apiError.continuationToken,
+                correlationId: apiError.correlationId)
+        }
         return handleInvalidResponseErrorCodes(
             apiError,
             context: context,

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -219,7 +219,8 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
         case .invalidCredentials:
             return .invalidPassword(apiError)
         case .userNotHaveAPassword,
-             .invalidRequestParameter:
+             .invalidRequestParameter,
+             .resetPasswordRequired:
             return .generalError(apiError)
         }
     }
@@ -232,7 +233,8 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
         case .userNotFound,
             .invalidCredentials,
             .userNotHaveAPassword,
-            .invalidRequestParameter:
+            .invalidRequestParameter,
+            .resetPasswordRequired:
             return .invalidRequest(apiError)
         }
     }

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -140,7 +140,7 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
         context: MSIDRequestContext
     ) -> MSALNativeAuthTokenValidatedResponse {
         var apiError = apiError
-        if (apiError.errorCodes?.contains(MSALNativeAuthESTSApiErrorCodes.resetPasswordRequired.rawValue) ?? false) {
+        if apiError.errorCodes?.contains(MSALNativeAuthESTSApiErrorCodes.resetPasswordRequired.rawValue) ?? false {
             let customErrorDescription = MSALNativeAuthErrorMessage.passwordResetRequired + (apiError.errorDescription ?? "")
             apiError = MSALNativeAuthTokenResponseError(
                 error: apiError.error,

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -90,6 +90,8 @@ extension MSALNativeAuthUserAccountResult {
         let errorCodes = error.userInfo[MSALSTSErrorCodesKey] as? [Int] ?? []
         if isMFARequiredError(errorCodes: errorCodes) {
             message = MSALNativeAuthErrorMessage.refreshTokenMFARequiredError + message
+        } else if isResetPasswordRequiredError(errorCodes: errorCodes) {
+            message = MSALNativeAuthErrorMessage.passwordResetRequired + message
         }
         let correlationId = correlationIdFromMSALError(error: error) ?? context.correlationId()
         return RetrieveAccessTokenError(type: .generalError, message: message, correlationId: correlationId, errorCodes: errorCodes)
@@ -102,5 +104,9 @@ extension MSALNativeAuthUserAccountResult {
     private func isMFARequiredError(errorCodes: [Int]) -> Bool {
         let mfaRequiredErrorCode = 50076
         return errorCodes.contains(mfaRequiredErrorCode)
+    }
+    
+    private func isResetPasswordRequiredError(errorCodes: [Int]) -> Bool {
+        return errorCodes.contains(MSALNativeAuthESTSApiErrorCodes.resetPasswordRequired.rawValue)
     }
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthTokenResponseValidatorTests.swift
@@ -168,6 +168,29 @@ final class MSALNativeAuthTokenResponseValidatorTest: MSALNativeAuthTestCase {
         }
     }
     
+    func test_invalidRequestResetPasswordRequired_theErrorDescriptionContainsCorrectInformation() {
+        let continuationTokenResponse = "ct"
+        let description = "reset password required"
+        let errorCodes = [50142]
+        let error = MSALNativeAuthTokenResponseError(error: .invalidRequest, subError: nil, errorDescription: description, errorCodes: errorCodes, errorURI: nil, innerErrors: nil, continuationToken: continuationTokenResponse)
+
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let result = sut.validate(context: context, msidConfiguration: MSALNativeAuthConfigStubs.msidConfiguration, result: .failure(error))
+        
+        guard case .error(let errorType) = result else {
+            return XCTFail("Unexpected response")
+        }
+        guard case .invalidRequest(let validatedError) = errorType else {
+            return XCTFail("Unexpected Error")
+        }
+        XCTAssertEqual(validatedError.error, .invalidRequest)
+        XCTAssertEqual(validatedError.errorDescription, MSALNativeAuthErrorMessage.passwordResetRequired + description)
+        XCTAssertEqual(validatedError.errorCodes, errorCodes)
+        XCTAssertNil(validatedError.subError)
+        XCTAssertNil(validatedError.innerErrors)
+        XCTAssertNil(validatedError.errorURI)
+    }
+    
     func test_invalidGrantMFARequired_triggerStrongAuthRequiredResponse() {
         let continuationTokenResponse = "ct"
         let error = MSALNativeAuthTokenResponseError(error: .invalidGrant, subError: .mfaRequired, errorDescription: nil, errorCodes: nil, errorURI: nil, innerErrors: nil, continuationToken: continuationTokenResponse)

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -388,7 +388,26 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let error = NSError(domain: "", code: 1, userInfo: userInfo)
         silentTokenProviderFactoryMock.silentTokenProvider.error = error
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
-        let expectedError = RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.refreshTokenMFARequiredError + message, correlationId: correlationId, errorCodes: [50076], errorUri: nil)
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.refreshTokenMFARequiredError + message, correlationId: correlationId, errorCodes: errorCodes, errorUri: nil)
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        sut.getAccessToken(correlationId: correlationId,
+                           delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+    
+    func test_errorWithResetPasswordRequiredErrorCode_ErrorMessageShouldContainsCorrectMessage() async {
+        let correlationId = UUID()
+        let errorCodes = [50142]
+        let message = "message"
+        let userInfo: [String : Any] = [
+            MSALErrorDescriptionKey: message,
+            MSALSTSErrorCodesKey: errorCodes
+        ]
+        let error = NSError(domain: "", code: 1, userInfo: userInfo)
+        silentTokenProviderFactoryMock.silentTokenProvider.error = error
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.passwordResetRequired + message, correlationId: correlationId, errorCodes: errorCodes, errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
         sut.getAccessToken(correlationId: correlationId,
                            delegate: delegate)


### PR DESCRIPTION
## Proposed changes

When reset password is required during a call to /token, we need some native auth specific handling to inform developers on how to handle this error.

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

