### PR TITLE
Use older version of xcpretty [MSAL] - second try

### DIFF
--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -50,10 +50,16 @@ jobs:
           /bin/bash -c "sudo xcode-select -s /Applications/Xcode_15.4.app"
     displayName: 'Switch to use Xcode 15.4'
   - task: CmdLine@2
+    displayName: Installing xcpretty
+    inputs:
+      script: |
+        gem install xcpretty -N -v 0.3.0
+      failOnStderr: true
+  - task: CmdLine@2
     displayName: Installing dependencies
     inputs:
       script: |
-        gem install xcpretty slather bundler -N
+        gem install slather bundler -N
       failOnStderr: true
   - checkout: self
     clean: true

--- a/azure_pipelines/templates/tests-with-conf-file.yml
+++ b/azure_pipelines/templates/tests-with-conf-file.yml
@@ -26,7 +26,7 @@ steps:
       script: |        
         cd $(Agent.BuildDirectory)/s
   
-  - script: 'gem install xcpretty'
+  - script: 'gem install xcpretty -v 0.3.0'
     displayName: 'Install xcpretty'
 
   - task: AzureCLI@2


### PR DESCRIPTION
## Proposed changes

Sometimes the tests in pipelines fail, but there is an error in xcpretty that doesn't allow it to show the actual error in the test; apparently happening in the new version of xcpretty: https://github.com/xcpretty/xcpretty/issues/391 

The error in the pipelines look like this:
```
Build & Testing Failed! \n /usr/local/lib/ruby/gems/3.0.0/gems/xcpretty-0.4.0/lib/xcpretty/parser.rb:366:in 'parse': uninitialized constant XCPretty::Parser::ERB (NameError)
	from /usr/local/lib/ruby/gems/3.0.0/gems/xcpretty-0.4.0/lib/xcpretty/formatters/formatter.rb:88:in 'pretty_format'
	from /usr/local/lib/ruby/gems/3.0.0/gems/xcpretty-0.4.0/lib/xcpretty/printer.rb:19:in 'pretty_print'
	from /usr/local/lib/ruby/gems/3.0.0/gems/xcpretty-0.4.0/bin/xcpretty:84:in 'block in <top (required)>'
	from /usr/local/lib/ruby/gems/3.0.0/gems/xcpretty-0.4.0/bin/xcpretty:83:in 'each_line'
	from /usr/local/lib/ruby/gems/3.0.0/gems/xcpretty-0.4.0/bin/xcpretty:83:in '<top (required)>'
	from /usr/local/lib/ruby/gems/3.0.0/bin/xcpretty:25:in 'load'
	from /usr/local/lib/ruby/gems/3.0.0/bin/xcpretty:25:in '<main>'
```

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

