### PR TITLE
Revert "Native Auth remove legacy interface"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## [1.9.0]
 * Add feature flags provider to be controlled from broker (#2540)
 * Added GitHub issue templates for better issue tracking and reporting (#2554)
-* Removed deprecated methods from native auth public interface (#2582)
 
 ## [1.8.1]
 * Cherry pick DUNA "resume" action fix #2558

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -184,6 +184,33 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         }
     }
 
+    /// Sign up a user with a given username and password.
+    /// - Parameters:
+    ///   - username: Username for the new account.
+    ///   - password: Optional. Password to be used for the new account.
+    ///   - attributes: Optional. User attributes to be used during account creation.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Sign Up flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'signUp(parameters:)' instead.")
+    public func signUp(
+        username: String,
+        password: String? = nil,
+        attributes: [String: Any]? = nil,
+        correlationId: UUID? = nil,
+        delegate: SignUpStartDelegate
+    ) {
+        Task {
+            let parameters = MSALNativeAuthSignUpParameters(username: username)
+            parameters.password = password
+            parameters.attributes = attributes
+            parameters.correlationId = correlationId
+            signUp(
+                parameters: parameters,
+                delegate: delegate
+            )
+        }
+    }
+
     /// Sign in a user using parameters.
     /// - Parameters:
     ///   - parameters: Parameters used for the Sign In flow.
@@ -225,6 +252,31 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         }
     }
 
+    /// Sign in a user with a given username and password.
+    /// - Parameters:
+    ///   - username: Username for the account
+    ///   - password: Optional. Password for the account.
+    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Sign In flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'signIn(parameters:)' instead.")
+    public func signIn(
+        username: String,
+        password: String? = nil,
+        scopes: [String]? = nil,
+        correlationId: UUID? = nil,
+        delegate: SignInStartDelegate
+    ) {
+        let parameters = MSALNativeAuthSignInParameters(username: username)
+        parameters.password = password
+        parameters.scopes = scopes
+        parameters.correlationId = correlationId
+        signIn(
+            parameters: parameters,
+            delegate: delegate
+        )
+    }
+
     /// Reset the password using parameters
     /// - Parameters:
     ///   - parameters: Parameters used for the Reset Password flow.
@@ -252,6 +304,25 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
                 await delegate.onResetPasswordStartError(error: error)
             }
         }
+    }
+
+    /// Reset the password for a given username.
+    /// - Parameters:
+    ///   - username: Username for the account.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Reset Password flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'resetPassword(parameters:)' instead.")
+    public func resetPassword(
+        username: String,
+        correlationId: UUID? = nil,
+        delegate: ResetPasswordStartDelegate
+    ) {
+        let parameters = MSALNativeAuthResetPasswordParameters(username: username)
+        parameters.correlationId = correlationId
+        resetPassword(
+            parameters: parameters,
+            delegate: delegate
+        )
     }
 
     /// Retrieve the current signed in account from the cache.

--- a/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthUserAccountResult.swift
@@ -96,4 +96,59 @@ import Foundation
                                correlationId: parameters.correlationId,
                                delegate: delegate)
     }
+
+    /// Retrieves the access token for the default OIDC(openid, offline_access, profile) scopes from the cache.
+    /// - Parameters:
+    ///   - forceRefresh: Optional. Ignore any existing access token in the cache and force MSAL to get a new access token from the service.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'getAccessToken(parameters:)' instead.")
+    @objc public func getAccessToken(forceRefresh: Bool = false,
+                                     correlationId: UUID? = nil,
+                                     delegate: CredentialsDelegate) {
+        MSALNativeAuthLogger.log(
+            level: .info,
+            context: nil,
+            format: "Retrieving access token without scopes.")
+
+        getAccessTokenInternal(forceRefresh: forceRefresh,
+                               scopes: [],
+                               claimsRequest: nil,
+                               correlationId: correlationId,
+                               delegate: delegate)
+    }
+
+    /// Retrieves the access token for the currently signed in account from the cache such that
+    /// the scope of retrieved access token is a superset of requested scopes. If the access token
+    /// has expired, it will be refreshed using the refresh token that's stored in the cache. If no
+    /// access token matching the requested scopes is found in cache then a new access token is fetched.
+    /// - Parameters:
+    ///   - scopes: Permissions you want included in the access token received in the result. Not all scopes are guaranteed to be included in the access token returned.
+    ///   - forceRefresh: Optional. Ignore any existing access token in the cache and force MSAL to get a new access token from the service.
+    ///   - correlationId: Optional. UUID to correlate this request with the server for debugging.
+    ///   - delegate: Delegate that receives callbacks for the Get Access Token flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'getAccessToken(parameters:)' instead.")
+    public func getAccessToken(scopes: [String],
+                               forceRefresh: Bool = false,
+                               correlationId: UUID? = nil,
+                               delegate: CredentialsDelegate) {
+
+        guard inputValidator.isInputValid(scopes) else {
+            Task { await delegate.onAccessTokenRetrieveError(error: RetrieveAccessTokenError(type: .invalidScope,
+                                                                                             correlationId: correlationId ?? UUID())) }
+            return
+        }
+
+        MSALNativeAuthLogger.log(
+            level: .info,
+            context: nil,
+            format: "Retrieving access token with scopes started."
+        )
+
+        getAccessTokenInternal(forceRefresh: forceRefresh,
+                               scopes: scopes,
+                               claimsRequest: nil,
+                               correlationId: correlationId,
+                               delegate: delegate)
+    }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterResetPasswordState.swift
@@ -56,4 +56,18 @@ import Foundation
             }
         }
     }
