### PR TITLE
Native Auth E2E Test Batch 3

### DIFF
--- a/MSAL/test/integration/native_auth/end_to_end/credentials/MSALNativeAuthUserAccountEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/credentials/MSALNativeAuthUserAccountEndToEndTests.swift
@@ -93,4 +93,38 @@ final class MSALNativeAuthUserAccountEndToEndTests: MSALNativeAuthEndToEndPasswo
         XCTAssertTrue(credentialsDelegateSpy.onAccessTokenRetrieveErrorCalled)
         XCTAssertTrue(credentialsDelegateSpy.error!.errorDescription!.contains("Send an interactive authorization request for this user and resource."))
     }
+    
+    // Sign in with username and password with extra scopes to get access token and validate the scopes
+    func test_signInWithExtraScopes() async throws {
+#if os(macOS)
+        throw XCTSkip("Bundle id for macOS is not added to the client id, test is not needed on both iOS and macOS")
+#endif
+        guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword(), let password = await retrievePasswordForSignInUsername() else {
+            XCTFail("Missing information")
+            return
+        }
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        sut.signIn(username: username, password: password, scopes: ["User.Read"], correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+
+        XCTAssertTrue(signInDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(signInDelegateSpy.result?.idToken)
+        XCTAssertEqual(signInDelegateSpy.result?.account.username, username)
+
+        let getAccessTokenExpectation = expectation(description: "getting access token")
+        let credentialsDelegateSpy = CredentialsDelegateSpy(expectation: getAccessTokenExpectation)
+
+        signInDelegateSpy.result?.getAccessToken(scopes: ["User.Read"], delegate: credentialsDelegateSpy)
+
+        await fulfillment(of: [getAccessTokenExpectation])
+
+        XCTAssertTrue(credentialsDelegateSpy.onAccessTokenRetrieveCompletedCalled)
+        XCTAssertNotNil(credentialsDelegateSpy.result?.accessToken)
+        XCTAssertNotNil(credentialsDelegateSpy.result?.scopes)
+        XCTAssertTrue(credentialsDelegateSpy.result!.scopes.contains("User.Read"))
+    }
 }

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
@@ -243,7 +243,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         
         // Verify error condition
         XCTAssertTrue(resetPasswordStartDelegate.onResetPasswordErrorCalled)
-        XCTAssertTrue(resetPasswordStartDelegate.error?.errorDescription!.contains("The tenant or user does not support native credential recovery."))
+        XCTAssertTrue(resetPasswordStartDelegate.error?.errorDescription?.contains("The tenant or user does not support native credential recovery.") ?? false)
     }
     
     // User Case 3.1.9 - Email exists but signup method was OTP, social, etc.

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
@@ -184,9 +184,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
     
     // User Case 3.1.5 SSPR - Email is not found in records
     func test_resetPassword_emailNotFound_error() async throws {
-        guard let sut = initialisePublicClientApplication(),
-              let username = retrieveUsernameForResetPassword()
-        else {
+        guard let sut = initialisePublicClientApplication() else {
             XCTFail("Missing information")
             return
         }
@@ -194,7 +192,9 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         let resetPasswordFailureExp = expectation(description: "reset password user not found")
         let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: resetPasswordFailureExp)
         
-        sut.resetPassword(username: username, delegate: resetPasswordStartDelegate)
+        let unknownUsername = UUID().uuidString + "@contoso.com"
+        
+        sut.resetPassword(username: unknownUsername, delegate: resetPasswordStartDelegate)
         
         await fulfillment(of: [resetPasswordFailureExp])
         

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
@@ -165,6 +165,21 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         
         // Verify that the codes are different
         XCTAssertNotEqual(code1, code2, "Resent code should be different from the original code")
+        
+        // Now submit the code...
+        let newPasswordRequiredState = await retrieveAndSubmitCode(resetPasswordStartDelegate: resetPasswordStartDelegate,
+                   username: username,
+                   retries: codeRetryCount)
+
+        // Now submit the password...
+        let resetPasswordCompletedExp = expectation(description: "reset password completed")
+        let resetPasswordRequiredDelegate = ResetPasswordRequiredDelegateSpy(expectation: resetPasswordCompletedExp)
+
+        let uniquePassword = generateRandomPassword()
+        newPasswordRequiredState?.submitPassword(password: uniquePassword, delegate: resetPasswordRequiredDelegate)
+
+        await fulfillment(of: [resetPasswordCompletedExp])
+        XCTAssertTrue(resetPasswordRequiredDelegate.onResetPasswordCompletedCalled)
     }
     
     // User Case 3.1.5 SSPR - Email is not found in records

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
@@ -31,7 +31,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
     private let codeRetryCount = 3
 
     func test_resetPassword_withoutAutomaticSignIn_succeeds() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(),
               let username = retrieveUsernameForResetPassword()
