### PR TITLE
[iOS SDK] E2E tests for JIT

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1436,7 +1436,6 @@
 		DECE10252BE3F0830036738C /* MSALNativeAuthESTSApiErrorDescriptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF1DD3B2AA9D07000D22194 /* MSALNativeAuthESTSApiErrorDescriptionsTests.swift */; };
 		DECE10282BE3F0830036738C /* MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2BBA362A3298080075F702 /* MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCodeTests.swift */; };
 		DED1F09D2DD644FC009CB97A /* JITDelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED1F09C2DD644F9009CB97A /* JITDelegateSpies.swift */; };
-		DED1F09E2DD644FC009CB97A /* JITDelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED1F09C2DD644F9009CB97A /* JITDelegateSpies.swift */; };
 		DED1F0A02DD64544009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED1F09F2DD64536009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift */; };
 		DED1F0A12DD64544009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED1F09F2DD64536009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift */; };
 		DEDB298B29D72D62008DA85B /* MSALNativeAuthInnerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB298A29D72D62008DA85B /* MSALNativeAuthInnerError.swift */; };

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1435,6 +1435,10 @@
 		DECE10202BE3F07F0036738C /* MSALNativeAuthSignUpContinueOauth2ErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F4DB2C2A1F5714009FBCD0 /* MSALNativeAuthSignUpContinueOauth2ErrorCodeTests.swift */; };
 		DECE10252BE3F0830036738C /* MSALNativeAuthESTSApiErrorDescriptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF1DD3B2AA9D07000D22194 /* MSALNativeAuthESTSApiErrorDescriptionsTests.swift */; };
 		DECE10282BE3F0830036738C /* MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2BBA362A3298080075F702 /* MSALNativeAuthResetPasswordPollCompletionOauth2ErrorCodeTests.swift */; };
+		DED1F09D2DD644FC009CB97A /* JITDelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED1F09C2DD644F9009CB97A /* JITDelegateSpies.swift */; };
+		DED1F09E2DD644FC009CB97A /* JITDelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED1F09C2DD644F9009CB97A /* JITDelegateSpies.swift */; };
+		DED1F0A02DD64544009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED1F09F2DD64536009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift */; };
+		DED1F0A12DD64544009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED1F09F2DD64536009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift */; };
 		DEDB298B29D72D62008DA85B /* MSALNativeAuthInnerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB298A29D72D62008DA85B /* MSALNativeAuthInnerError.swift */; };
 		DEDB29A529DDA9DC008DA85B /* MSALNativeAuthSignInInitiateResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB29A429DDA9DC008DA85B /* MSALNativeAuthSignInInitiateResponseError.swift */; };
 		DEDB29A829DDAEB3008DA85B /* MSALNativeAuthSignInChallengeOauth2ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDB29A629DDAEB3008DA85B /* MSALNativeAuthSignInChallengeOauth2ErrorCode.swift */; };