+
+    /// Sign in the user that just reset the password.
+    /// - Parameters:
+    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - delegate: Delegate that receives callbacks for the Sign In flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'signIn(parameters:)' instead.")
+    public func signIn(scopes: [String]? = nil, delegate: SignInAfterResetPasswordDelegate) {
+        let parameters = MSALNativeAuthSignInAfterResetPasswordParameters()
+        parameters.scopes = scopes
+        signIn(
+            parameters: parameters,
+            delegate: delegate
+        )
+    }
 }

--- a/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/SignInAfterSignUpState.swift
@@ -51,4 +51,17 @@ import Foundation
             }
         }
     }
+
+    /// Sign in the user that signed up.
+    /// - Parameters:
+    ///   - scopes: Optional. Permissions you want included in the access token received after sign in flow has completed.
+    ///   - delegate: Delegate that receives callbacks for the Sign In flow.
+    @available(*, deprecated, message: "This method is now deprecated. Use the method 'signIn(parameters:)' instead.")
+    public func signIn(scopes: [String]? = nil, delegate: SignInAfterSignUpDelegate) {
+        let parameters = MSALNativeAuthSignInAfterSignUpParameters()
+        parameters.scopes = scopes
+        signIn(
+            parameters: parameters,
+            delegate: delegate)
+    }
 }

--- a/MSAL/test/integration/native_auth/end_to_end/credentials/MSALNativeAuthUserAccountEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/credentials/MSALNativeAuthUserAccountEndToEndTests.swift
@@ -119,11 +119,7 @@ final class MSALNativeAuthUserAccountEndToEndTests: MSALNativeAuthEndToEndPasswo
         let signInExpectation = expectation(description: "signing in")
         let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
 
-        let params = MSALNativeAuthSignInParameters(username: username)
-        params.password = password
-        params.scopes = ["User.Read"]
-        params.correlationId = correlationId
-        sut.signIn(parameters: params, delegate: signInDelegateSpy)
+        sut.signIn(username: username, password: password, scopes: ["User.Read"], correlationId: correlationId, delegate: signInDelegateSpy)
 
         await fulfillment(of: [signInExpectation])
 
@@ -134,9 +130,7 @@ final class MSALNativeAuthUserAccountEndToEndTests: MSALNativeAuthEndToEndPasswo
         let getAccessTokenExpectation = expectation(description: "getting access token")
         let credentialsDelegateSpy = CredentialsDelegateSpy(expectation: getAccessTokenExpectation)
 
-        let getTokenParam = MSALNativeAuthGetAccessTokenParameters()
-        getTokenParam.scopes = ["User.Read"]
-        signInDelegateSpy.result?.getAccessToken(parameters: getTokenParam, delegate: credentialsDelegateSpy)
+        signInDelegateSpy.result?.getAccessToken(scopes: ["User.Read"], delegate: credentialsDelegateSpy)
 
         await fulfillment(of: [getAccessTokenExpectation])
 

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
@@ -86,8 +86,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         let codeRequiredExp = expectation(description: "code required")
         let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: codeRequiredExp)
 
-        let param = MSALNativeAuthResetPasswordParameters(username: username)
-        sut.resetPassword(parameters: param, delegate: resetPasswordStartDelegate)
+        sut.resetPassword(username: username, delegate: resetPasswordStartDelegate)
 
         await fulfillment(of: [codeRequiredExp])
         XCTAssertTrue(resetPasswordStartDelegate.onResetPasswordCodeRequiredCalled)