@@ -71,10 +71,173 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         await fulfillment(of: [resetPasswordCompletedExp])
         XCTAssertTrue(resetPasswordRequiredDelegate.onResetPasswordCompletedCalled)
     }
+        
+    // User Case 3.1.3. SSPR – New password being set doesn’t meet password complexity requirements set on portal
+    func test_resetPassword_passwordComplexity_error() async throws {
+        throw XCTSkip("Retrieving OTP failure")
+        
+        guard let sut = initialisePublicClientApplication(),
+              let username = retrieveUsernameForResetPassword()
+        else {
+            XCTFail("Missing information")
+            return
+        }
+        let codeRequiredExp = expectation(description: "code required")
+        let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        sut.resetPassword(username: username, delegate: resetPasswordStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp])
+        XCTAssertTrue(resetPasswordStartDelegate.onResetPasswordCodeRequiredCalled)
+        
+        guard resetPasswordStartDelegate.onResetPasswordCodeRequiredCalled else {
+            XCTFail("onResetPasswordCodeRequired not called")
+            return
+        }
+        
+        XCTAssertEqual(resetPasswordStartDelegate.channelTargetType?.isEmailType, true)
+        XCTAssertFalse(resetPasswordStartDelegate.sentTo?.isEmpty ?? true)
+        XCTAssertNotNil(resetPasswordStartDelegate.codeLength)
+
+        // Now submit the code...
+        let newPasswordRequiredState = await retrieveAndSubmitCode(resetPasswordStartDelegate: resetPasswordStartDelegate,
+                   username: username,
+                   retries: codeRetryCount)
+
+        // Now submit the password...
+        let resetPasswordCompletedExp = expectation(description: "reset password completed")
+        let resetPasswordRequiredDelegate = ResetPasswordRequiredDelegateSpy(expectation: resetPasswordCompletedExp)
+
+        let uniquePassword = "INVALID_Passwprd"
+        newPasswordRequiredState?.submitPassword(password: uniquePassword, delegate: resetPasswordRequiredDelegate)
+
+        await fulfillment(of: [resetPasswordCompletedExp])
+        XCTAssertTrue(resetPasswordRequiredDelegate.onResetPasswordCompletedCalled)
+    }
+    
+    // User Case 3.1.4 SSPR - Resend email OTP
+    func test_resetPassword_resendCode_succeeds() async throws {
+        throw XCTSkip("Retrieving OTP failure")
+        
+        guard let sut = initialisePublicClientApplication(),
+              let username = retrieveUsernameForResetPassword()
+        else {
+            XCTFail("Missing information")
+            return
+        }
+        let codeRequiredExp = expectation(description: "code required")
+        let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        sut.resetPassword(username: username, delegate: resetPasswordStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp])
+        XCTAssertTrue(resetPasswordStartDelegate.onResetPasswordCodeRequiredCalled)
+        
+        guard resetPasswordStartDelegate.onResetPasswordCodeRequiredCalled else {
+            XCTFail("onResetPasswordCodeRequired not called")
+            return
+        }
+        
+        // Now get code1...
+        guard let code1 = await retrieveCodeFor(email: username) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+        
+        // Resend code
+        let resendCodeRequiredExp = expectation(description: "code required again")
+        let resetPasswordResendCodeDelegate = ResetPasswordResendCodeDelegateSpy(expectation: resendCodeRequiredExp)
+        
+        // Call resend code method
+        resetPasswordStartDelegate.newState?.resendCode(delegate: resetPasswordResendCodeDelegate)
+        
+        await fulfillment(of: [resendCodeRequiredExp])
+            
+        // Verify that resend code method was called
+        XCTAssertTrue(resetPasswordResendCodeDelegate.onResetPasswordResendCodeCodeRequiredCalled,
+                          "Resend code method should have been called")
+            
+        // Now get code2...
+        guard let code2 = await retrieveCodeFor(email: username) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+        
+        // Verify that the codes are different
+        XCTAssertNotEqual(code1, code2, "Resent code should be different from the original code")
+    }
+    
+    // User Case 3.1.5 SSPR - Email is not found in records
+    func test_resetPassword_emailNotFound_error() async throws {
+        guard let sut = initialisePublicClientApplication(),
+              let username = retrieveUsernameForResetPassword()
+        else {
+            XCTFail("Missing information")
+            return
+        }
+        
+        let resetPasswordFailureExp = expectation(description: "reset password user not found")
+        let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: resetPasswordFailureExp)
+        
+        sut.resetPassword(username: username, delegate: resetPasswordStartDelegate)
+        
+        await fulfillment(of: [resetPasswordFailureExp])
+        
+        // Verify error condition
+        XCTAssertTrue(resetPasswordStartDelegate.onResetPasswordErrorCalled)
+        XCTAssertEqual(resetPasswordStartDelegate.error?.isUserNotFound, true)
+    }
+    
+    // User Case 3.1.6 SSPR - When SSPR requires a challenge type not supported by the client, redirect to web-fallback
+    func test_resetPassword_webfallback_error() async throws {
+        guard let sut = initialisePublicClientApplication(challengeTypes: [.password]),
+              let username = retrieveUsernameForResetPassword()
+        else {
+            XCTFail("Missing information")
+            return
+        }
+        
+        let resetPasswordFailureExp = expectation(description: "reset password web-fallback")
+        let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: resetPasswordFailureExp)
+        
+        sut.resetPassword(username: username, delegate: resetPasswordStartDelegate)
+        
+        await fulfillment(of: [resetPasswordFailureExp])
+        
+        // Verify error condition
+        XCTAssertTrue(resetPasswordStartDelegate.onResetPasswordErrorCalled)
+        XCTAssertEqual(resetPasswordStartDelegate.error?.isBrowserRequired, true)
+    }
+    
+    // User Case 3.1.8 SSPR – Email exists but not linked to any password
+    // Not applicable
+    
+    // User Case 3.1.9 - Email exists but signup method was OTP, social, etc.
+    func test_resetPassword_socialAccount_error() async throws {
+        throw XCTSkip("Skipping test as it requires a Social account, not present in MSIDLAB")
+        
+        guard let sut = initialisePublicClientApplication() else {
+            XCTFail("Missing information")
+            return
+        }
+        
+        let username = "invalid"
+        
+        let resetPasswordFailureExp = expectation(description: "reset password user not found")
+        let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: resetPasswordFailureExp)
+        
+        sut.resetPassword(username: username, delegate: resetPasswordStartDelegate)
+        
+        await fulfillment(of: [resetPasswordFailureExp])
+        
+        // Verify error condition
+        XCTAssertTrue(resetPasswordStartDelegate.onResetPasswordErrorCalled)
+        XCTAssertEqual(resetPasswordStartDelegate.error?.isInvalidUsername, true)
+    }
 
     // SSPR - with automatic sign in
     func test_resetPassword_withAutomaticSignIn_succeeds() async throws {
-        throw XCTSkip("1secmail service is down. Ignoring test for now.")
+        throw XCTSkip("Retrieving OTP failure")
         
         guard let sut = initialisePublicClientApplication(),
               let username = retrieveUsernameForResetPassword()

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
@@ -236,7 +236,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
             return
         }
         