@@ -2609,6 +2613,8 @@
 		DECC1F9329521E34006D9FB1 /* MSALLogMask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSALLogMask.h; sourceTree = "<group>"; };
 		DECC1FB229531032006D9FB1 /* MSALLogMaskTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALLogMaskTests.m; sourceTree = "<group>"; };
 		DECC1FB4295322A8006D9FB1 /* MSALNativeLoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeLoggingTests.swift; sourceTree = "<group>"; };
+		DED1F09C2DD644F9009CB97A /* JITDelegateSpies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JITDelegateSpies.swift; sourceTree = "<group>"; };
+		DED1F09F2DD64536009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInJITEndToEndTests.swift; sourceTree = "<group>"; };
 		DEDB298A29D72D62008DA85B /* MSALNativeAuthInnerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInnerError.swift; sourceTree = "<group>"; };
 		DEDB29A429DDA9DC008DA85B /* MSALNativeAuthSignInInitiateResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInInitiateResponseError.swift; sourceTree = "<group>"; };
 		DEDB29A629DDAEB3008DA85B /* MSALNativeAuthSignInChallengeOauth2ErrorCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInChallengeOauth2ErrorCode.swift; sourceTree = "<group>"; };
@@ -3008,8 +3014,10 @@
 		28188F572C8F480300CFDD05 /* mfa */ = {
 			isa = PBXGroup;
 			children = (
+				DED1F09F2DD64536009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift */,
 				28188F5F2C8F482D00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift */,
 				28188F642C8F4C1100CFDD05 /* MFADelegateSpies.swift */,
+				DED1F09C2DD644F9009CB97A /* JITDelegateSpies.swift */,
 			);
 			path = mfa;
 			sourceTree = "<group>";
@@ -6597,6 +6605,7 @@
 				281A0E1B2C21E20600CB30CB /* MSALNativeAuthEndToEndBaseTestCase.swift in Sources */,
 				28188F652C8F4C1100CFDD05 /* MFADelegateSpies.swift in Sources */,
 				281A0E192C21E20000CB30CB /* MSALNativeAuthResetPasswordEndToEndTests.swift in Sources */,
+				DED1F09E2DD644FC009CB97A /* JITDelegateSpies.swift in Sources */,
 				281A0E0C2C21E1F000CB30CB /* MSALNativeAuthSignUpUsernameEndToEndTests.swift in Sources */,
 				281A0E152C21E1F500CB30CB /* SignUpDelegateSpies.swift in Sources */,
 				28188F622C8F48BD00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift in Sources */,
@@ -6609,6 +6618,7 @@
 				281A0E1A2C21E20300CB30CB /* ResetPasswordDelegateSpies.swift in Sources */,
 				2809E8352C3C37B7009F14D7 /* MSALNativeAuthEndToEndPasswordTestCase.swift in Sources */,
 				280095EB2C32CAFC00F1653E /* ClientIdType.swift in Sources */,
+				DED1F0A12DD64544009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7723,6 +7733,7 @@
 				DE1BD1012C3C283C00B0888E /* MSALNativeAuthSignUpUsernameEndToEndTests.swift in Sources */,
 				28188F662C8F4C1100CFDD05 /* MFADelegateSpies.swift in Sources */,
 				DE1BD1032C3C284100B0888E /* SignUpDelegateSpies.swift in Sources */,
+				DED1F09D2DD644FC009CB97A /* JITDelegateSpies.swift in Sources */,
 				DE1BD1092C3C285D00B0888E /* MSALNativeAuthSignOutEndToEndTests.swift in Sources */,
 				DE1BD1052C3C284700B0888E /* MSALNativeAuthSignInUsernameEndToEndTests.swift in Sources */,
 				28188F632C8F48BD00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift in Sources */,
@@ -7735,6 +7746,7 @@
 				DE1BD1082C3C284D00B0888E /* ResetPasswordDelegateSpies.swift in Sources */,
 				DE6BF3242C418C8A000BB2D9 /* MSALNativeAuthEndToEndPasswordTestCase.swift in Sources */,
 				DE1BD10B2C3C286100B0888E /* ClientIdType.swift in Sources */,
+				DED1F0A02DD64544009CB97A /* MSALNativeAuthSignInJITEndToEndTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1036,6 +1036,7 @@
 		DE1BD10A2C3C285F00B0888E /* MSALNativeAuthEndToEndBaseTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B235D9E2A3CFB4300657331 /* MSALNativeAuthEndToEndBaseTestCase.swift */; };
 		DE1BD10B2C3C286100B0888E /* ClientIdType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 280095EA2C32CAFC00F1653E /* ClientIdType.swift */; };
 		DE1D8AA829E6B7D900E11D48 /* MSALNativeAuthRequestConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1D8AA729E6B7D900E11D48 /* MSALNativeAuthRequestConfigurator.swift */; };