@@ -131,8 +130,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         let codeRequiredExp = expectation(description: "code required")
         let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: codeRequiredExp)
 
-        let param = MSALNativeAuthResetPasswordParameters(username: username)
-        sut.resetPassword(parameters: param, delegate: resetPasswordStartDelegate)
+        sut.resetPassword(username: username, delegate: resetPasswordStartDelegate)
 
         await fulfillment(of: [codeRequiredExp])
         XCTAssertTrue(resetPasswordStartDelegate.onResetPasswordCodeRequiredCalled)
@@ -198,8 +196,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         
         let unknownUsername = UUID().uuidString + "@contoso.com"
         
-        let param = MSALNativeAuthResetPasswordParameters(username: unknownUsername)
-        sut.resetPassword(parameters: param, delegate: resetPasswordStartDelegate)
+        sut.resetPassword(username: unknownUsername, delegate: resetPasswordStartDelegate)
         
         await fulfillment(of: [resetPasswordFailureExp])
         
@@ -220,8 +217,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         let resetPasswordFailureExp = expectation(description: "reset password web-fallback")
         let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: resetPasswordFailureExp)
         
-        let param = MSALNativeAuthResetPasswordParameters(username: username)
-        sut.resetPassword(parameters: param, delegate: resetPasswordStartDelegate)
+        sut.resetPassword(username: username, delegate: resetPasswordStartDelegate)
         
         await fulfillment(of: [resetPasswordFailureExp])
         
@@ -242,8 +238,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         let resetPasswordFailureExp = expectation(description: "does not support password")
         let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: resetPasswordFailureExp)
         
-        let param = MSALNativeAuthResetPasswordParameters(username: username)
-        sut.resetPassword(parameters: param, delegate: resetPasswordStartDelegate)
+        sut.resetPassword(username: username, delegate: resetPasswordStartDelegate)
         
         await fulfillment(of: [resetPasswordFailureExp])
         
@@ -266,8 +261,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         let resetPasswordFailureExp = expectation(description: "reset password user not found")
         let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: resetPasswordFailureExp)
         
-        let param = MSALNativeAuthResetPasswordParameters(username: username)
-        sut.resetPassword(parameters: param, delegate: resetPasswordStartDelegate)
+        sut.resetPassword(username: username, delegate: resetPasswordStartDelegate)
         
         await fulfillment(of: [resetPasswordFailureExp])
         

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/MSALNativeAuthSignInUserNameAndPasswordEndToEndTests.swift
@@ -40,10 +40,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         let signInExpectation = expectation(description: "signing in")
         let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
 
-        let parameters = MSALNativeAuthSignInParameters(username: username)
-        parameters.password = password
-        parameters.correlationId = correlationId
-        sut.signIn(parameters: parameters, delegate: signInDelegateSpy)
+        sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
 
         await fulfillment(of: [signInExpectation])
 
@@ -84,11 +81,8 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
 
         let signInExpectation = expectation(description: "signing in")
         let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
-        
-        let signInParam = MSALNativeAuthSignInParameters(username: username)
-        signInParam.password = "An Invalid Password"
-        signInParam.correlationId = correlationId
-        sut.signIn(parameters: signInParam, delegate: signInDelegateSpy)
+
+        sut.signIn(username: username, password: "An Invalid Password", correlationId: correlationId, delegate: signInDelegateSpy)
 
         await fulfillment(of: [signInExpectation])
 
@@ -114,6 +108,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         let signInParam = MSALNativeAuthSignInParameters(username: username)
         signInParam.password = password
         signInParam.correlationId = correlationId
+        
         sut.signIn(parameters: signInParam, delegate: signInDelegateSpy)
 
         await fulfillment(of: [signInExpectation])
@@ -126,10 +121,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         let signInExpectation2 = expectation(description: "signing in")
         let signInDelegateSpy2 = SignInPasswordStartDelegateSpy(expectation: signInExpectation2)
 
-        let signInParam2 = MSALNativeAuthSignInParameters(username: username)
-        signInParam2.password = password
-        signInParam2.correlationId = correlationId
-        sut.signIn(parameters: signInParam2, delegate: signInDelegateSpy2)
+        sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy2)
         
         XCTAssertTrue(signInDelegateSpy.onSignInCompletedCalled)
         XCTAssertNotNil(signInDelegateSpy.result?.idToken)
@@ -148,10 +140,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         let signInExpectation = expectation(description: "signing in")
         let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
 