-        let username = "invalid"
+        let username = "invalid"  // TODO: use social account instead
         
         let resetPasswordFailureExp = expectation(description: "reset password user not found")
         let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: resetPasswordFailureExp)

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/ResetPasswordDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/ResetPasswordDelegateSpies.swift
@@ -121,6 +121,36 @@ class ResetPasswordRequiredDelegateSpy: ResetPasswordRequiredDelegate {
     }
 }
 
+class ResetPasswordResendCodeDelegateSpy: ResetPasswordResendCodeDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onResetPasswordResendCodeErrorCalled = false
+    private(set) var error: ResendCodeError?
+    private(set) var onResetPasswordResendCodeCodeRequiredCalled = false
+    private(set) var resetPasswordCodeRequiredState: ResetPasswordCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onResetPasswordResendCodeError(error: MSAL.ResendCodeError, newState: MSAL.ResetPasswordCodeRequiredState?) {
+        onResetPasswordResendCodeErrorCalled = true
+        self.error = error
+    }
+
+    func onResetPasswordResendCodeCodeRequired(newState: ResetPasswordCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        onResetPasswordResendCodeCodeRequiredCalled = true
+        resetPasswordCodeRequiredState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        expectation.fulfill()
+    }
+}
+
 class SignInAfterResetPasswordDelegateSpy: SignInAfterResetPasswordDelegate {
     private let expectation: XCTestExpectation
     private(set) var onSignInAfterResetPasswordErrorCalled = false

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
@@ -85,6 +85,92 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         XCTAssertTrue(signInDelegateSpy.error!.isInvalidCredentials)
     }
     
