### PR TITLE
Fix E2E Native Auth error

### DIFF
--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
@@ -24,6 +24,7 @@
 
 import Foundation
 import XCTest
+import MSAL
 
 final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuthEndToEndPasswordTestCase {
     // Hero Scenario 1.2.1. Sign in - Use email and password to get token


### PR DESCRIPTION
## Proposed changes

The previous pipeline skipped the checking the E2E test which caused the failure of MSAL Objc automation. A quick fix PR to resolve the issue.
