### PR TITLE
[MSAL2.x]Ensure valid broker capable redirect URI is required for AAD scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [TBD]
+* Removed deprecated APIs, including legacy initializers, account management methods, token acquisition methods, and the MSALTelemetry interface (#2577)
+* Enforced requirement for a valid ParentViewController (with a window) in interactive token requests (#2590)
 * Removed deprecated methods from native auth public interface (#2588)
+* Removed the deprecated MSALLogger interface and implementation class (#2591)
+* Enforced a valid broker-capable redirect URI format for AAD scenarios (#2592)
+
 
 ## [1.9.0]
 * Add feature flags provider to be controlled from broker (#2540)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Removed the deprecated MSALLogger interface and implementation class (#2591)
 * Enforced a valid broker-capable redirect URI format for AAD scenarios (#2592)
 
-
 ## [1.9.0]
 * Add feature flags provider to be controlled from broker (#2540)
 * Added GitHub issue templates for better issue tracking and reporting (#2554)

--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -58,6 +58,7 @@ static NSSet *s_recoverableErrorCode;
                                    @(MSIDErrorServerNonHttpsRedirect) : @(MSALInternalErrorNonHttpsRedirect),
                                    @(MSIDErrorMismatchedAccount): @(MSALInternalErrorMismatchedUser),
                                    @(MSIDErrorRedirectSchemeNotRegistered): @(MSALInternalErrorRedirectSchemeNotRegistered),
+                                   @(MSIDErrorInvalidRedirectURI): @(MSALInternalErrorInvalidRedirectURI),
 
                                    // Cache
                                    @(MSIDErrorCacheMultipleUsers) : @(MSALInternalErrorAmbiguousAccount),

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -193,6 +193,7 @@
             {
                 *error = [MSALErrorConverter msalErrorFromMsidError:msidError];
             }
+            
             return nil;
         }
     }
@@ -898,15 +899,23 @@
 
 - (BOOL)isAADNonConsumerTenant:(MSALAuthority *)authority
 {
-    if (![authority isKindOfClass:[MSALAADAuthority class]]) return NO;
+    // Ensure the authority is of type MSALAADAuthority
+    if (![authority isKindOfClass:[MSALAADAuthority class]]) {
+        return NO;
+    }
     
     MSIDAuthority *msidAuthority = ((MSALAADAuthority *)authority).msidAuthority;
-    if (![msidAuthority isKindOfClass:[MSIDAADAuthority class]]) return NO;
     
-    MSIDAADAuthority *aadMsidAuthority = (MSIDAADAuthority *)msidAuthority;
-    MSIDAADTenant *tenant = aadMsidAuthority.tenant;
+    // Ensure the underlying MSID authority is of type MSIDAADAuthority
+    if (![msidAuthority isKindOfClass:[MSIDAADAuthority class]]) {
+        return NO;
+    }
     
-    return (tenant && tenant.type != MSIDAADTenantTypeConsumers);
+    MSIDAADAuthority *aadAuthority = (MSIDAADAuthority *)msidAuthority;
+    MSIDAADTenant *tenant = aadAuthority.tenant;
+    
+    // Return YES if the tenant exists and is not of type 'Consumers'
+    return (tenant != nil && tenant.type != MSIDAADTenantTypeConsumers);
 }
 
 - (void)acquireTokenWithParameters:(MSALInteractiveTokenParameters *)parameters

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -185,10 +185,16 @@
                                                                     bypassRedirectValidation:config.bypassRedirectURIValidation
                                                                                        error:&msidError];
     
-    if (!msalRedirectUri && !config.bypassRedirectURIValidation)
+    if (!config.bypassRedirectURIValidation)
     {
-        if (error) *error = [MSALErrorConverter msalErrorFromMsidError:msidError];
-        return nil;
+        if (!msalRedirectUri || (!msalRedirectUri.brokerCapable && config.authority.msidAuthority.supportsBrokeredAuthentication && [self isAADNonConsumerTenant:config.authority]))
+        {
+            if (error)
+            {
+                *error = [MSALErrorConverter msalErrorFromMsidError:msidError];
+            }
+            return nil;
+        }
     }
         
 #if TARGET_OS_IPHONE
@@ -888,6 +894,19 @@
             MSID_LOG_WITH_CTX_PII(MSIDLogLevelWarning, context, @"Failed to update external account with result %@", MSID_PII_LOG_MASKABLE(updateError));
         }
     }
+}
+
+- (BOOL)isAADNonConsumerTenant:(MSALAuthority *)authority
+{
+    if (![authority isKindOfClass:[MSALAADAuthority class]]) return NO;
+    
+    MSIDAuthority *msidAuthority = ((MSALAADAuthority *)authority).msidAuthority;
+    if (![msidAuthority isKindOfClass:[MSIDAADAuthority class]]) return NO;
+    
+    MSIDAADAuthority *aadMsidAuthority = (MSIDAADAuthority *)msidAuthority;
+    MSIDAADTenant *tenant = aadMsidAuthority.tenant;
+    
+    return (tenant && tenant.type != MSIDAADTenantTypeConsumers);
 }
 
 - (void)acquireTokenWithParameters:(MSALInteractiveTokenParameters *)parameters

--- a/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.m
+++ b/MSAL/src/MSIDInteractiveRequestParameters+MSALRequest.m
@@ -55,7 +55,7 @@
     
     if (parentViewController.view.window == nil)
     {
-        NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"parentViewController has no window! Provide a valid controller with view and window.", nil, nil, nil, nil, nil, YES);
+        NSError *msidError = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"parentViewController has no window! Provide a valid controller with its view attached to a valid window.", nil, nil, nil, nil, nil, YES);
         if (error) *error = msidError;
         return NO;
     }

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -223,6 +223,19 @@ typedef NS_ENUM(NSInteger, MSALInternalError)
     MSALInternalErrorRedirectSchemeNotRegistered        = -42001,
     
     /**
+     The provided redirect URI is invalid.
+
+     Valid formats include:
+     - Default MSAL format: "msauth.[my.app.bundleId]://auth"
+     - ADAL format: "<custom_scheme>://[my.app.bundleId]"
+
+     Ensure the redirect URI matches one of the valid formats.
+     e.g. an app with the bundle Id "com.contoso.myapp" would need redirect URI in the form: msauth.com.contoso.myapp://auth.
+     See MSALErrorDescriptionKey for detailed error information.
+     */
+    MSALInternalErrorInvalidRedirectURI                 = -42011,
+    
+    /**
      Protocol error, such as a missing required parameter.
      */
     MSALInternalErrorInvalidRequest                     = -42002,

--- a/MSAL/src/public/MSALWebviewParameters.h
+++ b/MSAL/src/public/MSALWebviewParameters.h
@@ -44,8 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Configuration options
 
 /**
- The view controller to present from. This property must be valid. If nil is provided, or if the view controller is not attached to a window (i.e., parentViewController.view.window is nil), MSAL will return an error and will not proceed with authentication.
- It is required to provide a valid parentViewController with a window to proceed with authentication.
+ The view controller to present from. If nil is provided, or if the view controller's view is not attached to a window (i.e., parentViewController.view.window is nil), MSAL will return an error and will not proceed with authentication.
+ A valid parentViewController with its view attached to a valid window is required to proceed with authentication.
  */
 @property (nonatomic, strong, nonnull) MSALViewController *parentViewController;
 
@@ -82,9 +82,9 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Constructing MSALWebviewParameters
 
 /**
-   Creates an instance of MSALWebviewParameters with a provided parentViewController.
-   @param parentViewController The view controller to present authorization UI from. This property must be valid
-   @note parentViewController is mandatory on iOS 13+  and macOS 10.15+. If nil is provided, or if the view controller is not attached to a window (i.e., parentViewController.view.window is nil), MSAL will return an error and authentication will not proceed. It is required to provide a valid parentViewController with a window to proceed with authentication.
+   Creates an instance of MSALWebviewParameters with the provided parentViewController.
+   @param parentViewController The view controller to present authorization UI from.
+   @note parentViewController is mandatory on iOS 13+  and macOS 10.15+. If nil is provided, or if the view controller's view is not attached to a window (i.e., parentViewController.view.window is nil), MSAL will return an error and authentication will not proceed. A valid parentViewController with its view attached to a valid window is required to proceed with authentication.
 */
 - (nonnull instancetype)initWithAuthPresentationViewController:(nonnull MSALViewController *)parentViewController;
 

--- a/MSAL/src/util/MSALRedirectUri.m
+++ b/MSAL/src/util/MSALRedirectUri.m
@@ -69,7 +69,7 @@
                              error:(NSError * __autoreleasing *)error
 {
     MSIDRedirectUriValidationResult validationResult = [MSIDRedirectUri redirectUriIsBrokerCapable:redirectUri
-                                                                                                error:error];
+                                                                                             error:error];
     return validationResult == MSIDRedirectUriValidationResultMatched;
 }
 