-        let signInParam = MSALNativeAuthSignInParameters(username: username)
-        signInParam.password = password
-        signInParam.correlationId = correlationId
-        sut.signIn(parameters: signInParam, delegate: signInDelegateSpy)
+        sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
 
         await fulfillment(of: [signInExpectation])
 
@@ -163,9 +152,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         let signInExpectation2 = expectation(description: "signing in")
         let signInDelegateSpy2 = SignInStartDelegateSpy(expectation: signInExpectation)
 
-        let signInParam2 = MSALNativeAuthSignInParameters(username: username2)
-        signInParam2.correlationId = correlationId
-        sut.signIn(parameters: signInParam2, delegate: signInDelegateSpy2)
+        sut.signIn(username: username2, correlationId: correlationId, delegate: signInDelegateSpy2)
 
         await fulfillment(of: [signInExpectation2])
 
@@ -194,11 +181,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
     /* User Case 1.2.6. Sign In - Ability to provide scope to control auth strength of the token
         Please refer to Crendentials test (test_signInWithExtraScopes())
      
-        let signInParam = MSALNativeAuthSignInParameters(username: username)
-        signInParam.password = password
-        signInParam.correlationId = correlationId
-        sut.signIn(parameters: signInParam, delegate: signInDelegateSpy)
-
+        sut.signIn(username: username, password: password, scopes: ["User.Read"], correlationId: correlationId, delegate: signInDelegateSpy)
         ...
         XCTAssertTrue(credentialsDelegateSpy.result!.scopes.contains("User.Read"))
     */
@@ -215,10 +198,7 @@ final class MSALNativeAuthSignInUsernameAndPasswordEndToEndTests: MSALNativeAuth
         let signInExpectation = expectation(description: "signing in")
         let signInDelegateSpy = SignInStartDelegateSpy(expectation: signInExpectation)
 
-        let signInParam = MSALNativeAuthSignInParameters(username: username)
-        signInParam.password = password
-        signInParam.correlationId = correlationId
-        sut.signIn(parameters: signInParam, delegate: signInDelegateSpy)
+        sut.signIn(username: username, password: password, correlationId: correlationId, delegate: signInDelegateSpy)
 
         await fulfillment(of: [signInExpectation])
 

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthResetPasswordControllerTests.swift
@@ -883,9 +883,8 @@ final class MSALNativeAuthResetPasswordControllerTests: MSALNativeAuthTestCase {
         let exp2 = expectation(description: "SignInAfterResetPassword expectation")
         signInControllerMock.expectation = exp2
         signInControllerMock.continuationTokenResult = .init(.failure(SignInAfterResetPasswordError(correlationId: correlationId)), correlationId: correlationId)
-        
-        let parameters = MSALNativeAuthSignInAfterResetPasswordParameters()
-        helper.signInAfterResetPasswordState?.signIn(parameters: parameters, delegate: SignInAfterResetPasswordDelegateStub())
+
+        helper.signInAfterResetPasswordState?.signIn(delegate: SignInAfterResetPasswordDelegateStub())
         await fulfillment(of: [exp2], timeout: 1)
 
         XCTAssertEqual(signInControllerMock.username, username)

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthSignUpControllerTests.swift
@@ -1843,8 +1843,7 @@ final class MSALNativeAuthSignUpControllerTests: MSALNativeAuthTestCase {
         let exp2 = expectation(description: "SignInAfterSignUp expectation")
         signInControllerMock.expectation = exp2
         signInControllerMock.continuationTokenResult = .init(.init(.failure(SignInAfterSignUpError(correlationId: correlationId)), correlationId: correlationId))
-        let parameters = MSALNativeAuthSignInAfterSignUpParameters()
-        helper.signInAfterSignUpState?.signIn(parameters: parameters, delegate: SignInAfterSignUpDelegateStub())
+        helper.signInAfterSignUpState?.signIn(delegate: SignInAfterSignUpDelegateStub())
         await fulfillment(of: [exp2], timeout: 1)
 
         XCTAssertEqual(signInControllerMock.username, username)

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -86,10 +86,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     func testSignUpPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-up public interface")
         let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
-        
-        let parameters = MSALNativeAuthSignUpParameters(username: "")
-        parameters.password = ""
-        sut.signUp(parameters: parameters, delegate: delegate)
+        sut.signUp(username: "", password: "", delegate: delegate)
         wait(for: [exp], timeout: 1)
         XCTAssertEqual(delegate.error?.type, .invalidUsername)
     }
@@ -97,10 +94,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     func testSignUpPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-up public interface")
         let delegate = SignUpPasswordStartDelegateSpy(expectation: exp)
-        
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
-        parameters.password = ""
-        sut.signUp(parameters: parameters, delegate: delegate)
+        sut.signUp(username: "correct", password: "", delegate: delegate)
         wait(for: [exp], timeout: 1)
         XCTAssertEqual(delegate.error?.type, .invalidPassword)
     }
