### PR TITLE
Replaced JIT with Register Strong Auth

### DIFF
--- a/MSAL/src/native_auth/controllers/jit/MSALNativeAuthJITController.swift
+++ b/MSAL/src/native_auth/controllers/jit/MSALNativeAuthJITController.swift
@@ -82,7 +82,7 @@ final class MSALNativeAuthJITController: MSALNativeAuthBaseController, MSALNativ
             MSALNativeAuthLogger.logPII(
                 level: .error,
                 context: telemetryInfo.context,
-                format: "JIT: an error occurred after calling /introspect API: \(MSALLogMask.maskPII(error))"
+                format: "RegisterStrongAuth: an error occurred after calling /introspect API: \(MSALLogMask.maskPII(error))"
             )
             stopTelemetryEvent(telemetryInfo, error: error)
             return .init(.error(error: error), correlationId: context.correlationId())
@@ -101,7 +101,7 @@ final class MSALNativeAuthJITController: MSALNativeAuthBaseController, MSALNativ
             authMethod: authMethod,
             verificationContact: verificationContact,
             context: context,
-            logErrorMessage: "JIT RequestChallenge: cannot create challenge request object"
+            logErrorMessage: "Request RegisterStrongAuth Challenge: cannot create challenge request object"
         )
         return await handleChallengeResponse(
             result,
@@ -122,7 +122,7 @@ final class MSALNativeAuthJITController: MSALNativeAuthBaseController, MSALNativ
             grantType: grantType,
             context: context,
             oobCode: challenge,
-            logErrorMessage: "JIT RequestContinue: cannot create challenge request object"
+            logErrorMessage: "Request RegisterStrongAuth Continue: cannot create challenge request object"
         )
         return await handleSubmitChallengeResponse(
             result,
@@ -196,7 +196,7 @@ final class MSALNativeAuthJITController: MSALNativeAuthBaseController, MSALNativ
         do {
             return try jitRequestProvider.introspect(parameters: params, context: context)
         } catch {
-            MSALNativeAuthLogger.log(level: .error, context: context, format: "Error creating JIT introspect request: \(error)")
+            MSALNativeAuthLogger.log(level: .error, context: context, format: "Error creating RegisterStrongAuth Introspect Request: \(error)")
             return nil
         }
     }
@@ -220,7 +220,7 @@ final class MSALNativeAuthJITController: MSALNativeAuthBaseController, MSALNativ
             )
             return try jitRequestProvider.challenge(parameters: params, context: context)
         } catch {
-            MSALNativeAuthLogger.log(level: .error, context: context, format: "Error creating JIT Challenge Request: \(error)")
+            MSALNativeAuthLogger.log(level: .error, context: context, format: "Error creating RegisterStrongAuth Challenge Request: \(error)")
             return nil
         }
     }
@@ -238,7 +238,7 @@ final class MSALNativeAuthJITController: MSALNativeAuthBaseController, MSALNativ
         do {
             return try jitRequestProvider.continue(parameters: params, context: context)
         } catch {
-            MSALNativeAuthLogger.log(level: .error, context: context, format: "Error creating JIT continue request: \(error)")
+            MSALNativeAuthLogger.log(level: .error, context: context, format: "Error creating RegisterStrongAuth Continue Request: \(error)")
             return nil
         }
     }