--- a/MSAL/src/util/MSALRedirectUri.m
+++ b/MSAL/src/util/MSALRedirectUri.m
@@ -66,8 +66,11 @@
 }
 
 + (BOOL)redirectUriIsBrokerCapable:(NSURL *)redirectUri
+                             error:(NSError * __autoreleasing *)error
 {
-    return [MSIDRedirectUri redirectUriIsBrokerCapable:redirectUri] == MSIDRedirectUriValidationResultMatched;
+    MSIDRedirectUriValidationResult validationResult = [MSIDRedirectUri redirectUriIsBrokerCapable:redirectUri
+                                                                                                error:error];
+    return validationResult == MSIDRedirectUriValidationResultMatched;
 }
 
 @end

--- a/MSAL/test/unit/MSALAcquireTokenTests.m
+++ b/MSAL/test/unit/MSALAcquireTokenTests.m
@@ -115,6 +115,8 @@
     self.accountMetadataCache = [[MSIDAccountMetadataCacheAccessor alloc] initWithDataSource:dataSource];
     [self.accountCache clearWithContext:nil error:nil];
     [self.tokenCache clearWithContext:nil error:nil];
+    NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
+    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
 }
 
 - (void)tearDown
@@ -125,10 +127,6 @@
 
 - (void)testAcquireTokenInteractiveWithParameters_whenB2CAuthority_shouldCacheTokens
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     __auto_type authority = [@"https://login.microsoftonline.com/tfp/contosob2c/b2c_1_policy" msalAuthority];
     
     MSIDTestURLResponse *oidcResponse =
