### PR TITLE
Add customClaims parameter to signIn after signUp/PasswordReset and GetAccessToken

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -303,6 +303,8 @@
 		28ABE1762C5D213700F5275D /* MSALNativeAuthSignInIntrospectIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28ABE1752C5D213700F5275D /* MSALNativeAuthSignInIntrospectIntegrationTests.swift */; };
 		28AF42FA2D96C15A009D1065 /* SignInAfterSignUpStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28AF42F92D96C14F009D1065 /* SignInAfterSignUpStateTests.swift */; };
 		28AF42FB2D96C15A009D1065 /* SignInAfterSignUpStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28AF42F92D96C14F009D1065 /* SignInAfterSignUpStateTests.swift */; };
+		28AF42FD2D96CBCF009D1065 /* SignInAfterResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28AF42FC2D96CBC2009D1065 /* SignInAfterResetPasswordTests.swift */; };
+		28AF42FE2D96CBCF009D1065 /* SignInAfterResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28AF42FC2D96CBC2009D1065 /* SignInAfterResetPasswordTests.swift */; };
 		28B28B832C6F46E50030D5C5 /* MFAStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B28B822C6F46E50030D5C5 /* MFAStates.swift */; };
 		28B28B8C2C6F4B570030D5C5 /* MFADelegates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B28B8B2C6F4B570030D5C5 /* MFADelegates.swift */; };
 		28B28B922C6F611F0030D5C5 /* MSALAuthMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B28B912C6F611F0030D5C5 /* MSALAuthMethod.swift */; };
@@ -2064,6 +2066,7 @@
 		28A600A92C78E09F00455666 /* MSALNativeAuthMFAControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthMFAControllerTests.swift; sourceTree = "<group>"; };
 		28ABE1752C5D213700F5275D /* MSALNativeAuthSignInIntrospectIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInIntrospectIntegrationTests.swift; sourceTree = "<group>"; };
 		28AF42F92D96C14F009D1065 /* SignInAfterSignUpStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAfterSignUpStateTests.swift; sourceTree = "<group>"; };
+		28AF42FC2D96CBC2009D1065 /* SignInAfterResetPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAfterResetPasswordTests.swift; sourceTree = "<group>"; };
 		28B28B822C6F46E50030D5C5 /* MFAStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAStates.swift; sourceTree = "<group>"; };
 		28B28B8B2C6F4B570030D5C5 /* MFADelegates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFADelegates.swift; sourceTree = "<group>"; };
 		28B28B912C6F611F0030D5C5 /* MSALAuthMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALAuthMethod.swift; sourceTree = "<group>"; };
@@ -4577,6 +4580,7 @@
 		E20C21822A7A6C7300E31598 /* sign_in */ = {
 			isa = PBXGroup;
 			children = (
+				28AF42FC2D96CBC2009D1065 /* SignInAfterResetPasswordTests.swift */,
 				28AF42F92D96C14F009D1065 /* SignInAfterSignUpStateTests.swift */,
 				E20C21832A7A6CA400E31598 /* SignInCodeRequiredStateTests.swift */,
 				E20C218A2A7A805800E31598 /* SignInPasswordRequiredStateTests.swift */,
@@ -7197,6 +7201,7 @@
 				E22427EC2B0662050006C55E /* SignUpPasswordRequiredDelegateDispatcherTests.swift in Sources */,
 				DE5738BC2A8F79A800D9120D /* MSALNativeAuthResetPasswordPollCompletionResponseErrorTests.swift in Sources */,
 				E22427FA2B0670600006C55E /* SignInVerifyCodeDelegateDispatcherTests.swift in Sources */,
+				28AF42FE2D96CBCF009D1065 /* SignInAfterResetPasswordTests.swift in Sources */,
 				E2EBD62A2A1BB7700049467A /* MSALNativeAuthSignUpResponseValidatorMock.swift in Sources */,
 				E25BC0852995430B00588549 /* MSALNativeAuthFactoriesMocks.swift in Sources */,
 				28A600962C78843C00455666 /* MFASendChallengeDelegateDispatcherTests.swift in Sources */,
@@ -7308,6 +7313,7 @@
 				A0274CBF24B432B100BD198D /* MSALAuthSchemeTests.m in Sources */,
 				DE8DC4F92C6621E700534E8F /* MSALNativeAuthResetPasswordControllerTests.swift in Sources */,
 				DE8DC5352C6621FD00534E8F /* SignUpCodeSentStateTests.swift in Sources */,
+				28AF42FD2D96CBCF009D1065 /* SignInAfterResetPasswordTests.swift in Sources */,
 				D69ADB401E516F9B00952049 /* MSALTestURLSessionDataTask.m in Sources */,
 				DE8DC5162C6621EF00534E8F /* SignInPasswordStartDelegateDispatcherTests.swift in Sources */,
 				6525115A29CD84A000D3B876 /* MSALPublicClientApplicationTests.m in Sources */,

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -301,6 +301,8 @@
 		28A600A82C78BDD200455666 /* MFARequiredStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A72C78BDD200455666 /* MFARequiredStateTests.swift */; };
 		28A600AA2C78E09F00455666 /* MSALNativeAuthMFAControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A600A92C78E09F00455666 /* MSALNativeAuthMFAControllerTests.swift */; };
 		28ABE1762C5D213700F5275D /* MSALNativeAuthSignInIntrospectIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28ABE1752C5D213700F5275D /* MSALNativeAuthSignInIntrospectIntegrationTests.swift */; };
