### PR TITLE
Moved throw from setting MSAL logging callback

### DIFF
--- a/MSAL/src/configuration/MSALLoggerConfig.m
+++ b/MSAL/src/configuration/MSALLoggerConfig.m
@@ -57,7 +57,7 @@
 #if DEBUG
         @throw [NSException
                 exceptionWithName:NSInternalInconsistencyException
-                reason:@"MSAL logging callback can only be set once per process and should never changed be once set."
+                reason:@"MSAL logging callback can only be set once per process and should never be changed once set."
                 userInfo:nil];
 #endif
         MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"MSAL logging callback can only be set once per process and should never be changed once set.");

--- a/MSAL/src/configuration/MSALLoggerConfig.m
+++ b/MSAL/src/configuration/MSALLoggerConfig.m
@@ -54,7 +54,8 @@
 {
     if (self.callback != nil)
     {
-        @throw @"MSAL logging callback can only be set once per process and should never changed once set.";
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"MSAL logging callback can only be set once per process and should never changed once set.");
+        return;
     }
     
     static dispatch_once_t once;

--- a/MSAL/src/configuration/MSALLoggerConfig.m
+++ b/MSAL/src/configuration/MSALLoggerConfig.m
@@ -55,9 +55,12 @@
     if (self.callback != nil)
     {
 #if DEBUG
-        @throw @"MSAL logging callback can only be set once per process and should never changed once set.";
+        @throw [NSException
+                exceptionWithName:NSInternalInconsistencyException
+                reason:@"MSAL logging callback can only be set once per process and should never changed be once set."
+                userInfo:nil];
 #endif
-        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"MSAL logging callback can only be set once per process and should never changed once set.");
+        MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"MSAL logging callback can only be set once per process and should never be changed once set.");
         return;
     }
     

--- a/MSAL/src/configuration/MSALLoggerConfig.m
+++ b/MSAL/src/configuration/MSALLoggerConfig.m
@@ -54,6 +54,9 @@
 {
     if (self.callback != nil)
     {
+#if DEBUG
+        @throw @"MSAL logging callback can only be set once per process and should never changed once set.";
+#endif
         MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"MSAL logging callback can only be set once per process and should never changed once set.");
         return;
     }


### PR DESCRIPTION
## Proposed changes

Moved throw from setting MSAL logging callback to debug mode, so that the process doesnt crash in production.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