@@ -223,10 +221,6 @@
 
 - (void)testAcquireTokenInteractive_whenB2CAuthority_shouldCacheTokens
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     __auto_type authority = [@"https://login.microsoftonline.com/tfp/contosob2c/b2c_1_policy" msalAuthority];
     
     MSIDTestURLResponse *oidcResponse =
@@ -329,10 +323,6 @@
 
 - (void)testAcquireTokenInteractive_whenB2CAuthorityWithQP_shouldRetainQP
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     __auto_type authority = [@"https://login.microsoftonline.com/tfp/contosob2c/b2c_1_policy" msalAuthority];
     MSIDTestURLResponse *oidcResponse =
     [MSIDTestURLResponse oidcResponseForAuthority:authority.msidAuthority.url.absoluteString
@@ -392,10 +382,6 @@
 
 - (void)testAcquireTokenSilent_whenNoATForScopeInCache_andFailedToRefreshTokenWithProtectionPoliciesRequired_shouldReturnProtectionPoliciesRequired
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     NSString *authority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", DEFAULT_TEST_UTID];
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:authority];
@@ -466,10 +452,6 @@
 
 - (void)testAcquireTokenSilent_whenNoATForScopeInCache_andInvalidRT_shouldReturnInteractionRequired
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     NSString *authority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", DEFAULT_TEST_UTID];
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:authority];
@@ -541,10 +523,6 @@
 
 - (void)testAcquireTokenSilent_whenNoATForScopeInCache_shouldUseRTAndReturnNewAT
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     NSString *authority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", DEFAULT_TEST_UTID];
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:authority];
@@ -622,10 +600,6 @@
 {
     NSString *claims = @"{\"id_token\":{\"nickname\":null}}";
     __auto_type claimsRequest = [[MSALClaimsRequest alloc] initWithJsonString:claims error:nil];
-    
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
     
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:DEFAULT_TEST_AUTHORITY];
     
