### PR TITLE
update Comment Asking Users to Use multipleCloudsSupported

### DIFF
--- a/MSAL/src/public/MSALTokenParameters.h
+++ b/MSAL/src/public/MSALTokenParameters.h
@@ -74,6 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Key-value pairs to pass to the /authorize and /token endpoints. This should not be url-encoded value.
+ @note Please do not pass instance_aware but use MSALPublicClientApplicationConfig.multipleCloudsSupported instead. 
  */
 @property (nonatomic, nullable) NSDictionary <NSString *, NSString *> *extraQueryParameters;
 


### PR DESCRIPTION
In this PR, we update the comment to ask users not to pass in instance_aware in extraQueryParameters but to use MSALPublicClientApplicationConfig.multipleCloudsSupported instead.


## Type of change

- [ ] Feature work
- [ ] Bug fix
- [x] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