+		28AF42FA2D96C15A009D1065 /* SignInAfterSignUpStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28AF42F92D96C14F009D1065 /* SignInAfterSignUpStateTests.swift */; };
+		28AF42FB2D96C15A009D1065 /* SignInAfterSignUpStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28AF42F92D96C14F009D1065 /* SignInAfterSignUpStateTests.swift */; };
 		28B28B832C6F46E50030D5C5 /* MFAStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B28B822C6F46E50030D5C5 /* MFAStates.swift */; };
 		28B28B8C2C6F4B570030D5C5 /* MFADelegates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B28B8B2C6F4B570030D5C5 /* MFADelegates.swift */; };
 		28B28B922C6F611F0030D5C5 /* MSALAuthMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B28B912C6F611F0030D5C5 /* MSALAuthMethod.swift */; };
@@ -2061,6 +2063,7 @@
 		28A600A72C78BDD200455666 /* MFARequiredStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFARequiredStateTests.swift; sourceTree = "<group>"; };
 		28A600A92C78E09F00455666 /* MSALNativeAuthMFAControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthMFAControllerTests.swift; sourceTree = "<group>"; };
 		28ABE1752C5D213700F5275D /* MSALNativeAuthSignInIntrospectIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInIntrospectIntegrationTests.swift; sourceTree = "<group>"; };
+		28AF42F92D96C14F009D1065 /* SignInAfterSignUpStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAfterSignUpStateTests.swift; sourceTree = "<group>"; };
 		28B28B822C6F46E50030D5C5 /* MFAStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAStates.swift; sourceTree = "<group>"; };
 		28B28B8B2C6F4B570030D5C5 /* MFADelegates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFADelegates.swift; sourceTree = "<group>"; };
 		28B28B912C6F611F0030D5C5 /* MSALAuthMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALAuthMethod.swift; sourceTree = "<group>"; };
@@ -4574,6 +4577,7 @@
 		E20C21822A7A6C7300E31598 /* sign_in */ = {
 			isa = PBXGroup;
 			children = (
+				28AF42F92D96C14F009D1065 /* SignInAfterSignUpStateTests.swift */,
 				E20C21832A7A6CA400E31598 /* SignInCodeRequiredStateTests.swift */,
 				E20C218A2A7A805800E31598 /* SignInPasswordRequiredStateTests.swift */,
 			);
@@ -7168,6 +7172,7 @@
 				DECC1FB329531032006D9FB1 /* MSALLogMaskTests.m in Sources */,
 				B2ADD76E22C08B6A0093FD43 /* MSALLegacySharedAccountTestUtil.m in Sources */,
 				58B81F7124AC5D7200E8799E /* MSALTestCacheTokenResponse.m in Sources */,
+				28AF42FA2D96C15A009D1065 /* SignInAfterSignUpStateTests.swift in Sources */,
 				DE0D659729C1DCCF005798B1 /* MSALNativeAuthTokenRequestParametersTest.swift in Sources */,
 				E25BC099299555C000588549 /* MSALNativeAuthTelemetryTestDispatcher.swift in Sources */,
 				E25BC0832995429D00588549 /* MSALNativeAuthCacheMocks.swift in Sources */,
@@ -7399,6 +7404,7 @@
 				2364C74C1FB3E5CC00835428 /* XCTestCase+HelperMethods.m in Sources */,
 				DE8DC54C2C66220D00534E8F /* MSALNativeAuthESTSApiErrorDescriptionsTests.swift in Sources */,
 				DE8DC4F72C6621E400534E8F /* MSALNativeAuthTestCase.swift in Sources */,
+				28AF42FB2D96C15A009D1065 /* SignInAfterSignUpStateTests.swift in Sources */,
 				DE8DC51A2C6621F100534E8F /* SignUpPasswordRequiredDelegateDispatcherTests.swift in Sources */,
 				DE8DC55B2C66221700534E8F /* MSALNativeAuthResetPasswordContinueRequestParametersTest.swift in Sources */,
 				DE8DC54D2C66220D00534E8F /* MSALNativeAuthSubErrorCodeTests.swift in Sources */,

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -133,12 +133,11 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         let config = factory.makeMSIDConfiguration(scopes: scopes)
         let response = await performAndValidateTokenRequest(request, config: config, context: context)
 
-        // currently, we don't handle claimsRequest in signIn with continuation token
         return await withCheckedContinuation { continuation in
             handleTokenResponse(
                 response,
                 scopes: scopes,
-                claimsRequestJson: nil,
+                claimsRequestJson: claimsRequestJson,
                 telemetryInfo: telemetryInfo,
                 onSuccess: { accountResult in
                     continuation.resume(

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -433,7 +433,13 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdMFAGetAuthMethods, context: context)
         let result = await performAndValidateIntrospectRequest(continuationToken: continuationToken, context: context)
         let telemetryInfo = TelemetryInfo(event: event, context: context)
-        return handleIntrospectResponse(result, scopes: scopes, telemetryInfo: telemetryInfo, continuationToken: continuationToken, claimsRequestJson: claimsRequestJson)
+        return handleIntrospectResponse(
+            result,
+            scopes: scopes,
+            telemetryInfo: telemetryInfo,
+            continuationToken: continuationToken,
+            claimsRequestJson: claimsRequestJson
+        )
     }
 
     func submitChallenge(

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -102,6 +102,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         username: String,
         continuationToken: String?,
         scopes: [String]?,
+        claimsRequestJson: String?,
         telemetryId: MSALNativeAuthTelemetryApiId,
         context: MSALNativeAuthRequestContext
     ) async -> SignInAfterPreviousFlowControllerResponse {
@@ -117,13 +118,12 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             return .init(.failure(error), correlationId: context.correlationId())
         }
         let scopes = joinScopes(scopes)
-        // currently, we don't support claimsRequest in signIn after signUp/SSPR
         guard let request = createTokenRequest(
             username: username,
             scopes: scopes,
             continuationToken: continuationToken,
             grantType: .continuationToken,
-            claimsRequestJson: nil,
+            claimsRequestJson: claimsRequestJson,
             context: context
         ) else {
             let error = SignInAfterSignUpError(correlationId: context.correlationId())

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInControlling.swift
@@ -39,6 +39,7 @@ protocol MSALNativeAuthSignInControlling {
         username: String,
         continuationToken: String?,
         scopes: [String]?,
+        claimsRequestJson: String?,
         telemetryId: MSALNativeAuthTelemetryApiId,
         context: MSALNativeAuthRequestContext
     ) async -> SignInAfterPreviousFlowControllerResponse

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult+Internal.swift
@@ -28,6 +28,7 @@ extension MSALNativeAuthUserAccountResult {
 
     func getAccessTokenInternal(forceRefresh: Bool,
                                 scopes: [String],
+                                claimsRequest: MSALClaimsRequest?,
                                 correlationId: UUID?,
                                 delegate: CredentialsDelegate) {
 
@@ -35,6 +36,7 @@ extension MSALNativeAuthUserAccountResult {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         params.forceRefresh = forceRefresh
         params.correlationId = correlationId
+        params.claimsRequest = claimsRequest
 
         let challengeTypes = MSALNativeAuthPublicClientApplication.convertChallengeTypes(configuration.challengeTypes)
         let authority = try? MSALCIAMAuthority(url: configuration.authority.url)

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -92,6 +92,7 @@ import Foundation
 
         getAccessTokenInternal(forceRefresh: parameters.forceRefresh,
                                scopes: parameters.scopes ?? [],
+                               claimsRequest: parameters.claimsRequest,
                                correlationId: parameters.correlationId,
                                delegate: delegate)
     }
@@ -112,6 +113,7 @@ import Foundation
 
         getAccessTokenInternal(forceRefresh: forceRefresh,
                                scopes: [],
+                               claimsRequest: nil,
                                correlationId: correlationId,
                                delegate: delegate)
     }
@@ -145,6 +147,7 @@ import Foundation
 
         getAccessTokenInternal(forceRefresh: forceRefresh,
                                scopes: scopes,
+                               claimsRequest: nil,
                                correlationId: correlationId,
                                delegate: delegate)
     }

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -90,7 +90,7 @@ import Foundation
             format: "Retrieving access token with parameters started."
         )
 
-        getAccessTokenInternal(forceRefresh: parameters.forceRefresh ?? false,
+        getAccessTokenInternal(forceRefresh: parameters.forceRefresh,
                                scopes: parameters.scopes ?? [],
                                correlationId: parameters.correlationId,
                                delegate: delegate)

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
@@ -32,6 +32,9 @@ public class MSALNativeAuthGetAccessTokenParameters: NSObject {
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
     public var scopes: [String]?
+    
+    /// The claims parameter that needs to be sent to the service.
+    public var claimsRequest: MSALClaimsRequest?
 
     /// UUID to correlate this request with the server for debugging.
     public var correlationId: UUID?

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthGetAccessTokenParameters.swift
@@ -32,7 +32,7 @@ public class MSALNativeAuthGetAccessTokenParameters: NSObject {
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
     public var scopes: [String]?
-    
+
     /// The claims parameter that needs to be sent to the service.
     public var claimsRequest: MSALClaimsRequest?
 

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
@@ -29,4 +29,7 @@ public class MSALNativeAuthSignInAfterResetPasswordParameters: NSObject {
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
     public var scopes: [String]?
+    
+    /// The claims parameter that needs to be sent to the service.
+    public var claimsRequest: MSALClaimsRequest?
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterResetPasswordParameters .swift
@@ -29,7 +29,7 @@ public class MSALNativeAuthSignInAfterResetPasswordParameters: NSObject {
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
     public var scopes: [String]?
-    
+
     /// The claims parameter that needs to be sent to the service.
     public var claimsRequest: MSALClaimsRequest?
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
@@ -29,7 +29,7 @@ public class MSALNativeAuthSignInAfterSignUpParameters: NSObject {
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
     public var scopes: [String]?
-    
+
     /// The claims parameter that needs to be sent to the service.
     public var claimsRequest: MSALClaimsRequest?
 }

--- a/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
+++ b/MSAL/src/native_auth/public/parameters/MSALNativeAuthSignInAfterSignUpParameters.swift
@@ -29,4 +29,7 @@ public class MSALNativeAuthSignInAfterSignUpParameters: NSObject {
     /// Permissions you want included in the access token received.
     /// Not all scopes are guaranteed to be included in the access token returned.
     public var scopes: [String]?
+    
+    /// The claims parameter that needs to be sent to the service.
+    public var claimsRequest: MSALClaimsRequest?
 }

--- a/MSAL/src/native_auth/public/state_machine/delegate/ResetPasswordDelegates.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate/ResetPasswordDelegates.swift
@@ -56,7 +56,8 @@ public protocol ResetPasswordVerifyCodeDelegate {
     @MainActor func onResetPasswordVerifyCodeError(error: VerifyCodeError, newState: ResetPasswordCodeRequiredState?)
 
     /// Notifies the delegate that a password is required from the user to continue.
-    /// - Note: If a flow requires this optional method and it is not implemented, then ``onResetPasswordVerifyCodeError(error:newState:)`` will be called.
+    /// - Note: If a flow requires this optional method and it is not implemented,
+    ///         then ``onResetPasswordVerifyCodeError(error:newState:)`` will be called.
     /// - Parameter newState: An object representing the new state of the flow with follow on methods.
     @MainActor @objc optional func onPasswordRequired(newState: ResetPasswordRequiredState)
 }
@@ -71,7 +72,8 @@ public protocol ResetPasswordResendCodeDelegate {
     @MainActor func onResetPasswordResendCodeError(error: ResendCodeError, newState: ResetPasswordCodeRequiredState?)
 
     /// Notifies the delegate that a verification code is required from the user to continue.
-    /// - Note: If a flow requires this optional method and it is not implemented, then ``onResetPasswordResendCodeError(error:newState:)`` will be called.
+    /// - Note: If a flow requires this optional method and it is not implemented,
+    ///         then ``onResetPasswordResendCodeError(error:newState:)`` will be called.
     /// - Parameters:
     ///   - newState: An object representing the new state of the flow with follow on methods.
     ///   - sentTo: The email/phone number that the code was sent to.
@@ -95,7 +97,8 @@ public protocol ResetPasswordRequiredDelegate {
     @MainActor func onResetPasswordRequiredError(error: PasswordRequiredError, newState: ResetPasswordRequiredState?)
 
     /// Notifies the delegate that the reset password operation completed successfully.
-    /// - Note: If a flow requires this optional method and it is not implemented, then ``onResetPasswordRequiredError(error:newState:)`` will be called.
+    /// - Note: If a flow requires this optional method and it is not implemented,
+    ///         then ``onResetPasswordRequiredError(error:newState:)`` will be called.
     /// - Parameter newState: An object representing the new state of the flow with follow on methods.
     @MainActor @objc optional func onResetPasswordCompleted(newState: SignInAfterResetPasswordState)
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterPreviousFlowBaseState+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterPreviousFlowBaseState+Internal.swift
@@ -28,6 +28,7 @@ extension SignInAfterPreviousFlowBaseState {
 
     func signInInternal(
         scopes: [String]?,
+        claimsRequestJson: String?,
         telemetryId: MSALNativeAuthTelemetryApiId
     ) async -> MSALNativeAuthSignInControlling.SignInAfterPreviousFlowControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
@@ -35,6 +36,7 @@ extension SignInAfterPreviousFlowBaseState {
             username: username,
             continuationToken: continuationToken,
             scopes: scopes,
+            claimsRequestJson: claimsRequestJson,
             telemetryId: telemetryId,
             context: context
         )

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -32,7 +32,12 @@ import Foundation
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(parameters: MSALNativeAuthSignInAfterResetPasswordParameters, delegate: SignInAfterResetPasswordDelegate) {
         Task {
-            let controllerResponse = await signInInternal(scopes: parameters.scopes, telemetryId: .telemetryApiIdSignInAfterPasswordReset)
+            let claimsRequestJson = parameters.claimsRequest?.jsonString()
+            let controllerResponse = await signInInternal(
+                scopes: parameters.scopes,
+                claimsRequestJson: claimsRequestJson,
+                telemetryId: .telemetryApiIdSignInAfterPasswordReset
+            )
             let delegateDispatcher = SignInAfterResetPasswordDelegateDispatcher(
                 delegate: delegate,
                 telemetryUpdate: controllerResponse.telemetryUpdate

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -33,7 +33,12 @@ import Foundation
     ///   - delegate: Delegate that receives callbacks for the Sign In flow.
     public func signIn(parameters: MSALNativeAuthSignInAfterSignUpParameters, delegate: SignInAfterSignUpDelegate) {
         Task {
-            let controllerResponse = await signInInternal(scopes: parameters.scopes, telemetryId: .telemetryApiIdSignInAfterSignUp)
+            let claimsRequestJson = parameters.claimsRequest?.jsonString()
+            let controllerResponse = await signInInternal(
+                scopes: parameters.scopes,
+                claimsRequestJson: claimsRequestJson,
+                telemetryId: .telemetryApiIdSignInAfterSignUp
+            )
             let delegateDispatcher = SignInAfterSignUpDelegateDispatcher(delegate: delegate, telemetryUpdate: controllerResponse.telemetryUpdate)
 
             switch controllerResponse.result {

--- a/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInStates+Internal.swift
@@ -37,14 +37,25 @@ extension SignInCodeRequiredState {
             ), newState: self), correlationId: context.correlationId())
         }
 
-        return await controller.submitCode(code, continuationToken: continuationToken, context: context, scopes: scopes, claimsRequestJson: claimsRequestJson)
+        return await controller.submitCode(
+            code,
+            continuationToken: continuationToken,
+            context: context,
+            scopes: scopes,
+            claimsRequestJson: claimsRequestJson
+        )
     }
 
     func resendCodeInternal() async -> MSALNativeAuthSignInControlling.SignInResendCodeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALLogger.log(level: .info, context: context, format: "SignIn flow, resend code requested")
 
-        return await controller.resendCode(continuationToken: continuationToken, context: context, scopes: scopes, claimsRequestJson: claimsRequestJson)
+        return await controller.resendCode(
+            continuationToken: continuationToken,
+            context: context,
+            scopes: scopes,
+            claimsRequestJson: claimsRequestJson
+        )
     }
 }
 
@@ -62,6 +73,13 @@ extension SignInPasswordRequiredState {
             )
         }
 
-        return await controller.submitPassword(password, username: username, continuationToken: continuationToken, context: context, scopes: scopes, claimsRequestJson: claimsRequestJson)
+        return await controller.submitPassword(
+            password,
+            username: username,
+            continuationToken: continuationToken,
+            context: context,
+            scopes: scopes,
+            claimsRequestJson: claimsRequestJson
+        )
     }
 }

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignInControllerTests.swift
@@ -193,6 +193,22 @@ class MSALNativeAuthSignInControllerTests: MSALNativeAuthTestCase {
         await fulfillment(of: [expectation], timeout: 1)
     }
     
+    func test_whenUserSpecifiesClaimsRequestJsonInSignInContinuationToken_ItIsIncludedInTokenParams() async throws {
+        let expectedContext = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let continuationToken = "continuationToken"
+        let expectedUsername = "username"
+        let expectedClaimsRequestJson = "claims"
+
+        tokenRequestProviderMock.mockRequestTokenFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
+        tokenRequestProviderMock.expectedTokenParams = MSALNativeAuthTokenRequestParameters(context: expectedContext, username: expectedUsername, continuationToken: continuationToken, grantType: MSALNativeAuthGrantType.continuationToken, scope: defaultScopes, password: nil, oobCode: nil, includeChallengeType: true, refreshToken: nil, claimsRequestJson: expectedClaimsRequestJson)
+
+        let result = await sut.signIn(username: expectedUsername, continuationToken: continuationToken, scopes: ["openid","profile","offline_access"], claimsRequestJson: expectedClaimsRequestJson, telemetryId: MSALNativeAuthTelemetryApiId.telemetryApiIdSignInAfterSignUp, context: MSALNativeAuthRequestContextMock())
+        
+        guard case let .failure(_) = result.result else {
+            return XCTFail("input should be .error")
+        }
+    }
+    
     func test_successfulResponseAndValidation_shouldCompleteSignIn() async {
         let expectedUsername = "username"
         let expectedPassword = "password"

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSignInControllerMock.swift
@@ -30,6 +30,7 @@ class MSALNativeAuthSignInControllerMock: MSALNativeAuthSignInControlling, MSALN
     private(set) var username: String?
     private(set) var continuationToken: String?
     private(set) var telemetryId: MSALNativeAuthTelemetryApiId?
+    private(set) var claimsRequestJson: String?
     var expectation: XCTestExpectation?
 
     var signInStartResult: MSALNativeAuthSignInControlling.SignInControllerResponse!
@@ -46,17 +47,25 @@ class MSALNativeAuthSignInControllerMock: MSALNativeAuthSignInControlling, MSALN
         return signInStartResult
     }
 
-    func signIn(username: String, continuationToken: String?, scopes: [String]?, telemetryId: MSAL.MSALNativeAuthTelemetryApiId, context: MSAL.MSALNativeAuthRequestContext) async -> SignInAfterPreviousFlowControllerResponse {
+    func signIn(
+        username: String,
+        continuationToken: String?,
+        scopes: [String]?,
+        claimsRequestJson: String?,
+        telemetryId: MSAL.MSALNativeAuthTelemetryApiId,
+        context: MSAL.MSALNativeAuthRequestContext
+    ) async -> SignInAfterPreviousFlowControllerResponse {
         self.username = username
         self.continuationToken = continuationToken
         self.telemetryId = telemetryId
+        self.claimsRequestJson = claimsRequestJson
         expectation?.fulfill()
 
         return continuationTokenResult
     }
 
     func submitCode(_ code: String, continuationToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String], claimsRequestJson: String?) async -> SignInSubmitCodeControllerResponse {
-        submitCodeResult
+        return submitCodeResult
     }
 
     func submitPassword(_ password: String, username: String, continuationToken: String, context: MSAL.MSALNativeAuthRequestContext, scopes: [String], claimsRequestJson: String?) async -> SignInSubmitPasswordControllerResponse {

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSilentTokenProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSilentTokenProviderMock.swift
@@ -35,6 +35,7 @@ class MSALNativeAuthSilentTokenProviderMock : MSALNativeAuthSilentTokenProviding
         if let expectedParameters = expectedParameters {
             XCTAssertEqual(expectedParameters.forceRefresh, parameters.forceRefresh)
             XCTAssertEqual(expectedParameters.correlationId, parameters.correlationId)
+            XCTAssertEqual(expectedParameters.claimsRequest, parameters.claimsRequest)
         }
         completionBlock(result, error)
     }

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -258,6 +258,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         accessToken.accessToken = "accessToken"
         accessToken.scopes = ["scope1", "scope2"]
         let contextCorrelationId = UUID()
+        var error: NSError?
+        let claimsRequest = MSALClaimsRequest(jsonString: "{}", error: &error)
         let homeAccountId = MSALAccountId(accountIdentifier: "fedcba98-7654-3210-0000-000000000000.00000000-0000-1234-5678-90abcdefffff", objectId: "", tenantId: "https://contoso.com/tfp/tenantName")
         let idToken = "newIdToken"
         let account = MSALAccount(username: "1234567890", homeAccountId: homeAccountId, environment: "contoso.com", tenantProfiles: [])!
@@ -270,6 +272,7 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let params = MSALSilentTokenParameters(scopes: accessToken.scopes?.array as? [String] ?? [], account: account)
         params.forceRefresh = false
         params.correlationId = contextCorrelationId
+        params.claimsRequest = claimsRequest
 
         silentTokenProviderFactoryMock.silentTokenProvider.result = silentTokenResult
         silentTokenProviderFactoryMock.silentTokenProvider.expectedParameters = params
@@ -284,6 +287,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         delegate.expectedScopes = accessToken.scopes?.array as? [String] ?? []
         let parameters = MSALNativeAuthGetAccessTokenParameters()
         parameters.correlationId = contextCorrelationId
+        parameters.claimsRequest = claimsRequest
+        
         sut.getAccessToken(parameters: parameters, delegate: delegate)
 
         await fulfillment(of: [delegateExp])

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInAfterResetPasswordTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInAfterResetPasswordTests.swift
@@ -25,9 +25,9 @@
 import XCTest
 @testable import MSAL
 
-final class SignInAfterSignUpStateTests: XCTestCase {
+final class SignInAfterResetPasswordStateTests: XCTestCase {
 
-    private var sut: SignInAfterSignUpState!
+    private var sut: SignInAfterResetPasswordState!
     private var controller: MSALNativeAuthSignInControllerMock!
     private var correlationId: UUID = UUID()
     private let claimsRequestJson = "{}"
@@ -45,13 +45,13 @@ final class SignInAfterSignUpStateTests: XCTestCase {
     func test_checkThatParametersSentToController_areExpected() {
         let exp = expectation(description: "signIn after signUp")
 
-        let expectedError = SignInAfterSignUpError(correlationId: correlationId)
+        let expectedError = SignInAfterResetPasswordError(correlationId: correlationId)
 
         controller.continuationTokenResult = .init(.init(.failure(SignInAfterSignUpError(correlationId: correlationId)), correlationId: correlationId))
 
-        let delegate = SignInAfterSignUpDelegateSpy(expectation: exp, expectedError: expectedError, expectedUserAccountResult: nil)
+        let delegate = SignInAfterResetPasswordDelegateSpy(expectation: exp, expectedError: expectedError, expectedUserAccountResult: nil)
 
-        let params = MSALNativeAuthSignInAfterSignUpParameters()
+        let params = MSALNativeAuthSignInAfterResetPasswordParameters()
         params.scopes = scopes
         var error: NSError?
         params.claimsRequest = MSALClaimsRequest(jsonString: claimsRequestJson, error: &error)
@@ -66,3 +66,4 @@ final class SignInAfterSignUpStateTests: XCTestCase {
     }
 
 }
+

--- a/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInAfterSignUpStateTests.swift
+++ b/MSAL/test/unit/native_auth/public/state_machine/sign_in/SignInAfterSignUpStateTests.swift
@@ -1,0 +1,68 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+import XCTest
+@testable import MSAL
+
+final class SignInAfterSignUpStateTests: XCTestCase {
+
+    private var sut: SignInAfterSignUpState!
+    private var controller: MSALNativeAuthSignInControllerMock!
+    private var correlationId: UUID = UUID()
+    private let claimsRequestJson = "{}"
+    private let scopes = ["scope"]
+    private let username = "username"
+    private let continuationToken = "continuationToken"
+
+    override func setUp() {
+        super.setUp()
+
+        controller = .init()
+        sut = .init(controller: controller, username: username, continuationToken: continuationToken, correlationId: correlationId)
+    }
+
+    func test_checkThatParametersSentToController_areExpected() {
+        let exp = expectation(description: "signIn after signUp")
+
+        let expectedError = SignInAfterSignUpError(message: "General error", correlationId: correlationId)
+
+        controller.continuationTokenResult = .init(.init(.failure(SignInAfterSignUpError(correlationId: correlationId)), correlationId: correlationId))
+
+        let delegate = SignInAfterSignUpDelegateSpy(expectation: exp, expectedError: expectedError, expectedUserAccountResult: nil)
+
+        let params = MSALNativeAuthSignInAfterSignUpParameters()
+        params.scopes = scopes
+        var error: NSError?
+        params.claimsRequest = MSALClaimsRequest(jsonString: claimsRequestJson, error: &error)
+        
+        sut.signIn(parameters: params, delegate: delegate)
+        wait(for: [exp], timeout: 1)
+        
+        XCTAssertEqual(controller.claimsRequestJson, claimsRequestJson)
+        XCTAssertEqual(controller.username, username)
+        XCTAssertEqual(controller.continuationToken, continuationToken)
+        XCTAssertFalse(delegate.onSignInCompletedCalled)
+    }
+
+}


### PR DESCRIPTION
## Proposed changes

Allow external developer to specify custom claims during signIn after signUp/Password reset or during access token retrieval.
## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
