### PR TITLE
Add official enum value for MSALPreferredAuthMethodQRPIN

### DIFF
--- a/MSAL/src/MSALDeviceInformation.m
+++ b/MSAL/src/MSALDeviceInformation.m
@@ -128,7 +128,7 @@ NSString *const MSAL_PRIMARY_REGISTRATION_CERTIFICATE_THUMBPRINT = @"primary_reg
 {
     switch (msidPreferredAuthConfig) {
         case MSIDPreferredAuthMethodQRPIN:
-            return 1; // Private enum value for QR+PIN
+            return MSALPreferredAuthMethodQRPIN;
             
         default:
             return MSALPreferredAuthMethodNone;

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -1040,8 +1040,8 @@
     // Extra parameters to be added to the /authorize endpoint.
     msidParams.extraAuthorizeURLQueryParameters = self.internalConfig.extraQueryParameters.extraAuthorizeURLQueryParameters;
     
-    // Private enum value for QR+PIN
-    if (parameters.preferredAuthMethod == 1)
+    // Setup QR+PIN accelerated experience if configured
+    if (parameters.preferredAuthMethod == MSALPreferredAuthMethodQRPIN)
     {
         NSMutableDictionary *extraAuthorizeURLQueryParameters = [msidParams.extraAuthorizeURLQueryParameters mutableCopy];
         [extraAuthorizeURLQueryParameters setObject:MSID_PREFERRED_AUTH_METHOD_QR_PIN forKey:MSID_PREFERRED_AUTH_METHOD_KEY];

--- a/MSAL/src/public/MSALDefinitions.h
+++ b/MSAL/src/public/MSALDefinitions.h
@@ -191,7 +191,11 @@ typedef NS_ENUM(NSUInteger, MSALPreferredAuthMethod)
     /*
         No preferred auth method passed with the request to the authetication server.
     */
-    MSALPreferredAuthMethodNone
+    MSALPreferredAuthMethodNone,
+    /*
+        QR+PIN authentication preferred.
+    */
+    MSALPreferredAuthMethodQRPIN
 };
 
 #if TARGET_OS_OSX


### PR DESCRIPTION
## Proposed changes

Currently our [official docs](https://learn.microsoft.com/en-us/entra/identity-platform/ios-qr-code-pin-authentication#configure-your-app-to-use-qr-code-authentication) direct developers to use a private enum value of "1" to configure QR+PIN as the preferred auth method. Configuring this in the token parameters causes interactive token requests to open directly to the QR code authentication page in the webview.

This PR opens a public enum value MSALPreferredAuthMethodQRPIN with the same value, which should not disturb any clients that have onboarded to the private value.

## Type of change

- [x] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