+    // User Case 1.2.4. Sign In - User signs in with account A, while data for account A already exists in SDK persistence
+    func test_signInWithAccountSigned() async throws {
+        guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword(), let password = await retrievePasswordForSignInUsername() else {
+            XCTFail("Missing information")
+            return
+        }
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+
+        XCTAssertTrue(signInDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(signInDelegateSpy.result?.idToken)
+        XCTAssertEqual(signInDelegateSpy.result?.account.username, username)
+        
+        // Now signed in the account again
+        let signInExpectation2 = expectation(description: "signing in")
+        let signInDelegateSpy2 = SignInPasswordStartDelegateSpy(expectation: signInExpectation2)
+
+        sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy2)
+        
+        XCTAssertTrue(signInDelegateSpy2.error!.description, "An account is already signed in.")
+    }
+    
+    // User Case 1.2.5. Sign In - User signs in with account B, while data for account A already exists in SDK persistence
+    // The same as 1.2.4
+    
+    // User Case 1.2.6. Sign In - Ability to provide scope to control auth strength of the token
+    
+    // User Case 1.2.7. Sign In - User email is registered with email OTP auth method, which is supported by the developer
+    func test_signInWithOTPSufficientChallengeResultsInSuccess() async throws {
+        guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword(), let password = await retrievePasswordForSignInUsername() else {
+            XCTFail("Missing information")
+            return
+        }
+
+        let signInExpectation = expectation(description: "signing in")
+        let passwordRequiredExpectation = expectation(description: "verifying password")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+        let signInPasswordRequiredDelegateSpy = SignInPasswordRequiredDelegateSpy(expectation: passwordRequiredExpectation)
+
+        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+
+        guard signInDelegateSpy.onSignInPasswordRequiredCalled else {
+            XCTFail("onSignInPasswordRequired not called")
+            return
+        }
+
+        XCTAssertNotNil(signInDelegateSpy.newStatePasswordRequired)
+
+        // Now submit the password..
+
+        signInDelegateSpy.newStatePasswordRequired?.submitPassword(password: password, delegate: signInPasswordRequiredDelegateSpy)
+
+        await fulfillment(of: [passwordRequiredExpectation])
+
+        XCTAssertTrue(signInPasswordRequiredDelegateSpy.onSignInCompletedCalled)
+    }
+    
+    // User Case 1.2.8. Sign In - User attempts to sign in with email and password, but server requires second factor authentication (MFA OTP)
+    // Please refer to MFA End to End Test
+    
+    // User Case 1.2.9. Sign In - User email is registered with email OTP auth method, which is not supported by the developer (aka redirect flow)
+    func test_signInWithOTPInsufficientChallengeResultsInError() async throws {
+        guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword(), let password = await retrievePasswordForSignInUsername() else {
+            XCTFail("Missing information")
+            return
+        }
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+
+        XCTAssertTrue(signInDelegateSpy.onSignInPasswordErrorCalled)
+        XCTAssertTrue(signInDelegateSpy.error!.isBrowserRequired)
+    }
+    
+    
     // Sign in - Password is incorrect (sent over delegate.newStatePasswordRequired)
     func test_signInAndSendingIncorrectPasswordResultsInError() async throws {
         guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword() else {

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
@@ -86,7 +86,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
     }
     
     // User Case 1.2.4. Sign In - User signs in with account A, while data for account A already exists in SDK persistence
-    func test_signInWithAccountSigned() async throws {
+    func test_signInWithSameAccountSigned() async throws {
         guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword(), let password = await retrievePasswordForSignInUsername() else {
             XCTFail("Missing information")
             return
@@ -109,12 +109,12 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
         sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy2)
         
-        XCTAssertTrue(signInDelegateSpy2.error!.description, "An account is already signed in.")
+        XCTAssertEqual(signInDelegateSpy2.error!.description, "An account is already signed in.")
     }
     
     // User Case 1.2.5. Sign In - User signs in with account B, while data for account A already exists in SDK persistence
-    func test_signInWithAccountSigned() async throws {
-        guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword(), let password = await retrievePasswordForSignInUsername() else {
+    func test_signInWithDifferentAccountSigned() async throws {
+        guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword(),         let uesrname2 = retrieveUsernameForSignInCode(), let password = await retrievePasswordForSignInUsername() else {
             XCTFail("Missing information")
             return
         }
@@ -133,12 +133,10 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         // Now signed in the account again
         let signInExpectation2 = expectation(description: "signing in")
         let signInDelegateSpy2 = SignInPasswordStartDelegateSpy(expectation: signInExpectation2)
-        
-        let uesrname2 = retrieveUsernameForSignInCode()
 
         sut.signIn(username: uesrname2, password: password, correlationId: correlationId, delegate: signInDelegateSpy2)
         
-        XCTAssertTrue(signInDelegateSpy2.error!.description, "An account is already signed in.")
+        XCTAssertEqual(signInDelegateSpy2.error!.description, "An account is already signed in.")
     }
     
     /* User Case 1.2.6. Sign In - Ability to provide scope to control auth strength of the token

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
@@ -114,7 +114,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
     
     // User Case 1.2.5. Sign In - User signs in with account B, while data for account A already exists in SDK persistence
     func test_signInWithDifferentAccountSigned() async throws {
-        guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword(),         let uesrname2 = retrieveUsernameForSignInCode(), let password = await retrievePasswordForSignInUsername() else {
+        guard let sut = initialisePublicClientApplication(), let username = retrieveUsernameForSignInUsernameAndPassword(), let uesrname2 = retrieveUsernameForSignInCode(), let password = await retrievePasswordForSignInUsername() else {
             XCTFail("Missing information")
             return
         }

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
@@ -162,7 +162,12 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
     }
     
     /* User Case 2.2.6 Sign In - Ability to provide scope to control auth strength of the token
-    Please refer to SignInUsernameAndPasswordEndToEndTests 1.2.6 for the test*/
+        Please refer to Crendentials test (test_signInWithExtraScopes())
+     
+        sut.signIn(username: username, password: password, scopes: ["User.Read"], correlationId: correlationId, delegate: signInDelegateSpy)
+        ...
+        XCTAssertTrue(credentialsDelegateSpy.result!.scopes.contains("User.Read"))
+     */
     
     // Hero Scenario 2.2.7. Sign in - Invalid OTP code
     func test_signInAndSendingIncorrectOTPResultsInError() async throws {

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUsernameEndToEndTests.swift
@@ -26,63 +26,6 @@ import Foundation
 import XCTest
 
 final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBaseTestCase {
-
-    // Hero Scenario 2.2.2. Sign in - User is not registered with given email
-    func test_signInWithUnknownUsernameResultsInError() async throws {
-        guard let sut = initialisePublicClientApplication(clientIdType: .code) else {
-            XCTFail("Missing information")
-            return
-        }
-
-        let signInExpectation = expectation(description: "signing in")
-        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
-
-        let unknownUsername = UUID().uuidString + "@contoso.com"
-
-        sut.signIn(username: unknownUsername, correlationId: correlationId, delegate: signInDelegateSpy)
-
-        await fulfillment(of: [signInExpectation])
-
-        XCTAssertTrue(signInDelegateSpy.onSignInErrorCalled)
-        XCTAssertTrue(signInDelegateSpy.error!.isUserNotFound)
-    }
-
-    // Hero Scenario 2.2.7. Sign in - Invalid OTP code
-    func test_signInAndSendingIncorrectOTPResultsInError() async throws {
-
-        guard let sut = initialisePublicClientApplication(clientIdType: .code), let username = retrieveUsernameForSignInCode() else {
-            XCTFail("Missing information")
-            return
-        }
-
-        let signInExpectation = expectation(description: "signing in")
-        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
-
-        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
-
-        await fulfillment(of: [signInExpectation])
-
-        guard signInDelegateSpy.onSignInCodeRequiredCalled else {
-            XCTFail("OTP not sent")
-            return
-        }
-        XCTAssertNotNil(signInDelegateSpy.newStateCodeRequired)
-        XCTAssertNotNil(signInDelegateSpy.sentTo)
-
-        // Now submit the code..
-
-        let verifyCodeExpectation = expectation(description: "verifying code")
-        let signInVerifyCodeDelegateSpy = SignInVerifyCodeDelegateSpy(expectation: verifyCodeExpectation)
-
-        signInDelegateSpy.newStateCodeRequired?.submitCode(code: "00000000", delegate: signInVerifyCodeDelegateSpy)
-
-        await fulfillment(of: [verifyCodeExpectation])
-
-        XCTAssertTrue(signInVerifyCodeDelegateSpy.onSignInVerifyCodeErrorCalled)
-        XCTAssertNotNil(signInVerifyCodeDelegateSpy.error)
-        XCTAssertEqual(signInVerifyCodeDelegateSpy.error?.isInvalidCode, true)
-    }
-
     // Hero Scenario 2.2.1. Sign in - Use email and OTP to get token and sign in
     func test_signInAndSendingCorrectOTPResultsInSuccess() async throws {
 
@@ -124,6 +67,84 @@ final class MSALNativeAuthSignInUsernameEndToEndTests: MSALNativeAuthEndToEndBas
         XCTAssertNotNil(signInVerifyCodeDelegateSpy.result)
         XCTAssertNotNil(signInVerifyCodeDelegateSpy.result?.idToken)
         XCTAssertEqual(signInVerifyCodeDelegateSpy.result?.account.username, username)
+    }
+
+    // Hero Scenario 2.2.2. Sign in - User is not registered with given email
+    func test_signInWithUnknownUsernameResultsInError() async throws {
+        guard let sut = initialisePublicClientApplication(clientIdType: .code) else {
+            XCTFail("Missing information")
+            return
+        }
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+
+        let unknownUsername = UUID().uuidString + "@contoso.com"
+
+        sut.signIn(username: unknownUsername, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+
+        XCTAssertTrue(signInDelegateSpy.onSignInErrorCalled)
+        XCTAssertTrue(signInDelegateSpy.error!.isUserNotFound)
+    }
+    
+    // User Case 2.2.3 Sign In - User email is registered with password method, which is not supported by client (aka redirect flow)
+    func test_signInWithInsufficientChallengeInError() async throws {
+        throw XCTSkip("Retrieving OTP failure")
+
+        guard let sut = initialisePublicClientApplication(clientIdType: .code), let username = retrieveUsernameForSignInCode() else {
+            XCTFail("Missing information")
+            return
+        }
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+
+        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+
+        // Verify error condition
+        XCTAssertTrue(signInDelegateSpy.onSignInErrorCalled)
+        XCTAssertEqual(signInDelegateSpy.error?.isBrowserRequired, true)
+    }
+
+    // Hero Scenario 2.2.7. Sign in - Invalid OTP code
+    func test_signInAndSendingIncorrectOTPResultsInError() async throws {
+        throw XCTSkip("The test account is locked")
+        
+        guard let sut = initialisePublicClientApplication(clientIdType: .code), let username = retrieveUsernameForSignInCode() else {
+            XCTFail("Missing information")
+            return
+        }
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
+
+        sut.signIn(username: username, correlationId: correlationId, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+
+        guard signInDelegateSpy.onSignInCodeRequiredCalled else {
+            XCTFail("OTP not sent")
+            return
+        }
+        XCTAssertNotNil(signInDelegateSpy.newStateCodeRequired)
+        XCTAssertNotNil(signInDelegateSpy.sentTo)
+
+        // Now submit the code..
+
+        let verifyCodeExpectation = expectation(description: "verifying code")
+        let signInVerifyCodeDelegateSpy = SignInVerifyCodeDelegateSpy(expectation: verifyCodeExpectation)
+
+        signInDelegateSpy.newStateCodeRequired?.submitCode(code: "00000000", delegate: signInVerifyCodeDelegateSpy)
+
+        await fulfillment(of: [verifyCodeExpectation])
+
+        XCTAssertTrue(signInVerifyCodeDelegateSpy.onSignInVerifyCodeErrorCalled)
+        XCTAssertNotNil(signInVerifyCodeDelegateSpy.error)
+        XCTAssertEqual(signInVerifyCodeDelegateSpy.error?.isInvalidCode, true)
     }
     
     // Sign In - Verify Custom URL Domain - "https://<tenantName>.ciamlogin.com/<tenantName>.onmicrosoft.com"

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/SignInDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/SignInDelegateSpies.swift
@@ -159,3 +159,33 @@ class SignInPasswordRequiredDelegateSpy: SignInPasswordRequiredDelegate {
         expectation.fulfill()
     }
 }
+
+class SignInResendCodeDelegateSpy: SignInResendCodeDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignInResendCodeErrorCalled = false
+    private(set) var error: ResendCodeError?
+    private(set) var onSignInResendCodeCodeRequiredCalled = false
+    private(set) var signInCodeRequiredState: SignInCodeRequiredState?
+    private(set) var sentTo: String?
+    private(set) var channelTargetType: MSALNativeAuthChannelType?
+    private(set) var codeLength: Int?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignInResendCodeError(error: MSAL.ResendCodeError, newState: MSAL.SignInCodeRequiredState?) {
+        onSignInResendCodeErrorCalled = true
+        self.error = error
+    }
+
+    func onSignInResendCodeCodeRequired(newState: SignInCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+        onSignInResendCodeCodeRequiredCalled = true
+        signInCodeRequiredState = newState
+        self.sentTo = sentTo
+        self.channelTargetType = channelTargetType
+        self.codeLength = codeLength
+
+        expectation.fulfill()
+    }
+}


### PR DESCRIPTION
PBI: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3128753

SSPR:
3.1.3 New password being set doesn’t meet password complexity requirements set on portal
3.1.4 Resend email OTP
3.1.5 Email is not found in records
3.1.6 When SSPR requires a challenge type not supported by the client, redirect to web-fallback
3.1.8 Email exists but not linked to any password (not applicable)
3.1.9 Email exists but signup method was OTP, social, etc.

SignIn:
2.2.1 Use email and OTP to get token and sign in 
2.2.3 User email is registered with password method, which is not supported by client (aka redirect flow)
2.2.5 Resend email OTP
2.2.6 Ability to provide scope to control auth strength of the token
2.2.7 Invalid OTP

SignIn:
1.2.4 User signs in with account A, while data for account A already exists in SDK persistence
1.2.5 User signs in with account B, while data for account A already exists in SDK persistence
1.2.6 Ability to provide scope to control auth strength of the token
1.2.7 User email is registered with email OTP auth method, which is supported by the developer
1.2.8 User attempts to sign in with email and password, but server requires second factor authentication (MFA OTP)
1.2.9 User email is registered with email OTP auth method, which is not supported by the developer (aka redirect flow)
