### PR TITLE
Add parameters to public methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [TBD]
+## [1.7.0]
 * Move native auth public methods to parameter class
 
 ## [1.6.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [TBD]
-* Added parameters for Native Auth public interfaces
+* Move native auth public methods to parameter class
 
 ## [1.6.3]
 * Merge 1.6.1-hotfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [TBD]
+* Added parameters for Native Auth public interfaces
+
 ## [1.6.3]
 * Merge 1.6.1-hotfix
 

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -258,7 +258,7 @@
 		281A0E1B2C21E20600CB30CB /* MSALNativeAuthEndToEndBaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B235D9E2A3CFB4300657331 /* MSALNativeAuthEndToEndBaseTestCase.swift */; };
 		281A0E1C2C21E3A400CB30CB /* MSALNativeAuthSignOutEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFB46EC2A52BA3700DBC006 /* MSALNativeAuthSignOutEndToEndTests.swift */; };
 		2826932A2A0974750037B93A /* MSALNativeAuthTokenRequestParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282693272A0974740037B93A /* MSALNativeAuthTokenRequestParameters.swift */; };
-		2826933B2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2826933A2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift */; };
+		2826933B2A0B98750037B93A /* MSALNativeAuthInternalSignInParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2826933A2A0B98750037B93A /* MSALNativeAuthInternalSignInParameters.swift */; };
 		285D0D692B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285D0D682B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift */; };
 		285E09F72C93340000492A2E /* MSALNativeAuthLogMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BBB7CD2C80C5740055AF64 /* MSALNativeAuthLogMessage.swift */; };
 		285F36082A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285F36072A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift */; };
@@ -1043,6 +1043,18 @@
 		DE1D8AA829E6B7D900E11D48 /* MSALNativeAuthRequestConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1D8AA729E6B7D900E11D48 /* MSALNativeAuthRequestConfigurator.swift */; };
 		DE40A4CA2A8F801200928CEE /* MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE40A4C92A8F801200928CEE /* MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests.swift */; };
 		DE40A4D32A8F80C100928CEE /* MSALNativeAuthSignUpContinueResponseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE40A4D22A8F80C100928CEE /* MSALNativeAuthSignUpContinueResponseErrorTests.swift */; };
+		DE43150A2D3E551F009A7FA2 /* MSALNativeAuthGetAccessTokenParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315032D3E551E009A7FA2 /* MSALNativeAuthGetAccessTokenParameters.swift */; };
+		DE43150B2D3E551F009A7FA2 /* MSALNativeAuthSignInParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315072D3E551E009A7FA2 /* MSALNativeAuthSignInParameters.swift */; };
+		DE43150C2D3E551F009A7FA2 /* MSALNativeAuthSignUpParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315082D3E551E009A7FA2 /* MSALNativeAuthSignUpParameters.swift */; };
+		DE43150D2D3E551F009A7FA2 /* MSALNativeAuthSignInAfterSignUpParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315062D3E551E009A7FA2 /* MSALNativeAuthSignInAfterSignUpParameters.swift */; };
+		DE43150E2D3E551F009A7FA2 /* MSALNativeAuthResetPasswordParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315042D3E551E009A7FA2 /* MSALNativeAuthResetPasswordParameters.swift */; };
+		DE43150F2D3E551F009A7FA2 /* MSALNativeAuthSignInAfterResetPasswordParameters .swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315052D3E551E009A7FA2 /* MSALNativeAuthSignInAfterResetPasswordParameters .swift */; };
+		DE4315102D3E551F009A7FA2 /* MSALNativeAuthGetAccessTokenParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315032D3E551E009A7FA2 /* MSALNativeAuthGetAccessTokenParameters.swift */; };
+		DE4315112D3E551F009A7FA2 /* MSALNativeAuthSignInParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315072D3E551E009A7FA2 /* MSALNativeAuthSignInParameters.swift */; };
+		DE4315122D3E551F009A7FA2 /* MSALNativeAuthSignUpParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315082D3E551E009A7FA2 /* MSALNativeAuthSignUpParameters.swift */; };
+		DE4315132D3E551F009A7FA2 /* MSALNativeAuthSignInAfterSignUpParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315062D3E551E009A7FA2 /* MSALNativeAuthSignInAfterSignUpParameters.swift */; };
+		DE4315142D3E551F009A7FA2 /* MSALNativeAuthResetPasswordParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315042D3E551E009A7FA2 /* MSALNativeAuthResetPasswordParameters.swift */; };
+		DE4315152D3E551F009A7FA2 /* MSALNativeAuthSignInAfterResetPasswordParameters .swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4315052D3E551E009A7FA2 /* MSALNativeAuthSignInAfterResetPasswordParameters .swift */; };
 		DE4F0F3129D6F1AA00D561FD /* MSALNativeAuthTokenIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4F0F2929D6F1AA00D561FD /* MSALNativeAuthTokenIntegrationTests.swift */; };
 		DE54B5912A434B9B00460B34 /* MSALNativeAuthTokenController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE54B5902A434B9B00460B34 /* MSALNativeAuthTokenController.swift */; };
 		DE54B5942A43587800460B34 /* MSALNativeAuthTokenRequestProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE54B5932A43587800460B34 /* MSALNativeAuthTokenRequestProvider.swift */; };
@@ -1086,7 +1098,7 @@
 		DE8DC4642C66219600534E8F /* ResetPasswordResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2EFAD0E2A69BBB800D6C3DE /* ResetPasswordResults.swift */; };
 		DE8DC4652C66219600534E8F /* MSALNativeAuthCredentialsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE92450B2A385ED800C0389F /* MSALNativeAuthCredentialsController.swift */; };
 		DE8DC4662C66219600534E8F /* MSALNativeAuthResultFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE34F43D170B71C00BC302A /* MSALNativeAuthResultFactory.swift */; };
-		DE8DC4672C66219600534E8F /* MSALNativeAuthSignInParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2826933A2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift */; };
+		DE8DC4672C66219600534E8F /* MSALNativeAuthInternalSignInParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2826933A2A0B98750037B93A /* MSALNativeAuthInternalSignInParameters.swift */; };
 		DE8DC4682C66219600534E8F /* MSALNativeAuthControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D5B05C2A028D2B0066E32B /* MSALNativeAuthControllerFactory.swift */; };
 		DE8DC4692C66219600534E8F /* MSALNativeAuthTokenController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE54B5902A434B9B00460B34 /* MSALNativeAuthTokenController.swift */; };
 		DE8DC46A2C66219600534E8F /* MSALNativeAuthControllerTelemetryWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2EFAD152A70300B00D6C3DE /* MSALNativeAuthControllerTelemetryWrapper.swift */; };
@@ -2013,7 +2025,7 @@
 		28188F5F2C8F482D00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInWithMFAEndToEndTests.swift; sourceTree = "<group>"; };
 		28188F642C8F4C1100CFDD05 /* MFADelegateSpies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFADelegateSpies.swift; sourceTree = "<group>"; };
 		282693272A0974740037B93A /* MSALNativeAuthTokenRequestParameters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenRequestParameters.swift; sourceTree = "<group>"; };
-		2826933A2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInParameters.swift; sourceTree = "<group>"; };
+		2826933A2A0B98750037B93A /* MSALNativeAuthInternalSignInParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalSignInParameters.swift; sourceTree = "<group>"; };
 		285D0D682B99C14F002A1D4A /* MSALNativeAuthTokenResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenResult.swift; sourceTree = "<group>"; };
 		285F36072A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInControlling.swift; sourceTree = "<group>"; };
 		285F58532C5BA33B00F4EFA4 /* MSALNativeAuthSignInIntrospectRequestParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInIntrospectRequestParameters.swift; sourceTree = "<group>"; };
@@ -2472,6 +2484,12 @@
 		DE1D8AA729E6B7D900E11D48 /* MSALNativeAuthRequestConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequestConfigurator.swift; sourceTree = "<group>"; };
 		DE40A4C92A8F801200928CEE /* MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpChallengeOauth2ErrorCodeTests.swift; sourceTree = "<group>"; };
 		DE40A4D22A8F80C100928CEE /* MSALNativeAuthSignUpContinueResponseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpContinueResponseErrorTests.swift; sourceTree = "<group>"; };
+		DE4315032D3E551E009A7FA2 /* MSALNativeAuthGetAccessTokenParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthGetAccessTokenParameters.swift; sourceTree = "<group>"; };
+		DE4315042D3E551E009A7FA2 /* MSALNativeAuthResetPasswordParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordParameters.swift; sourceTree = "<group>"; };
+		DE4315052D3E551E009A7FA2 /* MSALNativeAuthSignInAfterResetPasswordParameters .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MSALNativeAuthSignInAfterResetPasswordParameters .swift"; sourceTree = "<group>"; };
+		DE4315062D3E551E009A7FA2 /* MSALNativeAuthSignInAfterSignUpParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInAfterSignUpParameters.swift; sourceTree = "<group>"; };
+		DE4315072D3E551E009A7FA2 /* MSALNativeAuthSignInParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInParameters.swift; sourceTree = "<group>"; };
+		DE4315082D3E551E009A7FA2 /* MSALNativeAuthSignUpParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpParameters.swift; sourceTree = "<group>"; };
 		DE4F0F2929D6F1AA00D561FD /* MSALNativeAuthTokenIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenIntegrationTests.swift; sourceTree = "<group>"; };
 		DE53C7D4293F9F5A00E5B2BB /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		DE54B5902A434B9B00460B34 /* MSALNativeAuthTokenController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthTokenController.swift; sourceTree = "<group>"; };
@@ -2917,7 +2935,7 @@
 			children = (
 				285F36072A24DF8300A2190F /* MSALNativeAuthSignInControlling.swift */,
 				E206FCEE2979BC4600AF4400 /* MSALNativeAuthSignInController.swift */,
-				2826933A2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift */,
+				2826933A2A0B98750037B93A /* MSALNativeAuthInternalSignInParameters.swift */,
 				28D811EC2C760303002BE1AA /* MSALNativeAuthMFAControlling.swift */,
 			);
 			path = sign_in;
@@ -4215,6 +4233,19 @@
 			path = responses;
 			sourceTree = "<group>";
 		};