@@ -120,9 +114,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
-        parameters.password = "correct"
-        sut.signUp(parameters: parameters, delegate: delegate)
+        sut.signUp(username: "correct", password: "correct", delegate: delegate)
 
         wait(for: [exp1, exp2])
 
@@ -145,9 +137,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
         
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
-        parameters.password = "correct"
-        sut.signUp(parameters: parameters, delegate: delegate)
+        sut.signUp(username: "correct", password: "correct", delegate: delegate)
         
         wait(for: [exp, exp2])
 
@@ -170,9 +160,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
-        parameters.password = "correct"
-        sut.signUp(parameters: parameters, delegate: delegate)
+        sut.signUp(username: "correct", password: "correct", delegate: delegate)
 
         wait(for: [exp, exp2])
 
@@ -190,9 +178,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
-        parameters.password = "correct"
-        sut.signUp(parameters: parameters, delegate: delegate)
+        sut.signUp(username: "correct", password: "correct", delegate: delegate)
 
         wait(for: [exp, exp2])
 
@@ -329,10 +315,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     func testSignUp_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-up public interface")
         let delegate = SignUpCodeStartDelegateSpy(expectation: exp)
-        
-        let parameters = MSALNativeAuthSignUpParameters(username: "")
-        sut.signUp(parameters: parameters, delegate: delegate)
-
+        sut.signUp(username: "", delegate: delegate)
         wait(for: [exp], timeout: 1)
         XCTAssertEqual(delegate.error?.type, .invalidUsername)
     }
@@ -352,8 +335,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
-        sut.signUp(parameters: parameters, delegate: delegate)
+        sut.signUp(username: "correct", delegate: delegate)
 
         wait(for: [exp, exp2])
 
@@ -376,8 +358,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
-        sut.signUp(parameters: parameters, delegate: delegate)
+        sut.signUp(username: "correct", delegate: delegate)
 
         wait(for: [exp, exp2])
 
@@ -400,8 +381,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
-        sut.signUp(parameters: parameters, delegate: delegate)
+        sut.signUp(username: "correct", delegate: delegate)
 
         wait(for: [exp, exp2])
 
@@ -419,8 +399,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignUpParameters(username: "correct")
-        sut.signUp(parameters: parameters, delegate: delegate)
+        sut.signUp(username: "correct", delegate: delegate)
 
         wait(for: [exp, exp2])
 
@@ -524,22 +503,14 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     func testSignInPassword_delegate_whenInvalidUsernameUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
         let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername, correlationId: correlationId))
-        
-        let parameters = MSALNativeAuthSignInParameters(username: "")
-        parameters.password = ""
-        parameters.correlationId = correlationId
-        sut.signIn(parameters: parameters, delegate: delegate)
+        sut.signIn(username: "", password: "", correlationId: correlationId, delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
     
     func testSignInPassword_delegate_whenInvalidPasswordUsed_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
         let delegate = SignInPasswordStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidCredentials, correlationId: correlationId))
-        
-        let parameters = MSALNativeAuthSignInParameters(username: "correct")
-        parameters.password = ""
-        parameters.correlationId = correlationId
-        sut.signIn(parameters: parameters, delegate: delegate)
+        sut.signIn(username: "correct", password: "", correlationId: correlationId, delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
 
@@ -551,10 +522,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         controllerFactoryMock.signInController.signInStartResult = .init(.init(.completed(MSALNativeAuthUserAccountResultStub.result), correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         }))
-        
-        let parameters = MSALNativeAuthSignInParameters(username: "correct")
-        parameters.password = "correct"
-        sut.signIn(parameters: parameters, delegate: delegate)
+        sut.signIn(username: "correct", password: "correct", delegate: delegate)
 
         wait(for: [exp1, exp2], timeout: 1)
     }
@@ -572,9 +540,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignInParameters(username: "correct")
-        parameters.password = "correct"
-        sut.signIn(parameters: parameters, delegate: delegate)
+        sut.signIn(username: "correct", password: "correct", delegate: delegate)
 
         wait(for: [exp, exp2], timeout: 1)
     }