+		DE20A8492DDE2CD200BC286C /* JITDelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED1F09C2DD644F9009CB97A /* JITDelegateSpies.swift */; };
 		DE38F0802DB2508400BE3101 /* MSALNativeAuthJITControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE38F07F2DB2507D00BE3101 /* MSALNativeAuthJITControllerTests.swift */; };
 		DE38F0812DB2508400BE3101 /* MSALNativeAuthJITControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE38F07F2DB2507D00BE3101 /* MSALNativeAuthJITControllerTests.swift */; };
 		DE38F0862DB2510A00BE3101 /* JITDelegatesSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE38F0852DB2510600BE3101 /* JITDelegatesSpies.swift */; };
@@ -6604,10 +6605,10 @@
 				281A0E1B2C21E20600CB30CB /* MSALNativeAuthEndToEndBaseTestCase.swift in Sources */,
 				28188F652C8F4C1100CFDD05 /* MFADelegateSpies.swift in Sources */,
 				281A0E192C21E20000CB30CB /* MSALNativeAuthResetPasswordEndToEndTests.swift in Sources */,
-				DED1F09E2DD644FC009CB97A /* JITDelegateSpies.swift in Sources */,
 				281A0E0C2C21E1F000CB30CB /* MSALNativeAuthSignUpUsernameEndToEndTests.swift in Sources */,
 				281A0E152C21E1F500CB30CB /* SignUpDelegateSpies.swift in Sources */,
 				28188F622C8F48BD00CFDD05 /* MSALNativeAuthSignInWithMFAEndToEndTests.swift in Sources */,
