### PR TITLE
[iOS SDK] Add new E2E test for authentication context MFA

### DIFF
--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
@@ -191,7 +191,130 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         // Now retrieve and submit the email OTP code
         await completeSignInWithMFAFlow(state: mfaRequiredState, username: username)
     }
-    
+
+    func test_signInAuthenticationContextClaim_mfaFlowIsTriggeredAndAccessTokenContainsClaims() async throws {
+        throw XCTSkip("Retrieving OTP failure")
+#if os(macOS)
+        throw XCTSkip("For some reason this test now requires Keychain access, reason needs to be investigated")
+#endif
+        guard let username = retrieveUsernameForSignInUsernamePasswordAndMFA(),
+              let password = await retrievePasswordForSignInUsername(),
+              let application = initialisePublicClientApplication()
+        else {
+            XCTFail("Something went wrong")
+            return
+        }
+
+        let authenticationContextId = "c4"
+        let authenticationContextRequestClaimJson = "{\"access_token\":{\"acrs\":{\"essential\":true,\"value\":\"\(authenticationContextId)\"}}}"
+        let authenticationContextATClaimJson = "\"acrs\":[\"\(authenticationContextId)\"]"
+
+        let parameters = MSALNativeAuthSignInParameters(username: username)
+        parameters.password = password
+        var error: NSError? = nil
+
+        parameters.claimsRequest = MSALClaimsRequest(jsonString: authenticationContextRequestClaimJson,
+                                                     error: &error)
+        parameters.correlationId = correlationId
+
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        application.signIn(parameters: parameters, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+
+        guard signInDelegateSpy.onSignInAwaitingMFACalled, let awaitingMFAState = signInDelegateSpy.newStateAwaitingMFA else {
+            XCTFail("Awaiting MFA not called")
+            return
+        }
+
+        // Request to send challenge to the default strong auth method
+        let mfaExpectation = expectation(description: "mfa")
+        let mfaDelegateSpy = MFARequestChallengeDelegateSpy(expectation: mfaExpectation)
+
+        awaitingMFAState.requestChallenge(delegate: mfaDelegateSpy)
+
+        await fulfillment(of: [mfaExpectation])
+
+        guard mfaDelegateSpy.onSelectionRequiredCalled, let mfaRequiredState = mfaDelegateSpy.newStateMFARequired, let authMethod = mfaDelegateSpy.authMethods?.first else {
+            XCTFail("Selection required not triggered")
+            return
+        }
+
+        XCTAssertTrue(authMethod.channelTargetType.isEmailType)
+
+        // Request to send challenge to a specific strong auth method
+
+        let mfaSendChallengeExpectation = expectation(description: "mfa")
+        let mfaSendChallengeDelegateSpy = MFARequestChallengeDelegateSpy(expectation: mfaSendChallengeExpectation)
+        mfaRequiredState.requestChallenge(authMethod: authMethod, delegate: mfaSendChallengeDelegateSpy)
+
+        await fulfillment(of: [mfaSendChallengeExpectation])
+
+        guard mfaSendChallengeDelegateSpy.onVerificationRequiredCalled, let newMfaRequiredState = mfaSendChallengeDelegateSpy.newStateMFARequired else {
+            XCTFail("Challenge not sent to MFA method")
+            return
+        }
+
+        XCTAssertNotNil(mfaSendChallengeDelegateSpy.sentTo)
+        XCTAssertNotNil(mfaSendChallengeDelegateSpy.codeLength)
+        XCTAssertTrue(mfaSendChallengeDelegateSpy.channelTargetType!.isEmailType)
+
+        guard let code = await retrieveCodeFor(email: username) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+
+        let submitChallengeExpectation = expectation(description: "submitChallenge")
+        let mfaSubmitChallengeDelegateSpy = MFASubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
+
+        newMfaRequiredState.submitChallenge(challenge: code, delegate: mfaSubmitChallengeDelegateSpy)
+
+        await fulfillment(of: [submitChallengeExpectation])
+
+        XCTAssertTrue(mfaSubmitChallengeDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result)
+        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result?.idToken)
+        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result?.idToken)
+        XCTAssertEqual(mfaSubmitChallengeDelegateSpy.result?.account.username, username)
+
+        let geAccessTokenExpectation = expectation(description: "get access token")
+        let credentialsDelegateSpy = CredentialsDelegateSpy(expectation: geAccessTokenExpectation)
+
+        signInDelegateSpy.result?.getAccessToken(parameters: MSALNativeAuthGetAccessTokenParameters(), delegate: credentialsDelegateSpy)
+
+        await fulfillment(of: [geAccessTokenExpectation])
+
+        XCTAssertTrue(credentialsDelegateSpy.onAccessTokenRetrieveCompletedCalled)
+        XCTAssertNotNil(credentialsDelegateSpy.result?.accessToken)
+
+        let atParts = credentialsDelegateSpy.result?.accessToken.components(separatedBy: ".")
+
+        // It should have 3 parts
+        guard let atParts, atParts.count == 3 else {
+            XCTFail("Invalid Access token received")
+            return
+        }
+
+        // We need to use the middle part
+        var atBody: String! = atParts[1]
+
+        //There could be the case that the length of the access token is not a multiple of 4 so we pad it with "="
+        let length = Double(atBody.lengthOfBytes(using: String.Encoding.utf8))
+        let requiredLength = 4 * ceil(length / 4.0)
+        let paddingLength = requiredLength - length
+        if paddingLength > 0 {
+            let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
+            atBody = atBody + padding
+        }
+        
+        let atEncodedData = Data(base64Encoded: atBody!, options: .ignoreUnknownCharacters)
+        let atString = String(data: atEncodedData!, encoding: .utf8)!
+
+        XCTAssertTrue(atString.contains(authenticationContextATClaimJson))
+    }
+
     // MARK: private methods
     
     private func signInUsernameAndPassword(username: String, password: String) async -> AwaitingMFAState? {

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
@@ -215,7 +215,6 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
 
         parameters.claimsRequest = MSALClaimsRequest(jsonString: authenticationContextRequestClaimJson,
                                                      error: &error)
-        parameters.correlationId = correlationId
 
         let signInExpectation = expectation(description: "signing in")
         let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
@@ -275,7 +274,6 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
 
         XCTAssertTrue(mfaSubmitChallengeDelegateSpy.onSignInCompletedCalled)
         XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result)
-        XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result?.idToken)
         XCTAssertNotNil(mfaSubmitChallengeDelegateSpy.result?.idToken)
         XCTAssertEqual(mfaSubmitChallengeDelegateSpy.result?.account.username, username)
 


### PR DESCRIPTION
## Proposed changes

Add new E2E test to check that MFA is triggered when authentication context claim is specified during signIn.
Test check also that returned access token contains authentication context claim (acrs).
This test is currently disabled cause the email OTP service issue.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

