### PR TITLE
Native Auth E2E test fix

### DIFF
--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
@@ -29,6 +29,7 @@ import MSAL
 final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPasswordTestCase {
 
     func test_signInUsingPasswordWithMFASubmitWrongChallengeResendChallengeThen_completeSuccessfully() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
 #if os(macOS)
         throw XCTSkip("For some reason this test now requires Keychain access, reason needs to be investigated")
 #endif
@@ -88,6 +89,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
     }
     
     func test_signInUsingPasswordWithMFAGetAuthMethods_thenCompleteSuccessfully() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
 #if os(macOS)
         throw XCTSkip("For some reason this test now requires Keychain access, reason needs to be investigated")
 #endif
@@ -146,6 +148,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
     }
     
     func test_signInUsingPasswordWithMFANoDefaultAuthMethod_completeSuccessfully() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
 #if os(macOS)
         throw XCTSkip("For some reason this test now requires Keychain access, reason needs to be investigated")
 #endif

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
@@ -29,7 +29,7 @@ import MSAL
 final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPasswordTestCase {
 
     func test_signInUsingPasswordWithMFASubmitWrongChallengeResendChallengeThen_completeSuccessfully() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
 #if os(macOS)
         throw XCTSkip("For some reason this test now requires Keychain access, reason needs to be investigated")
 #endif
@@ -89,7 +89,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
     }
     
     func test_signInUsingPasswordWithMFAGetAuthMethods_thenCompleteSuccessfully() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
 #if os(macOS)
         throw XCTSkip("For some reason this test now requires Keychain access, reason needs to be investigated")
 #endif