@@ -255,7 +255,7 @@ final class MSALNativeAuthJITController: MSALNativeAuthBaseController, MSALNativ
             MSALNativeAuthLogger.logPII(
                 level: .error,
                 context: context,
-                format: "JIT request continue: received continue error response: \(MSALLogMask.maskPII(error.errorDescription))"
+                format: "Request RegisterStrongAuth Continue: received continue error response: \(MSALLogMask.maskPII(error.errorDescription))"
             )
             stopTelemetryEvent(event, context: context, error: error)
             return .init(.error(
@@ -306,7 +306,7 @@ final class MSALNativeAuthJITController: MSALNativeAuthBaseController, MSALNativ
             MSALNativeAuthLogger.logPII(
                 level: .error,
                 context: context,
-                format: "JIT request challenge: received challenge error response: \(MSALLogMask.maskPII(error.errorDescription))"
+                format: "Request RegisterStrongAuth Challenge: received challenge error response: \(MSALLogMask.maskPII(error.errorDescription))"
             )
             stopTelemetryEvent(event, context: context, error: error)
             return .init(.error(

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -188,7 +188,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 let error = SignInAfterSignUpError(correlationId: context.correlationId())
                 MSALNativeAuthLogger.logPII(level: .error,
                                   context: context,
-                                  format: "Request RegisterStrongAuth Challenge, received invalid response \(MSALLogMask.maskPII(apiError.errorDescription))")
+                                  format: "Request RegisterStrongAuth Challenge, received invalid response \(MSALLogMask.maskPII(apiError.errorDescription))") // swiftlint:disable:this line_length
                 self.stopTelemetryEvent(telemetryInfo.event, context: context, error: error)
                 return .init(.failure(error), correlationId: context.correlationId())
             }
@@ -626,7 +626,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .jitRequired:
             let error = VerifyCodeError(type: .generalError, correlationId: context.correlationId())
-            MSALNativeAuthLogger.log(level: .error, context: context, format: "Submit code: received unexpected RegisterStrongAuth required API result")
+            MSALNativeAuthLogger.log(level: .error, context: context, format: "Submit code: received unexpected RegisterStrongAuth required API result") // swiftlint:disable:this line_length
             stopTelemetryEvent(telemetryInfo.event, context: context, error: error)
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         }

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -159,11 +159,11 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             self.stopTelemetryEvent(telemetryInfo.event, context: context, error: error)
             return .init(.failure(error), correlationId: context.correlationId())
         case .jitAuthMethodsSelectionRequired(let authMethods, let jitRequiredState):
-            MSALNativeAuthLogger.log(level: .info, context: context, format: "JIT required after sing in after previous flow")
+            MSALNativeAuthLogger.log(level: .info, context: context, format: "RegisterStrongAuth required after sing in after previous flow")
             let jitController = createJITController()
             guard let authMethod = authMethods.first else {
                 let error = SignInAfterSignUpError(correlationId: context.correlationId())
-                MSALNativeAuthLogger.log(level: .error, context: context, format: "JIT required, did not receive any default methods")
+                MSALNativeAuthLogger.log(level: .error, context: context, format: "RegisterStrongAuth required, did not receive any default methods")
                 self.stopTelemetryEvent(telemetryInfo.event, context: context, error: error)
                 return .init(.failure(error), correlationId: context.correlationId())
             }
@@ -181,14 +181,14 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                 let error = SignInAfterSignUpError(correlationId: context.correlationId())
                 MSALNativeAuthLogger.log(level: .error,
                                   context: context,
-                                  format: "Request JIT challenge, received verification required on SignInAfterPreviousFlow")
+                                  format: "Request RegisterStrongAuth Challenge, received verification required on SignInAfterPreviousFlow")
                 self.stopTelemetryEvent(telemetryInfo.event, context: context, error: error)
                 return .init(.failure(error), correlationId: context.correlationId())
             case .error(let apiError, _):
                 let error = SignInAfterSignUpError(correlationId: context.correlationId())
                 MSALNativeAuthLogger.logPII(level: .error,
                                   context: context,
-                                  format: "Request JIT challenge, received invalid response \(MSALLogMask.maskPII(apiError.errorDescription))")
+                                  format: "Request RegisterStrongAuth Challenge, received invalid response \(MSALLogMask.maskPII(apiError.errorDescription))")
                 self.stopTelemetryEvent(telemetryInfo.event, context: context, error: error)
                 return .init(.failure(error), correlationId: context.correlationId())
             }
@@ -314,7 +314,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
                     self?.stopTelemetryEvent(telemetryInfo.event, context: context, delegateDispatcherResult: result)
                 })
         case.jitRequired(continuationToken: let newContinuationToken):