@@ -721,10 +695,6 @@
 
 - (void)skipTest_testAcquireTokenInteractive_whenClaimsIsEmpty_shouldNotSendClaims
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:DEFAULT_TEST_AUTHORITY];
     
     // Mock tenant discovery response
@@ -816,10 +786,6 @@
 
 - (void)testAcquireTokenInteractive_whenDuplicateClaimsIsPassedInEQP_shouldReturnError
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     MSALPublicClientApplicationConfig *config = [[MSALPublicClientApplicationConfig alloc] initWithClientId:UNIT_TEST_CLIENT_ID
                                                                                                 redirectUri:nil
                                                                                                   authority:[DEFAULT_TEST_AUTHORITY msalAuthority]];
@@ -861,10 +827,6 @@
 
 - (void)testAcquireTokenInteractive_whenMultipleCloudsSetToYes_shouldSendInstanceAwareToServer
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:DEFAULT_TEST_AUTHORITY];
     
     // Mock tenant discovery response
@@ -934,10 +896,6 @@
 - (void)testAcquireTokenInteractive_whenCapabilitiesSet_shouldSendCapabilitiesToServer
 {
     NSString *expectedClaims = @"{\"access_token\":{\"xms_cc\":{\"values\":[\"llt\"]}}}";
-    
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
     
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:DEFAULT_TEST_AUTHORITY];
     
@@ -1037,10 +995,6 @@
     __auto_type claimsRequest = [[MSALClaimsRequest alloc] initWithJsonString:claims error:nil];
     NSString *expectedClaims = @"{\"access_token\":{\"polids\":{\"essential\":true,\"values\":[\"5ce770ea-8690-4747-aa73-c5b3cd509cd4\"]},\"xms_cc\":{\"values\":[\"llt\"]}}}";
     
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:DEFAULT_TEST_AUTHORITY];
     
     // Mock tenant discovery response
@@ -1137,10 +1091,6 @@
 {
     NSString *claims = @"{\"access_token\":{\"polids\":{\"essential\":true,\"values\":[\"5ce770ea-8690-4747-aa73-c5b3cd509cd4\"]}}}";
     __auto_type claimsRequest = [[MSALClaimsRequest alloc] initWithJsonString:claims error:nil];
-    
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray *override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
     
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:DEFAULT_TEST_AUTHORITY];
     
@@ -1239,10 +1189,6 @@
 
 - (void)testAcquireTokenInteractive_whenInstanceAware_shouldReturnCloudAuthorityInResult
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:DEFAULT_TEST_AUTHORITY];
     
     // Mock tenant discovery response
@@ -1375,10 +1321,6 @@
 
 - (void)testAcquireTokenSilent_whenExtendedLifetimeTokenEnabledAndServiceUnavailable_shouldReturnExtendedLifetimeToken
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Seed a cache object with a user and an expired AT
     NSMutableDictionary *json = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                           RT:@"i am a refresh token!"
@@ -1453,10 +1395,6 @@
 
 - (void)testAcquireTokenSilent_whenExtendedLifetimeTokenDisabledAndServiceUnavailable_shouldNotReturnToken
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Seed a cache object with a user and an expired AT
     NSMutableDictionary *json = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                           RT:@"i am a refresh token!"
@@ -1534,10 +1472,6 @@
 
 - (void)testAcquireTokenSilent_whenATAvailable_andMixedCaseInputScope_shouldReturnToken
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-
     // Seed a cache object with a user and an AT
     NSMutableDictionary *json = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                           RT:@"i am a refresh token!"
@@ -1600,10 +1534,6 @@
 
 - (void)testAcquireTokenSilent_whenATAvailableAndExpired_andMixedCaseInputScope_shouldReturnToken
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-
     // Seed a cache object with a user and an AT
     NSMutableDictionary *json = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                           RT:@"i am a refresh token!"
@@ -1685,10 +1615,6 @@
 
 - (void)testAcquireTokenSilent_whenATAvailableAndExtendedLifetimeTokenEnabled_shouldReturnTokenWithExtendedFlagBeingNo
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Seed a cache object with a user and an AT
     NSMutableDictionary *json = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                           RT:@"i am a refresh token!"