+				DE20A8492DDE2CD200BC286C /* JITDelegateSpies.swift in Sources */,
 				281A0E172C21E1FB00CB30CB /* MSALNativeAuthSignInUsernameEndToEndTests.swift in Sources */,
 				281A0E1C2C21E3A400CB30CB /* MSALNativeAuthSignOutEndToEndTests.swift in Sources */,
 				DEFE87732CA6BC91009D11DC /* CredentialsDelegateSpies.swift in Sources */,

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/JITDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/JITDelegateSpies.swift
@@ -1,0 +1,75 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import XCTest
+import MSAL
+
+class RegisterStrongAuthChallengeDelegateSpy: RegisterStrongAuthChallengeDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onRegisterStrongAuthVerificationRequiredCalled = false
+    private(set) var onRegisterStrongAuthChallengeErrorCalled = false
+    private(set) var newStateVerificationRequired: RegisterStrongAuthVerificationRequiredState?
+    private(set) var error: RegisterStrongAuthChallengeError?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onRegisterStrongAuthVerificationRequired(result: MSALNativeAuthRegisterStrongAuthVerificationRequiredResult) {
+        onRegisterStrongAuthVerificationRequiredCalled = true
+        newStateVerificationRequired = result.newState
+        expectation.fulfill()
+    }
+
+    func onRegisterStrongAuthChallengeError(error: MSAL.RegisterStrongAuthChallengeError, newState: MSAL.RegisterStrongAuthState?) {
+        onRegisterStrongAuthChallengeErrorCalled = true
+        self.error = error
+        expectation.fulfill()
+    }
+}
+
+class RegisterStrongAuthSubmitChallengeDelegateSpy: RegisterStrongAuthSubmitChallengeDelegate {
+    private let expectation: XCTestExpectation
+    private(set) var onSignInCompletedCalled = false
+    private(set) var onRegisterStrongAuthSubmitChallengeErrorCalled = false
+    private(set) var result: MSALNativeAuthUserAccountResult?
+    private(set) var error: RegisterStrongAuthSubmitChallengeError?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onSignInCompleted(result: MSALNativeAuthUserAccountResult) {
+        onSignInCompletedCalled = true
+        self.result = result
+        expectation.fulfill()
+    }
+
+    func onRegisterStrongAuthSubmitChallengeError(error: RegisterStrongAuthSubmitChallengeError, newState: RegisterStrongAuthVerificationRequiredState?) {
+        onRegisterStrongAuthSubmitChallengeErrorCalled = true
+        self.error = error
+        expectation.fulfill()
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/JITDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/JITDelegateSpies.swift
@@ -30,9 +30,11 @@ class RegisterStrongAuthChallengeDelegateSpy: RegisterStrongAuthChallengeDelegat
     private let expectation: XCTestExpectation
     private(set) var onRegisterStrongAuthVerificationRequiredCalled = false
     private(set) var onRegisterStrongAuthChallengeErrorCalled = false
+    private(set) var onSignInCompletedCalled = false
     private(set) var newStateVerificationRequired: RegisterStrongAuthVerificationRequiredState?
     private(set) var error: RegisterStrongAuthChallengeError?
-
+    private(set) var result: MSALNativeAuthUserAccountResult?
+    
     init(expectation: XCTestExpectation) {
         self.expectation = expectation
     }
@@ -46,6 +48,12 @@ class RegisterStrongAuthChallengeDelegateSpy: RegisterStrongAuthChallengeDelegat
     func onRegisterStrongAuthChallengeError(error: MSAL.RegisterStrongAuthChallengeError, newState: MSAL.RegisterStrongAuthState?) {
         onRegisterStrongAuthChallengeErrorCalled = true
         self.error = error
+        expectation.fulfill()
+    }
+
+    func onSignInCompleted(result: MSALNativeAuthUserAccountResult) {
+        onSignInCompletedCalled = true
+        self.result = result
         expectation.fulfill()
     }
 }

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInJITEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInJITEndToEndTests.swift
@@ -1,0 +1,346 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import XCTest
+import MSAL
+
+final class MSALNativeAuthSignInJITEndToEndTests: MSALNativeAuthEndToEndPasswordTestCase {
+
+    func test_createUserAndAddSameEmailAsStrongAuthMethod_thenAutomaticallySignInSuccessfully_withPreverified() async throws {
+        throw XCTSkip("Retrieving OTP failure")
+#if os(macOS)
+        throw XCTSkip("For some reason this test now requires Keychain access, reason needs to be investigated")
+#endif
+
+        // Step 1: Create User
+        guard let application = initialisePublicClientApplication() else {
+            XCTFail("Failed to initialize public client application")
+            return
+        }
+
+        let username = generateSignUpRandomEmail()
+        let password = generateRandomPassword()
+
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        let signUpParam = MSALNativeAuthSignUpParameters(username: username)
+        signUpParam.password = password
+        signUpParam.correlationId = correlationId
+
+        application.signUp(parameters: signUpParam, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp])
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        guard signUpStartDelegate.onSignUpCodeRequiredCalled else {
+            XCTFail("onSignUpCodeRequired not called")
+            return
+        }
+
+        // Step 2: Get & Submit Code for Sign Up
+        guard let code = await retrieveCodeFor(email: username) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        signUpStartDelegate.newState?.submitCode(code: code, delegate: signUpVerifyCodeDelegate)
+
+        await fulfillment(of: [signUpCompleteExp])
+
+        guard signUpVerifyCodeDelegate.onSignUpCompletedCalled,
+              let signInAfterSignUpState = signUpVerifyCodeDelegate.signInAfterSignUpState else {
+            XCTFail("onSignUpCompleted not called or state is nil")
+            return
+        }
+
+        // Step 3: Attempt to Sign In automtically
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInAfterSignUpDelegateSpy(expectation: signInExpectation)
+
+        let signInParameters = MSALNativeAuthSignInAfterSignUpParameters()
+        signInAfterSignUpState.signIn(parameters: signInParameters, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+
+        guard signInDelegateSpy.onSignInStrongAuthMethodRegistrationCalled,
+              let strongAuthState = signInDelegateSpy.newStateStrongAuthMethodRegistration,
+              let authMethod = signInDelegateSpy.authMethods?.first else {
+            XCTFail("Sign in failed or strong auth method registration not required")
+            return
+        }
+
+        // Step 4: Add Strong Auth Method, but don't specify verification contact so it's preverified
+        let challengeParameters = MSALNativeAuthChallengeAuthMethodParameters(authMethod: authMethod)
+        let challengeExpectation = expectation(description: "challenging auth method")
+        let challengeDelegateSpy = RegisterStrongAuthChallengeDelegateSpy(expectation: challengeExpectation)
+
+        strongAuthState.challengeAuthMethod(parameters: challengeParameters, delegate: challengeDelegateSpy)
+
+        await fulfillment(of: [challengeExpectation])
+
+        guard challengeDelegateSpy.onRegisterStrongAuthVerificationRequiredCalled,
+              let verificationState = challengeDelegateSpy.newStateVerificationRequired else {
+            XCTFail("Challenge auth method failed")
+            return
+        }
+
+        // Step 5: Get Code for Register Strong Auth
+        guard let code = await retrieveCodeFor(email: username) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+
+        // Step 6: Submit Code to Register Strong Auth
+        let submitChallengeExpectation = expectation(description: "submitChallenge")
+        let submitChallengeDelegateSpy = RegisterStrongAuthSubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
+
+        verificationState.submitChallenge(challenge: code, delegate: submitChallengeDelegateSpy)
+
+        await fulfillment(of: [submitChallengeExpectation])
+
+        checkSubmitChallengeDelegate(submitChallengeDelegateSpy, username: username)
+    }
+
+    func test_createUserAndAddDifferentEmailAsStrongAuthMethod_thenAutomaticallySignInSuccessfully() async throws {
+        throw XCTSkip("Retrieving OTP failure")
+#if os(macOS)
+        throw XCTSkip("For some reason this test now requires Keychain access, reason needs to be investigated")
+#endif
+
+        // Step 1: Create User
+        guard let application = initialisePublicClientApplication() else {
+            XCTFail("Failed to initialize public client application")
+            return
+        }
+
+        let username = generateSignUpRandomEmail()
+        let password = generateRandomPassword()
+
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        let signUpParam = MSALNativeAuthSignUpParameters(username: username)
+        signUpParam.password = password
+        signUpParam.correlationId = correlationId
+
+        application.signUp(parameters: signUpParam, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp])
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        guard signUpStartDelegate.onSignUpCodeRequiredCalled else {
+            XCTFail("onSignUpCodeRequired not called")
+            return
+        }
+
+        // Step 2: Get & Submit Code for Sign Up
+        guard let code = await retrieveCodeFor(email: username) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        signUpStartDelegate.newState?.submitCode(code: code, delegate: signUpVerifyCodeDelegate)
+
+        await fulfillment(of: [signUpCompleteExp])
+
+        guard signUpVerifyCodeDelegate.onSignUpCompletedCalled,
+              let signInAfterSignUpState = signUpVerifyCodeDelegate.signInAfterSignUpState else {
+            XCTFail("onSignUpCompleted not called or state is nil")
+            return
+        }
+
+        // Step 3: Attempt to Sign In automatically
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInAfterSignUpDelegateSpy(expectation: signInExpectation)
+
+        let signInParameters = MSALNativeAuthSignInAfterSignUpParameters()
+        signInAfterSignUpState.signIn(parameters: signInParameters, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+
+        guard signInDelegateSpy.onSignInStrongAuthMethodRegistrationCalled,
+              let strongAuthState = signInDelegateSpy.newStateStrongAuthMethodRegistration,
+              let authMethod = signInDelegateSpy.authMethods?.first else {
+            XCTFail("Sign in failed or strong auth method registration not required")
+            return
+        }
+
+        // Step 4: Add Strong Auth Method and specify different email
+        let newEmail = generateSignUpRandomEmail()
+        let challengeParameters = MSALNativeAuthChallengeAuthMethodParameters(authMethod: authMethod)
+        challengeParameters.verificationContact = newEmail
+        let challengeExpectation = expectation(description: "challenging auth method")
+        let challengeDelegateSpy = RegisterStrongAuthChallengeDelegateSpy(expectation: challengeExpectation)
+
+        strongAuthState.challengeAuthMethod(parameters: challengeParameters, delegate: challengeDelegateSpy)
+
+        await fulfillment(of: [challengeExpectation])
+
+        guard challengeDelegateSpy.onRegisterStrongAuthVerificationRequiredCalled,
+              let verificationState = challengeDelegateSpy.newStateVerificationRequired else {
+            XCTFail("Challenge auth method failed")
+            return
+        }
+
+        // Step 5: Get Code for Register Strong Auth
+        guard let code = await retrieveCodeFor(email: newEmail) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+
+        // Step 6: Submit Code to Register Strong Auth
+        let submitChallengeExpectation = expectation(description: "submitChallenge")
+        let submitChallengeDelegateSpy = RegisterStrongAuthSubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
+
+        verificationState.submitChallenge(challenge: code, delegate: submitChallengeDelegateSpy)
+
+        await fulfillment(of: [submitChallengeExpectation])
+
+        checkSubmitChallengeDelegate(submitChallengeDelegateSpy, username: username)
+    }
+
+    func test_createUserAndAddDifferentEmailAsStrongAuthMethod_thenSignInSuccessfully() async throws {
+        throw XCTSkip("Retrieving OTP failure")
+#if os(macOS)
+        throw XCTSkip("For some reason this test now requires Keychain access, reason needs to be investigated")
+#endif
+
+        // Step 1: Create User
+        guard let application = initialisePublicClientApplication() else {
+            XCTFail("Failed to initialize public client application")
+            return
+        }
+
+        let username = generateSignUpRandomEmail()
+        let password = generateRandomPassword()
+
+        let codeRequiredExp = expectation(description: "code required")
+        let signUpStartDelegate = SignUpPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        let signUpParam = MSALNativeAuthSignUpParameters(username: username)
+        signUpParam.password = password
+        signUpParam.correlationId = correlationId
+
+        application.signUp(parameters: signUpParam, delegate: signUpStartDelegate)
+
+        await fulfillment(of: [codeRequiredExp])
+        checkSignUpStartDelegate(signUpStartDelegate)
+
+        guard signUpStartDelegate.onSignUpCodeRequiredCalled else {
+            XCTFail("onSignUpCodeRequired not called")
+            return
+        }
+
+        // Step 2: Get & Submit Code for Sign Up
+        guard let code = await retrieveCodeFor(email: username) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+
+        let signUpCompleteExp = expectation(description: "sign-up complete")
+        let signUpVerifyCodeDelegate = SignUpVerifyCodeDelegateSpy(expectation: signUpCompleteExp)
+
+        signUpStartDelegate.newState?.submitCode(code: code, delegate: signUpVerifyCodeDelegate)
+
+        await fulfillment(of: [signUpCompleteExp])
+
+        guard signUpVerifyCodeDelegate.onSignUpCompletedCalled else {
+            XCTFail("onSignUpCompleted not called")
+            return
+        }
+
+        // Step 3: Attempt to Sign In with new flow
+        let signInExpectation = expectation(description: "signing in")
+        let signInDelegateSpy = SignInPasswordStartDelegateSpy(expectation: signInExpectation)
+
+        let signInParameters = MSALNativeAuthSignInParameters(username: username)
+        signInParameters.password = password
+
+        application.signIn(parameters: signInParameters, delegate: signInDelegateSpy)
+
+        await fulfillment(of: [signInExpectation])
+
+        guard signInDelegateSpy.onSignInStrongAuthMethodRegistrationCalled,
+              let strongAuthState = signInDelegateSpy.newStateStrongAuthMethodRegistration,
+              let authMethod = signInDelegateSpy.authMethods?.first else {
+            XCTFail("Sign in failed or strong auth method registration not required")
+            return
+        }
+
+        // Step 4: Add Strong Auth Method and specify different email
+        let newEmail = generateSignUpRandomEmail()
+        let challengeParameters = MSALNativeAuthChallengeAuthMethodParameters(authMethod: authMethod)
+        challengeParameters.verificationContact = newEmail
+        let challengeExpectation = expectation(description: "challenging auth method")
+        let challengeDelegateSpy = RegisterStrongAuthChallengeDelegateSpy(expectation: challengeExpectation)
+
+        strongAuthState.challengeAuthMethod(parameters: challengeParameters, delegate: challengeDelegateSpy)
+
+        await fulfillment(of: [challengeExpectation])
+
+        guard challengeDelegateSpy.onRegisterStrongAuthVerificationRequiredCalled,
+              let verificationState = challengeDelegateSpy.newStateVerificationRequired else {
+            XCTFail("Challenge auth method failed")
+            return
+        }
+
+        // Step 5: Get Code for Register Strong Auth
+        guard let code = await retrieveCodeFor(email: newEmail) else {
+            XCTFail("OTP code could not be retrieved")
+            return
+        }
+
+        // Step 6: Submit Code to Register Strong Auth
+        let submitChallengeExpectation = expectation(description: "submitChallenge")
+        let submitChallengeDelegateSpy = RegisterStrongAuthSubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
+
+        verificationState.submitChallenge(challenge: code, delegate: submitChallengeDelegateSpy)
+
+        await fulfillment(of: [submitChallengeExpectation])
+
+        checkSubmitChallengeDelegate(submitChallengeDelegateSpy, username: username)
+    }
+
+    private func checkSignUpStartDelegate(_ delegate: SignUpPasswordStartDelegateSpy) {
+        XCTAssertTrue(delegate.onSignUpCodeRequiredCalled)
+        XCTAssertEqual(delegate.channelTargetType?.isEmailType, true)
+        XCTAssertFalse(delegate.sentTo?.isEmpty ?? true)
+        XCTAssertNotNil(delegate.codeLength)
+    }
+
+    private func checkSubmitChallengeDelegate(_ delegate: RegisterStrongAuthSubmitChallengeDelegateSpy, username: String) {
+        XCTAssertTrue(delegate.onSignInCompletedCalled)
+        XCTAssertNotNil(delegate.result)
+        XCTAssertNotNil(delegate.result?.idToken)
+        XCTAssertEqual(delegate.result?.account.username, username)
+    }
+}

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInJITEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInJITEndToEndTests.swift
@@ -104,27 +104,10 @@ final class MSALNativeAuthSignInJITEndToEndTests: MSALNativeAuthEndToEndPassword
 
         await fulfillment(of: [challengeExpectation])
 
-        guard challengeDelegateSpy.onRegisterStrongAuthVerificationRequiredCalled,
-              let verificationState = challengeDelegateSpy.newStateVerificationRequired else {
-            XCTFail("Challenge auth method failed")
-            return
-        }
-
-        // Step 5: Get Code for Register Strong Auth
-        guard let code = await retrieveCodeFor(email: username) else {
-            XCTFail("OTP code could not be retrieved")
-            return
-        }
-
-        // Step 6: Submit Code to Register Strong Auth
-        let submitChallengeExpectation = expectation(description: "submitChallenge")
-        let submitChallengeDelegateSpy = RegisterStrongAuthSubmitChallengeDelegateSpy(expectation: submitChallengeExpectation)
-
-        verificationState.submitChallenge(challenge: code, delegate: submitChallengeDelegateSpy)
-
-        await fulfillment(of: [submitChallengeExpectation])
-
-        checkSubmitChallengeDelegate(submitChallengeDelegateSpy, username: username)
+        XCTAssertTrue(challengeDelegateSpy.onSignInCompletedCalled)
+        XCTAssertNotNil(challengeDelegateSpy.result)
+        XCTAssertNotNil(challengeDelegateSpy.result?.idToken)
+        XCTAssertEqual(challengeDelegateSpy.result?.account.username, username)
     }
 
     func test_createUserAndAddDifferentEmailAsStrongAuthMethod_thenAutomaticallySignInSuccessfully() async throws {

--- a/MSAL/test/integration/native_auth/end_to_end/sign_in/SignInDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_in/SignInDelegateSpies.swift
@@ -31,9 +31,12 @@ class SignInPasswordStartDelegateSpy: SignInStartDelegate {
     private(set) var onSignInPasswordErrorCalled = false
     private(set) var onSignInCompletedCalled = false
     private(set) var onSignInAwaitingMFACalled = false
+    private(set) var onSignInStrongAuthMethodRegistrationCalled = false
     private(set) var error: MSAL.SignInStartError?
     private(set) var result: MSAL.MSALNativeAuthUserAccountResult?
     private(set) var newStateAwaitingMFA: MSAL.AwaitingMFAState?
+    private(set) var newStateStrongAuthMethodRegistration: MSAL.RegisterStrongAuthState?
+    private(set) var authMethods: [MSALAuthMethod]?
 
     init(expectation: XCTestExpectation) {
         self.expectation = expectation
@@ -57,6 +60,14 @@ class SignInPasswordStartDelegateSpy: SignInStartDelegate {
         onSignInAwaitingMFACalled = true
         
         self.newStateAwaitingMFA = newState
+        expectation.fulfill()
+    }
+
+    public func onSignInStrongAuthMethodRegistration(authMethods: [MSALAuthMethod], newState: RegisterStrongAuthState) {
+        onSignInStrongAuthMethodRegistrationCalled = true
+        self.authMethods = authMethods
+        self.newStateStrongAuthMethodRegistration = newState
+
         expectation.fulfill()
     }
 }

--- a/MSAL/test/integration/native_auth/end_to_end/sign_up/SignUpDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/sign_up/SignUpDelegateSpies.swift
@@ -245,7 +245,10 @@ class SignInAfterSignUpDelegateSpy: SignInAfterSignUpDelegate {
     private(set) var onSignInAfterSignUpErrorCalled = false
     private(set) var error: SignInAfterSignUpError?
     private(set) var onSignInCompletedCalled = false
+    private(set) var onSignInStrongAuthMethodRegistrationCalled = false
     private(set) var result: MSALNativeAuthUserAccountResult?
+    private(set) var newStateStrongAuthMethodRegistration: MSAL.RegisterStrongAuthState?
+    private(set) var authMethods: [MSALAuthMethod]?
 
     init(expectation: XCTestExpectation) {
         self.expectation = expectation
@@ -261,6 +264,14 @@ class SignInAfterSignUpDelegateSpy: SignInAfterSignUpDelegate {
     func onSignInCompleted(result: MSALNativeAuthUserAccountResult) {
         onSignInCompletedCalled = true
         self.result = result
+
+        expectation.fulfill()
+    }
+
+    public func onSignInStrongAuthMethodRegistration(authMethods: [MSALAuthMethod], newState: RegisterStrongAuthState) {
+        onSignInStrongAuthMethodRegistrationCalled = true
+        self.authMethods = authMethods
+        self.newStateStrongAuthMethodRegistration = newState
 
         expectation.fulfill()
     }


### PR DESCRIPTION
## Proposed changes

Added the 3 following E2E tests:
- Ensure JIT is triggered in signIn after signUp (preverified).
- Ensure JIT is triggered in signIn after signUp and a second email is used as verification contact.
- Ensure JIT is triggered on first signIn.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