@@ -599,9 +565,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignInParameters(username: "correct")
-        parameters.password = "correct"
-        sut.signIn(parameters: parameters, delegate: delegate)
+        sut.signIn(username: "correct", password: "correct", delegate: delegate)
 
         wait(for: [exp1, exp2], timeout: 1)
     }
@@ -655,9 +619,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignInParameters(username: "correct")
-        parameters.password = "correct"
-        sut.signIn(parameters: parameters, delegate: delegate)
+        sut.signIn(username: "correct", password: "correct", delegate: delegate)
 
         wait(for: [exp, exp2], timeout: 1)
     }
@@ -776,10 +738,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     func testSignIn_delegate_whenInvalidUser_shouldReturnCorrectError() {
         let expectation = expectation(description: "sign-in public interface")
         let delegate = SignInCodeStartDelegateSpy(expectation: expectation, expectedError: .init(type: .invalidUsername, correlationId: correlationId))
-        
-        let parameters = MSALNativeAuthSignInParameters(username: "")
-        sut.signIn(parameters: parameters, delegate: delegate)
-        
+        sut.signIn(username: "", delegate: delegate)
         wait(for: [expectation], timeout: 1)
     }
 
@@ -801,8 +760,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         controllerFactoryMock.signInController.signInStartResult = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
-        let parameters = MSALNativeAuthSignInParameters(username: "correct")
-        sut.signIn(parameters: parameters, delegate: delegate)
+        sut.signIn(username: "correct", delegate: delegate)
 
         wait(for: [exp1, exp2], timeout: 1)
     }
@@ -825,8 +783,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignInParameters(username: "correct")
-        sut.signIn(parameters: parameters, delegate: delegate)
+        sut.signIn(username: "correct", delegate: delegate)
 
         wait(for: [exp, exp2], timeout: 1)
     }
@@ -844,8 +801,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignInParameters(username: "correct")
-        sut.signIn(parameters: parameters, delegate: delegate)
+        sut.signIn(username: "correct", delegate: delegate)
 
         wait(for: [exp1, exp2], timeout: 1)
 
@@ -867,8 +823,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthSignInParameters(username: "correct")
-        sut.signIn(parameters: parameters, delegate: delegate)
+        sut.signIn(username: "correct", delegate: delegate)
 
         wait(for: [exp, exp2], timeout: 1)
     }
@@ -978,9 +933,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     func testResetPassword_delegate_whenInvalidUser_shouldReturnCorrectError() {
         let exp = expectation(description: "sign-in public interface")
         let delegate = ResetPasswordStartDelegateSpy(expectation: exp)
-        
-        let parameters = MSALNativeAuthResetPasswordParameters(username: "")
-        sut.resetPassword(parameters: parameters, delegate: delegate)
+        sut.resetPassword(username: "", delegate: delegate)
         wait(for: [exp])
         XCTAssertEqual(delegate.error?.type, .invalidUsername)
     }
@@ -1000,9 +953,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         controllerFactoryMock.resetPasswordController.resetPasswordResponse = .init(expectedResult, correlationId: correlationId, telemetryUpdate: { _ in
             exp2.fulfill()
         })
-        
-        let parameters = MSALNativeAuthResetPasswordParameters(username: "correct")
-        sut.resetPassword(parameters: parameters, delegate: delegate)
+        sut.resetPassword(username: "correct", delegate: delegate)
 
         wait(for: [exp1, exp2], timeout: 1)
 
@@ -1028,8 +979,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             exp2.fulfill()
         })
 
-        let parameters = MSALNativeAuthResetPasswordParameters(username: "correct")
-        sut.resetPassword(parameters: parameters, delegate: delegate)
+        sut.resetPassword(username: "correct", delegate: delegate)
 
         wait(for: [exp, exp2])
 
@@ -1192,11 +1142,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
         // MSALNativeAuthSignUpRequestProviderMock class - checkStartParameters and checkChallengeParameters functions
-        let parameters = MSALNativeAuthSignUpParameters(username: "username")
-        parameters.password = "password"
-        parameters.attributes = ["key": "value"]
-        parameters.correlationId = correlationId
-        sut.signUp(parameters: parameters, delegate: delegatePasswordStart)
+        sut.signUp(username: "username", password: "password", attributes: ["key": "value"], correlationId: correlationId, delegate: delegatePasswordStart)
         
         wait(for: [expectationPasswordStart])
         