@@ -148,7 +148,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
     }
     
     func test_signInUsingPasswordWithMFANoDefaultAuthMethod_completeSuccessfully() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
 #if os(macOS)
         throw XCTSkip("For some reason this test now requires Keychain access, reason needs to be investigated")
 #endif

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
@@ -31,6 +31,8 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
     private let codeRetryCount = 3
 
     func test_resetPassword_withoutAutomaticSignIn_succeeds() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(),
               let username = retrieveUsernameForResetPassword()
         else {
@@ -72,6 +74,8 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
 
     // SSPR - with automatic sign in
     func test_resetPassword_withAutomaticSignIn_succeeds() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(),
               let username = retrieveUsernameForResetPassword()
         else {

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
@@ -49,6 +49,8 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.2.7. Sign in - Invalid OTP code
     func test_signInAndSendingIncorrectOTPResultsInError() async throws {
+        throw XCTSkip("The test account is locked")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .code), let username = retrieveUsernameForSignInCode() else {
             XCTFail("Missing information")
             return
@@ -84,7 +86,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.2.1. Sign in - Use email and OTP to get token and sign in
     func test_signInAndSendingCorrectOTPResultsInSuccess() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
 
         guard let sut = initialisePublicClientApplication(clientIdType: .code), let username = retrieveUsernameForSignInCode() else {
             XCTFail("Missing information")
@@ -128,7 +130,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
     
     // Sign In - Verify Custom URL Domain - "https://<tenantName>.ciamlogin.com/<tenantName>.onmicrosoft.com"
     func test_signInCustomSubdomainLongInSuccess() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .code, customAuthorityURLFormat: .tenantSubdomainLongVersion), let username = retrieveUsernameForSignInCode() else {
             XCTFail("Missing information")
@@ -172,7 +174,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
     
     // Sign In - Verify Custom URL Domain - "https://<tenantName>.ciamlogin.com/<tenantId>"
     func test_signInCustomSubdomainIdInSuccess() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .code, customAuthorityURLFormat: .tenantSubdomainTenantId), let username = retrieveUsernameForSignInCode() else {
             XCTFail("Missing information")
@@ -216,7 +218,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
     
     // Sign In - Verify Custom URL Domain - "https://<tenantName>.ciamlogin.com/"
     func test_signInCustomSubdomainShortInSuccess() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .code, customAuthorityURLFormat: .tenantSubdomainShortVersion), let username = retrieveUsernameForSignInCode() else {
             XCTFail("Missing information")

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
@@ -49,8 +49,6 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.2.7. Sign in - Invalid OTP code
     func test_signInAndSendingIncorrectOTPResultsInError() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
-
         guard let sut = initialisePublicClientApplication(clientIdType: .code), let username = retrieveUsernameForSignInCode() else {
             XCTFail("Missing information")
             return

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
@@ -49,6 +49,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.2.7. Sign in - Invalid OTP code
     func test_signInAndSendingIncorrectOTPResultsInError() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
 
         guard let sut = initialisePublicClientApplication(clientIdType: .code), let username = retrieveUsernameForSignInCode() else {
             XCTFail("Missing information")
@@ -85,6 +86,7 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.2.1. Sign in - Use email and OTP to get token and sign in
     func test_signInAndSendingCorrectOTPResultsInSuccess() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
 
         guard let sut = initialisePublicClientApplication(clientIdType: .code), let username = retrieveUsernameForSignInCode() else {
             XCTFail("Missing information")
@@ -128,6 +130,8 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
     
     // Sign In - Verify Custom URL Domain - "https://<tenantName>.ciamlogin.com/<tenantName>.onmicrosoft.com"
     func test_signInCustomSubdomainLongInSuccess() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .code, customAuthorityURLFormat: .tenantSubdomainLongVersion), let username = retrieveUsernameForSignInCode() else {
             XCTFail("Missing information")
             return
@@ -170,6 +174,8 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
     
     // Sign In - Verify Custom URL Domain - "https://<tenantName>.ciamlogin.com/<tenantId>"
     func test_signInCustomSubdomainIdInSuccess() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .code, customAuthorityURLFormat: .tenantSubdomainTenantId), let username = retrieveUsernameForSignInCode() else {
             XCTFail("Missing information")
             return
@@ -212,6 +218,8 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
     
     // Sign In - Verify Custom URL Domain - "https://<tenantName>.ciamlogin.com/"
     func test_signInCustomSubdomainShortInSuccess() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .code, customAuthorityURLFormat: .tenantSubdomainShortVersion), let username = retrieveUsernameForSignInCode() else {
             XCTFail("Missing information")
             return

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift
@@ -29,7 +29,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Hero Scenario 1.1.1. Sign up - with Email verification as LAST step (Email & Password)
     func test_signUpWithPassword_withEmailVerificationLastStep_succeeds() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")
@@ -89,7 +89,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
     
     // Use case 1.1.2. Sign up - with Email & Password, Resend email OOB
     func test_signUpWithEmailPassword_resendEmail_success() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")
@@ -143,7 +143,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Hero Scenario 1.1.3. Sign up - with Email verification as LAST step & Custom Attributes (Email & Password)
     func test_signUpWithPassword_withEmailVerificationAsLastStepAndCustomAttributes_succeeds() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .passwordAndAttributes) else {
             XCTFail("Missing information")
@@ -205,7 +205,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Hero Scenario 1.1.4. Sign up - with Email verification as FIRST step (Email & Password)
     func test_signUpWithPassword_withEmailVerificationAsFirstStepAndThenSetPassword_succeeds() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")
@@ -281,7 +281,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
     
     // Use case 1.1.5. Sign up - with Email & Password, Verify email address using email OTP, resend OTP and then set password
     func test_signUpWithEmailOTP_andSetPasswordAfterOTP_success() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")
@@ -349,7 +349,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Hero Scenario 1.1.6. Sign up - with Email verification as FIRST step & Custom Attribute (Email & Password)
     func test_signUpWithPasswordWithEmailVerificationAsFirstStepAndCustomAttributes_succeeds() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .passwordAndAttributes) else {
             XCTFail("Missing information")
@@ -443,7 +443,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Sign up - with Email verification as FIRST step & Custom Attributes over MULTIPLE screens (Email & Password)
     func test_signUpWithPasswordWithEmailVerificationAsFirstStepAndCustomAttributesOverMultipleScreens_succeeds() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .passwordAndAttributes) else {
             XCTFail("Missing information")
@@ -555,7 +555,7 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Sign up – without automatic sign in (Email & Password)
     func test_signUpWithPasswordWithoutAutomaticSignIn() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests.swift
@@ -29,6 +29,8 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Hero Scenario 1.1.1. Sign up - with Email verification as LAST step (Email & Password)
     func test_signUpWithPassword_withEmailVerificationLastStep_succeeds() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")
             return
@@ -87,6 +89,8 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
     
     // Use case 1.1.2. Sign up - with Email & Password, Resend email OOB
     func test_signUpWithEmailPassword_resendEmail_success() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")
             return
@@ -139,6 +143,8 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Hero Scenario 1.1.3. Sign up - with Email verification as LAST step & Custom Attributes (Email & Password)
     func test_signUpWithPassword_withEmailVerificationAsLastStepAndCustomAttributes_succeeds() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .passwordAndAttributes) else {
             XCTFail("Missing information")
             return
@@ -199,6 +205,8 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Hero Scenario 1.1.4. Sign up - with Email verification as FIRST step (Email & Password)
     func test_signUpWithPassword_withEmailVerificationAsFirstStepAndThenSetPassword_succeeds() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")
             return
@@ -273,6 +281,8 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
     
     // Use case 1.1.5. Sign up - with Email & Password, Verify email address using email OTP, resend OTP and then set password
     func test_signUpWithEmailOTP_andSetPasswordAfterOTP_success() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")
             return
@@ -339,6 +349,8 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Hero Scenario 1.1.6. Sign up - with Email verification as FIRST step & Custom Attribute (Email & Password)
     func test_signUpWithPasswordWithEmailVerificationAsFirstStepAndCustomAttributes_succeeds() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .passwordAndAttributes) else {
             XCTFail("Missing information")
             return
@@ -431,6 +443,8 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Sign up - with Email verification as FIRST step & Custom Attributes over MULTIPLE screens (Email & Password)
     func test_signUpWithPasswordWithEmailVerificationAsFirstStepAndCustomAttributesOverMultipleScreens_succeeds() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .passwordAndAttributes) else {
             XCTFail("Missing information")
             return
@@ -541,6 +555,8 @@ final class MSALNativeAuthSignUpUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
     // Sign up – without automatic sign in (Email & Password)
     func test_signUpWithPasswordWithoutAutomaticSignIn() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")
             return

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameEndToEndTests.swift
@@ -29,6 +29,8 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.1.1. Sign up – with Email Verification (Email & Email OTP)
     func test_signUpWithCode_withEmailVerification_succeeds() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .code) else {
             XCTFail("Missing information")
             return
@@ -73,6 +75,8 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.1.2. Sign up – with Email Verification as LAST step & Custom Attributes (Email & Email OTP)
     func test_signUpWithCode_withEmailVerificationAsLastStepAndCustomAttributes_succeeds() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .codeAndAttributes) else {
             XCTFail("OTP code not retrieved from email")
             return
@@ -114,6 +118,8 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.1.3. Sign up – with Email Verification as FIRST step & Custom Attributes (Email & Email OTP)
     func test_signUpWithCode_withEmailVerificationAsFirstStepAndCustomAttributes_succeeds() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .codeAndAttributes) else {
             XCTFail("Missing information")
             return
@@ -168,6 +174,8 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.1.4. Sign up – with Email Verification as FIRST step & Custom Attributes over MULTIPLE screens (Email & Email OTP)
     func test_signUpWithCode_withEmailVerificationAsFirstStepAndCustomAttributesOverMultipleScreens_succeeds() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .codeAndAttributes) else {
             XCTFail("Missing information")
             return
@@ -239,6 +247,8 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
     
     // use case 2.1.5. Sign up - with Email & OTP resend email OTP
     func test_signUpWithEmailOTP_resendEmail_success() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .code) else {
             XCTFail("Missing information")
             return
@@ -366,6 +376,8 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.1.9. Sign up – without automatic sign in (Email & Email OTP)
     func test_signUpWithoutAutomaticSignIn() async throws {
+        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        
         guard let sut = initialisePublicClientApplication(clientIdType: .code) else {
             XCTFail("Missing information")
             return

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/MSALNativeAuthSignUpUsernameEndToEndTests.swift
@@ -29,7 +29,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.1.1. Sign up – with Email Verification (Email & Email OTP)
     func test_signUpWithCode_withEmailVerification_succeeds() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .code) else {
             XCTFail("Missing information")
@@ -75,7 +75,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.1.2. Sign up – with Email Verification as LAST step & Custom Attributes (Email & Email OTP)
     func test_signUpWithCode_withEmailVerificationAsLastStepAndCustomAttributes_succeeds() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .codeAndAttributes) else {
             XCTFail("OTP code not retrieved from email")
@@ -118,7 +118,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.1.3. Sign up – with Email Verification as FIRST step & Custom Attributes (Email & Email OTP)
     func test_signUpWithCode_withEmailVerificationAsFirstStepAndCustomAttributes_succeeds() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .codeAndAttributes) else {
             XCTFail("Missing information")
@@ -174,7 +174,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.1.4. Sign up – with Email Verification as FIRST step & Custom Attributes over MULTIPLE screens (Email & Email OTP)
     func test_signUpWithCode_withEmailVerificationAsFirstStepAndCustomAttributesOverMultipleScreens_succeeds() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .codeAndAttributes) else {
             XCTFail("Missing information")
@@ -247,7 +247,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
     
     // use case 2.1.5. Sign up - with Email & OTP resend email OTP
     func test_signUpWithEmailOTP_resendEmail_success() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .code) else {
             XCTFail("Missing information")
@@ -376,7 +376,7 @@ final class MSALNativeAuthSignUpUsernameEndToEndTests: MSALNativeAuthEndToEndBas
 
     // Hero Scenario 2.1.9. Sign up – without automatic sign in (Email & Email OTP)
     func test_signUpWithoutAutomaticSignIn() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(clientIdType: .code) else {
             XCTFail("Missing information")


### PR DESCRIPTION
## Proposed changes

The third party of 1secmail used for E2E test OTP code fetching is down. Disable the tests until find an alternative solution/ the service back to normal.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