@@ -1763,10 +1689,6 @@
 
 - (void)testAcquireTokenInteractive_whenInsufficientScopesReturned_shouldReturnNilResultAndError
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:DEFAULT_TEST_AUTHORITY];
     [MSIDTestURLSession addResponse:discoveryResponse];
     
@@ -1845,10 +1767,6 @@
 
 - (void)testAcquireTokenSilent_whenInsufficientScopesReturned_shouldReturnNilResultAndError
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Seed a cache object with a user and an AT
     NSMutableDictionary *json = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                           RT:@"i am a refresh token!"
@@ -1938,10 +1856,6 @@
 
 - (void)testAcquireTokenSilent_whenClaimsIsPassed_shouldSkipAtAndUseRt
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Add an AT and RT to cache
     MSIDAADV2TokenResponse *response = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                                  RT:@"i am a refresh token!"
@@ -2024,10 +1938,6 @@
 
 - (void)testAcquireTokenSilent_whenClaimsEmpty_shouldNotSkipAccessToken
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Add an AT and RT to cache
     MSIDAADV2TokenResponse *response = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                                  RT:@"i am a refresh token!"
@@ -2097,10 +2007,6 @@
 
 - (void)testAcquireTokenSilent_whenCapabilitiesSet_shouldNotSkipAccessToken
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Add an AT and RT to cache
     MSIDAADV2TokenResponse *response = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                                  RT:@"i am a refresh token!"
@@ -2168,10 +2074,6 @@
 
 - (void)testAcquireTokenSilent_whenCapabilitiesSetAndExpiredAt_shouldSendCapabilitiesToServer
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Add an expired AT and valid RT to cache
     NSMutableDictionary *json = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                           RT:@"i am a refresh token!"
@@ -2256,10 +2158,6 @@
 
 - (void)testAcquireTokenSilent_whenClaimsIsPassedAndCapabilitiesSet_shouldSkipAtAndUseRt
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Add an AT and RT to cache
     MSIDAADV2TokenResponse *response = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                                  RT:@"i am a refresh token!"
@@ -2345,10 +2243,6 @@
 
 - (void)testAcquireTokenSilent_whenClaimsIsPassedAndInvalidRt_shouldReturnInteractionRequired
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Add an AT and RT to cache
     MSIDAADV2TokenResponse *response = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                                  RT:@"i am a refresh token!"
@@ -2431,10 +2325,6 @@
 
 - (void)testAcquireTokenSilent_whenATExpiredAndFRTInCache_shouldRefreshAccessTokenUsingFRT
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Seed a cache object with a user and an AT
     NSMutableDictionary *json = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                           RT:@"i am a refresh token!"
@@ -2509,10 +2399,6 @@
 
 - (void)testAcquireTokenSilent_whenATExpiredAndNoAppMetadataInCacheAndFRTInCache_shouldRefreshAccessTokenUsingFRT
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Seed a cache object with a user and an AT
     NSMutableDictionary *json = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                           RT:@"i am a refresh token!"
@@ -2600,10 +2486,6 @@
 
 - (void)testAcquireTokenSilent_whenFRTUsedAndServerReturnsClientMismatch_shouldUpdateAppMetadata
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     NSString *authority = [NSString stringWithFormat:@"https://login.microsoftonline.com/%@", DEFAULT_TEST_UTID];
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:authority];
     MSIDTestURLResponse *oidcResponse = [MSIDTestURLResponse oidcResponseForAuthority:authority];
@@ -2698,10 +2580,6 @@
 
 - (void)testAcquireTokenSilent_whenMRRTUsedAndServerReturnsInvalidGrant_ShouldUseFRTToRefreshAccessToken
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Seed a cache object with a user and an AT
     NSMutableDictionary *json = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                           RT:@"i am a refresh token!"