@@ -1208,9 +1154,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         // Correlation Id is validated internally against expectedTokenParams in the
         // MSALNativeAuthTokenRequestProviderMock class - checkContext function
-        let parametersSingInAfterSignUp = MSALNativeAuthSignInAfterSignUpParameters()
-        parametersSingInAfterSignUp.scopes = ["scope1", "scope2"]
-        delegateVerifyCode.newSignInAfterSignUpState?.signIn(parameters: parametersSingInAfterSignUp, delegate: delegateSignInAfterSignUp)
+        delegateVerifyCode.newSignInAfterSignUpState?.signIn(scopes: ["scope1", "scope2"], delegate: delegateSignInAfterSignUp)
         
         wait(for: [expectationSignInAfterSingUp])
         
@@ -1303,10 +1247,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
         // MSALNativeAuthSignUpRequestProviderMock class - checkStartParameters and checkChallengeParameters functions
-        let parameters = MSALNativeAuthSignUpParameters(username: "username")
-        parameters.attributes = ["key": "value"]
-        parameters.correlationId = correlationId
-        sut.signUp(parameters: parameters, delegate: delegateCodeStart)
+        sut.signUp(username: "username", attributes: ["key": "value"], correlationId: correlationId, delegate: delegateCodeStart)
         
         wait(for: [expectationCodeStart])
         
@@ -1318,10 +1259,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         // Correlation Id is validated internally against expectedTokenParams in the
         // MSALNativeAuthTokenRequestProviderMock class - checkContext function
-        
-        let parametersSingInAfterSignUp = MSALNativeAuthSignInAfterSignUpParameters()
-        parametersSingInAfterSignUp.scopes = ["scope1", "scope2"]
-        delegateVerifyCode.newSignInAfterSignUpState?.signIn(parameters: parametersSingInAfterSignUp, delegate: delegateSignInAfterSignUp)
+        delegateVerifyCode.newSignInAfterSignUpState?.signIn(scopes: ["scope1", "scope2"], delegate: delegateSignInAfterSignUp)
         wait(for: [expectationSignInAfterSingUp])
         
         // User account result is validated internally against expectedUserAccountResult in the
@@ -1404,11 +1342,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         // Correlation Id is validated internally against contextMock on both initiate and challenge in the
         // MSALNativeAuthSignInRequestProviderMock class - checkContext function
-        let parameters = MSALNativeAuthSignInParameters(username: "username")
-        parameters.password = "password"
-        parameters.scopes = ["scope1", "scope2"]
-        parameters.correlationId = correlationId
-        sut.signIn(parameters: parameters, delegate: delegatePasswordStart)
+        sut.signIn(username: "username", password: "password", scopes: ["scope1", "scope2"], correlationId: correlationId, delegate: delegatePasswordStart)
         
         wait(for: [expectationPasswordStart])
         
@@ -1501,10 +1435,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         
         // Correlation Id is validated internally against contextMock on both initiate and challenge in the
         // MSALNativeAuthSignInRequestProviderMock class - checkContext function
-        let parameters = MSALNativeAuthSignInParameters(username: "username")
-        parameters.scopes = ["scope1", "scope2"]
-        parameters.correlationId = correlationId
-        sut.signIn(parameters: parameters, delegate: delegateCodeStart)
+        sut.signIn(username: "username", scopes: ["scope1", "scope2"], correlationId: correlationId, delegate: delegateCodeStart)
         wait(for: [expectationCodeStart])
         
         // Correlation Id is validated internally against expectedTokenParams
@@ -1609,9 +1540,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         // Correlation Id is validated internally against expectedStartRequestParameters and expectedChallengeRequestParameters in the
         // MSALNativeAuthResetPasswordRequestProviderMock class - checkParameters(params: MSALNativeAuthResetPasswordStartRequestProviderParameters)
         // and checkParameters(token: String, context: MSIDRequestContext) functions
-        let parameters = MSALNativeAuthResetPasswordParameters(username: "username")
-        parameters.correlationId = correlationId
-        sut.resetPassword(parameters: parameters, delegate: delegatePasswordResetStart)
+        sut.resetPassword(username: "username", correlationId: correlationId, delegate: delegatePasswordResetStart)
         
         wait(for: [expectationPasswordResetStart])
         
@@ -1632,9 +1561,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
 
         // Correlation Id is validated internally against expectedTokenParams in the
         // MSALNativeAuthTokenRequestProviderMock class - checkContext function
