### PR TITLE
Update broker submodule check to test on visionOS

### DIFF
--- a/azure_pipelines/broker_submodule_check.yml
+++ b/azure_pipelines/broker_submodule_check.yml
@@ -32,6 +32,15 @@ resources:
 
 jobs:
 - job: 'Validate_Pull_Request'
+  strategy:
+    maxParallel: 3
+    matrix:
+      IOS_LIB:
+        target: "ios_library"
+      MAC_LIB:
+        target: "mac_library"
+      VISION_LIB:
+        target: "vision_library"
   displayName: Validate Pull Request
   pool:
     vmImage: 'macOS-14'
@@ -145,11 +154,15 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        echo "Downloading simulator for visionOS"
-        sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
-        defaults write com.apple.dt.Xcode AllowUnsupportedVisionOSHost -bool YES
-        defaults write com.apple.CoreSimulator AllowUnsupportedVisionOSHost -bool YES
-        xcodebuild -downloadPlatform visionOS
+        if [ $(target) == 'vision_library' ]; then
+            echo "Downloading simulator for visionOS"
+            sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+            defaults write com.apple.dt.Xcode AllowUnsupportedVisionOSHost -bool YES
+            defaults write com.apple.CoreSimulator AllowUnsupportedVisionOSHost -bool YES
+            xcodebuild -downloadPlatform visionOS
+        else
+            echo "Not visionOS job, no download needed"
+        fi
       failOnStderr: false
 
 
@@ -160,5 +173,21 @@ jobs:
       script: |
         cd azure-activedirectory-tokenbroker-for-objc
         echo "executing build:./build.py"
-        python3 ./build.py
+        { output=$(./build.py --show-build-settings --target $(target) 2>&1 1>&3-) ;} 3>&1
+        final_status=$(<./build/status.txt)
+        echo "FINAL STATUS  = ${final_status}"
+        echo "POSSIBLE ERRORS: ${output}"
+        
+        if [ $final_status != "0" ]; then
+          echo "Build & Testing Failed! \n ${output}" >&2
+        fi
+      failOnStderr: true
+
+  - task: Bash@3
+    condition: always()
+    displayName: Cleanup
+    inputs:
+      targetType: 'inline'
+      script: |
+        rm -rf ./build/status.txt
         


### PR DESCRIPTION
## Proposed changes

This PR updates the broker submodule check pipeline to split the testing on separate threads per platform, and to run the broker unit tests on visionOS.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