@@ -2793,10 +2671,6 @@
 
 - (void)testAcquireTokenSilent_whenNoFRTInCache_ShouldUseMRRTToRefreshAccessToken
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     // Seed a cache object with a user and an AT
     NSMutableDictionary *json = [MSIDTestTokenResponse v2TokenResponseWithAT:DEFAULT_TEST_ACCESS_TOKEN
                                                                           RT:@"i am a refresh token!"
@@ -2871,10 +2745,6 @@
 
 - (void)testAcquireTokenSilent_whenNilAccountPassed_shouldReturnInteractionRequiredError
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     NSError *error = nil;
     MSALPublicClientApplication *application = [[MSALPublicClientApplication alloc] initWithClientId:UNIT_TEST_CLIENT_ID
                                                                                                error:&error];
@@ -2901,10 +2771,6 @@
 
 - (void)testAcquireTokenInteractive_whenAccountMismatch_shouldReturnAccountMismatchError
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
-    NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
-    [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
-    
     MSIDTestURLResponse *discoveryResponse = [MSIDTestURLResponse discoveryResponseForAuthority:DEFAULT_TEST_AUTHORITY];
     [MSIDTestURLSession addResponse:discoveryResponse];
     

--- a/MSAL/test/unit/MSALB2CPolicyTests.m
+++ b/MSAL/test/unit/MSALB2CPolicyTests.m
@@ -113,7 +113,6 @@
 
 - (void)testAcquireToken_whenMultipleB2CPolicies_shouldHaveMultipleUsers
 {
-    [MSIDTestBundle overrideBundleId:@"com.microsoft.unittests"];
     NSArray* override = @[ @{ @"CFBundleURLSchemes" : @[UNIT_TEST_DEFAULT_REDIRECT_SCHEME] } ];
     [MSIDTestBundle overrideObject:override forKey:@"CFBundleURLTypes"];
 

--- a/MSAL/test/unit/utils/MSALTestConstants.h
+++ b/MSAL/test/unit/utils/MSALTestConstants.h
@@ -35,16 +35,12 @@
 // Unit test correlation ID
 #define UNIT_TEST_CORRELATION_ID            @"60032DDF-822D-470B-9957-D694F92E3D27"
 
-// Unit test redirect scheme : msal<clientId>
-#define UNIT_TEST_DEFAULT_REDIRECT_SCHEME   @"msal"UNIT_TEST_CLIENT_ID
+// Unit test redirect scheme : msauth.<bundleid>
+#define UNIT_TEST_DEFAULT_REDIRECT_SCHEME   @"msauth."UNIT_TEST_DEFAULT_BUNDLE_ID
 
-// Unit test redirect uri : msal<clientId>://auth
-#if TARGET_OS_IPHONE
+// Unit test redirect uri : msauth.<bundleid>://auth
 #define UNIT_TEST_DEFAULT_REDIRECT_URI      UNIT_TEST_DEFAULT_REDIRECT_SCHEME"://auth"
-#else
-#define UNIT_TEST_DEFAULT_REDIRECT_URI      @"msauth.com.microsoft.unit-test-host://auth"
-#endif
 
-#define UNIT_TEST_DEFAULT_BUNDLE_ID         @"com.microsoft.mytest.bundleId"
+#define UNIT_TEST_DEFAULT_BUNDLE_ID         @"com.microsoft.unit-test-host"
 
 #define UT_SLICE_PARAMS_QUERY 

--- a/MSAL/test/unit/utils/MSALTestConstants.h
+++ b/MSAL/test/unit/utils/MSALTestConstants.h
@@ -35,10 +35,10 @@
 // Unit test correlation ID
 #define UNIT_TEST_CORRELATION_ID            @"60032DDF-822D-470B-9957-D694F92E3D27"
 
-// Unit test redirect scheme : msauth.<bundleid>
+// Unit test redirect scheme : msauth.<bundle_id>
 #define UNIT_TEST_DEFAULT_REDIRECT_SCHEME   @"msauth."UNIT_TEST_DEFAULT_BUNDLE_ID
 
-// Unit test redirect uri : msauth.<bundleid>://auth
+// Unit test redirect uri : msauth.<bundle_id>://auth
 #define UNIT_TEST_DEFAULT_REDIRECT_URI      UNIT_TEST_DEFAULT_REDIRECT_SCHEME"://auth"
 
 #define UNIT_TEST_DEFAULT_BUNDLE_ID         @"com.microsoft.unit-test-host"


### PR DESCRIPTION
## Proposed changes

Ensure valid broker capable redirect URI is required for AAD scenarios
Related CC PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1509
## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