-        let parametersSingInAfterSignUp = MSALNativeAuthSignInAfterResetPasswordParameters()
-        parametersSingInAfterSignUp.scopes = ["scope1", "scope2"]
-        delegatePasswordResetRequired.signInAfterResetPasswordState?.signIn(parameters: parametersSingInAfterSignUp, delegate: delegateSignInAfterResetPassword)
+        delegatePasswordResetRequired.signInAfterResetPasswordState?.signIn(scopes: ["scope1", "scope2"], delegate: delegateSignInAfterResetPassword)
         wait(for: [expectationSignInAfterResetPassword])
 
         // User account result is validated internally against expectedUserAccountResult in the

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -137,10 +137,7 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedResult: expectedResult)
         delegate.expectedAccessToken = accessToken.accessToken
         delegate.expectedScopes = accessToken.scopes?.array as? [String] ?? []
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.correlationId = contextCorrelationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(correlationId: contextCorrelationId, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
 
@@ -179,12 +176,10 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedResult: expectedResult)
         delegate.expectedAccessToken = accessToken.accessToken
         delegate.expectedScopes = accessToken.scopes?.array as? [String] ?? []
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.scopes = accessToken.scopes?.array as? [String] ?? []
-        getParams.forceRefresh = true
-        getParams.correlationId = contextCorrelationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(scopes: accessToken.scopes?.array as? [String] ?? [],
+                           forceRefresh: true,
+                           correlationId: contextCorrelationId,
+                           delegate: delegate)
 
         await fulfillment(of: [delegateExp])
 
@@ -216,12 +211,10 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         factory.silentTokenProvider.error = expectedError
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.scopes = ["scope"]
-        getParams.forceRefresh = true
-        getParams.correlationId = correlationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(scopes: ["scope"],
+                           forceRefresh: true,
+                           correlationId: correlationId,
+                           delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }
@@ -250,12 +243,10 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         factory.silentTokenProvider.error = expectedError
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.scopes = ["scope"]
-        getParams.forceRefresh = true
-        getParams.correlationId = correlationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(scopes: ["scope"],
+                           forceRefresh: true,
+                           correlationId: correlationId,
+                           delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }
@@ -433,9 +424,7 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "inner_user_info_error_description", correlationId: innerCorrelationId, errorCodes: [], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }
@@ -445,9 +434,7 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "user_info_error_description", correlationId: withoutInnerCorrelationId, errorCodes: [], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }
@@ -458,10 +445,7 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: errorWithoutInnerErrorWithoutDescriptionMock.localizedDescription, correlationId: correlationId, errorCodes: [], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.correlationId = correlationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(correlationId: correlationId, delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }
@@ -472,11 +456,9 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "user_info_error_description", correlationId: correlationId, errorCodes: [], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.correlationId = correlationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
-        
+        sut.getAccessToken(correlationId: correlationId,
+                           delegate: delegate)
+
         await fulfillment(of: [delegateExp])
     }
 
@@ -492,10 +474,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: errorCodes, errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.correlationId = correlationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(correlationId: correlationId,
+                           delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }
@@ -512,10 +492,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: [], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.correlationId = correlationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(correlationId: correlationId,
+                           delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }
@@ -533,10 +511,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: [1, 2, 3], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.correlationId = correlationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(correlationId: correlationId,
+                           delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }
@@ -554,10 +530,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: "The operation couldn’t be completed. ( error 1.)", correlationId: correlationId, errorCodes: [], errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.correlationId = correlationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(correlationId: correlationId,
+                           delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }
@@ -575,10 +549,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.refreshTokenMFARequiredError + message, correlationId: correlationId, errorCodes: errorCodes, errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-        
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.correlationId = correlationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(correlationId: correlationId,
+                           delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }
@@ -596,10 +568,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let delegateExp = expectation(description: "delegateDispatcher delegate exp")
         let expectedError = RetrieveAccessTokenError(type: .generalError, message: MSALNativeAuthErrorMessage.passwordResetRequired + message, correlationId: correlationId, errorCodes: errorCodes, errorUri: nil)
         let delegate = CredentialsDelegateSpy(expectation: delegateExp, expectedError: expectedError)
-
-        let getParams = MSALNativeAuthGetAccessTokenParameters()
-        getParams.correlationId = correlationId
-        sut.getAccessToken(parameters: getParams, delegate: delegate)
+        sut.getAccessToken(correlationId: correlationId,
+                           delegate: delegate)
 
         await fulfillment(of: [delegateExp])
     }


### PR DESCRIPTION
Reverts AzureAD/microsoft-authentication-library-for-objc#2582