-            MSALNativeAuthLogger.log(level: .info, context: context, format: "JIT required after submit password")
+            MSALNativeAuthLogger.log(level: .info, context: context, format: "RegisterStrongAuth required after submit password")
             let jitController = createJITController()
             let jitIntrospectResponse = await jitController.getJITAuthMethods(continuationToken: newContinuationToken, context: context)
             switch jitIntrospectResponse.result {
@@ -626,7 +626,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .jitRequired:
             let error = VerifyCodeError(type: .generalError, correlationId: context.correlationId())
-            MSALNativeAuthLogger.log(level: .error, context: context, format: "Submit code: received unexpected JIT required API result")
+            MSALNativeAuthLogger.log(level: .error, context: context, format: "Submit code: received unexpected RegisterStrongAuth required API result")
             stopTelemetryEvent(telemetryInfo.event, context: context, error: error)
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         }
@@ -812,7 +812,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             MSALNativeAuthLogger.log(level: .info, context: telemetryInfo.context, format: "Multi factor authentication required")
             return .awaitingMFA(state)
         case .jitRequired(let continuationToken):
-            MSALNativeAuthLogger.log(level: .info, context: telemetryInfo.context, format: "JIT required.")
+            MSALNativeAuthLogger.log(level: .info, context: telemetryInfo.context, format: "RegisterStrongAuth required.")
             let jitController = createJITController()
             let jitIntrospectResponse = await jitController.getJITAuthMethods(continuationToken: continuationToken,
                                                                               context: telemetryInfo.context)

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -116,7 +116,7 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
                         MSALNativeAuthLogger.log(
                             level: .error,
                             context: context,
-                            format: "Token: JIT required response, expected continuation token not empty")
+                            format: "Token: RegisterStrongAuth required response, expected continuation token not empty")
                         return .error(.generalError(
                             MSALNativeAuthTokenResponseError(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody)
                         ))

--- a/MSAL/src/native_auth/public/state_machine/state/JITStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/JITStates+Internal.swift
@@ -27,7 +27,7 @@ extension RegisterStrongAuthBaseState {
                                   verificationContact: String?) async -> MSALNativeAuthJITControlling.JITRequestChallengeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALNativeAuthLogger.log(level: .warning, context: context, format: MSALNativeAuthLogMessage.privatePreviewLog)
-        MSALNativeAuthLogger.log(level: .info, context: context, format: "JIT, request challenge")
+        MSALNativeAuthLogger.log(level: .info, context: context, format: "RegisterStrongAuth, Request Challenge")
         return await controller.requestJITChallenge(continuationToken: continuationToken,
                                                     authMethod: authMethod,
                                                     verificationContact: verificationContact,
@@ -40,9 +40,9 @@ extension RegisterStrongAuthVerificationRequiredState {
     func submitChallengeInternal(challenge: String) async -> MSALNativeAuthJITControlling.JITSubmitChallengeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALNativeAuthLogger.log(level: .warning, context: context, format: MSALNativeAuthLogMessage.privatePreviewLog)
-        MSALNativeAuthLogger.log(level: .info, context: context, format: "JIT, submit challenge")
+        MSALNativeAuthLogger.log(level: .info, context: context, format: "RegisterStrongAuth, Submit Challenge")
         guard inputValidator.isInputValid(challenge) else {
-            MSALNativeAuthLogger.log(level: .error, context: context, format: "JIT, invalid challenge")
+            MSALNativeAuthLogger.log(level: .error, context: context, format: "RegisterStrongAuth, invalid challenge")
             return .init(
                 .error(error: RegisterStrongAuthSubmitChallengeError(type: .invalidChallenge, correlationId: correlationId), newState: self),
                 correlationId: context.correlationId()


### PR DESCRIPTION
## Proposed changes

Replaced occurrences of the word "JIT"  with "Register Strong Auth" whenever present in logs. 
Formatted logs around JIT to be more clear.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

