### PR TITLE
Support sendable result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBD
+* Support sendable result #2518
+
 ## [1.7.0]
 * Add support for claims request in native authentication signIn (#2496)
 * Move native auth public methods to parameter class (#2492)

--- a/MSAL/src/public/MSALResult.h
+++ b/MSAL/src/public/MSALResult.h
@@ -35,6 +35,7 @@
     MSALResult represents information returned to the application after a successful interactive or silent token acquisition.
     It contains information requested by the application (e.g. access_token and id_token), and information that can be used to get a token silently from MSAL (e.g. account).
  */
+NS_SWIFT_SENDABLE
 @interface MSALResult : NSObject
 
 #pragma mark - Token response


### PR DESCRIPTION
## Proposed changes

Swift 6 enforced more strict concurrency checks and now requires  MSALResult to be marked as "tread safe",  i.e "sendable". MSALResult is already thread safe since we use "atomic" properties.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