+		DE4315092D3E551E009A7FA2 /* parameters */ = {
+			isa = PBXGroup;
+			children = (
+				DE4315032D3E551E009A7FA2 /* MSALNativeAuthGetAccessTokenParameters.swift */,
+				DE4315042D3E551E009A7FA2 /* MSALNativeAuthResetPasswordParameters.swift */,
+				DE4315052D3E551E009A7FA2 /* MSALNativeAuthSignInAfterResetPasswordParameters .swift */,
+				DE4315062D3E551E009A7FA2 /* MSALNativeAuthSignInAfterSignUpParameters.swift */,
+				DE4315072D3E551E009A7FA2 /* MSALNativeAuthSignInParameters.swift */,
+				DE4315082D3E551E009A7FA2 /* MSALNativeAuthSignUpParameters.swift */,
+			);
+			path = parameters;
+			sourceTree = "<group>";
+		};
 		DE54B5962A4358A200460B34 /* token */ = {
 			isa = PBXGroup;
 			children = (
@@ -4659,6 +4690,7 @@
 		E260964129489CA60060DD7C /* public */ = {
 			isa = PBXGroup;
 			children = (
+				DE4315092D3E551E009A7FA2 /* parameters */,
 				28DCD08829D70FA000C4601E /* state_machine */,
 				E2DC31BB29AFA1E700051CE7 /* MSALNativeAuthPublicClientApplication.swift */,
 				E2F6269C2A780DDE00C4A303 /* MSALNativeAuthPublicClientApplication+Internal.swift */,
@@ -6630,7 +6662,7 @@
 				DEE34F65D170B71C00BC302A /* MSALNativeAuthResetPasswordChallengeResponse.swift in Sources */,
 				D61BD2B01EBD09F90007E484 /* MSALPublicClientApplication.m in Sources */,
 				DEDB29AD29DDAF53008DA85B /* MSALNativeAuthTokenResponseError.swift in Sources */,
-				2826933B2A0B98750037B93A /* MSALNativeAuthSignInParameters.swift in Sources */,
+				2826933B2A0B98750037B93A /* MSALNativeAuthInternalSignInParameters.swift in Sources */,
 				28EDF94129E6D52E00A99F2A /* SignInStartError.swift in Sources */,
 				D61BD2AD1EBD09F90007E484 /* MSALError.m in Sources */,
 				DE54B5AD2A459B0400460B34 /* MSALNativeAuthTokenResponseValidator.swift in Sources */,
@@ -6770,6 +6802,12 @@
 				B223B0BA22ADF8E600FB8713 /* MSALLegacySharedMSAAccount.m in Sources */,
 				2877081F2A14F67400E371ED /* MSALNativeAuthSignInChallengeValidatedResponse.swift in Sources */,
 				E206FC5F296D65DE00AF4400 /* MSALNativeAuthInternalError.swift in Sources */,
+				DE43150A2D3E551F009A7FA2 /* MSALNativeAuthGetAccessTokenParameters.swift in Sources */,
+				DE43150B2D3E551F009A7FA2 /* MSALNativeAuthSignInParameters.swift in Sources */,
+				DE43150C2D3E551F009A7FA2 /* MSALNativeAuthSignUpParameters.swift in Sources */,
+				DE43150D2D3E551F009A7FA2 /* MSALNativeAuthSignInAfterSignUpParameters.swift in Sources */,
+				DE43150E2D3E551F009A7FA2 /* MSALNativeAuthResetPasswordParameters.swift in Sources */,
+				DE43150F2D3E551F009A7FA2 /* MSALNativeAuthSignInAfterResetPasswordParameters .swift in Sources */,
 				232D68D8223DB8C200594BBD /* MSALSilentTokenParameters.m in Sources */,
 				DE729ECD2A1793A100A761D9 /* MSALNativeAuthChannelType.swift in Sources */,
 				E2EFAD162A70300B00D6C3DE /* MSALNativeAuthControllerTelemetryWrapper.swift in Sources */,
@@ -7008,13 +7046,19 @@
 				DE8DC4592C66218C00534E8F /* MSALNativeAuthCacheAccessor.swift in Sources */,
 				B2A3C28C2145FD0F0082525C /* MSALAccountsProvider.m in Sources */,
 				DE8DC4D52C6621CC00534E8F /* MSALNativeAuthSignUpChallengeResponseError.swift in Sources */,
+				DE4315102D3E551F009A7FA2 /* MSALNativeAuthGetAccessTokenParameters.swift in Sources */,
+				DE4315112D3E551F009A7FA2 /* MSALNativeAuthSignInParameters.swift in Sources */,
+				DE4315122D3E551F009A7FA2 /* MSALNativeAuthSignUpParameters.swift in Sources */,
+				DE4315132D3E551F009A7FA2 /* MSALNativeAuthSignInAfterSignUpParameters.swift in Sources */,
+				DE4315142D3E551F009A7FA2 /* MSALNativeAuthResetPasswordParameters.swift in Sources */,
+				DE4315152D3E551F009A7FA2 /* MSALNativeAuthSignInAfterResetPasswordParameters .swift in Sources */,
 				DE8DC4852C6621A300534E8F /* SignInAfterPreviousFlowBaseState+Internal.swift in Sources */,
 				DE8DC49E2C6621AE00534E8F /* MSALNativeAuthResetPasswordRequestProvider.swift in Sources */,
 				28EE65252C8B10F000015F90 /* MSALNativeAuthSignInIntrospectOauth2ErrorCode.swift in Sources */,
 				DE8DC4E32C6621D000534E8F /* MSALNativeAuthResetPasswordContinueOauth2ErrorCode.swift in Sources */,
 				DE8DC4722C66219E00534E8F /* SignInAfterSignUpDelegateDispatcher.swift in Sources */,
 				DE8DC4952C6621A600534E8F /* CredentialsDelegates.swift in Sources */,
-				DE8DC4672C66219600534E8F /* MSALNativeAuthSignInParameters.swift in Sources */,
+				DE8DC4672C66219600534E8F /* MSALNativeAuthInternalSignInParameters.swift in Sources */,
 				0D96DB3827850E8200DEAF87 /* MSALWipeCacheForAllAccountsConfig.m in Sources */,
 				DE8DC4C92C6621C700534E8F /* MSALNativeAuthResetPasswordChallengeResponse.swift in Sources */,
 				28EE65132C8B0E4500015F90 /* MSALNativeAuthSignInIntrospectValidatedResponse.swift in Sources */,

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthInternalSignInParameters.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthInternalSignInParameters.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@_implementationOnly import MSAL_Private
+
+class MSALNativeAuthInternalSignInParameters {
+    let username: String
+    let password: String?
+    let context: MSALNativeAuthRequestContext
+    let scopes: [String]?
+
+    init(
+        username: String,
+        password: String?,
+        context: MSALNativeAuthRequestContext,
+        scopes: [String]?) {
+        self.username = username
+        self.password = password
+        self.context = context
+        self.scopes = scopes
+    }
+}

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -74,7 +74,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
 
     // MARK: - Internal
 
-    func signIn(params: MSALNativeAuthSignInParameters) async -> SignInControllerResponse {
+    func signIn(params: MSALNativeAuthInternalSignInParameters) async -> SignInControllerResponse {
         let eventId: MSALNativeAuthTelemetryApiId =
         params.password == nil ? .telemetryApiIdSignInWithCodeStart : .telemetryApiIdSignInWithPasswordStart
         MSALLogger.log(level: .info, context: params.context, format: "SignIn started")
@@ -737,7 +737,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
     // swiftlint:disable:next function_body_length
     private func handleChallengeResponse(
         _ validatedResponse: MSALNativeAuthSignInChallengeValidatedResponse,
-        params: MSALNativeAuthSignInParameters,
+        params: MSALNativeAuthInternalSignInParameters,
         telemetryInfo: TelemetryInfo
     ) async -> SignInControllerResponse {
         let scopes = joinScopes(params.scopes)

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
@@ -33,7 +33,7 @@ protocol MSALNativeAuthSignInControlling {
     typealias SignInSubmitPasswordControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignInPasswordRequiredResult>
     typealias SignInResendCodeControllerResponse = MSALNativeAuthControllerTelemetryWrapper<SignInResendCodeResult>
 
-    func signIn(params: MSALNativeAuthSignInParameters) async -> SignInControllerResponse
+    func signIn(params: MSALNativeAuthInternalSignInParameters) async -> SignInControllerResponse
 
     func signIn(
         username: String,

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -73,7 +73,7 @@ extension MSALNativeAuthPublicClientApplication {
 
         let controller = controllerFactory.makeSignInController(cacheAccessor: cacheAccessor)
 
-        let params = MSALNativeAuthSignInParameters(
+        let params = MSALNativeAuthInternalSignInParameters(
             username: username,
             password: password,
             context: context,

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -151,7 +151,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
 
     /// Sign up a user using parameters.
     /// - Parameters:
-    ///   - parameters: Parameters used for signUp operation.
+    ///   - parameters: Parameters used for the Sign Up flow.
     ///   - delegate: Delegate that receives callbacks for the Sign Up flow.
     public func signUp(
         parameters: MSALNativeAuthSignUpParameters,
@@ -213,7 +213,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
 
     /// Sign in a user using parameters.
     /// - Parameters:
-    ///   - parameters: Parameters used for signIn operation.
+    ///   - parameters: Parameters used for the Sign In flow.
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(
         parameters: MSALNativeAuthSignInParameters,
@@ -277,7 +277,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
 
     /// Reset the password using parameters
     /// - Parameters:
-    ///   - parameters: Parameters used for resetPassword operation.
+    ///   - parameters: Parameters used for the Reset Password flow.
     ///   - delegate: Delegate that receives callbacks for the Reset Password flow.
     public func resetPassword(
         parameters: MSALNativeAuthResetPasswordParameters,

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -267,6 +267,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         signIn(
             parameters: MSALNativeAuthSignInParameters(username: username,
                                                        password: password,
+                                                       scopes: scopes,
                                                        correlationId: correlationId),
             delegate: delegate
         )

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -276,7 +276,6 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
     /// Reset the password for a given username.
     /// - Parameters:
     ///   - parameters: parameters used for resetPassword operation.
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     ///   - delegate: Delegate that receives callbacks for the Reset Password flow.
     public func resetPassword(
         parameters: MSALNativeAuthResetPasswordParameters,

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -200,11 +200,12 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: SignUpStartDelegate
     ) {
         Task {
+            let parameters = MSALNativeAuthSignUpParameters(username: username)
+            parameters.password = password
+            parameters.attributes = attributes
+            parameters.correlationId = correlationId
             signUp(
-                parameters: MSALNativeAuthSignUpParameters(username: username,
-                                                           password: password,
-                                                           attributes: attributes,
-                                                           correlationId: correlationId),
+                parameters: parameters,
                 delegate: delegate
             )
         }
@@ -264,11 +265,12 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         correlationId: UUID? = nil,
         delegate: SignInStartDelegate
     ) {
+        let parameters = MSALNativeAuthSignInParameters(username: username)
+        parameters.password = password
+        parameters.scopes = scopes
+        parameters.correlationId = correlationId
         signIn(
-            parameters: MSALNativeAuthSignInParameters(username: username,
-                                                       password: password,
-                                                       scopes: scopes,
-                                                       correlationId: correlationId),
+            parameters: parameters,
             delegate: delegate
         )
     }
@@ -313,9 +315,10 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         correlationId: UUID? = nil,
         delegate: ResetPasswordStartDelegate
     ) {
+        let parameters = MSALNativeAuthResetPasswordParameters(username: username)
+        parameters.correlationId = correlationId
         resetPassword(
-            parameters: MSALNativeAuthResetPasswordParameters(username: username,
-                                                              correlationId: correlationId),
+            parameters: parameters,
             delegate: delegate
         )
     }

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -151,24 +151,18 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
 
     /// Sign up a user with a given username and password.
     /// - Parameters:
-    ///   - username: Username for the new account.
-    ///   - password: Optional. Password to be used for the new account.
-    ///   - attributes: Optional. User attributes to be used during account creation.
-    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - parameters: parameters used for signUp operation.
     ///   - delegate: Delegate that receives callbacks for the Sign Up flow.
     public func signUp(
-        username: String,
-        password: String? = nil,
-        attributes: [String: Any]? = nil,
-        correlationId: UUID? = nil,
+        parameters: MSALNativeAuthSignUpParameters,
         delegate: SignUpStartDelegate
     ) {
         Task {
             let controllerResponse = await signUpInternal(
-                username: username,
-                password: password,
-                attributes: attributes,
-                correlationId: correlationId
+                username: parameters.username,
+                password: parameters.password,
+                attributes: parameters.attributes,
+                correlationId: parameters.correlationId
             )
 
             let delegateDispatcher = SignUpStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
@@ -190,26 +184,46 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         }
     }
 
-    /// Sign in a user with a given username and password.
+    /// Sign up a user with a given username and password.
     /// - Parameters:
-    ///   - username: Username for the account
-    ///   - password: Optional. Password for the account.
-    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - username: Username for the new account.
+    ///   - password: Optional. Password to be used for the new account.
+    ///   - attributes: Optional. User attributes to be used during account creation.
     ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
-    ///   - delegate: Delegate that receives callbacks for the Sign In flow.
-    public func signIn(
+    ///   - delegate: Delegate that receives callbacks for the Sign Up flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'signUp(parameters:)' instead.")
+    public func signUp(
         username: String,
         password: String? = nil,
-        scopes: [String]? = nil,
+        attributes: [String: Any]? = nil,
         correlationId: UUID? = nil,
+        delegate: SignUpStartDelegate
+    ) {
+        Task {
+            signUp(
+                parameters: MSALNativeAuthSignUpParameters(username: username,
+                                                           password: password,
+                                                           attributes: attributes,
+                                                           correlationId: correlationId),
+                delegate: delegate
+            )
+        }
+    }
+
+    /// Sign in a user with a given username and password.
+    /// - Parameters:
+    ///   - parameters: parameters used for signUp operation.
+    ///   - delegate: Delegate that receives callbacks for the Sign In flow.
+    public func signIn(
+        parameters: MSALNativeAuthSignInParameters,
         delegate: SignInStartDelegate
     ) {
         Task {
             let controllerResponse = await signInInternal(
-                username: username,
-                password: password,
-                scopes: scopes,
-                correlationId: correlationId
+                username: parameters.username,
+                password: parameters.password,
+                scopes: parameters.scopes,
+                correlationId: parameters.correlationId
             )
 
             let delegateDispatcher = SignInStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
@@ -235,18 +249,41 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         }
     }
 
+    /// Sign in a user with a given username and password.
+    /// - Parameters:
+    ///   - username: Username for the account
+    ///   - password: Optional. Password for the account.
+    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Sign In flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'signIn(parameters:)' instead.")
+    public func signIn(
+        username: String,
+        password: String? = nil,
+        scopes: [String]? = nil,
+        correlationId: UUID? = nil,
+        delegate: SignInStartDelegate
+    ) {
+        signIn(
+            parameters: MSALNativeAuthSignInParameters(username: username,
+                                                       password: password,
+                                                       correlationId: correlationId),
+            delegate: delegate
+        )
+    }
+
     /// Reset the password for a given username.
     /// - Parameters:
-    ///   - username: Username for the account.
+    ///   - parameters: parameters used for resetPassword operation.
     ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     ///   - delegate: Delegate that receives callbacks for the Reset Password flow.
     public func resetPassword(
-        username: String,
-        correlationId: UUID? = nil,
+        parameters: MSALNativeAuthResetPasswordParameters,
         delegate: ResetPasswordStartDelegate
     ) {
         Task {
-            let controllerResponse = await resetPasswordInternal(username: username, correlationId: correlationId)
+            let controllerResponse = await resetPasswordInternal(username: parameters.username,
+                                                                 correlationId: parameters.correlationId)
 
             let delegateDispatcher = ResetPasswordStartDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
@@ -263,6 +300,24 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                 await delegate.onResetPasswordStartError(error: error)
             }
         }
+    }
+
+    /// Reset the password for a given username.
+    /// - Parameters:
+    ///   - username: Username for the account.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Reset Password flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'resetPassword(parameters:)' instead.")
+    public func resetPassword(
+        username: String,
+        correlationId: UUID? = nil,
+        delegate: ResetPasswordStartDelegate
+    ) {
+        resetPassword(
+            parameters: MSALNativeAuthResetPasswordParameters(username: username,
+                                                              correlationId: correlationId),
+            delegate: delegate
+        )
     }
 
     /// Retrieve the current signed in account from the cache.

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -149,7 +149,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
 
     // MARK: delegate methods
 
-    /// Sign up a user with a given username and password.
+    /// Sign up a user for a provided parameters.
     /// - Parameters:
     ///   - parameters: parameters used for signUp operation.
     ///   - delegate: Delegate that receives callbacks for the Sign Up flow.

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -149,9 +149,9 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
 
     // MARK: delegate methods
 
-    /// Sign up a user for a provided parameters.
+    /// Sign up a user using parameters.
     /// - Parameters:
-    ///   - parameters: parameters used for signUp operation.
+    ///   - parameters: Parameters used for signUp operation.
     ///   - delegate: Delegate that receives callbacks for the Sign Up flow.
     public func signUp(
         parameters: MSALNativeAuthSignUpParameters,
@@ -210,9 +210,9 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         }
     }
 
-    /// Sign in a user with a given username and password.
+    /// Sign in a user using parameters.
     /// - Parameters:
-    ///   - parameters: parameters used for signUp operation.
+    ///   - parameters: Parameters used for signIn operation.
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(
         parameters: MSALNativeAuthSignInParameters,
@@ -273,9 +273,9 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         )
     }
 
-    /// Reset the password for a given username.
+    /// Reset the password using parameters
     /// - Parameters:
-    ///   - parameters: parameters used for resetPassword operation.
+    ///   - parameters: Parameters used for resetPassword operation.
     ///   - delegate: Delegate that receives callbacks for the Reset Password flow.
     public func resetPassword(
         parameters: MSALNativeAuthResetPasswordParameters,

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -105,7 +105,7 @@ extension MSALNativeAuthUserAccountResult {
         let mfaRequiredErrorCode = 50076
         return errorCodes.contains(mfaRequiredErrorCode)
     }
-    
+
     private func isResetPasswordRequiredError(errorCodes: [Int]) -> Bool {
         return errorCodes.contains(MSALNativeAuthESTSApiErrorCodes.resetPasswordRequired.rawValue)
     }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -78,7 +78,7 @@ import Foundation
 
     // Retrieves the access token for the currently signed in account from the cache for the provided parameters.
     /// - Parameters:
-    ///   - parameters: Parameters used for getAccessToken operation.
+    ///   - parameters: Parameters used for the Get Access Token flow.
     ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
     ///
     @objc public func getAccessToken(parameters: MSALNativeAuthGetAccessTokenParameters,

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -78,7 +78,7 @@ import Foundation
 
     // Retrieves the access token for the currently signed in account from the cache for the provided parameters.
     /// - Parameters:
-    ///   - parameters: parameters used for getAccessToken operation.
+    ///   - parameters: Parameters used for getAccessToken operation.
     ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
     ///
     @objc public func getAccessToken(parameters: MSALNativeAuthGetAccessTokenParameters,

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -76,6 +76,26 @@ import Foundation
         }
     }
 
+    // Retrieves the access token for the default OIDC(openid, offline_access, profile) scopes from the cache.
+    /// - Parameters:
+    ///   - parameters: parameters used for getAccessToken operation.
+    ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
+    ///
+    func getAccessToken(parameters: MSALNativeAuthGetAccessTokenParameters,
+                        delegate: CredentialsDelegate) {
+
+        MSALLogger.log(
+            level: .info,
+            context: nil,
+            format: "Retrieving access token with parameters started."
+        )
+
+        getAccessTokenInternal(forceRefresh: parameters.forceRefresh ?? false,
+                               scopes: parameters.scopes ?? [],
+                               correlationId: parameters.correlationId,
+                               delegate: delegate)
+    }
+
     /// Retrieves the access token for the default OIDC(openid, offline_access, profile) scopes from the cache.
     /// - Parameters:
     ///   - forceRefresh: Optional. Ignore any existing access token in the cache and force MSAL to get a new access token from the service.

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -101,6 +101,7 @@ import Foundation
     ///   - forceRefresh: Optional. Ignore any existing access token in the cache and force MSAL to get a new access token from the service.
     ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'getAccessToken(parameters:)' instead.")
     @objc public func getAccessToken(forceRefresh: Bool = false,
                                      correlationId: UUID? = nil,
                                      delegate: CredentialsDelegate) {
@@ -124,6 +125,7 @@ import Foundation
     ///   - forceRefresh: Optional. Ignore any existing access token in the cache and force MSAL to get a new access token from the service.
     ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
     ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'getAccessToken(parameters:)' instead.")
     public func getAccessToken(scopes: [String],
                                forceRefresh: Bool = false,
                                correlationId: UUID? = nil,

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -76,7 +76,7 @@ import Foundation
         }
     }
 
-    // Retrieves the access token for the default OIDC(openid, offline_access, profile) scopes from the cache.
+    // Retrieves the access token for the currently signed in account from the cache for the provided parameters.
     /// - Parameters:
     ///   - parameters: parameters used for getAccessToken operation.
     ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -81,8 +81,8 @@ import Foundation
     ///   - parameters: parameters used for getAccessToken operation.
     ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
     ///
-    func getAccessToken(parameters: MSALNativeAuthGetAccessTokenParameters,
-                        delegate: CredentialsDelegate) {
+    @objc public func getAccessToken(parameters: MSALNativeAuthGetAccessTokenParameters,
+                                     delegate: CredentialsDelegate) {
 
         MSALLogger.log(
             level: .info,

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
@@ -23,23 +23,34 @@
 // THE SOFTWARE.  
 
 /// Encapsulates the parameters passed to the getAccessToken methods of MSALNativeAuthUserAccountResult
-public class MSALNativeAuthGetAccessTokenParameters {
+@objcMembers
+public class MSALNativeAuthGetAccessTokenParameters: NSObject {
 
     /// Set to true to ignore any existing access token in the cache and force MSAL to get a new access token from the service.
-    var forceRefresh: Bool?
+    public var forceRefresh: Bool?
 
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
-    var scopes: [String]?
+    public var scopes: [String]?
 
     /// UUID to correlate this request with the server for debugging.
-    var correlationId: UUID?
+    public var correlationId: UUID?
 
-    init (forceRefresh: Bool? = nil,
-          scopes: [String]? = nil,
-          correlationId: UUID? = nil) {
+    public init (forceRefresh: Bool? = nil,
+                 scopes: [String]? = nil,
+                 correlationId: UUID? = nil) {
         self.forceRefresh = forceRefresh
         self.scopes = scopes
         self.correlationId = correlationId
+    }
+
+    // Needed for Objective C, if all properties are optional, this initialiser is required
+    override public init() {
+
+    }
+
+    // Needed for Objective C, because Bool? is not a recognised type ih Objective C
+    public func setForceRefresh(_ forceRefresh: Bool) {
+        self.forceRefresh = forceRefresh
     }
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
@@ -34,4 +34,12 @@ public class MSALNativeAuthGetAccessTokenParameters {
 
     /// UUID to correlate this request with the server for debugging.
     var correlationId: UUID?
+
+    init (forceRefresh: Bool? = nil,
+          scopes: [String]? = nil,
+          correlationId: UUID? = nil) {
+        self.forceRefresh = forceRefresh
+        self.scopes = scopes
+        self.correlationId = correlationId
+    }
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-/// Encapsulates the parameters passed to the getAccessToken methods of MSALNativeAuthUserAccountResult
+/// Encapsulates the parameters passed to the getAccessToken method of MSALNativeAuthUserAccountResult
 @objcMembers
 public class MSALNativeAuthGetAccessTokenParameters: NSObject {
 

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
@@ -36,19 +36,6 @@ public class MSALNativeAuthGetAccessTokenParameters: NSObject {
     /// UUID to correlate this request with the server for debugging.
     public var correlationId: UUID?
 
-    public init (forceRefresh: Bool? = nil,
-                 scopes: [String]? = nil,
-                 correlationId: UUID? = nil) {
-        self.forceRefresh = forceRefresh
-        self.scopes = scopes
-        self.correlationId = correlationId
-    }
-
-    // Needed for Objective C, if all properties are optional, this initialiser is required
-    override public init() {
-
-    }
-
     // Needed for Objective C, because Bool? is not a recognised type ih Objective C
     public func setForceRefresh(_ forceRefresh: Bool) {
         self.forceRefresh = forceRefresh

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+/// Encapsulates the parameters passed to the getAccessToken methods of MSALNativeAuthUserAccountResult
+public class MSALNativeAuthGetAccessTokenParameters {
+
+    /// Set to true to ignore any existing access token in the cache and force MSAL to get a new access token from the service.
+    var forceRefresh: Bool?
+
+    /// Permissions you want included in the access token received.
+    /// Not all scopes are guaranteed to be included in the access token returned.
+    var scopes: [String]?
+
+    /// UUID to correlate this request with the server for debugging.
+    var correlationId: UUID?
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
@@ -27,7 +27,7 @@
 public class MSALNativeAuthGetAccessTokenParameters: NSObject {
 
     /// Set to true to ignore any existing access token in the cache and force MSAL to get a new access token from the service.
-    public var forceRefresh: Bool?
+    public var forceRefresh: Bool = false
 
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
@@ -35,9 +35,4 @@ public class MSALNativeAuthGetAccessTokenParameters: NSObject {
 
     /// UUID to correlate this request with the server for debugging.
     public var correlationId: UUID?
-
-    // Needed for Objective C, because Bool? is not a recognised type ih Objective C
-    public func setForceRefresh(_ forceRefresh: Bool) {
-        self.forceRefresh = forceRefresh
-    }
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthResetPasswordParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthResetPasswordParameters.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-/// Encapsulates the parameters passed to the resetPassword methods of MSALNativeAuthPublicClientApplication
+/// Encapsulates the parameters passed to the resetPassword method of MSALNativeAuthPublicClientApplication
 @objcMembers
 public class MSALNativeAuthResetPasswordParameters: NSObject {
 

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthResetPasswordParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthResetPasswordParameters.swift
@@ -32,9 +32,7 @@ public class MSALNativeAuthResetPasswordParameters: NSObject {
     /// UUID to correlate this request with the server for debugging.
     public var correlationId: UUID?
 
-    public init(username: String,
-                correlationId: UUID? = nil) {
+    public init(username: String) {
         self.username = username
-        self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthResetPasswordParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthResetPasswordParameters.swift
@@ -23,16 +23,17 @@
 // THE SOFTWARE.  
 
 /// Encapsulates the parameters passed to the resetPassword methods of MSALNativeAuthPublicClientApplication
-public class MSALNativeAuthResetPasswordParameters {
+@objcMembers
+public class MSALNativeAuthResetPasswordParameters: NSObject {
 
     /// username of the account to reset password.
-    var username: String
+    public var username: String
 
     /// UUID to correlate this request with the server for debugging.
-    var correlationId: UUID?
+    public var correlationId: UUID?
 
-    init(username: String,
-         correlationId: UUID? = nil) {
+    public init(username: String,
+                correlationId: UUID? = nil) {
         self.username = username
         self.correlationId = correlationId
     }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthResetPasswordParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthResetPasswordParameters.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+/// Encapsulates the parameters passed to the resetPassword methods of MSALNativeAuthPublicClientApplication
+public class MSALNativeAuthResetPasswordParameters {
+
+    /// username of the account to reset password.
+    var username: String
+
+    /// UUID to correlate this request with the server for debugging.
+    var correlationId: UUID?
+
+    init(username: String,
+         correlationId: UUID? = nil) {
+        self.username = username
+        self.correlationId = correlationId
+    }
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
@@ -29,8 +29,4 @@ public class MSALNativeAuthSignInAfterResetPasswordParameters: NSObject {
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
     public var scopes: [String]?
-
-    public init(scopes: [String]? = nil) {
-        self.scopes = scopes
-    }
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-/// Encapsulates the parameters passed to the signIn methods after  resetPassword
+/// Encapsulates the parameters passed to the signIn method after resetPassword
 @objcMembers
 public class MSALNativeAuthSignInAfterResetPasswordParameters: NSObject {
 

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
@@ -23,13 +23,14 @@
 // THE SOFTWARE.  
 
 /// Encapsulates the parameters passed to the signIn methods after  resetPassword
-public class MSALNativeAuthSignInAfterResetPasswordParameters {
+@objcMembers
+public class MSALNativeAuthSignInAfterResetPasswordParameters: NSObject {
 
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
-    var scopes: [String]?
+    public var scopes: [String]?
 
-    init(scopes: [String]? = nil) {
+    public init(scopes: [String]? = nil) {
         self.scopes = scopes
     }
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+/// Encapsulates the parameters passed to the signIn methods after  resetPassword
+public class MSALNativeAuthSignInAfterResetPasswordParameters {
+
+    /// Permissions you want included in the access token received.
+    /// Not all scopes are guaranteed to be included in the access token returned.
+    var scopes: [String]?
+
+    init(scopes: [String]? = nil) {
+        self.scopes = scopes
+    }
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+/// Encapsulates the parameters passed to the signIn methods after signUp
+public class MSALNativeAuthSignInAfterSignUpParameters {
+
+    /// Permissions you want included in the access token received.
+    /// Not all scopes are guaranteed to be included in the access token returned.
+    var scopes: [String]?
+
+    init(scopes: [String]? = nil) {
+        self.scopes = scopes
+    }
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-/// Encapsulates the parameters passed to the signIn methods after signUp
+/// Encapsulates the parameters passed to the signIn method after signUp
 @objcMembers
 public class MSALNativeAuthSignInAfterSignUpParameters: NSObject {
 

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
@@ -29,8 +29,4 @@ public class MSALNativeAuthSignInAfterSignUpParameters: NSObject {
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
     public var scopes: [String]?
-
-    public init(scopes: [String]? = nil) {
-        self.scopes = scopes
-    }
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
@@ -23,13 +23,14 @@
 // THE SOFTWARE.  
 
 /// Encapsulates the parameters passed to the signIn methods after signUp
-public class MSALNativeAuthSignInAfterSignUpParameters {
+@objcMembers
+public class MSALNativeAuthSignInAfterSignUpParameters: NSObject {
 
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
-    var scopes: [String]?
+    public var scopes: [String]?
 
-    init(scopes: [String]? = nil) {
+    public init(scopes: [String]? = nil) {
         self.scopes = scopes
     }
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
@@ -23,25 +23,26 @@
 // THE SOFTWARE.  
 
 /// Encapsulates the parameters passed to the signIn methods of MSALNativeAuthPublicClientApplication
-public class MSALNativeAuthSignInParameters {
+@objcMembers
+public class MSALNativeAuthSignInParameters: NSObject {
 
     /// username of the account to sign in.
-    var username: String
+    public var username: String
 
     /// assword of the account to sign in.
-    var password: String?
+    public var password: String?
 
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
-    var scopes: [String]?
+    public var scopes: [String]?
 
     /// UUID to correlate this request with the server for debugging.
-    var correlationId: UUID?
+    public var correlationId: UUID?
 
-    init(username: String,
-         password: String? = nil,
-         scopes: [String]? = nil,
-         correlationId: UUID? = nil) {
+    public init(username: String,
+                password: String? = nil,
+                scopes: [String]? = nil,
+                correlationId: UUID? = nil) {
         self.username = username
         self.password = password
         self.scopes = scopes

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
@@ -16,28 +16,35 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
 
-@_implementationOnly import MSAL_Private
+/// Encapsulates the parameters passed to the signIn methods of MSALNativeAuthPublicClientApplication
+public class MSALNativeAuthSignInParameters {
 
-class MSALNativeAuthSignInParameters {
-    let username: String
-    let password: String?
-    let context: MSALNativeAuthRequestContext
-    let scopes: [String]?
+    /// username of the account to sign in.
+    var username: String
 
-    init(
-        username: String,
-        password: String?,
-        context: MSALNativeAuthRequestContext,
-        scopes: [String]?) {
+    /// assword of the account to sign in.
+    var password: String?
+
+    /// Permissions you want included in the access token received.
+    /// Not all scopes are guaranteed to be included in the access token returned.
+    var scopes: [String]?
+
+    /// UUID to correlate this request with the server for debugging.
+    var correlationId: UUID?
+
+    init(username: String,
+         password: String? = nil,
+         scopes: [String]? = nil,
+         correlationId: UUID? = nil) {
         self.username = username
         self.password = password
-        self.context = context
         self.scopes = scopes
+        self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-/// Encapsulates the parameters passed to the signIn methods of MSALNativeAuthPublicClientApplication
+/// Encapsulates the parameters passed to the signIn method of MSALNativeAuthPublicClientApplication
 @objcMembers
 public class MSALNativeAuthSignInParameters: NSObject {
 

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
@@ -29,7 +29,7 @@ public class MSALNativeAuthSignInParameters: NSObject {
     /// username of the account to sign in.
     public var username: String
 
-    /// assword of the account to sign in.
+    /// password of the account to sign in.
     public var password: String?
 
     /// Permissions you want included in the access token received.

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInParameters.swift
@@ -39,13 +39,7 @@ public class MSALNativeAuthSignInParameters: NSObject {
     /// UUID to correlate this request with the server for debugging.
     public var correlationId: UUID?
 
-    public init(username: String,
-                password: String? = nil,
-                scopes: [String]? = nil,
-                correlationId: UUID? = nil) {
+    public init(username: String) {
         self.username = username
-        self.password = password
-        self.scopes = scopes
-        self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignUpParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignUpParameters.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-/// Encapsulates the parameters passed to the signUp methods of MSALNativeAuthPublicClientApplication
+/// Encapsulates the parameters passed to the signUp method of MSALNativeAuthPublicClientApplication
 @objcMembers
 public class MSALNativeAuthSignUpParameters: NSObject {
 

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignUpParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignUpParameters.swift
@@ -1,0 +1,49 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+/// Encapsulates the parameters passed to the signUp methods of MSALNativeAuthPublicClientApplication
+public class MSALNativeAuthSignUpParameters {
+
+    /// username of the account to sign up.
+    var username: String
+
+    /// password of the account to sign up.
+    var password: String?
+
+    /// user attributes to be used during account creation.
+    var attributes: [String: Any]?
+
+    /// UUID to correlate this request with the server for debugging.
+    var correlationId: UUID?
+
+    init(username: String,
+         password: String? = nil,
+         attributes: [String: Any]? = nil,
+         correlationId: UUID? = nil) {
+        self.username = username
+        self.password = password
+        self.attributes = attributes
+        self.correlationId = correlationId
+    }
+}

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignUpParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignUpParameters.swift
@@ -23,24 +23,25 @@
 // THE SOFTWARE.  
 
 /// Encapsulates the parameters passed to the signUp methods of MSALNativeAuthPublicClientApplication
-public class MSALNativeAuthSignUpParameters {
+@objcMembers
+public class MSALNativeAuthSignUpParameters: NSObject {
 
     /// username of the account to sign up.
-    var username: String
+    public var username: String
 
     /// password of the account to sign up.
-    var password: String?
+    public var password: String?
 
     /// user attributes to be used during account creation.
-    var attributes: [String: Any]?
+    public var attributes: [String: Any]?
 
     /// UUID to correlate this request with the server for debugging.
-    var correlationId: UUID?
+    public var correlationId: UUID?
 
-    init(username: String,
-         password: String? = nil,
-         attributes: [String: Any]? = nil,
-         correlationId: UUID? = nil) {
+    public init(username: String,
+                password: String? = nil,
+                attributes: [String: Any]? = nil,
+                correlationId: UUID? = nil) {
         self.username = username
         self.password = password
         self.attributes = attributes

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignUpParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignUpParameters.swift
@@ -38,13 +38,7 @@ public class MSALNativeAuthSignUpParameters: NSObject {
     /// UUID to correlate this request with the server for debugging.
     public var correlationId: UUID?
 
-    public init(username: String,
-                password: String? = nil,
-                attributes: [String: Any]? = nil,
-                correlationId: UUID? = nil) {
+    public init(username: String) {
         self.username = username
-        self.password = password
-        self.attributes = attributes
-        self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -58,8 +58,10 @@ import Foundation
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     @available(*, deprecated, message: "This method is now deprecated. Use the method 'signIn(parameters:)' instead.")
     public func signIn(scopes: [String]? = nil, delegate: SignInAfterResetPasswordDelegate) {
+        let parameters = MSALNativeAuthSignInAfterResetPasswordParameters()
+        parameters.scopes = scopes
         signIn(
-            parameters: MSALNativeAuthSignInAfterResetPasswordParameters(scopes: scopes),
+            parameters: parameters,
             delegate: delegate
         )
     }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -28,7 +28,7 @@ import Foundation
 @objcMembers public class SignInAfterResetPasswordState: SignInAfterPreviousFlowBaseState {
     /// Sign in the user that just reset the password.
     /// - Parameters:
-    ///   - parameters: parameters used for signInAfterSignUp operation..
+    ///   - parameters: parameters used to signIn the user after reset password operation.
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(parameters: MSALNativeAuthSignInAfterResetPasswordParameters, delegate: SignInAfterResetPasswordDelegate) {
         Task {

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -28,7 +28,7 @@ import Foundation
 @objcMembers public class SignInAfterResetPasswordState: SignInAfterPreviousFlowBaseState {
     /// Sign in the user that just reset the password.
     /// - Parameters:
-    ///   - parameters: Parameters used to signIn the user after reset password operation.
+    ///   - parameters: Parameters used to Sign In the user after the Reset Password flow..
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(parameters: MSALNativeAuthSignInAfterResetPasswordParameters, delegate: SignInAfterResetPasswordDelegate) {
         Task {

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -28,7 +28,7 @@ import Foundation
 @objcMembers public class SignInAfterResetPasswordState: SignInAfterPreviousFlowBaseState {
     /// Sign in the user that just reset the password.
     /// - Parameters:
-    ///   - parameters: parameters used to signIn the user after reset password operation.
+    ///   - parameters: Parameters used to signIn the user after reset password operation.
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(parameters: MSALNativeAuthSignInAfterResetPasswordParameters, delegate: SignInAfterResetPasswordDelegate) {
         Task {

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -28,11 +28,11 @@ import Foundation
 @objcMembers public class SignInAfterResetPasswordState: SignInAfterPreviousFlowBaseState {
     /// Sign in the user that just reset the password.
     /// - Parameters:
-    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - parameters: parameters used for signInAfterSignUp operation..
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
-    public func signIn(scopes: [String]? = nil, delegate: SignInAfterResetPasswordDelegate) {
+    public func signIn(parameters: MSALNativeAuthSignInAfterResetPasswordParameters, delegate: SignInAfterResetPasswordDelegate) {
         Task {
-            let controllerResponse = await signInInternal(scopes: scopes, telemetryId: .telemetryApiIdSignInAfterPasswordReset)
+            let controllerResponse = await signInInternal(scopes: parameters.scopes, telemetryId: .telemetryApiIdSignInAfterPasswordReset)
             let delegateDispatcher = SignInAfterResetPasswordDelegateDispatcher(
                 delegate: delegate,
                 telemetryUpdate: controllerResponse.telemetryUpdate
@@ -50,5 +50,17 @@ import Foundation
                 await delegate.onSignInAfterResetPasswordError(error: error)
             }
         }
+    }
+
+    /// Sign in the user that just reset the password.
+    /// - Parameters:
+    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - delegate: Delegate that receives callbacks for the Sign In flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'signIn(parameters:)' instead.")
+    public func signIn(scopes: [String]? = nil, delegate: SignInAfterResetPasswordDelegate) {
+        signIn(
+            parameters: MSALNativeAuthSignInAfterResetPasswordParameters(scopes: scopes),
+            delegate: delegate
+        )
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -28,7 +28,7 @@ import Foundation
 @objcMembers public class SignInAfterResetPasswordState: SignInAfterPreviousFlowBaseState {
     /// Sign in the user that just reset the password.
     /// - Parameters:
-    ///   - parameters: Parameters used to Sign In the user after the Reset Password flow..
+    ///   - parameters: Parameters used to Sign In the user after the Reset Password flow.
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(parameters: MSALNativeAuthSignInAfterResetPasswordParameters, delegate: SignInAfterResetPasswordDelegate) {
         Task {

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -53,8 +53,10 @@ import Foundation
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     @available(*, deprecated, message: "This method is now deprecated. Use the method 'signIn(parameters:)' instead.")
     public func signIn(scopes: [String]? = nil, delegate: SignInAfterSignUpDelegate) {
+        let parameters = MSALNativeAuthSignInAfterSignUpParameters()
+        parameters.scopes = scopes
         signIn(
-            parameters: MSALNativeAuthSignInAfterSignUpParameters(scopes: scopes),
+            parameters: parameters,
             delegate: delegate)
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -29,7 +29,7 @@ import Foundation
 
     /// Sign in the user that signed up.
     /// - Parameters:
-    ///   - parameters: parameters used for signInAfterSignUp operation..
+    ///   - parameters: Parameters used to signIn the user after sign up operation..
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(parameters: MSALNativeAuthSignInAfterSignUpParameters, delegate: SignInAfterSignUpDelegate) {
         Task {

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -26,13 +26,14 @@ import Foundation
 
 /// An object of this type is created when a user has signed up successfully.
 @objcMembers public class SignInAfterSignUpState: SignInAfterPreviousFlowBaseState {
+
     /// Sign in the user that signed up.
     /// - Parameters:
-    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - parameters: parameters used for signInAfterSignUp operation..
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
-    public func signIn(scopes: [String]? = nil, delegate: SignInAfterSignUpDelegate) {
+    public func signIn(parameters: MSALNativeAuthSignInAfterSignUpParameters, delegate: SignInAfterSignUpDelegate) {
         Task {
-            let controllerResponse = await signInInternal(scopes: scopes, telemetryId: .telemetryApiIdSignInAfterSignUp)
+            let controllerResponse = await signInInternal(scopes: parameters.scopes, telemetryId: .telemetryApiIdSignInAfterSignUp)
             let delegateDispatcher = SignInAfterSignUpDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {
@@ -44,5 +45,16 @@ import Foundation
                 )
             }
         }
+    }
+
+    /// Sign in the user that signed up.
+    /// - Parameters:
+    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - delegate: Delegate that receives callbacks for the Sign In flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'signIn(parameters:)' instead.")
+    public func signIn(scopes: [String]? = nil, delegate: SignInAfterSignUpDelegate) {
+        signIn(
+            parameters: MSALNativeAuthSignInAfterSignUpParameters(scopes: scopes),
+            delegate: delegate)
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -29,7 +29,7 @@ import Foundation
 
     /// Sign in the user that signed up.
     /// - Parameters:
-    ///   - parameters: Parameters used to signIn the user after sign up operation..
+    ///   - parameters: Parameters used to Sign In the user after the Sign Up flow..
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(parameters: MSALNativeAuthSignInAfterSignUpParameters, delegate: SignInAfterSignUpDelegate) {
         Task {

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -29,7 +29,7 @@ import Foundation
 
     /// Sign in the user that signed up.
     /// - Parameters:
-    ///   - parameters: Parameters used to Sign In the user after the Sign Up flow..
+    ///   - parameters: Parameters used to Sign In the user after the Sign Up flow.
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(parameters: MSALNativeAuthSignInAfterSignUpParameters, delegate: SignInAfterSignUpDelegate) {
         Task {

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthMFAControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthMFAControllerTests.swift
@@ -57,7 +57,7 @@ class MSALNativeAuthMFAControllerTests: MSALNativeAuthSignInControllerTests {
         signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: expectedCredentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .introspectRequired
         
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
 
         XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
         checkTelemetryEventResult(id: .telemetryApiIdSignInWithCodeStart, isSuccessful: false)
@@ -78,7 +78,7 @@ class MSALNativeAuthMFAControllerTests: MSALNativeAuthSignInControllerTests {
         signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: expectedCredentialToken)
         signInResponseValidatorMock.challengeValidatedResponse = .introspectRequired
         
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: "pwd", context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: "pwd", context: expectedContext, scopes: nil))
 
         XCTAssertFalse(cacheAccessorMock.validateAndSaveTokensWasCalled)
         checkTelemetryEventResult(id: .telemetryApiIdSignInWithPasswordStart, isSuccessful: false)

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -101,7 +101,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, message: "SignIn Initiate: Cannot create Initiate request object", correlationId: defaultUUID))
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
 
         helper.onSignInPasswordError(result)
 
@@ -131,7 +131,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "scope2"]))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "scope2"]))
 
         helper.onSignInPasswordError(result)
 
@@ -160,7 +160,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "openid", "profile"]))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: ["scope1", "openid", "profile"]))
 
         helper.onSignInPasswordError(result)
 
@@ -195,7 +195,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
 
         cacheAccessorMock.expectedMSIDTokenResult = tokenResult
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
 
         helper.onSignInCompleted(result)
 
@@ -230,7 +230,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
 
         cacheAccessorMock.expectedMSIDTokenResult = nil
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
 
         helper.onSignInPasswordError(result)
 
@@ -263,7 +263,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
         tokenResponseValidatorMock.expectedTokenResponse = tokenResponse
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
 
         helper.onSignInPasswordError(result)
 
@@ -311,7 +311,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         helper.expectedChannelTargetType = expectedChannelTargetType
         helper.expectedCodeLength = expectedCodeLength
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
         result.telemetryUpdate?(.success(()))
 
         helper.onSignInCodeRequired(result)
@@ -345,7 +345,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         helper.expectedChannelTargetType = expectedChannelTargetType
         helper.expectedCodeLength = expectedCodeLength
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
         result.telemetryUpdate?(.failure(.init(message: "error", correlationId: defaultUUID)))
 
         helper.onSignInCodeRequired(result)
@@ -377,7 +377,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
         signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: sentTo, channelType: channelTargetType, codeLength: codeLength)
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
         result.telemetryUpdate?(.success(()))
 
         helper.onSignInCodeRequired(result)
@@ -443,7 +443,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, message: "SignIn Initiate: Cannot create Initiate request object", correlationId: defaultUUID))
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
 
         helper.onSignInError(result)
 
@@ -473,7 +473,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: SignInStartError(type: .generalError, correlationId: defaultUUID))
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
 
         helper.onSignInError(result)
 
@@ -507,7 +507,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         
         let helper = SignInCodeStartWithPasswordRequiredTestsValidatorHelper(expectation: expectation)
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
         result.telemetryUpdate?(.success(()))
 
         helper.onSignInPasswordRequired(result.result)
@@ -531,7 +531,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInCodeStartWithPasswordRequiredTestsValidatorHelper(expectation: expectation)
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
         result.telemetryUpdate?(.failure(.init(message: "error", correlationId: defaultUUID)))
 
         helper.onSignInPasswordRequired(result.result)
@@ -912,7 +912,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
 
         helper.onSignInError(result)
 
@@ -934,7 +934,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
 
         let helper = SignInCodeStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
 
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: nil, context: expectedContext, scopes: nil))
 
         helper.onSignInError(result)
 
@@ -965,7 +965,7 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         let helper = SignInPasswordStartTestsValidatorHelper(expectation: expectation, expectedError: delegateError)
         tokenResponseValidatorMock.tokenValidatedResponse = .error(validatorError)
         
-        let result = await sut.signIn(params: MSALNativeAuthSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
+        let result = await sut.signIn(params: MSALNativeAuthInternalSignInParameters(username: expectedUsername, password: expectedPassword, context: expectedContext, scopes: nil))
 
         helper.onSignInPasswordError(result)
         

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
@@ -42,7 +42,7 @@ class MSALNativeAuthSignInControllerMock: MSALNativeAuthSignInControlling, MSALN
     var getAuthMethodsResponse: MFAGetAuthMethodsControllerResponse!
     var submitChallengeResponse: MFASubmitChallengeControllerResponse!
 
-    func signIn(params: MSAL.MSALNativeAuthSignInParameters) async -> MSALNativeAuthSignInControlling.SignInControllerResponse {
+    func signIn(params: MSAL.MSALNativeAuthInternalSignInParameters) async -> MSALNativeAuthSignInControlling.SignInControllerResponse {
         return signInStartResult
     }
 

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -195,7 +195,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     func testSignUpUsingParametersPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-up public interface")
         let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct", password: "")
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
+        parameters.password = ""
         sut.signUp(parameters: parameters, delegate: delegate)
         wait(for: [exp], timeout: 1)
         XCTAssertEqual(delegate.error?.type, .invalidPassword)
@@ -204,7 +205,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     func testSignUpUsingParametersPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-up public interface")
         let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
-        let parameters = MSALNativeAuthSignUpParameters(username: "", password: "")
+        let parameters = MSALNativeAuthSignUpParameters(username: "")
+        parameters.password = ""
         sut.signUp(parameters: parameters, delegate: delegate)
         wait(for: [exp], timeout: 1)
         XCTAssertEqual(delegate.error?.type, .invalidUsername)
@@ -224,7 +226,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct", password: "correct")
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
+        parameters.password = "correct"
         sut.signUp(parameters: parameters, delegate: delegate)
 
         wait(for: [exp1, exp2])
@@ -248,7 +251,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct", password: "correct")
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
+        parameters.password = "correct"
         sut.signUp(parameters: parameters, delegate: delegate)
 
         wait(for: [exp, exp2])
@@ -272,7 +276,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct", password: "correct")
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
+        parameters.password = "correct"
         sut.signUp(parameters: parameters, delegate: delegate)
 
         wait(for: [exp, exp2])
@@ -291,7 +296,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct", password: "correct")
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
+        parameters.password = "correct"
         sut.signUp(parameters: parameters, delegate: delegate)
 
         wait(for: [exp, exp2])
@@ -592,7 +598,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     func testSignInUsingParametersPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
         let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername, correlationId: correlationId))
-        let parameters = MSALNativeAuthSignInParameters(username: "", password: "", correlationId: correlationId)
+        let parameters = MSALNativeAuthSignInParameters(username: "")
+        parameters.password = ""
+        parameters.correlationId = correlationId
         sut.signIn(parameters: parameters, delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
@@ -600,7 +608,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     func testSignInUsingParametersPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
         let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidCredentials, correlationId: correlationId))
-        let parameters = MSALNativeAuthSignInParameters(username: "correct", password: "", correlationId: correlationId)
+        let parameters = MSALNativeAuthSignInParameters(username: "correct")
+        parameters.password = ""
+        parameters.correlationId = correlationId
         sut.signIn(parameters: parameters, delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
@@ -613,7 +623,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         controllerFactoryMock.signInController.signInStartResult = .init(.init(.completed(MSALNativeAuthUserAccountResultStub.result), correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         }))
-        let parameters = MSALNativeAuthSignInParameters(username: "correct", password: "correct")
+        let parameters = MSALNativeAuthSignInParameters(username: "correct")
+        parameters.password = "correct"
         sut.signIn(parameters: parameters, delegate: delegate)
 
         wait(for: [exp1, exp2], timeout: 1)
@@ -632,7 +643,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignInParameters(username: "correct", password: "correct")
+        let parameters = MSALNativeAuthSignInParameters(username: "correct")
+        parameters.password = "correct"
         sut.signIn(parameters: parameters, delegate: delegate)
 
         wait(for: [exp, exp2], timeout: 1)
@@ -658,7 +670,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignInParameters(username: "correct", password: "correct")
+        let parameters = MSALNativeAuthSignInParameters(username: "correct")
+        parameters.password = "correct"
         sut.signIn(parameters: parameters, delegate: delegate)
 
         wait(for: [exp1, exp2], timeout: 1)
@@ -682,7 +695,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignInParameters(username: "correct", password: "correct")
+        let parameters = MSALNativeAuthSignInParameters(username: "correct")
+        parameters.password = "correct"
         sut.signIn(parameters: parameters, delegate: delegate)
 
         wait(for: [exp, exp2], timeout: 1)
@@ -1610,10 +1624,10 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
         // MSALNativeAuthSignUpRequestProviderMock class - checkStartParameters and checkChallengeParameters functions
-        let parametersSignUp = MSALNativeAuthSignUpParameters(username: "username",
-                                                        password: "password",
-                                                        attributes: ["key": "value"],
-                                                        correlationId: correlationId)
+        let parametersSignUp = MSALNativeAuthSignUpParameters(username: "username")
+        parametersSignUp.password = "password"
+        parametersSignUp.attributes = ["key": "value"]
+        parametersSignUp.correlationId = correlationId
         sut.signUp(parameters: parametersSignUp, delegate: delegatePasswordStart)
 
         wait(for: [expectationPasswordStart])
@@ -1626,7 +1640,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         // Correlation Id is validated internally against expectedTokenParams in the
         // MSALNativeAuthTokenRequestProviderMock class - checkContext function
-        let parametersSingInAfterSignUp = MSALNativeAuthSignInAfterSignUpParameters(scopes: ["scope1", "scope2"])
+        let parametersSingInAfterSignUp = MSALNativeAuthSignInAfterSignUpParameters()
+        parametersSingInAfterSignUp.scopes = ["scope1", "scope2"]
         delegateVerifyCode.newSignInAfterSignUpState?.signIn(parameters: parametersSingInAfterSignUp,
                                                              delegate: delegateSignInAfterSignUp)
 
@@ -1721,9 +1736,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
         // MSALNativeAuthSignUpRequestProviderMock class - checkStartParameters and checkChallengeParameters functions
-        let parametersSignUp = MSALNativeAuthSignUpParameters(username: "username",
-                                                        attributes: ["key": "value"],
-                                                        correlationId: correlationId)
+        let parametersSignUp = MSALNativeAuthSignUpParameters(username: "username")
+        parametersSignUp.attributes = ["key": "value"]
+        parametersSignUp.correlationId = correlationId
         sut.signUp(parameters: parametersSignUp, delegate: delegateCodeStart)
 
         wait(for: [expectationCodeStart])
@@ -1736,7 +1751,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         // Correlation Id is validated internally against expectedTokenParams in the
         // MSALNativeAuthTokenRequestProviderMock class - checkContext function
-        let parametersSignInAfterSignUp = MSALNativeAuthSignInAfterSignUpParameters(scopes: ["scope1", "scope2"])
+        let parametersSignInAfterSignUp = MSALNativeAuthSignInAfterSignUpParameters()
+        parametersSignInAfterSignUp.scopes = ["scope1", "scope2"]
         delegateVerifyCode.newSignInAfterSignUpState?.signIn(parameters: parametersSignInAfterSignUp,
                                                              delegate: delegateSignInAfterSignUp)
         wait(for: [expectationSignInAfterSingUp])
@@ -1821,7 +1837,10 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         // Correlation Id is validated internally against contextMock on both initiate and challenge in the
         // MSALNativeAuthSignInRequestProviderMock class - checkContext function
-        let parameters = MSALNativeAuthSignInParameters(username: "username", password: "password", scopes: ["scope1", "scope2"], correlationId: correlationId)
+        let parameters = MSALNativeAuthSignInParameters(username: "username")
+        parameters.password = "password"
+        parameters.scopes = ["scope1", "scope2"]
+        parameters.correlationId = correlationId
         sut.signIn(parameters: parameters, delegate: delegatePasswordStart)
 
         wait(for: [expectationPasswordStart])
@@ -1915,7 +1934,9 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         // Correlation Id is validated internally against contextMock on both initiate and challenge in the
         // MSALNativeAuthSignInRequestProviderMock class - checkContext function
-        let parameters = MSALNativeAuthSignInParameters(username: "username", scopes: ["scope1", "scope2"], correlationId: correlationId)
+        let parameters = MSALNativeAuthSignInParameters(username: "username")
+        parameters.scopes = ["scope1", "scope2"]
+        parameters.correlationId = correlationId
         sut.signIn(parameters: parameters, delegate: delegateCodeStart)
         wait(for: [expectationCodeStart])
 
@@ -2021,7 +2042,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
         // MSALNativeAuthResetPasswordRequestProviderMock class - checkParameters(params: MSALNativeAuthResetPasswordStartRequestProviderParameters)
         // and checkParameters(token: String, context: MSIDRequestContext) functions
-        let parametersResetPassword = MSALNativeAuthResetPasswordParameters(username: "username", correlationId: correlationId)
+        let parametersResetPassword = MSALNativeAuthResetPasswordParameters(username: "username")
+        parametersResetPassword.correlationId = correlationId
         sut.resetPassword(parameters: parametersResetPassword, delegate: delegatePasswordResetStart)
 
         wait(for: [expectationPasswordResetStart])
@@ -2043,7 +2065,8 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         // Correlation Id is validated internally against expectedTokenParams in the
         // MSALNativeAuthTokenRequestProviderMock class - checkContext function
-        let parametersSingInAfterResetPassword = MSALNativeAuthSignInAfterResetPasswordParameters(scopes: ["scope1", "scope2"])
+        let parametersSingInAfterResetPassword = MSALNativeAuthSignInAfterResetPasswordParameters()
+        parametersSingInAfterResetPassword.scopes = ["scope1", "scope2"]
         delegatePasswordResetRequired.signInAfterResetPasswordState?.signIn(parameters: parametersSingInAfterResetPassword,
                                                                             delegate: delegateSignInAfterResetPassword)
         wait(for: [expectationSignInAfterResetPassword])

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -81,7 +81,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
     // MARK: - Delegates
 
-    // Sign Up with password
+    // MARK: - Sign Up with password
 
     func testSignUpPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-up public interface")
@@ -190,7 +190,121 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
-    // Sign Up with code
+    // MARK: - Sign Up using parameters with password
+
+    func testSignUpUsingParametersPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct", password: "")
+        sut.signUp(parameters: parameters, delegate: delegate)
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(delegate.error?.type, .invalidPassword)
+    }
+
+    func testSignUpUsingParametersPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
+        let parameters = MSALNativeAuthSignUpParameters(username: "", password: "")
+        sut.signUp(parameters: parameters, delegate: delegate)
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(delegate.error?.type, .invalidUsername)
+    }
+
+    func testSignUpUsingParametersPassword_delegate_whenValidDataIsPassed_shouldReturnCodeRequired() {
+        let exp1 = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "sign-up public interface telemetry")
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: exp1)
+
+        let expectedResult: SignUpStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: MSALNativeAuthChannelType(value: "email"),
+            codeLength: 1
+        )
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct", password: "correct")
+        sut.signUp(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp1, exp2])
+
+        XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
+        XCTAssertNotNil(controllerFactoryMock.signUpController.signUpStartRequestParameters)
+    }
+
+    func testSignUpUsingParametersPassword_delegate_butDelegateMethodIsNotImplemented_shouldReturnError() {
+        let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "sign-up public interface telemetry")
+        let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        let expectedResult: SignUpStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: MSALNativeAuthChannelType(value: "email"),
+            codeLength: 1
+        )
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct", password: "correct")
+        sut.signUp(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired")
+        )
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
+    }
+
+    func testSignUpUsingParametersPassword_delegate_whenSendAttributes_shouldReturnAttributesInvalid() {
+        let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
+        let expectedInvalidAttributes = ["attribute"]
+
+        let expectedResult: SignUpStartResult = .attributesInvalid(expectedInvalidAttributes)
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct", password: "correct")
+        sut.signUp(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.attributeNames, expectedInvalidAttributes)
+    }
+
+    func testSignUpUsingParametersPassword_delegate_whenSendAttributes_butDelegateMethodIsNotImplemented_itShouldReturnAttributesInvalid() {
+        let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = SignUpPasswordStartDelegateOptionalMethodsNotImplemented(expectation: exp)
+        let expectedInvalidAttributes = ["attribute"]
+
+        let expectedResult: SignUpStartResult = .attributesInvalid(expectedInvalidAttributes)
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct", password: "correct")
+        sut.signUp(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid")
+        )
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
+    }
+
+    // MARK: - Sign Up with code
 
     func testSignUp_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-up public interface")
@@ -291,7 +405,94 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         XCTAssertEqual(delegate.error?.correlationId, correlationId)
     }
 
-    // Sign in with password
+    // MARK: - Sign Up using parameters with code
+
+    func testSignUpUsingParameters_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-up public interface")
+        let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
+        let parameters = MSALNativeAuthSignUpParameters(username: "")
+        sut.signUp(parameters: parameters, delegate: delegate)
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(delegate.error?.type, .invalidUsername)
+    }
+
+    func testSignUpUsingParameters_delegate_whenValidDataIsPassed_shouldReturnCodeRequired() {
+        let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
+
+        let expectedResult: SignUpStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: MSALNativeAuthChannelType(value: "email"),
+            codeLength: 1
+        )
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
+        sut.signUp(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp, exp2])
+
+        XCTAssertNil(controllerFactoryMock.signUpController.signUpStartRequestParameters?.attributes)
+        XCTAssertNotNil(controllerFactoryMock.signUpController.signUpStartRequestParameters)
+    }
+
+    func testSignUpUsingParameters_delegate_butDelegateMethodIsNotImplemented_shouldReturnError() {
+        let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        let expectedResult: SignUpStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.signUpController, username: "", continuationToken: "continuationToken", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: MSALNativeAuthChannelType(value: "email"),
+            codeLength: 1
+        )
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
+        sut.signUp(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpCodeRequired")
+        )
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
+    }
+
+    func testSignUpUsingParameters_delegate_whenSendAttributes_butDelegateMethodIsNotImplemented_itShouldReturnAttributesInvalid() {
+        let exp = expectation(description: "sign-up public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = SignUpStartDelegateOptionalMethodsNotImplemented(expectation: exp)
+        let expectedInvalidAttributes = ["attribute"]
+
+        let expectedResult: SignUpStartResult = .attributesInvalid(expectedInvalidAttributes)
+        controllerFactoryMock.signUpController.startResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
+        sut.signUp(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignUpAttributesInvalid")
+        )
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
+    }
+
+    // MARK: - Sign in with password
 
     func testSignInPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
@@ -386,7 +587,108 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         wait(for: [exp, exp2], timeout: 1)
     }
 
-    // Sign in with code
+    // MARK: - Sign in using parameters with password
+
+    func testSignInUsingParametersPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
+        let expectation = expectation(description: "sign-in public interface")
+        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername, correlationId: correlationId))
+        let parameters = MSALNativeAuthSignInParameters(username: "", password: "", correlationId: correlationId)
+        sut.signIn(parameters: parameters, delegate: delegate)
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testSignInUsingParametersPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
+        let expectation = expectation(description: "sign-in public interface")
+        let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidCredentials, correlationId: correlationId))
+        let parameters = MSALNativeAuthSignInParameters(username: "correct", password: "", correlationId: correlationId)
+        sut.signIn(parameters: parameters, delegate: delegate)
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testSignInUsingParametersPassword_delegate_whenValidUserAndPasswordAreUsed_shouldReturnSuccess() {
+        let exp1 = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = SignInPasswordStartDelegateSpy(expectation: exp1, expectedUserAccountResult: MSALNativeAuthUserAccountResultStub.result)
+
+        controllerFactoryMock.signInController.signInStartResult = .init(.init(.completed(MSALNativeAuthUserAccountResultStub.result), correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        }))
+        let parameters = MSALNativeAuthSignInParameters(username: "correct", password: "correct")
+        sut.signIn(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp1, exp2], timeout: 1)
+    }
+
+    func testSignInUsingParametersPassword_delegate_whenSuccessIsReturnedButUserHasNotImplementedOptionalDelegate_shouldReturnError() {
+        let exp = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCompleted"), correlationId: correlationId)
+        let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
+
+        let expectedResult: SignInStartResult = .completed(MSALNativeAuthUserAccountResultStub.result)
+
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignInParameters(username: "correct", password: "correct")
+        sut.signIn(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp, exp2], timeout: 1)
+    }
+
+    func testSignInUsingParametersPassword_delegate_whenCodeIsRequiredAndUserHasImplementedOptionalDelegate_shouldReturnCodeRequired() {
+        let exp1 = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let delegate = SignInPasswordStartDelegateSpy(expectation: exp1)
+        delegate.expectedSentTo = "sentTo"
+        delegate.expectedCodeLength = 1
+        delegate.expectedChannelTargetType = MSALNativeAuthChannelType(value: "email")
+
+        let expectedResult: SignInStartResult = .codeRequired(
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: MSALNativeAuthChannelType(value: "email"),
+            codeLength: 1
+        )
+
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignInParameters(username: "correct", password: "correct")
+        sut.signIn(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp1, exp2], timeout: 1)
+    }
+
+    func testSignInUsingParametersPassword_delegate_whenCodeIsRequiredButUserHasNotImplementedOptionalDelegate_shouldReturnError() {
+        let exp = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"), correlationId: correlationId)
+        let delegate = SignInPasswordStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
+
+        let expectedResult: SignInStartResult = .codeRequired(
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: MSALNativeAuthChannelType(value: "email"),
+            codeLength: 1
+        )
+
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignInParameters(username: "correct", password: "correct")
+        sut.signIn(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp, exp2], timeout: 1)
+    }
+
+    // MARK: - Sign in with code
 
     func testSignIn_delegate_whenInvalidUser_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
@@ -481,7 +783,107 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         wait(for: [exp, exp2], timeout: 1)
     }
 
-    // ResetPassword
+    // MARK: - Sign in using parameters with code
+
+    func testSignInUsingParameters_delegate_whenInvalidUser_shouldReturnCorrectError() {
+        let expectation = expectation(description: "sign-in public interface")
+        let delegate = SignInCodeStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername, correlationId: correlationId))
+        let parameters = MSALNativeAuthSignInParameters(username: "")
+        sut.signIn(parameters: parameters, delegate: delegate)
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testSignInUsingParameters_delegate_whenValidUserIsUsed_shouldReturnCodeRequired() {
+        let exp1 = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = SignInCodeStartDelegateSpy(expectation: exp1)
+        delegate.expectedSentTo = "sentTo"
+        delegate.expectedCodeLength = 1
+        delegate.expectedChannelTargetType = MSALNativeAuthChannelType(value: "email")
+
+        let expectedResult: SignInStartResult = .codeRequired(
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: MSALNativeAuthChannelType(value: "email"),
+            codeLength: 1
+        )
+
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+        let parameters = MSALNativeAuthSignInParameters(username: "correct")
+        sut.signIn(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp1, exp2], timeout: 1)
+    }
+
+    func testSignInUsingParameters_delegate_whenValidUserIsUsedButUserHasNotImplementedOptionalDelegate_shouldReturnError() {
+        let exp = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInCodeRequired"), correlationId: correlationId)
+        let delegate = SignInCodeStartDelegateOptionalMethodNotImplemented(expectation: exp, expectedError: expectedError)
+
+        let expectedResult: SignInStartResult = .codeRequired(
+            newState: SignInCodeRequiredState(scopes: [], controller: controllerFactoryMock.signInController, continuationToken: "", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: MSALNativeAuthChannelType(value: "email"),
+            codeLength: 1
+        )
+
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignInParameters(username: "correct")
+        sut.signIn(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp, exp2], timeout: 1)
+    }
+
+    func testSignInUsingParameters_delegate_whenPasswordIsRequiredAndUserHasImplementedOptionalDelegate_shouldReturnPasswordRequired() {
+        let exp1 = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let delegate = SignInCodeStartDelegateWithPasswordRequiredSpy(expectation: exp1)
+
+        let expectedState = SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, continuationToken: "continuationToken", correlationId: correlationId)
+        let expectedResult: SignInStartResult = .passwordRequired(newState: expectedState)
+
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignInParameters(username: "correct")
+        sut.signIn(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp1, exp2], timeout: 1)
+
+        XCTAssertEqual(delegate.passwordRequiredState?.continuationToken, expectedState.continuationToken)
+    }
+
+    func testSignInUsingParameters_delegate_whenPasswordIsRequiredButUserHasNotImplementedOptionalDelegate_shouldReturnError() {
+        let exp = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+
+        let expectedError = SignInStartError(type: .generalError, message: String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onSignInPasswordRequired"), correlationId: correlationId)
+        let delegate = SignInCodeStartDelegateSpy(expectation: exp, expectedError: expectedError)
+
+        let expectedResult: SignInStartResult = .passwordRequired(
+            newState: SignInPasswordRequiredState(scopes: [], username: "", controller: controllerFactoryMock.signInController, continuationToken: "", correlationId: correlationId)
+        )
+
+        controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthSignInParameters(username: "correct")
+        sut.signIn(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp, exp2], timeout: 1)
+    }
+
+    // MARK: - ResetPassword
 
     func testResetPassword_delegate_whenInvalidUser_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-in public interface")
@@ -542,7 +944,73 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCodeRequired")
         )
     }
-    
+
+    // MARK: - ResetPassword using parameters
+
+    func testResetPasswordUsingParameters_delegate_whenInvalidUser_shouldReturnCorrectError() {
+        let exp = expectation(description: "sign-in public interface")
+        let delegate = ResetPasswordStartDelegateSpy(expectation: exp)
+        let parameters = MSALNativeAuthResetPasswordParameters(username: "")
+        sut.resetPassword(parameters: parameters, delegate: delegate)
+        wait(for: [exp])
+        XCTAssertEqual(delegate.error?.type, .invalidUsername)
+    }
+
+    func testResetPasswordUsingParameters_delegate_whenValidUserIsUsed_shouldReturnCodeRequired() {
+        let exp1 = expectation(description: "sign-in public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = ResetPasswordStartDelegateSpy(expectation: exp1)
+
+        let expectedResult: ResetPasswordStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.resetPasswordController, username: "username", continuationToken: "continuationToken", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: MSALNativeAuthChannelType(value: "email"),
+            codeLength: 1
+        )
+
+        controllerFactoryMock.resetPasswordController.resetPasswordResponse = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthResetPasswordParameters(username: "correct")
+        sut.resetPassword(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp1, exp2], timeout: 1)
+
+        XCTAssertEqual(delegate.newState?.continuationToken, "continuationToken")
+        XCTAssertEqual(delegate.newState?.username, "username")
+        XCTAssertEqual(delegate.sentTo, "sentTo")
+        XCTAssertEqual(delegate.channelTargetType?.isEmailType, true)
+        XCTAssertEqual(delegate.codeLength, 1)
+    }
+
+    func testResetPasswordUsingParameters_delegate_butDelegateMethodIsNotImplemented_shouldReturnError() {
+        let exp = expectation(description: "reset-password public interface")
+        let exp2 = expectation(description: "expectation Telemetry")
+        let delegate = ResetPasswordStartDelegateOptionalMethodsNotImplemented(expectation: exp)
+
+        let expectedResult: ResetPasswordStartResult = .codeRequired(
+            newState: .init(controller: controllerFactoryMock.resetPasswordController, username: "username", continuationToken: "continuationToken", correlationId: correlationId),
+            sentTo: "sentTo",
+            channelTargetType: MSALNativeAuthChannelType(value: "email"),
+            codeLength: 1
+        )
+        controllerFactoryMock.resetPasswordController.resetPasswordResponse = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
+            exp2.fulfill()
+        })
+
+        let parameters = MSALNativeAuthResetPasswordParameters(username: "correct")
+        sut.resetPassword(parameters: parameters, delegate: delegate)
+
+        wait(for: [exp, exp2])
+
+        XCTAssertEqual(delegate.error?.type, .generalError)
+        XCTAssertEqual(
+            delegate.error?.errorDescription,
+            String(format: MSALNativeAuthErrorMessage.delegateNotImplemented, "onResetPasswordCodeRequired")
+        )
+    }
+
     // MARK: - CorrelationId
         
     // SignUp Password
@@ -1055,7 +1523,538 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         // SignInAfterSignUpDelegateSpy class - onSignInCompleted function
         XCTAssertTrue(delegateSignInAfterResetPassword.onSignInCompletedCalled)
     }
-    
+
+    // MARK: - CorrelationId using parameters
+
+    // SignUp using parameters Password
+    // Testing SingUpStart -> SingUpChallenge -> SingUpContinue -> SignInToken with Password
+
+    func testSignUpUsingParametersPassword_correlationId_whenSetOnStart_itCascadesToAll() {
+        let expectationPasswordStart = expectation(description: "Sign Up Password Start")
+        let delegatePasswordStart = SignUpPasswordStartDelegateSpy(expectation: expectationPasswordStart)
+        let expectationVerifyCode = expectation(description: "Sign Up Verify Code")
+        let delegateVerifyCode = SignUpVerifyCodeDelegateSpy(expectation: expectationVerifyCode)
+        let expectationSignInAfterSingUp = expectation(description: "Sign In After Sign Up")
+        let delegateSignInAfterSignUp = SignInAfterSignUpDelegateSpy(expectation: expectationSignInAfterSingUp)
+
+        let signUpRequestProviderMock = MSALNativeAuthSignUpRequestProviderMock()
+        signUpRequestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedStartRequestParameters = expectedSignUpStartPasswordParams
+        signUpRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedChallengeRequestParameters = expectedSignUpChallengeParams()
+        signUpRequestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedContinueRequestParameters = expectedSignUpContinueParams(token: "continuationToken 2")
+
+        let signUpResponseValidatorMock = MSALNativeAuthSignUpResponseValidatorMock()
+        signUpResponseValidatorMock.mockValidateSignUpStartFunc(.success(continuationToken: "continuationToken"))
+        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", MSALNativeAuthChannelType(value: "email"), 4, "continuationToken 2"))
+        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success(continuationToken: "continuationToken"))
+
+        let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
+
+        let expectedUsername = "username"
+        let expectedScopes = "scope1 scope2 openid profile offline_access"
+
+        let tokenResponse = MSIDCIAMTokenResponse()
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+
+        let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: expectedUsername, continuationToken: "continuationToken", grantType: MSALNativeAuthGrantType.continuationToken, scope: expectedScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedContext = contextMock
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+
+        let tokenResponseValidatorMock = MSALNativeAuthTokenResponseValidatorMock()
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+
+        let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
+        let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
+                                                                rawIdToken: MSALNativeAuthUserAccountResultStub.rawIdToken,
+                                                                configuration: MSALNativeAuthConfigStubs.configuration,
+                                                                cacheAccessor: MSALNativeAuthCacheAccessorMock())
+        authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
+
+        let tokenResult = MSIDTokenResult()
+        tokenResult.rawIdToken = "idToken"
+        let cacheAccessorMock = MSALNativeAuthCacheAccessorMock()
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+
+        delegateSignInAfterSignUp.expectedUserAccountResult = userAccountResult
+        let signInAfterSignUpController = MSALNativeAuthSignInController(clientId: clientId,
+                                                                         signInRequestProvider: signInRequestProviderMock,
+                                                                         tokenRequestProvider: tokenRequestProviderMock,
+                                                                         cacheAccessor: cacheAccessorMock,
+                                                                         factory: authResultFactoryMock,
+                                                                         signInResponseValidator: MSALNativeAuthSignInResponseValidatorMock(),
+                                                                         tokenResponseValidator: tokenResponseValidatorMock)
+        let signUpController = MSALNativeAuthSignUpController(config: configuration,
+                                                              requestProvider: signUpRequestProviderMock,
+                                                              responseValidator: signUpResponseValidatorMock,
+                                                              signInController: signInAfterSignUpController)
+
+        let controllerFactory = MSALNativeAuthControllerProtocolFactoryMock(signUpController: signUpController)
+
+        sut = MSALNativeAuthPublicClientApplication(
+            controllerFactory: controllerFactory,
+            cacheAccessorFactory: cacheAccessorFactoryMock,
+            inputValidator: MSALNativeAuthInputValidator(),
+            internalChallengeTypes: [],
+            configuration: MSALPublicClientApplicationConfig(
+                clientId: "",
+                redirectUri: "",
+                authority: nil
+            )
+        )
+
+        // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
+        // MSALNativeAuthSignUpRequestProviderMock class - checkStartParameters and checkChallengeParameters functions
+        let parametersSignUp = MSALNativeAuthSignUpParameters(username: "username",
+                                                        password: "password",
+                                                        attributes: ["key": "value"],
+                                                        correlationId: correlationId)
+        sut.signUp(parameters: parametersSignUp, delegate: delegatePasswordStart)
+
+        wait(for: [expectationPasswordStart])
+
+        // Correlation Id is validated internally against expectedContinueRequestParameters in the
+        // MSALNativeAuthSignUpRequestProviderMock class - checkContinueParameters function
+        delegatePasswordStart.newState?.submitCode(code: "1234", delegate: delegateVerifyCode)
+
+        wait(for: [expectationVerifyCode])
+
+        // Correlation Id is validated internally against expectedTokenParams in the
+        // MSALNativeAuthTokenRequestProviderMock class - checkContext function
+        let parametersSingInAfterSignUp = MSALNativeAuthSignInAfterSignUpParameters(scopes: ["scope1", "scope2"])
+        delegateVerifyCode.newSignInAfterSignUpState?.signIn(parameters: parametersSingInAfterSignUp,
+                                                             delegate: delegateSignInAfterSignUp)
+
+        wait(for: [expectationSignInAfterSingUp])
+
+        // User account result is validated internally against expectedUserAccountResult in the
+        // SignInAfterSignUpDelegateSpy class - onSignInCompleted function
+        XCTAssertTrue(delegateSignInAfterSignUp.onSignInCompletedCalled)
+    }
+
+    // SignUp using parameters Code
+    // Testing SingUpStart -> SingUpChallenge -> SingUpContinue -> SignInToken with Code
+
+    func testSignUpUsingParametersCode_correlationId_whenSetOnStart_itCascadesToAll() {
+        let expectationCodeStart = expectation(description: "Sign Up Code Start")
+        let delegateCodeStart = SignUpCodeStartDelegateSpy(expectation: expectationCodeStart)
+        let expectationVerifyCode = expectation(description: "Sign Up Verify Code")
+        let delegateVerifyCode = SignUpVerifyCodeDelegateSpy(expectation: expectationVerifyCode)
+        let expectationSignInAfterSingUp = expectation(description: "Sign In After Sign Up")
+        let delegateSignInAfterSignUp = SignInAfterSignUpDelegateSpy(expectation: expectationSignInAfterSingUp)
+
+        let signUpRequestProviderMock = MSALNativeAuthSignUpRequestProviderMock()
+        signUpRequestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedStartRequestParameters = expectedSignUpStartCodeParams
+        signUpRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedChallengeRequestParameters = expectedSignUpChallengeParams()
+        signUpRequestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signUpRequestProviderMock.expectedContinueRequestParameters = expectedSignUpContinueParams(token: "continuationToken 2")
+
+        let signUpResponseValidatorMock = MSALNativeAuthSignUpResponseValidatorMock()
+        signUpResponseValidatorMock.mockValidateSignUpStartFunc(.success(continuationToken: "continuationToken"))
+        signUpResponseValidatorMock.mockValidateSignUpChallengeFunc(.codeRequired("sentTo", MSALNativeAuthChannelType(value: "email"), 4, "continuationToken 2"))
+        signUpResponseValidatorMock.mockValidateSignUpContinueFunc(.success(continuationToken: "continuationToken"))
+
+        let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
+
+        let expectedUsername = "username"
+        let expectedScopes = "scope1 scope2 openid profile offline_access"
+
+        let tokenResponse = MSIDCIAMTokenResponse()
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+
+        let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: expectedUsername, continuationToken: "continuationToken", grantType: MSALNativeAuthGrantType.continuationToken, scope: expectedScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedContext = contextMock
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+
+        let tokenResponseValidatorMock = MSALNativeAuthTokenResponseValidatorMock()
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+
+        let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
+        let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
+                                                                rawIdToken: MSALNativeAuthUserAccountResultStub.rawIdToken,
+                                                                configuration: MSALNativeAuthConfigStubs.configuration,
+                                                                cacheAccessor: MSALNativeAuthCacheAccessorMock())
+        authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
+
+        let tokenResult = MSIDTokenResult()
+        tokenResult.rawIdToken = "idToken"
+        let cacheAccessorMock = MSALNativeAuthCacheAccessorMock()
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+
+        delegateSignInAfterSignUp.expectedUserAccountResult = userAccountResult
+        let signInAfterSignUpController = MSALNativeAuthSignInController(clientId: clientId,
+                                                                         signInRequestProvider: signInRequestProviderMock,
+                                                                         tokenRequestProvider: tokenRequestProviderMock,
+                                                                         cacheAccessor: cacheAccessorMock,
+                                                                         factory: authResultFactoryMock,
+                                                                         signInResponseValidator: MSALNativeAuthSignInResponseValidatorMock(),
+                                                                         tokenResponseValidator: tokenResponseValidatorMock)
+        let signUpController = MSALNativeAuthSignUpController(config: configuration,
+                                                              requestProvider: signUpRequestProviderMock,
+                                                              responseValidator: signUpResponseValidatorMock,
+                                                              signInController: signInAfterSignUpController)
+
+        let controllerFactory = MSALNativeAuthControllerProtocolFactoryMock(signUpController: signUpController)
+
+        sut = MSALNativeAuthPublicClientApplication(
+            controllerFactory: controllerFactory,
+            cacheAccessorFactory: cacheAccessorFactoryMock,
+            inputValidator: MSALNativeAuthInputValidator(),
+            internalChallengeTypes: [],
+            configuration: MSALPublicClientApplicationConfig(
+                clientId: "",
+                redirectUri: "",
+                authority: nil
+            )
+        )
+
+        // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
+        // MSALNativeAuthSignUpRequestProviderMock class - checkStartParameters and checkChallengeParameters functions
+        let parametersSignUp = MSALNativeAuthSignUpParameters(username: "username",
+                                                        attributes: ["key": "value"],
+                                                        correlationId: correlationId)
+        sut.signUp(parameters: parametersSignUp, delegate: delegateCodeStart)
+
+        wait(for: [expectationCodeStart])
+
+        // Correlation Id is validated internally against expectedContinueRequestParameters in the
+        // MSALNativeAuthSignUpRequestProviderMock class - checkContinueParameters function
+        delegateCodeStart.newState?.submitCode(code: "1234", delegate: delegateVerifyCode)
+
+        wait(for: [expectationVerifyCode])
+
+        // Correlation Id is validated internally against expectedTokenParams in the
+        // MSALNativeAuthTokenRequestProviderMock class - checkContext function
+        let parametersSignInAfterSignUp = MSALNativeAuthSignInAfterSignUpParameters(scopes: ["scope1", "scope2"])
+        delegateVerifyCode.newSignInAfterSignUpState?.signIn(parameters: parametersSignInAfterSignUp,
+                                                             delegate: delegateSignInAfterSignUp)
+        wait(for: [expectationSignInAfterSingUp])
+
+        // User account result is validated internally against expectedUserAccountResult in the
+        // SignInAfterSignUpDelegateSpy class - onSignInCompleted function
+        XCTAssertTrue(delegateSignInAfterSignUp.onSignInCompletedCalled)
+    }
+
+    // SignIn using parameters Password
+    // Testing SignInInitiate -> SignInChallenge -> SignInToken with Password
+
+    func testSignInUsingParametersPassword_correlationId_whenSetOnStart_itCascadesToAll() {
+        let expectationPasswordStart = expectation(description: "Sign In Password Start")
+        let delegatePasswordStart = SignInPasswordStartDelegateSpy(expectation: expectationPasswordStart)
+        let expectationVerifyCode = expectation(description: "Sign In Verify Code")
+        let delegateVerifyCode = SignInVerifyCodeDelegateSpy(expectation: expectationVerifyCode)
+
+        let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.expectedUsername = "username"
+
+        signInRequestProviderMock.expectedContext = contextMock
+        let continuationToken = "<continuationToken>"
+        let expectedSentTo = "sentTo"
+        let expectedChannelTargetType = MSALNativeAuthChannelType(value: "email")
+        let expectedCodeLength = 4
+        let signInResponseValidatorMock = MSALNativeAuthSignInResponseValidatorMock()
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+
+        let expectedScopes = "scope1 scope2 openid profile offline_access"
+
+        let tokenResponse = MSIDCIAMTokenResponse()
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+
+        let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: nil, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.oobCode, scope: expectedScopes, password: nil, oobCode: "1234", includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedContext = contextMock
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+
+        let tokenResponseValidatorMock = MSALNativeAuthTokenResponseValidatorMock()
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+
+        let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
+        let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
+                                                                rawIdToken: MSALNativeAuthUserAccountResultStub.rawIdToken,
+                                                                configuration: MSALNativeAuthConfigStubs.configuration,
+                                                                cacheAccessor: MSALNativeAuthCacheAccessorMock())
+        authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
+
+        let tokenResult = MSIDTokenResult()
+        tokenResult.rawIdToken = "idToken"
+        let cacheAccessorMock = MSALNativeAuthCacheAccessorMock()
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+
+        delegateVerifyCode.expectedUserAccountResult = userAccountResult
+        let signInController = MSALNativeAuthSignInController(clientId: clientId,
+                                                                         signInRequestProvider: signInRequestProviderMock,
+                                                                         tokenRequestProvider: tokenRequestProviderMock,
+                                                                         cacheAccessor: cacheAccessorMock,
+                                                                         factory: authResultFactoryMock,
+                                                                         signInResponseValidator: signInResponseValidatorMock,
+                                                                         tokenResponseValidator: tokenResponseValidatorMock)
+        let controllerFactory = MSALNativeAuthControllerProtocolFactoryMock(signInController: signInController)
+
+        sut = MSALNativeAuthPublicClientApplication(
+            controllerFactory: controllerFactory,
+            cacheAccessorFactory: cacheAccessorFactoryMock,
+            inputValidator: MSALNativeAuthInputValidator(),
+            internalChallengeTypes: [],
+            configuration: MSALPublicClientApplicationConfig(
+                clientId: "",
+                redirectUri: "",
+                authority: nil
+            )
+        )
+
+        // Correlation Id is validated internally against contextMock on both initiate and challenge in the
+        // MSALNativeAuthSignInRequestProviderMock class - checkContext function
+        let parameters = MSALNativeAuthSignInParameters(username: "username", password: "password", scopes: ["scope1", "scope2"], correlationId: correlationId)
+        sut.signIn(parameters: parameters, delegate: delegatePasswordStart)
+
+        wait(for: [expectationPasswordStart])
+
+        // Correlation Id is validated internally against expectedTokenParams
+        // MSALNativeAuthTokenRequestProviderMock class - checkContext function
+        delegatePasswordStart.newSignInCodeRequiredState?.submitCode(code: "1234", delegate: delegateVerifyCode)
+        wait(for: [expectationVerifyCode])
+
+        // User account result is validated internally against expectedUserAccountResult in the
+        // SignInVerifyCodeDelegateSpy class - onSignInCompleted function
+        XCTAssertTrue(delegateVerifyCode.onSignInCompletedCalled)
+    }
+
+    // SignIn using parameters Code
+    // Testing SignInInitiate -> SignInChallenge -> SignInToken with Code
+
+    func testSignInUsingParametersCode_correlationId_whenSetOnStart_itCascadesToAll() {
+        let expectationCodeStart = expectation(description: "Sign In Code Start")
+        let delegateCodeStart = SignInCodeStartDelegateSpy(expectation: expectationCodeStart)
+        let expectationVerifyCode = expectation(description: "Sign In Verify Code")
+        let delegateVerifyCode = SignInVerifyCodeDelegateSpy(expectation: expectationVerifyCode)
+
+        let signInRequestProviderMock = MSALNativeAuthSignInRequestProviderMock()
+        signInRequestProviderMock.mockInitiateRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        signInRequestProviderMock.expectedUsername = "username"
+        signInRequestProviderMock.expectedContext = contextMock
+
+        let continuationToken = "<continuationToken>"
+        let expectedSentTo = "sentTo"
+        let expectedChannelTargetType = MSALNativeAuthChannelType(value: "email")
+        let expectedCodeLength = 4
+        delegateCodeStart.expectedSentTo = expectedSentTo
+        delegateCodeStart.expectedChannelTargetType = expectedChannelTargetType
+        delegateCodeStart.expectedCodeLength = expectedCodeLength
+
+        let signInResponseValidatorMock = MSALNativeAuthSignInResponseValidatorMock()
+        signInResponseValidatorMock.initiateValidatedResponse = .success(continuationToken: continuationToken)
+        signInResponseValidatorMock.challengeValidatedResponse = .codeRequired(continuationToken: continuationToken, sentTo: expectedSentTo, channelType: expectedChannelTargetType, codeLength: expectedCodeLength)
+
+        let expectedScopes = "scope1 scope2 openid profile offline_access"
+
+        let tokenResponse = MSIDCIAMTokenResponse()
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+
+        let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: nil, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.oobCode, scope: expectedScopes, password: nil, oobCode: "1234", includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedContext = contextMock
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+
+        let tokenResponseValidatorMock = MSALNativeAuthTokenResponseValidatorMock()
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+
+        let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
+        let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
+                                                                rawIdToken: MSALNativeAuthUserAccountResultStub.rawIdToken,
+                                                                configuration: MSALNativeAuthConfigStubs.configuration,
+                                                                cacheAccessor: MSALNativeAuthCacheAccessorMock())
+        authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
+
+        let tokenResult = MSIDTokenResult()
+        tokenResult.rawIdToken = "idToken"
+        let cacheAccessorMock = MSALNativeAuthCacheAccessorMock()
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+
+        delegateVerifyCode.expectedUserAccountResult = userAccountResult
+        let signInController = MSALNativeAuthSignInController(clientId: clientId,
+                                                                         signInRequestProvider: signInRequestProviderMock,
+                                                                         tokenRequestProvider: tokenRequestProviderMock,
+                                                                         cacheAccessor: cacheAccessorMock,
+                                                                         factory: authResultFactoryMock,
+                                                                         signInResponseValidator: signInResponseValidatorMock,
+                                                                         tokenResponseValidator: tokenResponseValidatorMock)
+        let controllerFactory = MSALNativeAuthControllerProtocolFactoryMock(signInController: signInController)
+
+        sut = MSALNativeAuthPublicClientApplication(
+            controllerFactory: controllerFactory,
+            cacheAccessorFactory: cacheAccessorFactoryMock,
+            inputValidator: MSALNativeAuthInputValidator(),
+            internalChallengeTypes: [],
+            configuration: MSALPublicClientApplicationConfig(
+                clientId: "",
+                redirectUri: "",
+                authority: nil
+            )
+        )
+
+        // Correlation Id is validated internally against contextMock on both initiate and challenge in the
+        // MSALNativeAuthSignInRequestProviderMock class - checkContext function
+        let parameters = MSALNativeAuthSignInParameters(username: "username", scopes: ["scope1", "scope2"], correlationId: correlationId)
+        sut.signIn(parameters: parameters, delegate: delegateCodeStart)
+        wait(for: [expectationCodeStart])
+
+        // Correlation Id is validated internally against expectedTokenParams
+        // MSALNativeAuthTokenRequestProviderMock class - checkContext function
+        delegateCodeStart.newSignInCodeRequiredState?.submitCode(code: "1234", delegate: delegateVerifyCode)
+        wait(for: [expectationVerifyCode])
+
+        // User account result is validated internally against expectedUserAccountResult in the
+        // SignInVerifyCodeDelegateSpy class - onSignInCompleted function
+        XCTAssertTrue(delegateVerifyCode.onSignInCompletedCalled)
+    }
+
+    // PasswordReset using parameters
+    // Testing PasswordResetStart -> PasswordResetChallenge -> PasswordResetContinue -> PasswordResetComplete -> PasswordResetSubmit -> PollCompletion
+
+    func testResetPasswordUsingParameters_correlationId_whenSetOnStart_itCascadesToAll() {
+        let expectationPasswordResetStart = expectation(description: "Password Reset Start")
+        let delegatePasswordResetStart = ResetPasswordStartDelegateSpy(expectation: expectationPasswordResetStart)
+        let expectationPasswordResetVerifyCode = expectation(description: "Password Reset Verify Code")
+        let delegatePasswordResetVerifyCode = ResetPasswordVerifyCodeDelegateSpy(expectation: expectationPasswordResetVerifyCode)
+        let expectationPasswordResetRequired = expectation(description: "Password Reset Required")
+        let delegatePasswordResetRequired = ResetPasswordRequiredDelegateSpy(expectation: expectationPasswordResetRequired)
+        let expectationSignInAfterResetPassword = expectation(description: "Sign In After Reset Password")
+        let delegateSignInAfterResetPassword = SignInAfterResetPasswordDelegateSpy(expectation: expectationSignInAfterResetPassword)
+
+        let resetPasswordRequestProviderMock = MSALNativeAuthResetPasswordRequestProviderMock ()
+        resetPasswordRequestProviderMock.mockStartRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        resetPasswordRequestProviderMock.expectedStartRequestParameters = expectedResetPasswordStartParams
+        resetPasswordRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        resetPasswordRequestProviderMock.expectedChallengeRequestParameters = expectedResetPasswordChallengeParams(token: "continuationToken")
+        resetPasswordRequestProviderMock.mockContinueRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        resetPasswordRequestProviderMock.expectedContinueRequestParameters = expectedResetPasswordContinueParams(token: "continuationToken 2")
+        resetPasswordRequestProviderMock.mockSubmitRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        resetPasswordRequestProviderMock.expectedSubmitRequestParameters = expectedResetPasswordSubmitParams(token: "continuationToken")
+        resetPasswordRequestProviderMock.mockPollCompletionRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        resetPasswordRequestProviderMock.expectedPollCompletionParameters = expectedResetPasswordPollCompletionParameters(token: "continuationToken 3")
+
+        let resetPasswordResponseValidator = MSALNativeAuthResetPasswordResponseValidatorMock()
+        resetPasswordResponseValidator.mockValidateResetPasswordStartFunc(.success(continuationToken: "continuationToken"))
+        resetPasswordResponseValidator.mockValidateResetPasswordChallengeFunc(.success("sentTo", MSALNativeAuthChannelType(value: "email"), 4, "continuationToken 2"))
+        resetPasswordResponseValidator.mockValidateResetPasswordContinueFunc(.success(continuationToken: "continuationToken"))
+        resetPasswordResponseValidator.mockValidateResetPasswordSubmitFunc(.success(continuationToken: "continuationToken 3", pollInterval: 0))
+        resetPasswordResponseValidator.mockValidateResetPasswordPollCompletionFunc(.success(status: .succeeded, continuationToken: "continuationToken"))
+
+        let expectedUsername = "username"
+        let expectedScopes = "scope1 scope2 openid profile offline_access"
+
+        let tokenResult = MSIDTokenResult()
+        tokenResult.rawIdToken = "idToken"
+        let cacheAccessorMock = MSALNativeAuthCacheAccessorMock()
+        cacheAccessorMock.expectedMSIDTokenResult = tokenResult
+
+        let tokenRequestProviderMock = MSALNativeAuthTokenRequestProviderMock()
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: contextMock, username: expectedUsername, continuationToken: "continuationToken", grantType: .continuationToken, scope: expectedScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil)
+        tokenRequestProviderMock.expectedContext = contextMock
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+
+        let tokenResponse = MSIDCIAMTokenResponse()
+        tokenResponse.accessToken = "accessToken"
+        tokenResponse.scope = "openid profile email"
+        tokenResponse.idToken = "idToken"
+        tokenResponse.refreshToken = "refreshToken"
+
+        let tokenResponseValidatorMock = MSALNativeAuthTokenResponseValidatorMock()
+        tokenResponseValidatorMock.tokenValidatedResponse = .success(tokenResponse)
+
+        let authResultFactoryMock = MSALNativeAuthResultFactoryMock()
+        let userAccountResult = MSALNativeAuthUserAccountResult(account: MSALNativeAuthUserAccountResultStub.account,
+                                                                rawIdToken: MSALNativeAuthUserAccountResultStub.rawIdToken,
+                                                                configuration: MSALNativeAuthConfigStubs.configuration,
+                                                                cacheAccessor: MSALNativeAuthCacheAccessorMock())
+        authResultFactoryMock.mockMakeUserAccountResult(userAccountResult)
+        delegateSignInAfterResetPassword.expectedUserAccountResult = userAccountResult
+
+        let signInAfterResetPasswordController = MSALNativeAuthSignInController(clientId: clientId,
+                                                                                signInRequestProvider: MSALNativeAuthSignInRequestProviderMock(),
+                                                                                tokenRequestProvider: tokenRequestProviderMock,
+                                                                                cacheAccessor: cacheAccessorMock,
+                                                                                factory: authResultFactoryMock,
+                                                                                signInResponseValidator: MSALNativeAuthSignInResponseValidatorMock(),
+                                                                                tokenResponseValidator: tokenResponseValidatorMock)
+
+        let resetPasswordController = MSALNativeAuthResetPasswordController(config: configuration,
+                                                                            requestProvider: resetPasswordRequestProviderMock,
+                                                                            responseValidator: resetPasswordResponseValidator,
+                                                                            signInController: signInAfterResetPasswordController)
+
+        let controllerFactory = MSALNativeAuthControllerProtocolFactoryMock(resetPasswordController: resetPasswordController)
+
+        sut = MSALNativeAuthPublicClientApplication(
+            controllerFactory: controllerFactory,
+            cacheAccessorFactory: cacheAccessorFactoryMock,
+            inputValidator: MSALNativeAuthInputValidator(),
+            internalChallengeTypes: [],
+            configuration: MSALPublicClientApplicationConfig(
+                clientId: "",
+                redirectUri: "",
+                authority: nil
+            )
+        )
+
+        // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
+        // MSALNativeAuthResetPasswordRequestProviderMock class - checkParameters(params: MSALNativeAuthResetPasswordStartRequestProviderParameters)
+        // and checkParameters(token: String, context: MSIDRequestContext) functions
+        let parametersResetPassword = MSALNativeAuthResetPasswordParameters(username: "username", correlationId: correlationId)
+        sut.resetPassword(parameters: parametersResetPassword, delegate: delegatePasswordResetStart)
+
+        wait(for: [expectationPasswordResetStart])
+
+        // Correlation Id is validated internally against expectedContinueRequestParameters in the
+        // MSALNativeAuthResetPasswordRequestProviderMock class - checkParameters(_ params: MSALNativeAuthResetPasswordContinueRequestParameters) function
+        delegatePasswordResetStart.newState?.submitCode(code: "1234", delegate: delegatePasswordResetVerifyCode)
+
+        wait(for: [expectationPasswordResetVerifyCode])
+
+        // Correlation Id is validated internally against expectedSubmitRequestParameters and expectedPollCompletionParameters
+        // MSALNativeAuthResetPasswordRequestProviderMock class - checkParameters(_ params: MSALNativeAuthResetPasswordSubmitRequestParameters) function
+        // and checkParameters(_ params: MSALNativeAuthResetPasswordPollCompletionRequestParameters) function
+        delegatePasswordResetVerifyCode.newPasswordRequiredState?.submitPassword(password: "password", delegate: delegatePasswordResetRequired)
+
+        wait(for: [expectationPasswordResetRequired])
+
+        XCTAssertTrue(delegatePasswordResetRequired.onResetPasswordCompletedCalled)
+
+        // Correlation Id is validated internally against expectedTokenParams in the
+        // MSALNativeAuthTokenRequestProviderMock class - checkContext function
+        let parametersSingInAfterResetPassword = MSALNativeAuthSignInAfterResetPasswordParameters(scopes: ["scope1", "scope2"])
+        delegatePasswordResetRequired.signInAfterResetPasswordState?.signIn(parameters: parametersSingInAfterResetPassword,
+                                                                            delegate: delegateSignInAfterResetPassword)
+        wait(for: [expectationSignInAfterResetPassword])
+
+        // User account result is validated internally against expectedUserAccountResult in the
+        // SignInAfterSignUpDelegateSpy class - onSignInCompleted function
+        XCTAssertTrue(delegateSignInAfterResetPassword.onSignInCompletedCalled)
+    }
+
+    // MARK: - Helper functions
+
     private var expectedSignUpStartPasswordParams: MSALNativeAuthSignUpStartRequestProviderParameters {
         .init(
             username: "username",

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -282,7 +282,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedResult: expectedResult)
         delegate.expectedAccessToken = accessToken.accessToken
         delegate.expectedScopes = accessToken.scopes?.array as? [String] ?? []
-        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: contextCorrelationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.correlationId = contextCorrelationId
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
@@ -322,9 +323,10 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedResult: expectedResult)
         delegate.expectedAccessToken = accessToken.accessToken
         delegate.expectedScopes = accessToken.scopes?.array as? [String] ?? []
-        let parameters = MSALNativeAuthGetAccessTokenParameters(forceRefresh: true,
-                                                                scopes: accessToken.scopes?.array as? [String] ?? [],
-                                                                correlationId: contextCorrelationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.forceRefresh = true
+        parameters.scopes = accessToken.scopes?.array as? [String] ?? []
+        parameters.correlationId = contextCorrelationId
 
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
@@ -359,9 +361,10 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
 
-        let parameters = MSALNativeAuthGetAccessTokenParameters(forceRefresh: true,
-                                                                scopes: ["scope"],
-                                                                correlationId: correlationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.forceRefresh = true
+        parameters.scopes = ["scope"]
+        parameters.correlationId = correlationId
 
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
@@ -392,9 +395,11 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         factory.silentTokenProvider.error = expectedError
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        let parameters = MSALNativeAuthGetAccessTokenParameters(forceRefresh: true,
-                                                                scopes: ["scope"],
-                                                                correlationId: correlationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.forceRefresh = true
+        parameters.scopes = ["scope"]
+        parameters.correlationId = correlationId
+
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
@@ -594,7 +599,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: errorWithoutInnerErrorWithoutDescriptionMock.localizedDescription, correlationId: correlationId, errorCodes: [], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.correlationId = correlationId
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
@@ -606,7 +612,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "user_info_error_description", correlationId: correlationId, errorCodes: [], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.correlationId = correlationId
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
@@ -624,7 +631,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: errorCodes, errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.correlationId = correlationId
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
@@ -642,7 +650,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: [], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.correlationId = correlationId
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
@@ -661,7 +670,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: [1, 2, 3], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.correlationId = correlationId
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
@@ -680,7 +690,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: [], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.correlationId = correlationId
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
@@ -699,7 +710,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.refreshTokenMFARequiredError + message, correlationId: correlationId, errorCodes: errorCodes, errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.correlationId = correlationId
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
@@ -718,7 +730,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.passwordResetRequired + message, correlationId: correlationId, errorCodes: errorCodes, errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        parameters.correlationId = correlationId
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -251,6 +251,155 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         await fulfillment(of: [delegateExp])
     }
 
+    // MARK: - get access token using parameters tests
+
+    func test_getAccessTokenUsingParameters_successfullyReturnsAccessToken() async {
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = "accessToken"
+        accessToken.scopes = ["scope1", "scope2"]
+        let contextCorrelationId = UUID()
+        let homeAccountId = MSALAccountId(accountIdentifier: "fedcba98-7654-3210-0000-000000000000.00000000-0000-1234-5678-90abcdefffff", objectId: "", tenantId: "https://contoso.com/tfp/tenantName")
+        let idToken = "newIdToken"
+        let account = MSALAccount(username: "1234567890", homeAccountId: homeAccountId, environment: "contoso.com", tenantProfiles: [])!
+        let silentTokenResult = MSALNativeAuthSilentTokenResult(accessTokenResult: MSALNativeAuthTokenResult(accessToken: accessToken.accessToken,
+                                                                                                             scopes: accessToken.scopes?.array as? [String] ?? [],
+                                                                                                             expiresOn: nil),
+                                                                rawIdToken: idToken,
+                                                                account: account,
+                                                                correlationId: contextCorrelationId)
+        let params = MSALSilentTokenParameters(scopes: accessToken.scopes?.array as? [String] ?? [], account: account)
+        params.forceRefresh = false
+        params.correlationId = contextCorrelationId
+
+        silentTokenProviderFactoryMock.silentTokenProvider.result = silentTokenResult
+        silentTokenProviderFactoryMock.silentTokenProvider.expectedParameters = params
+
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedResult = MSALNativeAuthTokenResult(accessToken: accessToken.accessToken,
+                                                       scopes: accessToken.scopes?.array as? [String] ?? [],
+                                                       expiresOn: accessToken.expiresOn)
+
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedResult: expectedResult)
+        delegate.expectedAccessToken = accessToken.accessToken
+        delegate.expectedScopes = accessToken.scopes?.array as? [String] ?? []
+        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: contextCorrelationId)
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+
+        XCTAssertEqual(delegate.expectedResult, expectedResult)
+        XCTAssertEqual(sut.idToken, idToken)
+        XCTAssertEqual(sut.account, account)
+    }
+
+    func test_getAccessTokenScopesUsingParametersAndForceRefresh_successfullyReturnsNewAccessToken() async {
+        let accessToken = MSIDAccessToken()
+        accessToken.accessToken = "newAccessToken"
+        accessToken.scopes = ["scope1", "scope2"]
+        let contextCorrelationId = UUID()
+        let homeAccountId = MSALAccountId(accountIdentifier: "fedcba98-7654-3210-0000-000000000000.00000000-0000-1234-5678-90abcdefffff", objectId: "", tenantId: "https://contoso.com/tfp/tenantName")
+        let idToken = "newIdToken"
+        let account = MSALAccount(username: "1234567890", homeAccountId: homeAccountId, environment: "contoso.com", tenantProfiles: [])!
+        let silentTokenResult = MSALNativeAuthSilentTokenResult(accessTokenResult: MSALNativeAuthTokenResult(accessToken: accessToken.accessToken,
+                                                                                                             scopes: accessToken.scopes?.array as? [String] ?? [],
+                                                                                                             expiresOn: nil),
+                                                                rawIdToken: idToken,
+                                                                account: account,
+                                                                correlationId: contextCorrelationId)
+
+        let params = MSALSilentTokenParameters(scopes: accessToken.scopes?.array as? [String] ?? [], account: account)
+        params.forceRefresh = true
+        params.correlationId = contextCorrelationId
+
+        silentTokenProviderFactoryMock.silentTokenProvider.result = silentTokenResult
+        silentTokenProviderFactoryMock.silentTokenProvider.expectedParameters = params
+
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedResult = MSALNativeAuthTokenResult(accessToken: accessToken.accessToken,
+                                                       scopes: accessToken.scopes?.array as? [String] ?? [],
+                                                       expiresOn: accessToken.expiresOn)
+
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedResult: expectedResult)
+        delegate.expectedAccessToken = accessToken.accessToken
+        delegate.expectedScopes = accessToken.scopes?.array as? [String] ?? []
+        let parameters = MSALNativeAuthGetAccessTokenParameters(forceRefresh: true,
+                                                                scopes: accessToken.scopes?.array as? [String] ?? [],
+                                                                correlationId: contextCorrelationId)
+
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+
+        XCTAssertEqual(delegate.expectedResult, expectedResult)
+        XCTAssertEqual(sut.idToken, idToken)
+        XCTAssertEqual(sut.account, account)
+    }
+
+    func test_getAccessTokenUsingParametersWithRedirectURI_thenInternalConfigIsCreatedCorrectly() async {
+        let factory = MSALNativeAuthSilentTokenProviderFactoryConfigTester()
+        factory.expectedBypassRedirectURIValidation = false
+        let correlationId = UUID()
+        let configuration = try! MSALNativeAuthConfiguration (
+            clientId: DEFAULT_TEST_CLIENT_ID,
+            authority: try! .init(
+                url: URL(string: DEFAULT_TEST_AUTHORITY)!
+            ),
+            challengeTypes: [.redirect], redirectUri: "contoso.com"
+        )
+        sut = MSALNativeAuthUserAccountResult(
+            account: account!,
+            rawIdToken: "rawIdToken",
+            configuration: configuration,
+            cacheAccessor: cacheAccessorMock,
+            silentTokenProviderFactory: factory
+        )
+
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: nil, correlationId: correlationId, errorCodes: [], errorUri: nil)
+        factory.silentTokenProvider.error = expectedError
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+
+        let parameters = MSALNativeAuthGetAccessTokenParameters(forceRefresh: true,
+                                                                scopes: ["scope"],
+                                                                correlationId: correlationId)
+
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
+    func test_getAccessTokenUsingParametersWithoutRedirectURI_thenInternalConfigIsCreatedCorrectly() async {
+        let factory = MSALNativeAuthSilentTokenProviderFactoryConfigTester()
+        factory.expectedBypassRedirectURIValidation = true
+        let correlationId = UUID()
+        let configuration = try! MSALNativeAuthConfiguration (
+            clientId: DEFAULT_TEST_CLIENT_ID,
+            authority: try! .init(
+                url: URL(string: DEFAULT_TEST_AUTHORITY)!
+            ),
+            challengeTypes: [.redirect],
+            redirectUri: nil
+        )
+        sut = MSALNativeAuthUserAccountResult(
+            account: account!,
+            rawIdToken: "rawIdToken",
+            configuration: configuration,
+            cacheAccessor: cacheAccessorMock,
+            silentTokenProviderFactory: factory
+        )
+
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: nil, correlationId: correlationId, errorCodes: [], errorUri: nil)
+        factory.silentTokenProvider.error = expectedError
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        let parameters = MSALNativeAuthGetAccessTokenParameters(forceRefresh: true,
+                                                                scopes: ["scope"],
+                                                                correlationId: correlationId)
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
     // MARK: - sign-out tests
 
     func test_signOut_successfullyCallsCacheAccessor() {
@@ -411,6 +560,166 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
         sut.getAccessToken(correlationId: correlationId,
                            delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
+    // MARK: - error tests using parameters
+
+    func testUsingParameters_errorWithInnerError() async {
+        silentTokenProviderFactoryMock.silentTokenProvider.error = errorWithInnerErrorMock
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: "inner_user_info_error_description", correlationId: innerCorrelationId, errorCodes: [], errorUri: nil)
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
+    func testUsingParameters_errorWithoutInnerError() async {
+        silentTokenProviderFactoryMock.silentTokenProvider.error = errorWithoutInnerErrorMock
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: "user_info_error_description", correlationId: withoutInnerCorrelationId, errorCodes: [], errorUri: nil)
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        let parameters = MSALNativeAuthGetAccessTokenParameters()
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
+    func testUsingParameters_errorWithoutInnerErrorWithoutDescription() async {
+        let correlationId = UUID()
+        silentTokenProviderFactoryMock.silentTokenProvider.error = errorWithoutInnerErrorWithoutDescriptionMock
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: errorWithoutInnerErrorWithoutDescriptionMock.localizedDescription, correlationId: correlationId, errorCodes: [], errorUri: nil)
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
+    func testUsingParameters_errorWithoutInnerErrorWithoutCorrelationId() async {
+        let correlationId = UUID()
+        silentTokenProviderFactoryMock.silentTokenProvider.error = errorWithoutInnerErrorWithoutCorrelationIdMock
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: "user_info_error_description", correlationId: correlationId, errorCodes: [], errorUri: nil)
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
+    func testUsingParameters_errorWithValidExternalErrorCodes_ParseShouldWorks() async {
+        let correlationId = UUID()
+        let errorCodes = [1, 2, 3]
+        let userInfo: [String : Any] = [
+            MSALSTSErrorCodesKey: errorCodes
+        ]
+        let error = NSError(domain: "", code: 1, userInfo: userInfo)
+
+        silentTokenProviderFactoryMock.silentTokenProvider.error = error
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: errorCodes, errorUri: nil)
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
+    func testUsingParameters_errorWithInvalidExternalErrorCodes_ParseShouldWorks() async {
+        let correlationId = UUID()
+        let errorCodes = ["123"]
+        let userInfo: [String : Any] = [
+            MSALSTSErrorCodesKey: errorCodes
+        ]
+        let error = NSError(domain: "", code: 1, userInfo: userInfo)
+
+        silentTokenProviderFactoryMock.silentTokenProvider.error = error
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: [], errorUri: nil)
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
+    func testUsingParameters_errorWithValidInnerErrorWithErrorCodes_ParseShouldWorks() async {
+        let correlationId = UUID()
+        let errorCodes = [1, 2, 3]
+        let userInfo: [String : Any] = [
+            MSALSTSErrorCodesKey: errorCodes
+        ]
+        let innerError = NSError(domain: "", code: 1, userInfo: userInfo)
+        let error = NSError(domain: "", code: 1, userInfo: [NSUnderlyingErrorKey: innerError])
+
+        silentTokenProviderFactoryMock.silentTokenProvider.error = error
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: [1, 2, 3], errorUri: nil)
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
+    func testUsingParameters_errorWithInvalidInnerErrorWithErrorCodes_ParseShouldWorks() async {
+        let correlationId = UUID()
+        let errorCodes = ["123"]
+        let userInfo: [String : Any] = [
+            MSALSTSErrorCodesKey: errorCodes
+        ]
+        let innerError = NSError(domain: "", code: 1, userInfo: userInfo)
+        let error = NSError(domain: "", code: 1, userInfo: [NSUnderlyingErrorKey: innerError])
+
+        silentTokenProviderFactoryMock.silentTokenProvider.error = error
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: [], errorUri: nil)
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
+    func testUsingParameters_errorWithMFARequiredErrorCode_ErrorMessageShouldContainsCorrectMessage() async {
+        let correlationId = UUID()
+        let errorCodes = [50076]
+        let message = "message"
+        let userInfo: [String : Any] = [
+            MSALErrorDescriptionKey: message,
+            MSALSTSErrorCodesKey: errorCodes
+        ]
+        let error = NSError(domain: "", code: 1, userInfo: userInfo)
+        silentTokenProviderFactoryMock.silentTokenProvider.error = error
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.refreshTokenMFARequiredError + message, correlationId: correlationId, errorCodes: errorCodes, errorUri: nil)
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
+
+        await fulfillment(of: [delegateExp])
+    }
+
+    func testUsingParameters_errorWithResetPasswordRequiredErrorCode_ErrorMessageShouldContainsCorrectMessage() async {
+        let correlationId = UUID()
+        let errorCodes = [50142]
+        let message = "message"
+        let userInfo: [String : Any] = [
+            MSALErrorDescriptionKey: message,
+            MSALSTSErrorCodesKey: errorCodes
+        ]
+        let error = NSError(domain: "", code: 1, userInfo: userInfo)
+        silentTokenProviderFactoryMock.silentTokenProvider.error = error
+        let delegateExp = expectation(description: "delegateDispatcher delegate exp")
+        let expectedError = RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.passwordResetRequired + message, correlationId: correlationId, errorCodes: errorCodes, errorUri: nil)
+        let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
+        let parameters = MSALNativeAuthGetAccessTokenParameters(correlationId: correlationId)
+        sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }


### PR DESCRIPTION
## Proposed changes

Added parameters to public interfaces
Deprecated existing public interfaces which had parameters added
Duplicated unit tests which were using the old interfaces to use the new ones
Renamed `MSALNativeAuthSignInParameters` to `MSALNativeAuthSignInInternalParameters` as it was clashing with the new parameters class

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [x] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

