### PR TITLE
Ensuing valid parantViewController is required for MSAL Interactive APIs

### DIFF
--- a/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.m
+++ b/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.m
@@ -37,12 +37,18 @@
                     customWebView:(WKWebView *)customWebView
                             error:(NSError **)error
 {
+    if (webParameters == nil)
+    {
+        NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"webviewParameters is a required parameter.", nil, nil, nil, nil, nil, YES);
+        if (error) *error = msidError;
+        return NO;
+    }
+    
     __typeof__(webParameters.parentViewController) parentViewController = webParameters.parentViewController;
     
-#if TARGET_OS_IPHONE
     if (parentViewController == nil)
     {
-        NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"parentViewController is a required parameter on iOS.", nil, nil, nil, nil, nil, YES);
+        NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"parentViewController is a required parameter.", nil, nil, nil, nil, nil, YES);
         if (error) *error = msidError;
         return NO;
     }
@@ -54,9 +60,10 @@
         return NO;
     }
     
+#if TARGET_OS_IPHONE
     self.presentationType = webParameters.presentationStyle;
 #endif
-        
+    
     self.parentViewController = parentViewController;
         
     self.prefersEphemeralWebBrowserSession = webParameters.prefersEphemeralWebBrowserSession;

--- a/MSAL/src/public/MSALWebviewParameters.h
+++ b/MSAL/src/public/MSALWebviewParameters.h
@@ -44,10 +44,10 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Configuration options
 
 /**
- The view controller to present from. If nil, MSAL will attempt to still proceed with the authentication, but the results will be unexpected.
- It is strongly recommended to provide a non-null parentViewController to avoid unexpected results.
+ The view controller to present from. This property must be valid. If nil is provided, or if the view controller is not attached to a window (i.e., parentViewController.view.window is nil), MSAL will return an error and will not proceed with authentication.
+ It is required to provide a valid parentViewController with a window to proceed with authentication.
  */
-@property (nullable, weak, nonatomic) MSALViewController *parentViewController;
+@property (nonatomic, strong, nonnull) MSALViewController *parentViewController;
 
 #if TARGET_OS_IPHONE
 
@@ -83,10 +83,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
    Creates an instance of MSALWebviewParameters with a provided parentViewController.
-   @param parentViewController The view controller to present authorization UI from.
-   @note parentViewController is mandatory on iOS 13+  and macOS 10.15+. Your app will experience unexpected results if parentViewController is not provided.
+   @param parentViewController The view controller to present authorization UI from. This property must be valid
+   @note parentViewController is mandatory on iOS 13+  and macOS 10.15+. If nil is provided, or if the view controller is not attached to a window (i.e., parentViewController.view.window is nil), MSAL will return an error and authentication will not proceed. It is required to provide a valid parentViewController with a window to proceed with authentication.
 */
-- (nonnull instancetype)initWithAuthPresentationViewController:(MSALViewController *)parentViewController;
+- (nonnull instancetype)initWithAuthPresentationViewController:(nonnull MSALViewController *)parentViewController;
 
 
 /**

--- a/MSAL/test/unit/MSALPublicClientApplicationTests.m
+++ b/MSAL/test/unit/MSALPublicClientApplicationTests.m
@@ -530,8 +530,6 @@
          XCTAssertTrue([obj isKindOfClass:[MSIDLocalInteractiveController class]]);
          completionBlock(nil, nil);
      }];
-
-    MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     
     MSALViewController *parentViewController = nil;
     MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithAuthPresentationViewController:parentViewController];
@@ -578,7 +576,6 @@
     static MSALViewController *controller;
     
 #if TARGET_OS_IPHONE
-    MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     dispatch_once(&once, ^{
         controller = [UIViewController new];
     });
@@ -628,7 +625,6 @@
          completionBlock(nil, nil);
      }];
 
-    MSALGlobalConfig.brokerAvailability = MSALBrokeredAvailabilityNone;
     MSALWebviewParameters *webParameters = nil;
     MSALInteractiveTokenParameters *parameters = [[MSALInteractiveTokenParameters alloc] initWithScopes:@[@"fakescope"]
                                                                                       webviewParameters:webParameters];


### PR DESCRIPTION
## Proposed changes

Ensuing valid parantViewController is required for MSAL Interactive APIs

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

