### PR TITLE
Native auth: backward compatibility, add new capabilities parameter 

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -272,6 +272,8 @@
 		287F6524298401AE00ED90BD /* MSALNativeAuthResponseSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287F6523298401AE00ED90BD /* MSALNativeAuthResponseSerializerTests.swift */; };
 		289747AC2979487900838C80 /* MSALNativeAuthUrlRequestSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289747A92979487900838C80 /* MSALNativeAuthUrlRequestSerializerTests.swift */; };
 		289747B129799C6B00838C80 /* MSALNativeAuthInputValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289747AF29799A8700838C80 /* MSALNativeAuthInputValidator.swift */; };
+		289C1D892DE73181009EEBEA /* MSALNativeAuthCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 289C1D882DE73181009EEBEA /* MSALNativeAuthCapabilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		289C1D8A2DE73181009EEBEA /* MSALNativeAuthCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 289C1D882DE73181009EEBEA /* MSALNativeAuthCapabilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		289E15592948E601006104D9 /* MSALNativeAuthCacheInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E15582948E601006104D9 /* MSALNativeAuthCacheInterface.swift */; };
 		289E156D2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E156C2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift */; };
 		289E44AC2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E44AB2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift */; };
@@ -329,6 +331,8 @@
 		28DE3FD02A0921E2003148A4 /* SignInTestsValidatorHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DE3FCF2A0921E2003148A4 /* SignInTestsValidatorHelpers.swift */; };
 		28DE70D629FAC16700EB75AA /* MSALNativeAuthSignInResponseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28DE70D529FAC16700EB75AA /* MSALNativeAuthSignInResponseValidator.swift */; };
 		28E4D9032A30ABA200280921 /* ResendCodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E4D9022A30ABA200280921 /* ResendCodeError.swift */; };
+		28E9B7782DE7276F00A162EA /* MSALNativeAuthPublicClientApplicationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E9B7772DE7276C00A162EA /* MSALNativeAuthPublicClientApplicationConfig.swift */; };
+		28E9B7792DE7276F00A162EA /* MSALNativeAuthPublicClientApplicationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E9B7772DE7276C00A162EA /* MSALNativeAuthPublicClientApplicationConfig.swift */; };
 		28EDF93E29E6D43900A99F2A /* SignUpStartError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28EDF93D29E6D43900A99F2A /* SignUpStartError.swift */; };
 		28EDF94129E6D52E00A99F2A /* SignInStartError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28EDF94029E6D52E00A99F2A /* SignInStartError.swift */; };
 		28EE65062C8B01D500015F90 /* MSALNativeAuthMFAControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D811EC2C760303002BE1AA /* MSALNativeAuthMFAControlling.swift */; };
@@ -2095,6 +2099,7 @@
 		287F6523298401AE00ED90BD /* MSALNativeAuthResponseSerializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResponseSerializerTests.swift; sourceTree = "<group>"; };
 		289747A92979487900838C80 /* MSALNativeAuthUrlRequestSerializerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthUrlRequestSerializerTests.swift; sourceTree = "<group>"; };
 		289747AF29799A8700838C80 /* MSALNativeAuthInputValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInputValidator.swift; sourceTree = "<group>"; };
+		289C1D882DE73181009EEBEA /* MSALNativeAuthCapabilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALNativeAuthCapabilities.h; sourceTree = "<group>"; };
 		289E15582948E601006104D9 /* MSALNativeAuthCacheInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCacheInterface.swift; sourceTree = "<group>"; };
 		289E156C2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCacheAccessor.swift; sourceTree = "<group>"; };
 		289E44AB2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFARequestChallengeError.swift; sourceTree = "<group>"; };
@@ -2147,6 +2152,7 @@
 		28DE3FCF2A0921E2003148A4 /* SignInTestsValidatorHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInTestsValidatorHelpers.swift; sourceTree = "<group>"; };
 		28DE70D529FAC16700EB75AA /* MSALNativeAuthSignInResponseValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInResponseValidator.swift; sourceTree = "<group>"; };
 		28E4D9022A30ABA200280921 /* ResendCodeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResendCodeError.swift; sourceTree = "<group>"; };
+		28E9B7772DE7276C00A162EA /* MSALNativeAuthPublicClientApplicationConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthPublicClientApplicationConfig.swift; sourceTree = "<group>"; };
 		28EDF93D29E6D43900A99F2A /* SignUpStartError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpStartError.swift; sourceTree = "<group>"; };
 		28EDF94029E6D52E00A99F2A /* SignInStartError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInStartError.swift; sourceTree = "<group>"; };
 		28F19BEA2A2F884D00575581 /* Array+joinScopes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+joinScopes.swift"; sourceTree = "<group>"; };
@@ -3324,6 +3330,14 @@
 				DE54B5972A44431C00460B34 /* token */,
 			);
 			path = validator;
+			sourceTree = "<group>";
+		};
+		28E9B7762DE7276000A162EA /* configuration */ = {
+			isa = PBXGroup;
+			children = (
+				28E9B7772DE7276C00A162EA /* MSALNativeAuthPublicClientApplicationConfig.swift */,
+			);
+			path = configuration;
 			sourceTree = "<group>";
 		};
 		28F19BE12A2F4A0100575581 /* sign_in */ = {
@@ -4902,6 +4916,7 @@
 		E260964129489CA60060DD7C /* public */ = {
 			isa = PBXGroup;
 			children = (
+				28E9B7762DE7276000A162EA /* configuration */,
 				DE4315092D3E551E009A7FA2 /* parameters */,
 				28DCD08829D70FA000C4601E /* state_machine */,
 				E2DC31BB29AFA1E700051CE7 /* MSALNativeAuthPublicClientApplication.swift */,
@@ -4909,6 +4924,7 @@
 				28B28B912C6F611F0030D5C5 /* MSALAuthMethod.swift */,
 				DE729ECC2A1793A100A761D9 /* MSALNativeAuthChannelType.swift */,
 				9BD78D7A2A126A1500AA7E12 /* MSALNativeAuthChallengeTypes.h */,
+				289C1D882DE73181009EEBEA /* MSALNativeAuthCapabilities.h */,
 			);
 			path = public;
 			sourceTree = "<group>";
@@ -5442,6 +5458,7 @@
 				B273D0B8226E859F005A7BB4 /* MSALPublicClientApplicationConfig+Internal.h in Headers */,
 				DE9244D82A31E1D500C0389F /* MSALCIAMOauth2Provider.h in Headers */,
 				96CF95252268FD0500D97374 /* MSALB2CAuthority.h in Headers */,
+				289C1D892DE73181009EEBEA /* MSALNativeAuthCapabilities.h in Headers */,
 				B26756CA22921C5B000F01D7 /* MSALB2COauth2Provider.h in Headers */,
 				96CF95172268FD0400D97374 /* MSALSliceConfig.h in Headers */,
 				B227037122A4BA3600030ADC /* MSALLegacySharedAccountsProvider.h in Headers */,
@@ -5507,6 +5524,7 @@
 				23014D5125672E53005E12F2 /* MSALAuthenticationSchemeBearer+Internal.h in Headers */,
 				96B5E6CF2256D152002232F9 /* MSALCacheConfig.h in Headers */,
 				B29A56A6228262770023F5E6 /* MSALExternalAccountProviding.h in Headers */,
+				289C1D8A2DE73181009EEBEA /* MSALNativeAuthCapabilities.h in Headers */,
 				1E72193A24773D1B00AB9B67 /* MSALHttpMethod.h in Headers */,
 				96B5E6E12256D166002232F9 /* MSALTelemetryConfig.h in Headers */,
 				96B5E6DB2256D15A002232F9 /* MSALHTTPConfig.h in Headers */,
@@ -6906,6 +6924,7 @@
 				B227037322A4BA3E00030ADC /* MSALLegacySharedAccountsProvider.m in Sources */,
 				E2ACA4952953415E00E98964 /* MSALNativeAuthGrantType.swift in Sources */,
 				DEE34F85D170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionRequestParameters.swift in Sources */,
+				28E9B7782DE7276F00A162EA /* MSALNativeAuthPublicClientApplicationConfig.swift in Sources */,
 				28F19BEB2A2F884D00575581 /* Array+joinScopes.swift in Sources */,
 				DE8EC8742A026BA0003FA561 /* MSALNativeAuthSignInRequestProvider.swift in Sources */,
 				232D616422485BA700260C42 /* MSALIndividualClaimRequestAdditionalInfo.m in Sources */,
@@ -7154,6 +7173,7 @@
 				B26756CD22921C5B000F01D7 /* MSALB2COauth2Provider.m in Sources */,
 				DE8DC4AD2C6621B400534E8F /* MSALNativeAuthSignUpChallengeRequestParameters.swift in Sources */,
 				DE8DC4CE2C6621C900534E8F /* MSALNativeAuthErrorMessage.swift in Sources */,
+				28E9B7792DE7276F00A162EA /* MSALNativeAuthPublicClientApplicationConfig.swift in Sources */,
 				96B5E6E32256D166002232F9 /* MSALTelemetryConfig.m in Sources */,
 				DE8DC45B2C66219600534E8F /* MSALNativeAuthSignUpController.swift in Sources */,
 				DE8DC4E22C6621D000534E8F /* MSALNativeAuthResetPasswordStartOauth2ErrorCode.swift in Sources */,

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -274,6 +274,8 @@
 		289747B129799C6B00838C80 /* MSALNativeAuthInputValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289747AF29799A8700838C80 /* MSALNativeAuthInputValidator.swift */; };
 		289C1D892DE73181009EEBEA /* MSALNativeAuthCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 289C1D882DE73181009EEBEA /* MSALNativeAuthCapabilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		289C1D8A2DE73181009EEBEA /* MSALNativeAuthCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 289C1D882DE73181009EEBEA /* MSALNativeAuthCapabilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		289C1D8C2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289C1D8B2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift */; };
+		289C1D8D2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289C1D8B2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift */; };
 		289E15592948E601006104D9 /* MSALNativeAuthCacheInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E15582948E601006104D9 /* MSALNativeAuthCacheInterface.swift */; };
 		289E156D2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E156C2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift */; };
 		289E44AC2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E44AB2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift */; };
@@ -2100,6 +2102,7 @@
 		289747A92979487900838C80 /* MSALNativeAuthUrlRequestSerializerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthUrlRequestSerializerTests.swift; sourceTree = "<group>"; };
 		289747AF29799A8700838C80 /* MSALNativeAuthInputValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInputValidator.swift; sourceTree = "<group>"; };
 		289C1D882DE73181009EEBEA /* MSALNativeAuthCapabilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALNativeAuthCapabilities.h; sourceTree = "<group>"; };
+		289C1D8B2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalCapability.swift; sourceTree = "<group>"; };
 		289E15582948E601006104D9 /* MSALNativeAuthCacheInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCacheInterface.swift; sourceTree = "<group>"; };
 		289E156C2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCacheAccessor.swift; sourceTree = "<group>"; };
 		289E44AB2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFARequestChallengeError.swift; sourceTree = "<group>"; };
@@ -5101,6 +5104,7 @@
 				DE0FECA92993AD3700B139A8 /* responses */,
 				DEDB29A229DDA992008DA85B /* errors */,
 				E235613329C9D528000E01CA /* MSALNativeAuthInternalChallengeType.swift */,
+				289C1D8B2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift */,
 			);
 			path = network;
 			sourceTree = "<group>";
@@ -6971,6 +6975,7 @@
 				DE8973FB2DA5274000C67203 /* MSALNativeAuthJITContinueResponse.swift in Sources */,
 				DE8973FD2DA5274000C67203 /* MSALNativeAuthJITChallengeResponse.swift in Sources */,
 				DE0D65AC29CC6A5A005798B1 /* MSALNativeAuthSignInInitiateResponse.swift in Sources */,
+				289C1D8C2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift in Sources */,
 				B266391C22B4B84600FEB673 /* NSString+MSALAccountIdenfiers.m in Sources */,
 				DEE34F87D170B71C00BC302A /* MSALNativeAuthResetPasswordPollCompletionResponse.swift in Sources */,
 				96B5E6D02256D152002232F9 /* MSALCacheConfig.m in Sources */,
@@ -7247,6 +7252,7 @@
 				DE8974012DA5274000C67203 /* MSALNativeAuthJITChallengeResponse.swift in Sources */,
 				DE8DC45D2C66219600534E8F /* MSALNativeAuthResetPasswordController.swift in Sources */,
 				DE8DC4DD2C6621CE00534E8F /* MSALNativeAuthSignInInitiateOauth2ErrorCode.swift in Sources */,
+				289C1D8D2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift in Sources */,
 				DE8974282DA56FEF00C67203 /* MSALNativeAuthJITIntrospectValidatedResponse.swift in Sources */,
 				DE8974292DA56FEF00C67203 /* MSALNativeAuthJITChallengeValidatedResponse.swift in Sources */,
 				DE89742A2DA56FEF00C67203 /* MSALNativeAuthJITContinueValidatedResponse.swift in Sources */,

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -276,6 +276,10 @@
 		289C1D8A2DE73181009EEBEA /* MSALNativeAuthCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 289C1D882DE73181009EEBEA /* MSALNativeAuthCapabilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		289C1D8C2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289C1D8B2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift */; };
 		289C1D8D2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289C1D8B2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift */; };
+		289C1D8F2DE8C66D009EEBEA /* MSALNativeAuthInternalConfigurationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289C1D8E2DE8C669009EEBEA /* MSALNativeAuthInternalConfigurationTest.swift */; };
+		289C1D902DE8C66D009EEBEA /* MSALNativeAuthInternalConfigurationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289C1D8E2DE8C669009EEBEA /* MSALNativeAuthInternalConfigurationTest.swift */; };
+		289C1D922DE8D05C009EEBEA /* MSALNativeAuthPublicClientApplicationConfigTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289C1D912DE8D059009EEBEA /* MSALNativeAuthPublicClientApplicationConfigTest.swift */; };
+		289C1D932DE8D05C009EEBEA /* MSALNativeAuthPublicClientApplicationConfigTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289C1D912DE8D059009EEBEA /* MSALNativeAuthPublicClientApplicationConfigTest.swift */; };
 		289E15592948E601006104D9 /* MSALNativeAuthCacheInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E15582948E601006104D9 /* MSALNativeAuthCacheInterface.swift */; };
 		289E156D2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E156C2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift */; };
 		289E44AC2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 289E44AB2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift */; };
@@ -2103,6 +2107,8 @@
 		289747AF29799A8700838C80 /* MSALNativeAuthInputValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInputValidator.swift; sourceTree = "<group>"; };
 		289C1D882DE73181009EEBEA /* MSALNativeAuthCapabilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALNativeAuthCapabilities.h; sourceTree = "<group>"; };
 		289C1D8B2DE899B7009EEBEA /* MSALNativeAuthInternalCapability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalCapability.swift; sourceTree = "<group>"; };
+		289C1D8E2DE8C669009EEBEA /* MSALNativeAuthInternalConfigurationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalConfigurationTest.swift; sourceTree = "<group>"; };
+		289C1D912DE8D059009EEBEA /* MSALNativeAuthPublicClientApplicationConfigTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthPublicClientApplicationConfigTest.swift; sourceTree = "<group>"; };
 		289E15582948E601006104D9 /* MSALNativeAuthCacheInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCacheInterface.swift; sourceTree = "<group>"; };
 		289E156C2948EB8A006104D9 /* MSALNativeAuthCacheAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCacheAccessor.swift; sourceTree = "<group>"; };
 		289E44AB2C9D7A9E00F6B9D7 /* MFARequestChallengeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFARequestChallengeError.swift; sourceTree = "<group>"; };
@@ -3076,6 +3082,7 @@
 				E2CE91012B0BA34F0009AEDD /* error */,
 				E2CD2E3F29FBE957009F8FFA /* state_machine */,
 				287F64F22981A00400ED90BD /* MSALNativeAuthPublicClientApplicationTest.swift */,
+				289C1D912DE8D059009EEBEA /* MSALNativeAuthPublicClientApplicationConfigTest.swift */,
 				DE87DE692A39E80B0032BF9E /* MSALNativeAuthUserAccountResultTests.swift */,
 			);
 			path = public;
@@ -3154,6 +3161,7 @@
 				E26594392B60268400723C1A /* MSALNativeAuthResponseCorrelatableTests.swift */,
 				E2DDF1B22B6A9E1D00E9FAB7 /* MSALNativeAuthCustomErrorSerializerTests.swift */,
 				E2F8900D2B75546A001FBC7C /* MSALNativeAuthUnknownCaseProtocolTests.swift */,
+				289C1D8E2DE8C669009EEBEA /* MSALNativeAuthInternalConfigurationTest.swift */,
 			);
 			path = network;
 			sourceTree = "<group>";
@@ -7421,6 +7429,7 @@
 				DE94C9E829F19E6B00C1EC1F /* MSALNativeAuthResetPasswordPollCompletionRequestParametersTest.swift in Sources */,
 				E22427FD2B0671A10006C55E /* ResetPasswordStartDelegateDispatcherTests.swift in Sources */,
 				DE0D659529C1DCC9005798B1 /* MSALNativeAuthSignInInitiateRequestParametersTest.swift in Sources */,
+				289C1D902DE8C66D009EEBEA /* MSALNativeAuthInternalConfigurationTest.swift in Sources */,
 				E2DDF1B32B6A9E1D00E9FAB7 /* MSALNativeAuthCustomErrorSerializerTests.swift in Sources */,
 				DE38F08D2DB251AB00BE3101 /* JITRequestChallengeDelegateDispatcherTests.swift in Sources */,
 				E2CD2E5129FC087A009F8FFA /* SignUpAttributesRequiredStateTests.swift in Sources */,
@@ -7462,6 +7471,7 @@
 				28AF42FA2D96C15A009D1065 /* SignInAfterSignUpStateTests.swift in Sources */,
 				DE0D659729C1DCCF005798B1 /* MSALNativeAuthTokenRequestParametersTest.swift in Sources */,
 				E25BC099299555C000588549 /* MSALNativeAuthTelemetryTestDispatcher.swift in Sources */,
+				289C1D932DE8D05C009EEBEA /* MSALNativeAuthPublicClientApplicationConfigTest.swift in Sources */,
 				E25BC0832995429D00588549 /* MSALNativeAuthCacheMocks.swift in Sources */,
 				960751BB2183E82C00F2BF2F /* MSALAccountIdTests.m in Sources */,
 				E20C217E2A7A61CC00E31598 /* ResetPasswordDelegateSpies.swift in Sources */,
@@ -7616,6 +7626,7 @@
 				DE8DC5222C6621F500534E8F /* ResetPasswordResendCodeDelegateDispatcherTests.swift in Sources */,
 				28EE65242C8B10AA00015F90 /* MFARequiredStateTests.swift in Sources */,
 				DE8DC5472C66220D00534E8F /* MSALNativeAuthResetPasswordStartOauth2ErrorCodeTests.swift in Sources */,
+				289C1D922DE8D05C009EEBEA /* MSALNativeAuthPublicClientApplicationConfigTest.swift in Sources */,
 				DE0A5E892C6B670E004A4AEC /* MSALLogMaskTests.m in Sources */,
 				28EE65202C8B107D00015F90 /* MFASubmitChallengeDelegateDispatcherTests.swift in Sources */,
 				DE8DC51F2C6621F100534E8F /* SignUpVerifyCodeDelegateDispatcherTests.swift in Sources */,
@@ -7655,6 +7666,7 @@
 				DE8DC4F62C6621E200534E8F /* MSALNativeAuthTelemetryTestDispatcher.swift in Sources */,
 				DE8DC5662C66221A00534E8F /* MSALNativeAuthResponseSerializerTests.swift in Sources */,
 				DE8DC5252C6621F500534E8F /* DispatchAccessTokenRetrieveCompletedTests.swift in Sources */,
+				289C1D8F2DE8C66D009EEBEA /* MSALNativeAuthInternalConfigurationTest.swift in Sources */,
 				DE8DC5542C66221000534E8F /* MSALNativeAuthSignInResponseValidatorTests.swift in Sources */,
 				DE8DC5032C6621EA00534E8F /* SignUpTestsValidatorHelpers.swift in Sources */,
 				232D6193224C53E500260C42 /* MSALClaimsRequestTests.m in Sources */,

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -1153,7 +1153,7 @@
 		DE8DC46A2C66219600534E8F /* MSALNativeAuthControllerTelemetryWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2EFAD152A70300B00D6C3DE /* MSALNativeAuthControllerTelemetryWrapper.swift */; };
 		DE8DC46C2C66219600534E8F /* MSALNativeAuthSignUpControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = E284F5E329F2F28A00DBED7D /* MSALNativeAuthSignUpControlling.swift */; };
 		DE8DC46D2C66219600534E8F /* MSALNativeAuthSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E206FCEE2979BC4600AF4400 /* MSALNativeAuthSignInController.swift */; };
-		DE8DC46E2C66219600534E8F /* MSALNativeAuthConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E205D62D29B783FF003887BC /* MSALNativeAuthConfiguration.swift */; };
+		DE8DC46E2C66219600534E8F /* MSALNativeAuthInternalConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E205D62D29B783FF003887BC /* MSALNativeAuthInternalConfiguration.swift */; };
 		DE8DC46F2C66219600534E8F /* SignInResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2EFACFD2A69915100D6C3DE /* SignInResults.swift */; };
 		DE8DC4712C66219E00534E8F /* ResetPasswordDelegateDispatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427D42B05886B0006C55E /* ResetPasswordDelegateDispatchers.swift */; };
 		DE8DC4722C66219E00534E8F /* SignInAfterSignUpDelegateDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22427DD2B05981A0006C55E /* SignInAfterSignUpDelegateDispatcher.swift */; };
@@ -1509,7 +1509,7 @@
 		DEFE87742CA6BC91009D11DC /* MSALNativeAuthUserAccountEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE876F2CA6BC91009D11DC /* MSALNativeAuthUserAccountEndToEndTests.swift */; };
 		E2025CC92B2A182200E32871 /* MSALNativeAuthSubErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2025CC82B2A182200E32871 /* MSALNativeAuthSubErrorCode.swift */; };
 		E2025D202B2B8EEA00E32871 /* MSALNativeAuthSubErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2025D1F2B2B8EEA00E32871 /* MSALNativeAuthSubErrorCodeTests.swift */; };
-		E205D62E29B783FF003887BC /* MSALNativeAuthConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E205D62D29B783FF003887BC /* MSALNativeAuthConfiguration.swift */; };
+		E205D62E29B783FF003887BC /* MSALNativeAuthInternalConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E205D62D29B783FF003887BC /* MSALNativeAuthInternalConfiguration.swift */; };
 		E206FC5F296D65DE00AF4400 /* MSALNativeAuthInternalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E206FC5E296D65DE00AF4400 /* MSALNativeAuthInternalError.swift */; };
 		E206FCEF2979BC4600AF4400 /* MSALNativeAuthSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E206FCEE2979BC4600AF4400 /* MSALNativeAuthSignInController.swift */; };
 		E20C21752A7A61B600E31598 /* SignUpDelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20C21742A7A61B600E31598 /* SignUpDelegateSpies.swift */; };
@@ -2678,7 +2678,7 @@
 		E02396F31E79E2F4004D6278 /* MSALTelemetryApiId.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALTelemetryApiId.h; sourceTree = "<group>"; };
 		E2025CC82B2A182200E32871 /* MSALNativeAuthSubErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSubErrorCode.swift; sourceTree = "<group>"; };
 		E2025D1F2B2B8EEA00E32871 /* MSALNativeAuthSubErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSubErrorCodeTests.swift; sourceTree = "<group>"; };
-		E205D62D29B783FF003887BC /* MSALNativeAuthConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthConfiguration.swift; sourceTree = "<group>"; };
+		E205D62D29B783FF003887BC /* MSALNativeAuthInternalConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalConfiguration.swift; sourceTree = "<group>"; };
 		E206FC5E296D65DE00AF4400 /* MSALNativeAuthInternalError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthInternalError.swift; sourceTree = "<group>"; };
 		E206FCEE2979BC4600AF4400 /* MSALNativeAuthSignInController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInController.swift; sourceTree = "<group>"; };
 		E20C21742A7A61B600E31598 /* SignUpDelegateSpies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpDelegateSpies.swift; sourceTree = "<group>"; };
@@ -4782,7 +4782,7 @@
 		E205D62C29B783D6003887BC /* configuration */ = {
 			isa = PBXGroup;
 			children = (
-				E205D62D29B783FF003887BC /* MSALNativeAuthConfiguration.swift */,
+				E205D62D29B783FF003887BC /* MSALNativeAuthInternalConfiguration.swift */,
 			);
 			path = configuration;
 			sourceTree = "<group>";
@@ -6958,7 +6958,7 @@
 				DEDB29A829DDAEB3008DA85B /* MSALNativeAuthSignInChallengeOauth2ErrorCode.swift in Sources */,
 				DE03478A2A39ED6A003CB3B6 /* MSALCIAMOauth2Provider.m in Sources */,
 				DE8973F32DA5256000C67203 /* MSALNativeAuthJITRequestProvider.swift in Sources */,
-				E205D62E29B783FF003887BC /* MSALNativeAuthConfiguration.swift in Sources */,
+				E205D62E29B783FF003887BC /* MSALNativeAuthInternalConfiguration.swift in Sources */,
 				D61BD2B21EBD09F90007E484 /* MSALAccount.m in Sources */,
 				DEEFCE562DB0FA4800237F5A /* MSALNativeAuthLogger.swift in Sources */,
 				DE0D65B629CC6BBA005798B1 /* MSALNativeAuthSignInChallengeResponse.swift in Sources */,
@@ -7238,7 +7238,7 @@
 				DE8DC45F2C66219600534E8F /* MSALNativeAuthSignInControlling.swift in Sources */,
 				DE8DC4C32C6621C500534E8F /* MSALNativeAuthSignUpStartResponse.swift in Sources */,
 				DE8DC4E12C6621D000534E8F /* MSALNativeAuthResetPasswordSubmitResponseError.swift in Sources */,
-				DE8DC46E2C66219600534E8F /* MSALNativeAuthConfiguration.swift in Sources */,
+				DE8DC46E2C66219600534E8F /* MSALNativeAuthInternalConfiguration.swift in Sources */,
 				28F8D2922D8C5C7E005084FA /* JITStates.swift in Sources */,
 				DE8DC4CF2C6621C900534E8F /* MSALNativeAuthESTSApiErrorDescriptions.swift in Sources */,
 				96B5E6D12256D152002232F9 /* MSALCacheConfig.m in Sources */,

--- a/MSAL/src/native_auth/client_application_wrapper/silent_token/MSALNativeAuthSilentTokenProvider.swift
+++ b/MSAL/src/native_auth/client_application_wrapper/silent_token/MSALNativeAuthSilentTokenProvider.swift
@@ -27,10 +27,8 @@ class MSALNativeAuthSilentTokenProvider: MSALNativeAuthSilentTokenProviding {
 
     private let application: MSALNativeAuthPublicClientApplication?
 
-    init(
-        configuration config: MSALPublicClientApplicationConfig,
-        challengeTypes: MSALNativeAuthChallengeTypes) throws {
-            self.application = try? MSALNativeAuthPublicClientApplication(configuration: config, challengeTypes: challengeTypes)
+    init(configuration: MSALNativeAuthPublicClientApplicationConfig) throws {
+        self.application = try? MSALNativeAuthPublicClientApplication(nativeAuthConfiguration: configuration)
         }
 
     func acquireTokenSilent(parameters: MSALSilentTokenParameters,

--- a/MSAL/src/native_auth/client_application_wrapper/silent_token/MSALNativeAuthSilentTokenProvider.swift
+++ b/MSAL/src/native_auth/client_application_wrapper/silent_token/MSALNativeAuthSilentTokenProvider.swift
@@ -29,7 +29,7 @@ class MSALNativeAuthSilentTokenProvider: MSALNativeAuthSilentTokenProviding {
 
     init(configuration: MSALNativeAuthPublicClientApplicationConfig) throws {
         self.application = try? MSALNativeAuthPublicClientApplication(nativeAuthConfiguration: configuration)
-        }
+    }
 
     func acquireTokenSilent(parameters: MSALSilentTokenParameters,
                             completionBlock: @escaping MSALNativeAuthSilentTokenResponse) {

--- a/MSAL/src/native_auth/client_application_wrapper/silent_token/factory/MSALNativeAuthSilentTokenProviderBuildable.swift
+++ b/MSAL/src/native_auth/client_application_wrapper/silent_token/factory/MSALNativeAuthSilentTokenProviderBuildable.swift
@@ -23,6 +23,5 @@
 // THE SOFTWARE.  
 
 protocol MSALNativeAuthSilentTokenProviderBuildable {
-    func makeSilentTokenProvider(configuration: MSALPublicClientApplicationConfig,
-                                 challengeTypes: MSALNativeAuthChallengeTypes) throws -> MSALNativeAuthSilentTokenProviding?
+    func makeSilentTokenProvider(configuration: MSALNativeAuthPublicClientApplicationConfig) throws -> MSALNativeAuthSilentTokenProviding?
 }

--- a/MSAL/src/native_auth/client_application_wrapper/silent_token/factory/MSALNativeAuthSilentTokenProviderFactory.swift
+++ b/MSAL/src/native_auth/client_application_wrapper/silent_token/factory/MSALNativeAuthSilentTokenProviderFactory.swift
@@ -23,8 +23,7 @@
 // THE SOFTWARE.  
 
 class MSALNativeAuthSilentTokenProviderFactory: MSALNativeAuthSilentTokenProviderBuildable {
-    func makeSilentTokenProvider(configuration: MSALPublicClientApplicationConfig,
-                                 challengeTypes: MSALNativeAuthChallengeTypes) throws -> MSALNativeAuthSilentTokenProviding? {
-        return try? MSALNativeAuthSilentTokenProvider(configuration: configuration, challengeTypes: challengeTypes)
+    func makeSilentTokenProvider(configuration: MSALNativeAuthPublicClientApplicationConfig) throws -> MSALNativeAuthSilentTokenProviding? {
+        return try? MSALNativeAuthSilentTokenProvider(configuration: configuration)
     }
 }

--- a/MSAL/src/native_auth/configuration/MSALNativeAuthInternalConfiguration.swift
+++ b/MSAL/src/native_auth/configuration/MSALNativeAuthInternalConfiguration.swift
@@ -32,6 +32,7 @@ struct MSALNativeAuthInternalConfiguration {
     let clientId: String
     let authority: MSIDCIAMAuthority
     let challengeTypes: [MSALNativeAuthInternalChallengeType]
+    let capabilities: [MSALNativeAuthInternalCapability]?
     let redirectUri: String?
     var sliceConfig: MSALSliceConfig?
 
@@ -39,6 +40,7 @@ struct MSALNativeAuthInternalConfiguration {
         clientId: String,
         authority: MSALCIAMAuthority,
         challengeTypes: MSALNativeAuthChallengeTypes,
+        capabilities: MSALNativeAuthCapabilities?,
         redirectUri: String?) throws {
         self.clientId = clientId
         self.authority = try MSIDCIAMAuthority(
@@ -47,6 +49,7 @@ struct MSALNativeAuthInternalConfiguration {
             context: MSALNativeAuthRequestContext()
         )
         self.challengeTypes = MSALNativeAuthInternalConfiguration.getInternalChallengeTypes(challengeTypes)
+        self.capabilities = MSALNativeAuthInternalConfiguration.getInternalCapabilities(capabilities)
         self.redirectUri = redirectUri
     }
 
@@ -65,5 +68,21 @@ struct MSALNativeAuthInternalConfiguration {
 
         internalChallengeTypes.append(.redirect)
         return internalChallengeTypes
+    }
+    
+    private static func getInternalCapabilities(
+        _ capabilities: MSALNativeAuthCapabilities?
+    ) -> [MSALNativeAuthInternalCapability]? {
+        guard let capabilities else { return nil }
+        var internalCapabilities: [MSALNativeAuthInternalCapability] = []
+        
+        if capabilities.contains(.mfaRequired) {
+            internalCapabilities.append(.mfaRequired)
+        }
+        
+        if capabilities.contains(.registrationRequired) {
+            internalCapabilities.append(.registrationRequired)
+        }
+        return internalCapabilities
     }
 }

--- a/MSAL/src/native_auth/configuration/MSALNativeAuthInternalConfiguration.swift
+++ b/MSAL/src/native_auth/configuration/MSALNativeAuthInternalConfiguration.swift
@@ -28,7 +28,7 @@ struct MSALNativeAuthInternalConfiguration {
     var challengeTypesString: String {
         return challengeTypes.map { $0.rawValue }.joined(separator: " ")
     }
-    
+
     var capabilitiesString: String? {
         return capabilities?.map { $0.rawValue }.joined(separator: " ")
     }
@@ -73,17 +73,17 @@ struct MSALNativeAuthInternalConfiguration {
         internalChallengeTypes.append(.redirect)
         return internalChallengeTypes
     }
-    
+
     private static func getInternalCapabilities(
         _ capabilities: MSALNativeAuthCapabilities?
     ) -> [MSALNativeAuthInternalCapability]? {
         guard let capabilities else { return nil }
         var internalCapabilities: [MSALNativeAuthInternalCapability] = []
-        
+
         if capabilities.contains(.mfaRequired) {
             internalCapabilities.append(.mfaRequired)
         }
-        
+
         if capabilities.contains(.registrationRequired) {
             internalCapabilities.append(.registrationRequired)
         }

--- a/MSAL/src/native_auth/configuration/MSALNativeAuthInternalConfiguration.swift
+++ b/MSAL/src/native_auth/configuration/MSALNativeAuthInternalConfiguration.swift
@@ -24,7 +24,7 @@
 
 @_implementationOnly import MSAL_Private
 
-struct MSALNativeAuthConfiguration {
+struct MSALNativeAuthInternalConfiguration {
     var challengeTypesString: String {
         return challengeTypes.map { $0.rawValue }.joined(separator: " ")
     }
@@ -38,7 +38,7 @@ struct MSALNativeAuthConfiguration {
     init(
         clientId: String,
         authority: MSALCIAMAuthority,
-        challengeTypes: [MSALNativeAuthInternalChallengeType],
+        challengeTypes: MSALNativeAuthChallengeTypes,
         redirectUri: String?) throws {
         self.clientId = clientId
         self.authority = try MSIDCIAMAuthority(
@@ -46,7 +46,24 @@ struct MSALNativeAuthConfiguration {
             validateFormat: false,
             context: MSALNativeAuthRequestContext()
         )
-        self.challengeTypes = challengeTypes
+        self.challengeTypes = MSALNativeAuthInternalConfiguration.getInternalChallengeTypes(challengeTypes)
         self.redirectUri = redirectUri
+    }
+
+    private static func getInternalChallengeTypes(
+        _ challengeTypes: MSALNativeAuthChallengeTypes
+    ) -> [MSALNativeAuthInternalChallengeType] {
+        var internalChallengeTypes = [MSALNativeAuthInternalChallengeType]()
+
+        if challengeTypes.contains(.OOB) {
+            internalChallengeTypes.append(.oob)
+        }
+
+        if challengeTypes.contains(.password) {
+            internalChallengeTypes.append(.password)
+        }
+
+        internalChallengeTypes.append(.redirect)
+        return internalChallengeTypes
     }
 }

--- a/MSAL/src/native_auth/configuration/MSALNativeAuthInternalConfiguration.swift
+++ b/MSAL/src/native_auth/configuration/MSALNativeAuthInternalConfiguration.swift
@@ -28,6 +28,10 @@ struct MSALNativeAuthInternalConfiguration {
     var challengeTypesString: String {
         return challengeTypes.map { $0.rawValue }.joined(separator: " ")
     }
+    
+    var capabilitiesString: String? {
+        return capabilities?.map { $0.rawValue }.joined(separator: " ")
+    }
 
     let clientId: String
     let authority: MSIDCIAMAuthority

--- a/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
+++ b/MSAL/src/native_auth/controllers/credentials/MSALNativeAuthCredentialsController.swift
@@ -50,7 +50,7 @@ final class MSALNativeAuthCredentialsController: MSALNativeAuthTokenController, 
         )
     }
 
-    convenience init(config: MSALNativeAuthConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
+    convenience init(config: MSALNativeAuthInternalConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
         let factory = MSALNativeAuthResultFactory(config: config, cacheAccessor: cacheAccessor)
         self.init(
             clientId: config.clientId,

--- a/MSAL/src/native_auth/controllers/factories/MSALNativeAuthControllerFactory.swift
+++ b/MSAL/src/native_auth/controllers/factories/MSALNativeAuthControllerFactory.swift
@@ -31,9 +31,9 @@ protocol MSALNativeAuthControllerBuildable {
 }
 
 final class MSALNativeAuthControllerFactory: MSALNativeAuthControllerBuildable {
-    private let config: MSALNativeAuthConfiguration
+    private let config: MSALNativeAuthInternalConfiguration
 
-    init(config: MSALNativeAuthConfiguration) {
+    init(config: MSALNativeAuthInternalConfiguration) {
         self.config = config
     }
 

--- a/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
+++ b/MSAL/src/native_auth/controllers/factories/MSALNativeAuthResultFactory.swift
@@ -26,7 +26,7 @@
 
 protocol MSALNativeAuthResultBuildable {
 
-    var config: MSALNativeAuthConfiguration {get}
+    var config: MSALNativeAuthInternalConfiguration {get}
 
     func makeAccount(tokenResult: MSIDTokenResult, context: MSIDRequestContext) -> MSALAccount
 
@@ -39,10 +39,10 @@ protocol MSALNativeAuthResultBuildable {
 
 final class MSALNativeAuthResultFactory: MSALNativeAuthResultBuildable {
 
-    let config: MSALNativeAuthConfiguration
+    let config: MSALNativeAuthInternalConfiguration
     let cacheAccessor: MSALNativeAuthCacheInterface
 
-    init(config: MSALNativeAuthConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
+    init(config: MSALNativeAuthInternalConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
         self.config = config
         self.cacheAccessor = cacheAccessor
     }

--- a/MSAL/src/native_auth/controllers/jit/MSALNativeAuthJITController.swift
+++ b/MSAL/src/native_auth/controllers/jit/MSALNativeAuthJITController.swift
@@ -47,7 +47,7 @@ final class MSALNativeAuthJITController: MSALNativeAuthBaseController, MSALNativ
         super.init(clientId: clientId)
     }
 
-    convenience init(config: MSALNativeAuthConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
+    convenience init(config: MSALNativeAuthInternalConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
         self.init(
             clientId: config.clientId,
             jitRequestProvider: MSALNativeAuthJITRequestProvider(

--- a/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
+++ b/MSAL/src/native_auth/controllers/reset_password/MSALNativeAuthResetPasswordController.swift
@@ -34,7 +34,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
     private let signInController: MSALNativeAuthSignInControlling
 
     init(
-        config: MSALNativeAuthConfiguration,
+        config: MSALNativeAuthInternalConfiguration,
         requestProvider: MSALNativeAuthResetPasswordRequestProviding,
         responseValidator: MSALNativeAuthResetPasswordResponseValidating,
         signInController: MSALNativeAuthSignInControlling
@@ -46,7 +46,7 @@ final class MSALNativeAuthResetPasswordController: MSALNativeAuthBaseController,
         super.init(clientId: config.clientId)
     }
 
-    convenience init(config: MSALNativeAuthConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
+    convenience init(config: MSALNativeAuthInternalConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
         self.init(
             config: config,
             requestProvider: MSALNativeAuthResetPasswordRequestProvider(

--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -39,7 +39,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
 
     private let signInRequestProvider: MSALNativeAuthSignInRequestProviding
     private let signInResponseValidator: MSALNativeAuthSignInResponseValidating
-    private let nativeAuthConfig: MSALNativeAuthConfiguration
+    private let nativeAuthConfig: MSALNativeAuthInternalConfiguration
     // MARK: - Init
 
     init(
@@ -50,7 +50,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         factory: MSALNativeAuthResultBuildable,
         signInResponseValidator: MSALNativeAuthSignInResponseValidating,
         tokenResponseValidator: MSALNativeAuthTokenResponseValidating,
-        nativeAuthConfig: MSALNativeAuthConfiguration
+        nativeAuthConfig: MSALNativeAuthInternalConfiguration
     ) {
         self.signInRequestProvider = signInRequestProvider
         self.signInResponseValidator = signInResponseValidator
@@ -64,7 +64,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         )
     }
 
-    convenience init(config: MSALNativeAuthConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
+    convenience init(config: MSALNativeAuthInternalConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
         let factory = MSALNativeAuthResultFactory(config: config, cacheAccessor: cacheAccessor)
         self.init(
             clientId: config.clientId,

--- a/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
+++ b/MSAL/src/native_auth/controllers/sign_up/MSALNativeAuthSignUpController.swift
@@ -37,7 +37,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
     // MARK: - Init
 
     init(
-        config: MSALNativeAuthConfiguration,
+        config: MSALNativeAuthInternalConfiguration,
         requestProvider: MSALNativeAuthSignUpRequestProviding,
         responseValidator: MSALNativeAuthSignUpResponseValidating,
         signInController: MSALNativeAuthSignInControlling
@@ -48,7 +48,7 @@ final class MSALNativeAuthSignUpController: MSALNativeAuthBaseController, MSALNa
         super.init(clientId: config.clientId)
     }
 
-    convenience init(config: MSALNativeAuthConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
+    convenience init(config: MSALNativeAuthInternalConfiguration, cacheAccessor: MSALNativeAuthCacheInterface) {
         self.init(
             config: config,
             requestProvider: MSALNativeAuthSignUpRequestProvider(

--- a/MSAL/src/native_auth/network/MSALNativeAuthInternalCapability.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthInternalCapability.swift
@@ -1,0 +1,28 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+enum MSALNativeAuthInternalCapability: String, Decodable {
+    case mfaRequired = "mfa_required"
+    case registrationRequired = "registration_required"
+}

--- a/MSAL/src/native_auth/network/MSALNativeAuthInternalChallengeType.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthInternalChallengeType.swift
@@ -25,6 +25,5 @@
 enum MSALNativeAuthInternalChallengeType: String, Decodable {
     case oob
     case password
-    case otp
     case redirect
 }

--- a/MSAL/src/native_auth/network/MSALNativeAuthRequestConfigurator.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthRequestConfigurator.swift
@@ -66,9 +66,9 @@ enum MSALNativeAuthRequestConfiguratorType {
 }
 
 class MSALNativeAuthRequestConfigurator: MSIDAADRequestConfigurator {
-    let config: MSALNativeAuthConfiguration
+    let config: MSALNativeAuthInternalConfiguration
 
-    init(config: MSALNativeAuthConfiguration) {
+    init(config: MSALNativeAuthInternalConfiguration) {
         self.config = config
     }
 

--- a/MSAL/src/native_auth/network/MSALNativeAuthRequestParametersKey.swift
+++ b/MSAL/src/native_auth/network/MSALNativeAuthRequestParametersKey.swift
@@ -27,6 +27,7 @@ import Foundation
 enum MSALNativeAuthRequestParametersKey: String {
     case clientId = "client_id"
     case challengeType = "challenge_type"
+    case capabilities
     case challengeTarget = "challenge_target"
     case challengeChannel = "challenge_channel"
     case grantType = "grant_type"

--- a/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestable.swift
+++ b/MSAL/src/native_auth/network/parameters/MSALNativeAuthRequestable.swift
@@ -28,13 +28,13 @@ protocol MSALNativeAuthRequestable {
     var endpoint: MSALNativeAuthEndpoint { get }
     var context: MSALNativeAuthRequestContext { get }
 
-    func makeEndpointUrl(config: MSALNativeAuthConfiguration) throws -> URL
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String]
+    func makeEndpointUrl(config: MSALNativeAuthInternalConfiguration) throws -> URL
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String]
 }
 
 extension MSALNativeAuthRequestable {
 
-    func makeEndpointUrl(config: MSALNativeAuthConfiguration) throws -> URL {
+    func makeEndpointUrl(config: MSALNativeAuthInternalConfiguration) throws -> URL {
         var components = URLComponents(url: config.authority.url, resolvingAgainstBaseURL: true)
         components?.path += endpoint.rawValue
 

--- a/MSAL/src/native_auth/network/parameters/jit/MSALNativeAuthJITChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/jit/MSALNativeAuthJITChallengeRequestParameters.swift
@@ -31,7 +31,7 @@ struct MSALNativeAuthJITChallengeRequestParameters: MSALNativeAuthRequestable {
     let authMethod: MSALAuthMethod
     let verificationContact: String
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/jit/MSALNativeAuthJITContinueRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/jit/MSALNativeAuthJITContinueRequestParameters.swift
@@ -31,7 +31,7 @@ struct MSALNativeAuthJITContinueRequestParameters: MSALNativeAuthRequestable {
     let continuationToken: String
     let oobCode: String?
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/jit/MSALNativeAuthJITIntrospectRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/jit/MSALNativeAuthJITIntrospectRequestParameters.swift
@@ -29,7 +29,7 @@ struct MSALNativeAuthJITIntrospectRequestParameters: MSALNativeAuthRequestable {
     let context: MSALNativeAuthRequestContext
     let continuationToken: String
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParameters.swift
@@ -29,7 +29,7 @@ struct MSALNativeAuthResetPasswordChallengeRequestParameters: MSALNativeAuthRequ
     let context: MSALNativeAuthRequestContext
     let continuationToken: String
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParameters.swift
@@ -31,7 +31,7 @@ struct MSALNativeAuthResetPasswordContinueRequestParameters: MSALNativeAuthReque
     let grantType: MSALNativeAuthGrantType
     let oobCode: String?
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParameters.swift
@@ -29,7 +29,7 @@ struct MSALNativeAuthResetPasswordPollCompletionRequestParameters: MSALNativeAut
     let context: MSALNativeAuthRequestContext
     let continuationToken: String
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParameters.swift
@@ -29,7 +29,7 @@ struct MSALNativeAuthResetPasswordStartRequestParameters: MSALNativeAuthRequesta
     let context: MSALNativeAuthRequestContext
     let username: String
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParameters.swift
@@ -35,8 +35,8 @@ struct MSALNativeAuthResetPasswordStartRequestParameters: MSALNativeAuthRequesta
         return [
             Key.clientId.rawValue: config.clientId,
             Key.username.rawValue: username,
-            Key.challengeType.rawValue: config.challengeTypesString
-        ]
-
+            Key.challengeType.rawValue: config.challengeTypesString,
+            Key.capabilities.rawValue: config.capabilitiesString
+        ].compactMapValues { $0 }
     }
 }

--- a/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParameters.swift
@@ -30,7 +30,7 @@ struct MSALNativeAuthResetPasswordSubmitRequestParameters: MSALNativeAuthRequest
     let continuationToken: String
     let newPassword: String
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParameters.swift
@@ -30,7 +30,7 @@ struct MSALNativeAuthSignInChallengeRequestParameters: MSALNativeAuthRequestable
     let mfaAuthMethodId: String?
     let continuationToken: String
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParameters.swift
@@ -35,7 +35,8 @@ struct MSALNativeAuthSignInInitiateRequestParameters: MSALNativeAuthRequestable 
         return [
             Key.clientId.rawValue: config.clientId,
             Key.username.rawValue: username,
-            Key.challengeType.rawValue: config.challengeTypesString
-        ]
+            Key.challengeType.rawValue: config.challengeTypesString,
+            Key.capabilities.rawValue: config.capabilitiesString
+        ].compactMapValues { $0 }
     }
 }

--- a/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParameters.swift
@@ -29,7 +29,7 @@ struct MSALNativeAuthSignInInitiateRequestParameters: MSALNativeAuthRequestable 
     let context: MSALNativeAuthRequestContext
     let username: String
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInIntrospectRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_in/MSALNativeAuthSignInIntrospectRequestParameters.swift
@@ -29,7 +29,7 @@ struct MSALNativeAuthSignInIntrospectRequestParameters: MSALNativeAuthRequestabl
     let context: MSALNativeAuthRequestContext
     let continuationToken: String
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParameters.swift
@@ -29,7 +29,7 @@ struct MSALNativeAuthSignUpChallengeRequestParameters: MSALNativeAuthRequestable
     let continuationToken: String
     let context: MSALNativeAuthRequestContext
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParameters.swift
@@ -33,7 +33,7 @@ struct MSALNativeAuthSignUpContinueRequestParameters: MSALNativeAuthRequestable 
     let attributes: String?
     let context: MSALNativeAuthRequestContext
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParameters.swift
@@ -39,7 +39,8 @@ struct MSALNativeAuthSignUpStartRequestParameters: MSALNativeAuthRequestable {
             Key.username.rawValue: username,
             Key.password.rawValue: password,
             Key.attributes.rawValue: attributes,
-            Key.challengeType.rawValue: config.challengeTypesString
+            Key.challengeType.rawValue: config.challengeTypesString,
+            Key.capabilities.rawValue: config.capabilitiesString
         ].compactMapValues { $0 }
     }
 }

--- a/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParameters.swift
@@ -31,7 +31,7 @@ struct MSALNativeAuthSignUpStartRequestParameters: MSALNativeAuthRequestable {
     let attributes: String?
     let context: MSALNativeAuthRequestContext
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
 
         return [

--- a/MSAL/src/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParameters.swift
+++ b/MSAL/src/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParameters.swift
@@ -38,7 +38,7 @@ struct MSALNativeAuthTokenRequestParameters: MSALNativeAuthRequestable {
     let refreshToken: String?
     let claimsRequestJson: String?
 
-    func makeRequestBody(config: MSALNativeAuthConfiguration) -> [String: String] {
+    func makeRequestBody(config: MSALNativeAuthInternalConfiguration) -> [String: String] {
         typealias Key = MSALNativeAuthRequestParametersKey
         var parameters = [
             Key.clientId.rawValue: config.clientId,

--- a/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/reset_password/MSALNativeAuthResetPasswordResponseValidator.swift
@@ -131,8 +131,7 @@ final class MSALNativeAuthResetPasswordResponseValidator: MSALNativeAuthResetPas
                 MSALNativeAuthLogger.log(level: .error, context: context, format: "Missing expected fields from backend")
                 return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
             }
-        case .password,
-             .otp:
+        case .password:
             let errorDescription = MSALNativeAuthErrorMessage.unexpectedChallengeType
             MSALNativeAuthLogger.log(level: .error, context: context, format: errorDescription)
             return .unexpectedError(.init(errorDescription: errorDescription))

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -134,12 +134,6 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
         _ context: MSIDRequestContext,
         response: MSALNativeAuthSignInChallengeResponse) -> MSALNativeAuthSignInChallengeValidatedResponse {
         switch response.challengeType {
-        case .otp:
-            MSALNativeAuthLogger.log(
-                level: .error,
-                context: context,
-                format: "signin/challenge: Received unexpected challenge type: \(response.challengeType)")
-            return .error(.unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedChallengeType)))
         case .oob:
             guard let continuationToken = response.continuationToken,
                     let targetLabel = response.challengeTargetLabel,

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -149,9 +149,6 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
                                          format: "Missing expected fields in signup/challenge with challenge_type = password")
                 return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
             }
-        case .otp:
-            MSALNativeAuthLogger.log(level: .error, context: context, format: "ChallengeType OTP not expected for signup/challenge")
-            return .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedResponseBody))
         }
     }
 

--- a/MSAL/src/native_auth/public/MSALNativeAuthCapabilities.h
+++ b/MSAL/src/native_auth/public/MSALNativeAuthCapabilities.h
@@ -22,23 +22,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef MSALNativeAuthChallengeTypes_h
-#define MSALNativeAuthChallengeTypes_h
+#ifndef MSALNativeAuthCapabilities_h
+#define MSALNativeAuthCapabilities_h
 
 #import <Foundation/Foundation.h>
 
-/// The set of challenge types that an application wishes to support for Native Auth operations.
+/// The set of capabilities that an application wishes to support for Native Auth operations.
 ///
 /// Valid options are:
-/// * OOB: The application can support asking a user to supply a verification code that is sent by email.
-/// * Password: The application can support asking a user to supply a password
+/// * MFARequired: The application can accommodate the challenge type specified by the user when MFA is required.
+/// * RegistrationRequired: The application can accommodate the challenge type specified by the user
+/// when registering a new strong authentication method.
 
-typedef NS_OPTIONS(NSInteger, MSALNativeAuthChallengeTypes) {
-    /// Specifies if the Challenge Type is OOB
-    MSALNativeAuthChallengeTypeOOB          = 1 << 0,
+typedef NS_OPTIONS(NSInteger, MSALNativeAuthCapabilities) {
+    /// Specifies that the challenge type are supported when MFA is required
+    MSALNativeAuthCapabilityMFARequired          = 1 << 0,
     
-    /// Specifies if the Challenge Type is Password
-    MSALNativeAuthChallengeTypePassword     = 1 << 1
+    /// Specifies that the challenge type are supported when the registration of a new strong authentication method is required
+    MSALNativeAuthCapabilityRegistrationRequired     = 1 << 1
 };
 
-#endif /* MSALNativeAuthChallengeTypes_h */
+#endif /* MSALNativeAuthCapabilities_h */

--- a/MSAL/src/native_auth/public/MSALNativeAuthCapabilities.h
+++ b/MSAL/src/native_auth/public/MSALNativeAuthCapabilities.h
@@ -32,8 +32,7 @@
 /// Valid options are:
 /// * MFARequired: The application can accommodate the challenge type specified by the user when MFA is required.
 /// * RegistrationRequired: The application can accommodate the challenge type specified by the user
-/// when registering a new strong authentication method.
-
+/// when registering a new strong authentication method is required.
 typedef NS_OPTIONS(NSInteger, MSALNativeAuthCapabilities) {
     /// Specifies that the challenge type are supported when MFA is required
     MSALNativeAuthCapabilityMFARequired          = 1 << 0,

--- a/MSAL/src/native_auth/public/MSALNativeAuthCapabilities.h
+++ b/MSAL/src/native_auth/public/MSALNativeAuthCapabilities.h
@@ -30,14 +30,14 @@
 /// The set of capabilities that an application wishes to support for Native Auth operations.
 ///
 /// Valid options are:
-/// * MFARequired: The application can accommodate the challenge type specified by the user when MFA is required.
-/// * RegistrationRequired: The application can accommodate the challenge type specified by the user
+/// * MFARequired: The application can accommodate the associated challenge type(s) specified by the user when MFA is required.
+/// * RegistrationRequired: The application can accommodate the associated challenge type(s) specified by the user
 /// when registering a new strong authentication method is required.
 typedef NS_OPTIONS(NSInteger, MSALNativeAuthCapabilities) {
-    /// Specifies that the challenge type are supported when MFA is required
+    /// Specifies that the associated challenge type(s) are supported when MFA is required
     MSALNativeAuthCapabilityMFARequired          = 1 << 0,
     
-    /// Specifies that the challenge type are supported when the registration of a new strong authentication method is required
+    /// Specifies that the associated challenge type(s) are supported when the registration of a new strong authentication method is required
     MSALNativeAuthCapabilityRegistrationRequired     = 1 << 1
 };
 

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -104,21 +104,4 @@ extension MSALNativeAuthPublicClientApplication {
             )
         )
     }
-
-    static func getInternalChallengeTypes(
-        _ challengeTypes: MSALNativeAuthChallengeTypes
-    ) -> [MSALNativeAuthInternalChallengeType] {
-        var internalChallengeTypes = [MSALNativeAuthInternalChallengeType]()
-
-        if challengeTypes.contains(.OOB) {
-            internalChallengeTypes.append(.oob)
-        }
-
-        if challengeTypes.contains(.password) {
-            internalChallengeTypes.append(.password)
-        }
-
-        internalChallengeTypes.append(.redirect)
-        return internalChallengeTypes
-    }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -121,21 +121,4 @@ extension MSALNativeAuthPublicClientApplication {
         internalChallengeTypes.append(.redirect)
         return internalChallengeTypes
     }
-
-    static func convertChallengeTypes(
-        _ internalChallengeTypes: [MSALNativeAuthInternalChallengeType]
-    ) -> MSALNativeAuthChallengeTypes {
-        var challenges: MSALNativeAuthChallengeTypes = []
-        for challenge in internalChallengeTypes {
-            switch challenge {
-            case .oob:
-                challenges.insert(.OOB)
-            case .password:
-                challenges.insert(.password)
-            default:
-                break
-            }
-        }
-        return challenges
-    }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -39,7 +39,7 @@ import Foundation
 ///             challengeTypes: [.OOB]
 ///          )
 ///         nativeAuth = try MSALNativeAuthPublicClientApplication(nativeAuthConfiguration: config)
-///        print("Initialised Native Auth successfully.")
+///         print("Initialised Native Auth successfully.")
 ///     } catch {
 ///         print("Unable to initialize MSAL \(error)")
 ///     }

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -30,14 +30,15 @@ import Foundation
 /// to the initialiser method.
 ///
 /// For example:
-// TODO: change this comment
+
 /// <pre>
 ///     do {
-///         nativeAuth = try MSALNativeAuthPublicClientApplication(
+///         let config = try MSALNativeAuthPublicClientApplicationConfig(
 ///             clientId: "Enter_the_Application_Id_Here",
 ///             tenantSubdomain: "Enter_the_Tenant_Subdomain_Here",
 ///             challengeTypes: [.OOB]
-///        )
+///          )
+///         nativeAuth = try MSALNativeAuthPublicClientApplication(nativeAuthConfiguration: config)
 ///        print("Initialised Native Auth successfully.")
 ///     } catch {
 ///         print("Unable to initialize MSAL \(error)")

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -68,6 +68,7 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
             clientId: nativeAuthConfiguration.clientId,
             authority: ciamAuthority,
             challengeTypes: nativeAuthConfiguration.challengeTypes,
+            capabilities: nativeAuthConfiguration.capabilities,
             redirectUri: nativeAuthConfiguration.redirectUri
         )
         internalConfig.sliceConfig = nativeAuthConfiguration.sliceConfig
@@ -97,7 +98,11 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         guard let ciamAuthority = config.authority as? MSALCIAMAuthority else {
             throw MSALNativeAuthInternalError.invalidAuthority
         }
-        let nativeAuthConfig = MSALNativeAuthPublicClientApplicationConfig(clientId: config.clientId, authority: ciamAuthority, challengeTypes: challengeTypes)
+        let nativeAuthConfig = MSALNativeAuthPublicClientApplicationConfig(
+            clientId: config.clientId,
+            authority: ciamAuthority,
+            challengeTypes: challengeTypes
+        )
         nativeAuthConfig.redirectUri = config.redirectUri
         nativeAuthConfig.sliceConfig = config.sliceConfig
         nativeAuthConfig.bypassRedirectURIValidation = config.bypassRedirectURIValidation

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -122,7 +122,11 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         tenantSubdomain: String,
         challengeTypes: MSALNativeAuthChallengeTypes,
         redirectUri: String? = nil) throws {
-            let nativeAuthConfig = try MSALNativeAuthPublicClientApplicationConfig(clientId: clientId, tenantSubdomain: tenantSubdomain, challengeTypes: challengeTypes)
+            let nativeAuthConfig = try MSALNativeAuthPublicClientApplicationConfig(
+                clientId: clientId,
+                tenantSubdomain: tenantSubdomain,
+                challengeTypes: challengeTypes
+            )
             nativeAuthConfig.redirectUri = redirectUri
             try self.init(nativeAuthConfiguration: nativeAuthConfig)
     }

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -55,12 +55,42 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
     lazy var cacheAccessor: MSALNativeAuthCacheAccessor = {
         return cacheAccessorFactory.makeCacheAccessor(tokenCache: tokenCache, accountMetadataCache: accountMetadataCache)
     }()
+    
+    /// Initialize a MSALNativePublicClientApplication with a given configuration
+    /// - Parameters:
+    ///   - nativeAuthConfiguration: Configuration for native auth PublicClientApplication
+    ///   - Throws: An error that occurred creating the application object
+    public init(nativeAuthConfiguration config: MSALNativeAuthPublicClientApplicationConfig) throws {
+        // TODO: cast config.authority to MSALCIAMAuthority
+        self.internalChallengeTypes =
+        MSALNativeAuthPublicClientApplication.getInternalChallengeTypes(config.challengeTypes)
+
+        var nativeConfiguration = try MSALNativeAuthConfiguration(
+            clientId: config.clientId,
+            authority: config.authority as! MSALCIAMAuthority,
+            challengeTypes: internalChallengeTypes,
+            redirectUri: config.redirectUri
+        )
+        nativeConfiguration.sliceConfig = config.sliceConfig
+
+        // TODO: refactor this, use MSALNativeAuthPublicClientApplicationConfig instead
+        self.controllerFactory = MSALNativeAuthControllerFactory(config: nativeConfiguration)
+        self.cacheAccessorFactory = MSALNativeAuthCacheAccessorFactory()
+        self.inputValidator = MSALNativeAuthInputValidator()
+//
+        if config.redirectUri == nil {
+            MSALNativeAuthLogger.log(level: .warning, context: nil, format: MSALNativeAuthErrorMessage.redirectUriNotSetWarning)
+        }
+
+        try super.init(configuration: config)
+    }
 
     /// Initialize a MSALNativePublicClientApplication with a given configuration and challenge types
     /// - Parameters:
     ///   - config: Configuration for PublicClientApplication
-    ///   - challengeTypes: The set of capabilities that this application can support as an ``MSALNativeAuthChallengeTypes`` optionset
+    ///   - challengeTypes: The set of challenge types that this application can support as an ``MSALNativeAuthChallengeTypes`` optionset
     /// - Throws: An error that occurred creating the application object
+    @available(*, deprecated, message: "Use init(nativeAuthConfiguration: ) instead.")
     public init(
         configuration config: MSALPublicClientApplicationConfig,
         challengeTypes: MSALNativeAuthChallengeTypes) throws {
@@ -94,9 +124,10 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
     /// - Parameters:
     ///   - clientId: The client ID of the application, this should come from the app developer portal.
     ///   - tenantSubdomain: The subdomain of the tenant, this should come from the app developer portal.
-    ///   - challengeTypes: The set of capabilities that this application can support as an ``MSALNativeAuthChallengeTypes`` optionset
-    ///   - redirectUri: Optional. The redirect URI for the application, this should come from the app developer portal. 
+    ///   - challengeTypes: The set of challenge types that this application can support as an ``MSALNativeAuthChallengeTypes`` optionset
+    ///   - redirectUri: Optional. The redirect URI for the application, this should come from the app developer portal.
     /// - Throws: An error that occurred creating the application object
+    @available(*, deprecated, message: "Use init(nativeAuthConfiguration: ) instead.")
     public init(
         clientId: String,
         tenantSubdomain: String,

--- a/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
+++ b/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
@@ -16,29 +16,28 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// THE SOFTWARE.  
+import Foundation
 
-#ifndef MSALNativeAuthChallengeTypes_h
-#define MSALNativeAuthChallengeTypes_h
+@objcMembers
+public final class MSALNativeAuthPublicClientApplicationConfig: MSALPublicClientApplicationConfig {
 
-#import <Foundation/Foundation.h>
+    private let challengeTypes: MSALNativeAuthChallengeTypes
+    // add comemnts
+    public var capabilities: MSALNativeAuthCapabilities?
 
-/// The set of challenge types that an application wishes to support for Native Auth operations.
-///
-/// Valid options are:
-/// * OOB: The application can support asking a user to supply a verification code that is sent by email.
-/// * Password: The application can support asking a user to supply a password
+    public init(clientId: String, authority: MSALCIAMAuthority, challengeTypes: MSALNativeAuthChallengeTypes) {
+        self.challengeTypes = challengeTypes
+        super.init(clientId: clientId, redirectUri: nil, authority: authority)
+    }
 
-typedef NS_OPTIONS(NSInteger, MSALNativeAuthChallengeTypes) {
-    /// Specifies if the Challenge Type is OOB
-    MSALNativeAuthChallengeTypeOOB          = 1 << 0,
-    
-    /// Specifies if the Challenge Type is Password
-    MSALNativeAuthChallengeTypePassword     = 1 << 1
-};
-
-#endif /* MSALNativeAuthChallengeTypes_h */
+    public init(clientId: String, tenantSubdomain: String, challengeTypes: MSALNativeAuthChallengeTypes) throws {
+        self.challengeTypes = challengeTypes
+        let ciamAuthority = try MSALNativeAuthAuthorityProvider().authority(rawTenant: tenantSubdomain)
+        super.init(clientId: clientId, redirectUri: nil, authority: ciamAuthority)
+    }
+}

--- a/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
+++ b/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
@@ -38,7 +38,8 @@ public final class MSALNativeAuthPublicClientApplicationConfig: MSALPublicClient
     ///   - challengeTypes: The set of challenge types that this application can support as an ``MSALNativeAuthChallengeTypes`` optionset
     public init(clientId: String, authority: MSALCIAMAuthority, challengeTypes: MSALNativeAuthChallengeTypes) {
         self.challengeTypes = challengeTypes
-        super.init(clientId: clientId, redirectUri: nil, authority: authority)
+        // calling the init without nestedAuthBrokerClientId and nestedAuthBrokerRedirectUri result in an error
+        super.init(clientId: clientId, redirectUri: nil, authority: authority, nestedAuthBrokerClientId: nil, nestedAuthBrokerRedirectUri: nil)
     }
 
     /// Initialize a MSALNativeAuthPublicClientApplicationConfig.
@@ -50,6 +51,7 @@ public final class MSALNativeAuthPublicClientApplicationConfig: MSALPublicClient
     public init(clientId: String, tenantSubdomain: String, challengeTypes: MSALNativeAuthChallengeTypes) throws {
         self.challengeTypes = challengeTypes
         let ciamAuthority = try MSALNativeAuthAuthorityProvider().authority(rawTenant: tenantSubdomain)
-        super.init(clientId: clientId, redirectUri: nil, authority: ciamAuthority)
+        // calling the init without nestedAuthBrokerClientId and nestedAuthBrokerRedirectUri result in an error
+        super.init(clientId: clientId, redirectUri: nil, authority: ciamAuthority, nestedAuthBrokerClientId: nil, nestedAuthBrokerRedirectUri: nil)
     }
 }

--- a/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
+++ b/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
@@ -26,15 +26,27 @@ import Foundation
 @objcMembers
 public final class MSALNativeAuthPublicClientApplicationConfig: MSALPublicClientApplicationConfig {
 
-    private let challengeTypes: MSALNativeAuthChallengeTypes
-    // add comemnts
+    let challengeTypes: MSALNativeAuthChallengeTypes
+    
+    /** The set of capabilities that this application can support as an ``MSALNativeAuthCapabilities`` optionset */
     public var capabilities: MSALNativeAuthCapabilities?
 
+    /// Initialize a MSALNativeAuthPublicClientApplicationConfig.
+    /// - Parameters:
+    ///   - clientId: The client ID of the application, this should come from the app developer portal.
+    ///   - authority: The target CIAM authority.
+    ///   - challengeTypes: The set of challenge types that this application can support as an ``MSALNativeAuthChallengeTypes`` optionset
     public init(clientId: String, authority: MSALCIAMAuthority, challengeTypes: MSALNativeAuthChallengeTypes) {
         self.challengeTypes = challengeTypes
         super.init(clientId: clientId, redirectUri: nil, authority: authority)
     }
 
+    /// Initialize a MSALNativeAuthPublicClientApplicationConfig.
+    /// - Parameters:
+    ///   - clientId: The client ID of the application, this should come from the app developer portal.
+    ///   - tenantSubdomain: The subdomain of the tenant, this should come from the app developer portal.
+    ///   - challengeTypes: The set of challenge types that this application can support as an ``MSALNativeAuthChallengeTypes`` optionset
+    /// - Throws: An error that occurred creating the application object
     public init(clientId: String, tenantSubdomain: String, challengeTypes: MSALNativeAuthChallengeTypes) throws {
         self.challengeTypes = challengeTypes
         let ciamAuthority = try MSALNativeAuthAuthorityProvider().authority(rawTenant: tenantSubdomain)

--- a/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
+++ b/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
@@ -54,4 +54,39 @@ public final class MSALNativeAuthPublicClientApplicationConfig: MSALPublicClient
         // calling the init without nestedAuthBrokerClientId and nestedAuthBrokerRedirectUri result in an error
         super.init(clientId: clientId, redirectUri: nil, authority: ciamAuthority, nestedAuthBrokerClientId: nil, nestedAuthBrokerRedirectUri: nil)
     }
+
+    static internal func convertChallengeTypes(
+        _ internalChallengeTypes: [MSALNativeAuthInternalChallengeType]
+    ) -> MSALNativeAuthChallengeTypes {
+        var challenges: MSALNativeAuthChallengeTypes = []
+        for challenge in internalChallengeTypes {
+            switch challenge {
+            case .oob:
+                challenges.insert(.OOB)
+            case .password:
+                challenges.insert(.password)
+            default:
+                break
+            }
+        }
+        return challenges
+    }
+
+    static internal func convertCapabilities(
+        _ internalCapabilities: [MSALNativeAuthInternalCapability]?
+    ) -> MSALNativeAuthCapabilities? {
+        guard let internalCapabilities else {
+            return nil
+        }
+        var capabilities: MSALNativeAuthCapabilities = []
+        for capability in internalCapabilities {
+            switch capability {
+            case .mfaRequired:
+                capabilities.insert(.mfaRequired)
+            case .registrationRequired:
+                capabilities.insert(.registrationRequired)
+            }
+        }
+        return capabilities
+    }
 }

--- a/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
+++ b/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
@@ -27,7 +27,7 @@ import Foundation
 public final class MSALNativeAuthPublicClientApplicationConfig: MSALPublicClientApplicationConfig {
 
     let challengeTypes: MSALNativeAuthChallengeTypes
-    
+
     /** The set of capabilities that this application can support as an ``MSALNativeAuthCapabilities`` optionset */
     public var capabilities: MSALNativeAuthCapabilities?
 

--- a/MSAL/src/native_auth/public/state_machine/result/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/result/MSALNativeAuthUserAccountResult+Internal.swift
@@ -38,6 +38,7 @@ extension MSALNativeAuthUserAccountResult {
         params.correlationId = correlationId
         params.claimsRequest = claimsRequest
 
+        // TODO: move this ugly method inside the native auth config class
         let challengeTypes = MSALNativeAuthPublicClientApplication.convertChallengeTypes(configuration.challengeTypes)
         let authority = try? MSALCIAMAuthority(url: configuration.authority.url)
         let config = MSALPublicClientApplicationConfig(clientId: configuration.clientId,
@@ -45,6 +46,7 @@ extension MSALNativeAuthUserAccountResult {
                                                        authority: authority)
         config.bypassRedirectURIValidation = configuration.redirectUri == nil
 
+        // TODO: refactor here, change signature of this function. Use Native auth configuration
         guard let silentTokenProvider = try? silentTokenProviderFactory.makeSilentTokenProvider(configuration: config, challengeTypes: challengeTypes)
         else {
             MSALNativeAuthLogger.log(

--- a/MSAL/src/native_auth/public/state_machine/result/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/result/MSALNativeAuthUserAccountResult+Internal.swift
@@ -31,29 +31,31 @@ extension MSALNativeAuthUserAccountResult {
                                 claimsRequest: MSALClaimsRequest?,
                                 correlationId: UUID?,
                                 delegate: CredentialsDelegate) {
-
-        let params = MSALSilentTokenParameters(scopes: scopes, account: account)
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        guard let authority = try? MSALCIAMAuthority(url: configuration.authority.url) else {
+            Task { await delegate.onAccessTokenRetrieveError(
+                error: RetrieveAccessTokenError(type: .generalError,
+                                                correlationId: correlationId ?? context.correlationId())) }
+            return
+        }
+        let params = MSALSilentTokenParameters(scopes: scopes, account: account)
         params.forceRefresh = forceRefresh
         params.correlationId = correlationId
         params.claimsRequest = claimsRequest
 
-        // TODO: move this ugly method inside the native auth config class
-        let challengeTypes = MSALNativeAuthPublicClientApplication.convertChallengeTypes(configuration.challengeTypes)
-        let authority = try? MSALCIAMAuthority(url: configuration.authority.url)
-        let config = MSALPublicClientApplicationConfig(clientId: configuration.clientId,
-                                                       redirectUri: configuration.redirectUri,
-                                                       authority: authority)
+        let challengeTypes = MSALNativeAuthPublicClientApplicationConfig.convertChallengeTypes(configuration.challengeTypes)
+        let capabilities = MSALNativeAuthPublicClientApplicationConfig.convertCapabilities(configuration.capabilities)
+        let config = MSALNativeAuthPublicClientApplicationConfig(
+            clientId: configuration.clientId,
+            authority: authority,
+            challengeTypes: challengeTypes
+        )
         config.bypassRedirectURIValidation = configuration.redirectUri == nil
+        config.capabilities = capabilities
 
-        // TODO: refactor here, change signature of this function. Use Native auth configuration
-        guard let silentTokenProvider = try? silentTokenProviderFactory.makeSilentTokenProvider(configuration: config, challengeTypes: challengeTypes)
+        guard let silentTokenProvider = try? silentTokenProviderFactory.makeSilentTokenProvider(configuration: config)
         else {
-            MSALNativeAuthLogger.log(
-                            level: .error,
-                            context: context,
-                            format: "Config or challenge types unexpectedly found nil."
-                        )
+            MSALNativeAuthLogger.log(level: .error, context: context, format: "Config or challenge types unexpectedly found nil.")
             Task { await delegate.onAccessTokenRetrieveError(
                 error: RetrieveAccessTokenError(type: .generalError,
                                                 correlationId: correlationId ?? context.correlationId())) }

--- a/MSAL/src/native_auth/public/state_machine/result/MSALNativeAuthUserAccountResult.swift
+++ b/MSAL/src/native_auth/public/state_machine/result/MSALNativeAuthUserAccountResult.swift
@@ -29,7 +29,7 @@ import Foundation
     /// The account object that holds account information.
     @objc public var account: MSALAccount
 
-    internal let configuration: MSALNativeAuthConfiguration
+    internal let configuration: MSALNativeAuthInternalConfiguration
     internal var rawIdToken: String?
     private let cacheAccessor: MSALNativeAuthCacheInterface
     private let inputValidator: MSALNativeAuthInputValidating
@@ -43,7 +43,7 @@ import Foundation
     init(
         account: MSALAccount,
         rawIdToken: String?,
-        configuration: MSALNativeAuthConfiguration,
+        configuration: MSALNativeAuthInternalConfiguration,
         cacheAccessor: MSALNativeAuthCacheInterface,
         inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
         silentTokenProviderFactory: MSALNativeAuthSilentTokenProviderBuildable = MSALNativeAuthSilentTokenProviderFactory()

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -76,6 +76,7 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALParameters.h>
 #import <MSAL/MSALPublicClientApplication+SingleAccount.h>
 #import <MSAL/MSALNativeAuthChallengeTypes.h>
+#import <MSAL/MSALNativeAuthCapabilities.h>
 #if TARGET_OS_IPHONE
 #import <MSAL/MSALLegacySharedAccountsProvider.h>
 #endif

--- a/MSAL/test/integration/native_auth/common/MSALNativeAuthIntegrationBaseTests.swift
+++ b/MSAL/test/integration/native_auth/common/MSALNativeAuthIntegrationBaseTests.swift
@@ -31,7 +31,7 @@ class MSALNativeAuthIntegrationBaseTests: XCTestCase {
     var defaultTimeout: TimeInterval = 5
     let mockAPIHandler = MockAPIHandler()
     let correlationId = UUID()
-    let config: MSALNativeAuthConfiguration = try! MSALNativeAuthConfiguration(
+    let config: MSALNativeAuthInternalConfiguration = try! MSALNativeAuthInternalConfiguration(
         clientId: UUID().uuidString,
         authority: MSALCIAMAuthority(url:
                                         URL(string: (ProcessInfo.processInfo.environment["authorityURL"] ?? "<mock api url not set>") + "/testTenant")!),

--- a/MSAL/test/integration/native_auth/common/MSALNativeAuthIntegrationBaseTests.swift
+++ b/MSAL/test/integration/native_auth/common/MSALNativeAuthIntegrationBaseTests.swift
@@ -36,7 +36,8 @@ class MSALNativeAuthIntegrationBaseTests: XCTestCase {
         authority: MSALCIAMAuthority(url:
                                         URL(string: (ProcessInfo.processInfo.environment["authorityURL"] ?? "<mock api url not set>") + "/testTenant")!),
                                                                                
-        challengeTypes: [.password, .oob, .redirect],
+        challengeTypes: [.password, .OOB],
+        capabilities: nil,
         redirectUri: nil
     )
     var sut: MSIDHttpRequest!

--- a/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
@@ -73,6 +73,7 @@ class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
     func initialisePublicClientApplication(
         clientIdType: ClientIdType = .password,
         challengeTypes: MSALNativeAuthChallengeTypes = [.OOB, .password],
+        capabilities: MSALNativeAuthCapabilities = [.mfaRequired, .registrationRequired],
         customAuthorityURLFormat: AuthorityURLFormat? = nil
     ) -> MSALNativeAuthPublicClientApplication? {
         let clientIdKey = getClientIdKey(type: clientIdType)
@@ -99,27 +100,22 @@ class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
                 format: customAuthorityURLFormat
             )
             
-            let authority = try? MSALCIAMAuthority(
+            let authority = try! MSALCIAMAuthority(
                 url: URL(string: customSubdomain)!,
                 validateFormat: false
             )
             
-            let configuration = MSALPublicClientApplicationConfig(
-                clientId: clientId,
-                redirectUri: nil,
-                authority: authority
-            )
-
+            let configuration = MSALNativeAuthPublicClientApplicationConfig(clientId: clientId, authority: authority, challengeTypes: challengeTypes)
+            configuration.capabilities = capabilities
+           
             return try? MSALNativeAuthPublicClientApplication(
-                configuration: configuration,
-                challengeTypes: challengeTypes
+                nativeAuthConfiguration: configuration
             )
+        } else if let configuration = try? MSALNativeAuthPublicClientApplicationConfig(clientId: clientId, tenantSubdomain: tenantSubdomain, challengeTypes: challengeTypes) {
+            configuration.capabilities = capabilities
+            return try? MSALNativeAuthPublicClientApplication(nativeAuthConfiguration: configuration)
         } else {
-            return try? MSALNativeAuthPublicClientApplication(
-                clientId: clientId,
-                tenantSubdomain: tenantSubdomain,
-                challengeTypes: challengeTypes
-            )
+            return nil
         }
     }
     

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
@@ -158,7 +158,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         await fulfillment(of: [resendCodeRequiredExp])
             
         // Verify that resend code method was called
-        XCTAssertTrue(resetPasswordResendCodeDelegate.onResetPasswordResendCodeCodeRequiredCalled,
+        XCTAssertTrue(resetPasswordResendCodeDelegate.onResetPasswordResendCodeRequiredCalled,
                           "Resend code method should have been called")
             
         // Now get code2...

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/ResetPasswordDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/ResetPasswordDelegateSpies.swift
@@ -125,7 +125,7 @@ class ResetPasswordResendCodeDelegateSpy: ResetPasswordResendCodeDelegate {
     private let expectation: XCTestExpectation
     private(set) var onResetPasswordResendCodeErrorCalled = false
     private(set) var error: ResendCodeError?
-    private(set) var onResetPasswordResendCodeCodeRequiredCalled = false
+    private(set) var onResetPasswordResendCodeRequiredCalled = false
     private(set) var resetPasswordCodeRequiredState: ResetPasswordCodeRequiredState?
     private(set) var sentTo: String?
     private(set) var channelTargetType: MSALNativeAuthChannelType?
@@ -141,7 +141,7 @@ class ResetPasswordResendCodeDelegateSpy: ResetPasswordResendCodeDelegate {
     }
 
     func onResetPasswordResendCodeRequired(newState: ResetPasswordCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
-        onResetPasswordResendCodeCodeRequiredCalled = true
+        onResetPasswordResendCodeRequiredCalled = true
         resetPasswordCodeRequiredState = newState
         self.sentTo = sentTo
         self.channelTargetType = channelTargetType

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/ResetPasswordDelegateSpies.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/ResetPasswordDelegateSpies.swift
@@ -140,7 +140,7 @@ class ResetPasswordResendCodeDelegateSpy: ResetPasswordResendCodeDelegate {
         self.error = error
     }
 
-    func onResetPasswordResendCodeCodeRequired(newState: ResetPasswordCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
+    func onResetPasswordResendCodeRequired(newState: ResetPasswordCodeRequiredState, sentTo: String, channelTargetType: MSALNativeAuthChannelType, codeLength: Int) {
         onResetPasswordResendCodeCodeRequiredCalled = true
         resetPasswordCodeRequiredState = newState
         self.sentTo = sentTo

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthConfigStubs.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthConfigStubs.swift
@@ -33,7 +33,7 @@ enum ErrorMock: Error {
 
 struct MSALNativeAuthConfigStubs {
 
-    static var configuration: MSALNativeAuthConfiguration {
+    static var configuration: MSALNativeAuthInternalConfiguration {
         try! .init(
             clientId: DEFAULT_TEST_CLIENT_ID,
             authority: try! .init(

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthConfigStubs.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthConfigStubs.swift
@@ -39,7 +39,9 @@ struct MSALNativeAuthConfigStubs {
             authority: try! .init(
                 url: URL(string: DEFAULT_TEST_AUTHORITY)!
             ),
-            challengeTypes: [.redirect], redirectUri: nil
+            challengeTypes: [.password],
+            capabilities: nil,
+            redirectUri: nil
         )
     }
 

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthFactoriesMocks.swift
@@ -28,7 +28,7 @@ import XCTest
 
 class MSALNativeAuthResultFactoryMock: MSALNativeAuthResultBuildable {
     
-    var config: MSAL.MSALNativeAuthConfiguration = MSALNativeAuthConfigStubs.configuration
+    var config: MSAL.MSALNativeAuthInternalConfiguration = MSALNativeAuthConfigStubs.configuration
     
     private(set) var makeMsidConfigurationResult: MSIDConfiguration?
     private(set) var makeAccount: MSALAccount?

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSilentTokenProviderFactoryConfigTester.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSilentTokenProviderFactoryConfigTester.swift
@@ -30,8 +30,7 @@ class MSALNativeAuthSilentTokenProviderFactoryConfigTester: MSALNativeAuthSilent
     var silentTokenProvider = MSALNativeAuthSilentTokenProviderMock()
     var expectedBypassRedirectURIValidation = true
 
-    func makeSilentTokenProvider(configuration: MSALPublicClientApplicationConfig,
-                                 challengeTypes: MSALNativeAuthChallengeTypes) throws -> (any MSAL.MSALNativeAuthSilentTokenProviding)? {
+    func makeSilentTokenProvider(configuration: MSAL.MSALNativeAuthPublicClientApplicationConfig) throws -> (any MSAL.MSALNativeAuthSilentTokenProviding)? {
         XCTAssertEqual(configuration.bypassRedirectURIValidation, expectedBypassRedirectURIValidation)
         return silentTokenProvider
     }

--- a/MSAL/test/unit/native_auth/mock/MSALNativeAuthSilentTokenProviderFactoryMock.swift
+++ b/MSAL/test/unit/native_auth/mock/MSALNativeAuthSilentTokenProviderFactoryMock.swift
@@ -27,8 +27,8 @@ import XCTest
 
 class MSALNativeAuthSilentTokenProviderFactoryMock: MSALNativeAuthSilentTokenProviderBuildable {
     var silentTokenProvider = MSALNativeAuthSilentTokenProviderMock()
-    func makeSilentTokenProvider(configuration: MSALPublicClientApplicationConfig,
-                                 challengeTypes: MSALNativeAuthChallengeTypes) throws -> (any MSAL.MSALNativeAuthSilentTokenProviding)? {
+
+    func makeSilentTokenProvider(configuration: MSAL.MSALNativeAuthPublicClientApplicationConfig) throws -> (any MSAL.MSALNativeAuthSilentTokenProviding)? {
         return silentTokenProvider
     }
 }

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthInternalConfigurationTest.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthInternalConfigurationTest.swift
@@ -1,0 +1,56 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+@_implementationOnly import MSAL_Unit_Test_Private
+
+final class MSALNativeAuthInternalConfigurationTest: XCTestCase {
+    
+    func test_challengeTypeRedirect_isAddedAutomatically() {
+        let sut = try? MSALNativeAuthInternalConfiguration(
+            clientId: DEFAULT_TEST_CLIENT_ID,
+            authority: try! .init(
+                url: URL(string: DEFAULT_TEST_AUTHORITY)!
+            ),
+            challengeTypes: [.password],
+            capabilities: nil,
+            redirectUri: nil)
+        XCTAssertEqual(sut?.challengeTypes, [.password, .redirect])
+        XCTAssertNil(sut?.capabilities)
+    }
+    
+    func test_capabilities_AreAddedCorrectlyToTheConfig() {
+        let sut = try? MSALNativeAuthInternalConfiguration(
+            clientId: DEFAULT_TEST_CLIENT_ID,
+            authority: try! .init(
+                url: URL(string: DEFAULT_TEST_AUTHORITY)!
+            ),
+            challengeTypes: [.password],
+            capabilities: [.mfaRequired, .registrationRequired],
+            redirectUri: nil)
+        XCTAssertEqual(sut?.capabilities, [.mfaRequired, .registrationRequired])
+    }
+}

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
@@ -36,7 +36,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     let context = MSALNativeAuthRequestContext(correlationId: UUID(uuidString: DEFAULT_TEST_UID)!)
 
     func test_signInInititate_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForSignIn(type: .signInInitiate),
             context: context
@@ -53,7 +53,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
             "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
-            "challenge_type": "password",
+            "challenge_type": "password redirect",
         ]
 
         XCTAssertEqual(request.parameters, expectedBodyParams)
@@ -63,7 +63,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_signInChallenge_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.otp], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.OOB], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForSignIn(type: .signInChallenge),
             context: context
@@ -82,7 +82,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
             "client_id": DEFAULT_TEST_CLIENT_ID,
             "continuation_token": "Test Credential Token",
             "id": "1",
-            "challenge_type": "otp"
+            "challenge_type": "oob redirect"
         ]
 
         XCTAssertEqual(request.parameters, expectedBodyParams)
@@ -92,7 +92,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
     
     func test_signInIntrospect_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.otp], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.OOB], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForSignIn(type: .signInIntrospect),
             context: context
@@ -118,7 +118,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_signInToken_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForToken(type: .signInWithPassword),
             context: context
@@ -146,7 +146,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
             "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
             "continuation_token": "Test Continuation Token",
             "grant_type": "password",
-            "challenge_type": "password",
+            "challenge_type": "password redirect",
             "scope": "<scope-1>",
             "password": "password",
             "oob": "oob",
@@ -160,7 +160,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_jitIntrospect_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForRegister(type: .jitIntrospect),
             context: context
@@ -186,7 +186,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_jitChallenge_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForRegister(type: .jitChallenge),
             context: context
@@ -220,7 +220,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_jitContinue_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForRegister(type: .jitContinue),
             context: context
@@ -250,7 +250,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_signUpStartRequest_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .OOB], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForSignUp(type: .signUpStart),
             context: context
@@ -272,7 +272,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
             "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
             "password": "strong-password",
             "attributes": "<attribute1: value1>",
-            "challenge_type": "password oob redirect"
+            "challenge_type": "oob password redirect"
         ]
 
         XCTAssertEqual(request.parameters, expectedBodyParams)
@@ -282,7 +282,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_signUpChallengeRequest_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .OOB], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForSignUp(type: .signUpChallenge),
             context: context
@@ -300,7 +300,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
             "continuation_token": "<continuation-token>",
-            "challenge_type": "password oob redirect"
+            "challenge_type": "oob password redirect"
         ]
 
         XCTAssertEqual(request.parameters, expectedBodyParams)
@@ -310,7 +310,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_signUpContinueRequest_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForSignUp(type: .signUpContinue),
             context: context
@@ -346,7 +346,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
 
     func test_resetPasswordStart_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .OOB], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordStart),
             context: context
@@ -364,7 +364,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
             "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
-            "challenge_type": "password oob redirect"
+            "challenge_type": "oob password redirect"
         ]
 
         XCTAssertEqual(request.parameters, expectedBodyParams)
@@ -374,7 +374,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_resetPasswordChallenge_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .OOB], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordChallenge),
             context: context
@@ -392,7 +392,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
             "continuation_token": "<continuation-token>",
-            "challenge_type": "password oob redirect"
+            "challenge_type": "oob password redirect"
         ]
 
         XCTAssertEqual(request.parameters, expectedBodyParams)
@@ -402,7 +402,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_resetPasswordContinue_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordContinue),
             context: context
@@ -433,7 +433,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_resetPasswordSubmit_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordSubmit),
             context: context
@@ -462,7 +462,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_resetPasswordPollCompletion_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForResetPassword(type: .resetPasswordPollCompletion),
             context: context
@@ -489,7 +489,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
     }
 
     func test_refreshToken_getsConfiguredSuccessfully() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let telemetry = MSALNativeAuthServerTelemetry(
             currentRequestTelemetry: telemetryProvider.telemetryForToken(type: .refreshToken),
             context: context

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
@@ -31,7 +31,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
 
     let telemetryProvider = MSALNativeAuthTelemetryProvider()
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
     
     let context = MSALNativeAuthRequestContext(correlationId: UUID(uuidString: DEFAULT_TEST_UID)!)
 

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
@@ -45,7 +45,7 @@ final class MSALNativeAuthRequestableTests: XCTestCase {
         }
         
         let authority = try MSALCIAMAuthority(url: authorityUrl)
-        var config = try MSALNativeAuthConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
+        var config = try MSALNativeAuthInternalConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
                                                       authority: authority,
                                                      challengeTypes: [.redirect], redirectUri: nil)
         
@@ -63,7 +63,7 @@ final class MSALNativeAuthRequestableTests: XCTestCase {
         }
         
         let authority = try MSALCIAMAuthority(url: authorityUrl)
-        let config = try MSALNativeAuthConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
+        let config = try MSALNativeAuthInternalConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
                                                       authority: authority,
                                                      challengeTypes: [.redirect], redirectUri: nil)
         

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestableTests.swift
@@ -47,7 +47,7 @@ final class MSALNativeAuthRequestableTests: XCTestCase {
         let authority = try MSALCIAMAuthority(url: authorityUrl)
         var config = try MSALNativeAuthInternalConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
                                                       authority: authority,
-                                                     challengeTypes: [.redirect], redirectUri: nil)
+                                                    challengeTypes: [.password], capabilities: nil, redirectUri: nil)
         
         config.sliceConfig = MSALSliceConfig(slice: nil, dc: sliceDc)
         let url = try request.makeEndpointUrl(config: config)
@@ -65,7 +65,9 @@ final class MSALNativeAuthRequestableTests: XCTestCase {
         let authority = try MSALCIAMAuthority(url: authorityUrl)
         let config = try MSALNativeAuthInternalConfiguration(clientId: DEFAULT_TEST_CLIENT_ID,
                                                       authority: authority,
-                                                     challengeTypes: [.redirect], redirectUri: nil)
+                                                             challengeTypes: [.password],
+                                                             capabilities: nil,
+                                                             redirectUri: nil)
         
         let url = try request.makeEndpointUrl(config: config)
         

--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthSignUpRequestProviderTests.swift
@@ -157,7 +157,7 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
             expectedBodyParams = [
                 Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
                 Key.username.rawValue: DEFAULT_TEST_ID_TOKEN_USERNAME,
-                Key.challengeType.rawValue: "redirect",
+                Key.challengeType.rawValue: "password redirect",
                 Key.password.rawValue: "1234"
             ]
             if expectAttributes {
@@ -167,7 +167,7 @@ final class MSALNativeAuthSignUpRequestProviderTests: XCTestCase {
             expectedBodyParams = [
                 Key.clientId.rawValue: DEFAULT_TEST_CLIENT_ID,
                 Key.continuationToken.rawValue: "continuation-token",
-                Key.challengeType.rawValue: "redirect"
+                Key.challengeType.rawValue: "password redirect"
             ]
         case .signUpContinue:
             expectedBodyParams = [

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift
@@ -37,7 +37,7 @@ final class MSALNativeAuthResetPasswordChallengeRequestParametersTest: XCTestCas
     )
 
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .OOB], capabilities: nil, redirectUri: nil))
         let parameters = MSALNativeAuthResetPasswordChallengeRequestParameters(
             context: MSALNativeAuthRequestContextMock(),
             continuationToken: "<continuation-token>"
@@ -49,7 +49,7 @@ final class MSALNativeAuthResetPasswordChallengeRequestParametersTest: XCTestCas
     }
 
     func test_allParametersFilled_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .OOB], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthResetPasswordChallengeRequestParameters(
             context: MSALNativeAuthRequestContextMock(),
             continuationToken: "<continuation-token>"
@@ -60,14 +60,14 @@ final class MSALNativeAuthResetPasswordChallengeRequestParametersTest: XCTestCas
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
             "continuation_token": "<continuation-token>",
-            "challenge_type": "password oob redirect"
+            "challenge_type": "oob password redirect"
         ]
 
         XCTAssertEqual(body, expectedBodyParams)
     }
 
     func test_allOptionalNil_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthResetPasswordChallengeRequestParameters(
             context: MSALNativeAuthRequestContextMock(),
             continuationToken: "<continuation-token>"

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordChallengeRequestParametersTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class MSALNativeAuthResetPasswordChallengeRequestParametersTest: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
 
     private let context = MSALNativeAuthRequestContextMock(
         correlationId: .init(uuidString: DEFAULT_TEST_UID)!

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParametersTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class MSALNativeAuthResetPasswordContinueRequestParametersTest: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
 
     private let context = MSALNativeAuthRequestContextMock(
         correlationId: .init(uuidString: DEFAULT_TEST_UID)!

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordContinueRequestParametersTest.swift
@@ -37,7 +37,7 @@ final class MSALNativeAuthResetPasswordContinueRequestParametersTest: XCTestCase
     )
 
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let parameters = MSALNativeAuthResetPasswordContinueRequestParameters(
             context: context,
             continuationToken: "<continuation-token>",
@@ -51,7 +51,7 @@ final class MSALNativeAuthResetPasswordContinueRequestParametersTest: XCTestCase
     }
 
     func test_allParametersFilled_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthResetPasswordContinueRequestParameters(
             context: context,
             continuationToken: "<continuation-token>",
@@ -72,7 +72,7 @@ final class MSALNativeAuthResetPasswordContinueRequestParametersTest: XCTestCase
     }
 
     func test_allOptionalNil_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthResetPasswordContinueRequestParameters(
             context: context,
             continuationToken: "<continuation-token>",

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParametersTest.swift
@@ -37,7 +37,7 @@ final class MSALNativeAuthResetPasswordPollCompletionRequestParametersTest: XCTe
     )
 
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let parameters = MSALNativeAuthResetPasswordPollCompletionRequestParameters(
             context: context,
             continuationToken: "<continuation-token"
@@ -49,7 +49,7 @@ final class MSALNativeAuthResetPasswordPollCompletionRequestParametersTest: XCTe
     }
 
     func test_allParametersFilled_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthResetPasswordPollCompletionRequestParameters(
             context: context,
             continuationToken: "<continuation-token"

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordPollCompletionRequestParametersTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class MSALNativeAuthResetPasswordPollCompletionRequestParametersTest: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
 
     private let context = MSALNativeAuthRequestContextMock(
         correlationId: .init(uuidString: DEFAULT_TEST_UID)!

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParametersTest.swift
@@ -37,7 +37,7 @@ final class MSALNativeAuthResetPasswordStartRequestParametersTest: XCTestCase {
     )
 
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.OOB], capabilities: nil, redirectUri: nil))
         let parameters = MSALNativeAuthResetPasswordStartRequestParameters(
             context: MSALNativeAuthRequestContextMock(),
             username: "username"
@@ -48,7 +48,7 @@ final class MSALNativeAuthResetPasswordStartRequestParametersTest: XCTestCase {
     }
 
     func test_allParametersFilled_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .OOB], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthResetPasswordStartRequestParameters(
             context: MSALNativeAuthRequestContextMock(),
             username: DEFAULT_TEST_ID_TOKEN_USERNAME
@@ -59,7 +59,7 @@ final class MSALNativeAuthResetPasswordStartRequestParametersTest: XCTestCase {
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
             "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
-            "challenge_type": "password oob redirect"
+            "challenge_type": "oob password redirect"
         ]
 
         XCTAssertEqual(body, expectedBodyParams)

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParametersTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class MSALNativeAuthResetPasswordStartRequestParametersTest: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
 
     private let context = MSALNativeAuthRequestContextMock(
         correlationId: .init(uuidString: DEFAULT_TEST_UID)!

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordStartRequestParametersTest.swift
@@ -64,4 +64,23 @@ final class MSALNativeAuthResetPasswordStartRequestParametersTest: XCTestCase {
 
         XCTAssertEqual(body, expectedBodyParams)
     }
+    
+    func test_capabilities_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: [.registrationRequired], redirectUri: nil))
+        let params = MSALNativeAuthResetPasswordStartRequestParameters(
+            context: MSALNativeAuthRequestContextMock(),
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "challenge_type": "redirect",
+            "capabilities": "registration_required"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
 }

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParametersTest.swift
@@ -37,7 +37,7 @@ final class MSALNativeAuthResetPasswordSubmitRequestParametersTest: XCTestCase {
     )
 
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let parameters = MSALNativeAuthResetPasswordSubmitRequestParameters(
             context: context,
             continuationToken: "<continuation-token>",
@@ -50,7 +50,7 @@ final class MSALNativeAuthResetPasswordSubmitRequestParametersTest: XCTestCase {
     }
 
     func test_allParametersFilled_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthResetPasswordSubmitRequestParameters(
             context: context,
             continuationToken: "<continuation-token>",

--- a/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/reset_password/MSALNativeAuthResetPasswordSubmitRequestParametersTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class MSALNativeAuthResetPasswordSubmitRequestParametersTest: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
 
     private let context = MSALNativeAuthRequestContextMock(
         correlationId: .init(uuidString: DEFAULT_TEST_UID)!

--- a/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParametersTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class MSALNativeAuthSignInChallengeRequestParametersTest: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
 
     private let context = MSALNativeAuthRequestContextMock(
         correlationId: .init(uuidString: DEFAULT_TEST_UID)!

--- a/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInChallengeRequestParametersTest.swift
@@ -37,7 +37,7 @@ final class MSALNativeAuthSignInChallengeRequestParametersTest: XCTestCase {
     )
 
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let parameters = MSALNativeAuthSignInChallengeRequestParameters(context: MSALNativeAuthRequestContextMock(),
                                                                         mfaAuthMethodId: nil,
                                                                         continuationToken: "Test Credential Token")
@@ -46,27 +46,8 @@ final class MSALNativeAuthSignInChallengeRequestParametersTest: XCTestCase {
         XCTAssertEqual(resultUrl?.absoluteString, "https://login.microsoftonline.com/common/oauth2/v2.0/challenge")
     }
 
-    func test_otpParameters_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.otp], redirectUri: nil))
-        let params = MSALNativeAuthSignInChallengeRequestParameters(
-            context: context, 
-            mfaAuthMethodId: nil,
-            continuationToken: "Test Credential Token"
-        )
-
-        let body = params.makeRequestBody(config: config)
-
-        let expectedBodyParams = [
-            "client_id": DEFAULT_TEST_CLIENT_ID,
-            "continuation_token": "Test Credential Token",
-            "challenge_type": "otp"
-        ]
-
-        XCTAssertEqual(body, expectedBodyParams)
-    }
-
     func test_nilParameters_shouldCreteCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthSignInChallengeRequestParameters(
             context: context,
             mfaAuthMethodId: nil,

--- a/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParametersTest.swift
@@ -37,7 +37,7 @@ final class MSALNativeAuthSignInInitiateRequestParametersTest: XCTestCase {
     )
     
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let parameters = MSALNativeAuthSignInInitiateRequestParameters(context: MSALNativeAuthRequestContextMock(),
                                                                        username: "username")
         var resultUrl: URL? = nil
@@ -46,7 +46,7 @@ final class MSALNativeAuthSignInInitiateRequestParametersTest: XCTestCase {
     }
 
     func test_passwordChallengeType_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthSignInInitiateRequestParameters(
             context: context,
             username: DEFAULT_TEST_ID_TOKEN_USERNAME
@@ -57,14 +57,14 @@ final class MSALNativeAuthSignInInitiateRequestParametersTest: XCTestCase {
         let expectedBodyParams = [
             "client_id": config.clientId,
             "username": params.username,
-            "challenge_type": "password",
+            "challenge_type": "password redirect",
         ]
 
         XCTAssertEqual(body, expectedBodyParams)
     }
 
-    func test_otpChallenge_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.oob], redirectUri: nil))
+    func test_oobChallenge_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.OOB], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthSignInInitiateRequestParameters(
             context: context,
             username: DEFAULT_TEST_ID_TOKEN_USERNAME
@@ -75,7 +75,7 @@ final class MSALNativeAuthSignInInitiateRequestParametersTest: XCTestCase {
         let expectedBodyParams = [
             "client_id": config.clientId,
             "username": params.username,
-            "challenge_type": "oob",
+            "challenge_type": "oob redirect",
         ]
 
         XCTAssertEqual(body, expectedBodyParams)

--- a/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParametersTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class MSALNativeAuthSignInInitiateRequestParametersTest: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
 
     private let context = MSALNativeAuthRequestContextMock(
         correlationId: .init(uuidString: DEFAULT_TEST_UID)!

--- a/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_in/MSALNativeAuthSignInInitiateRequestParametersTest.swift
@@ -75,7 +75,26 @@ final class MSALNativeAuthSignInInitiateRequestParametersTest: XCTestCase {
         let expectedBodyParams = [
             "client_id": config.clientId,
             "username": params.username,
-            "challenge_type": "oob redirect",
+            "challenge_type": "oob redirect"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
+    
+    func test_capabilities_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: [.mfaRequired, .registrationRequired], redirectUri: nil))
+        let params = MSALNativeAuthSignInInitiateRequestParameters(
+            context: context,
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": config.clientId,
+            "username": params.username,
+            "capabilities": "mfa_required registration_required",
+            "challenge_type": "redirect"
         ]
 
         XCTAssertEqual(body, expectedBodyParams)

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParametersTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class MSALNativeAuthSignUpChallengeRequestParametersTest: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
 
     private let context = MSALNativeAuthRequestContextMock(
         correlationId: .init(uuidString: DEFAULT_TEST_UID)!

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpChallengeRequestParametersTest.swift
@@ -37,7 +37,7 @@ final class MSALNativeAuthSignUpChallengeRequestParametersTest: XCTestCase {
     )
 
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let parameters = MSALNativeAuthSignUpChallengeRequestParameters(
             continuationToken: "token",
             context: MSALNativeAuthRequestContextMock()
@@ -48,7 +48,7 @@ final class MSALNativeAuthSignUpChallengeRequestParametersTest: XCTestCase {
     }
 
     func test_allChallengeTypes_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .OOB], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthSignUpChallengeRequestParameters(
             continuationToken: "<continuation-token>",
             context: context
@@ -59,7 +59,7 @@ final class MSALNativeAuthSignUpChallengeRequestParametersTest: XCTestCase {
         let expectedBodyParams = [
             "client_id": DEFAULT_TEST_CLIENT_ID,
             "continuation_token": "<continuation-token>",
-            "challenge_type": "password oob redirect"
+            "challenge_type": "oob password redirect"
         ]
 
         XCTAssertEqual(body, expectedBodyParams)

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParametersTest.swift
@@ -37,7 +37,7 @@ final class MSALNativeAuthSignUpContinueRequestParametersTest: XCTestCase {
     )
 
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let parameters = MSALNativeAuthSignUpContinueRequestParameters(
             grantType: .oobCode,
             continuationToken: "token",
@@ -52,7 +52,7 @@ final class MSALNativeAuthSignUpContinueRequestParametersTest: XCTestCase {
     }
 
     func test_allChallengeTypes_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthSignUpContinueRequestParameters(
             grantType: .oobCode,
             continuationToken: "<continuation-token>",

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpContinueRequestParametersTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class MSALNativeAuthSignUpContinueRequestParametersTest: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
 
     private let context = MSALNativeAuthRequestContextMock(
         correlationId: .init(uuidString: DEFAULT_TEST_UID)!

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParametersTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class MSALNativeAuthSignUpStartRequestParametersTest: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
 
     private let context = MSALNativeAuthRequestContextMock(
         correlationId: .init(uuidString: DEFAULT_TEST_UID)!

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParametersTest.swift
@@ -70,4 +70,26 @@ final class MSALNativeAuthSignUpStartRequestParametersTest: XCTestCase {
 
         XCTAssertEqual(body, expectedBodyParams)
     }
+    
+    func test_capabilities_shouldCreateCorrectBodyRequest() throws {
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [], capabilities: [.mfaRequired], redirectUri: nil))
+        let params = MSALNativeAuthSignUpStartRequestParameters(
+            username: DEFAULT_TEST_ID_TOKEN_USERNAME,
+            password: "password",
+            attributes: nil,
+            context: context
+        )
+
+        let body = params.makeRequestBody(config: config)
+
+        let expectedBodyParams = [
+            "client_id": DEFAULT_TEST_CLIENT_ID,
+            "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
+            "password": "password",
+            "challenge_type": "redirect",
+            "capabilities": "mfa_required"
+        ]
+
+        XCTAssertEqual(body, expectedBodyParams)
+    }
 }

--- a/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/sign_up/MSALNativeAuthSignUpStartRequestParametersTest.swift
@@ -37,7 +37,7 @@ final class MSALNativeAuthSignUpStartRequestParametersTest: XCTestCase {
     )
 
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let parameters = MSALNativeAuthSignUpStartRequestParameters(
             username: "username",
             password: nil,
@@ -50,7 +50,7 @@ final class MSALNativeAuthSignUpStartRequestParametersTest: XCTestCase {
     }
 
     func test_allChallengeTypes_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .oob, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .OOB], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthSignUpStartRequestParameters(
             username: DEFAULT_TEST_ID_TOKEN_USERNAME,
             password: "strong-password",
@@ -65,7 +65,7 @@ final class MSALNativeAuthSignUpStartRequestParametersTest: XCTestCase {
             "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
             "password": "strong-password",
             "attributes": "<attribute1: value1>",
-            "challenge_type": "password oob redirect"
+            "challenge_type": "oob password redirect"
         ]
 
         XCTAssertEqual(body, expectedBodyParams)

--- a/MSAL/test/unit/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParametersTest.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class MSALNativeAuthTokenRequestParametersTest: XCTestCase {
     let baseUrl = URL(string: DEFAULT_TEST_AUTHORITY)!
-    var config: MSALNativeAuthConfiguration! = nil
+    var config: MSALNativeAuthInternalConfiguration! = nil
     private let context = MSALNativeAuthRequestContextMock(
         correlationId: .init(uuidString: DEFAULT_TEST_UID)!
     )

--- a/MSAL/test/unit/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParametersTest.swift
+++ b/MSAL/test/unit/native_auth/network/parameters/token/MSALNativeAuthTokenRequestParametersTest.swift
@@ -36,7 +36,7 @@ final class MSALNativeAuthTokenRequestParametersTest: XCTestCase {
     )
 
     func testMakeEndpointUrl_whenRightUrlStringIsUsed_noExceptionThrown() {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let parameters = MSALNativeAuthTokenRequestParameters(context: MSALNativeAuthRequestContextMock(),
                                                                     username: "username",
                                                                     continuationToken: "Test Credential Token",
@@ -53,7 +53,7 @@ final class MSALNativeAuthTokenRequestParametersTest: XCTestCase {
     }
 
     func test_passwordParameters_shouldCreateCorrectBodyRequest() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthTokenRequestParameters(
             context: context,
             username: DEFAULT_TEST_ID_TOKEN_USERNAME,
@@ -74,7 +74,7 @@ final class MSALNativeAuthTokenRequestParametersTest: XCTestCase {
             "username": DEFAULT_TEST_ID_TOKEN_USERNAME,
             "continuation_token": "Test continuation Token",
             "grant_type": "password",
-            "challenge_type": "password",
+            "challenge_type": "password redirect",
             "scope": "<scope-1>",
             "password": "password",
             "oob": "oob",
@@ -85,7 +85,7 @@ final class MSALNativeAuthTokenRequestParametersTest: XCTestCase {
     }
 
     func test_nilParameters_shouldCreateCorrectParameters() throws {
-        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password, .redirect], redirectUri: nil))
+        XCTAssertNoThrow(config = try .init(clientId: DEFAULT_TEST_CLIENT_ID, authority: MSALCIAMAuthority(url: baseUrl), challengeTypes: [.password], capabilities: nil, redirectUri: nil))
         let params = MSALNativeAuthTokenRequestParameters(
             context: context,
             username: nil,

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthResetPasswordResponseValidatorTests.swift
@@ -53,7 +53,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
 
     func test_whenResetPasswordStartSuccessResponseDoesNotContainsTokenOrRedirect_itReturnsUnexpectedError() {
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .success(
-            .init(continuationToken: nil, challengeType: .otp)
+            .init(continuationToken: nil, challengeType: .oob)
         )
 
         let result = sut.validate(response, with: context)
@@ -64,7 +64,7 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
 
     func test_whenResetPasswordStartSuccessResponseContainsToken_itReturnsSuccess() {
         let response: Result<MSALNativeAuthResetPasswordStartResponse, Error> = .success(
-            .init(continuationToken: "continuationToken", challengeType: .otp)
+            .init(continuationToken: "continuationToken", challengeType: .oob)
         )
 
         let result = sut.validate(response, with: context)
@@ -194,20 +194,6 @@ final class MSALNativeAuthResetPasswordResponseValidatorTests: XCTestCase {
 
         let result = sut.validate(response, with: context)
         XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
-    }
-
-    func test_whenResetPasswordChallengeSuccessResponseHasInvalidChallengeChannel_itReturnsUnexpectedError() {
-        let response: Result<MSALNativeAuthResetPasswordChallengeResponse, Error> = .success(.init(
-            challengeType: .otp,
-            bindingMethod: nil,
-            challengeTargetLabel: "challenge-type-label",
-            challengeChannel: .none,
-            continuationToken: nil,
-            codeLength: 6)
-        )
-
-        let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: MSALNativeAuthErrorMessage.unexpectedChallengeType)))
     }
 
     func test_whenResetPasswordChallengeErrorResponseIsNotExpected_itReturnsUnexpectedError() {

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTests.swift
@@ -115,15 +115,6 @@ final class MSALNativeAuthSignInResponseValidatorTests: MSALNativeAuthTestCase {
         }
     }
     
-    func test_whenChallengeTypeOTP_validationShouldFail() {
-        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let challengeResponse = MSALNativeAuthSignInChallengeResponse(continuationToken: "something", challengeType: .otp, bindingMethod: nil, challengeTargetLabel: "some", challengeChannel: "email", codeLength: 2, interval: nil)
-        let result = sut.validateChallenge(context: context, result: .success(challengeResponse))
-        if case .error(.unexpectedError(.init(errorDescription: "Unexpected challenge type"))) = result {} else {
-            XCTFail("Unexpected result: \(result)")
-        }
-    }
-    
     func test_whenIntrospectRequiredError_validationNotFail() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let challengeErrorResponse = MSALNativeAuthSignInChallengeResponseError(error: .invalidRequest, subError: .introspectRequired, correlationId: defaultUUID)
@@ -170,7 +161,7 @@ final class MSALNativeAuthSignInResponseValidatorTests: MSALNativeAuthTestCase {
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
-        initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .otp)
+        initiateResponse = MSALNativeAuthSignInInitiateResponse(continuationToken: nil, challengeType: .oob)
         result = sut.validateInitiate(context: context, result: .success(initiateResponse))
         if case .error(.unexpectedError(.init(errorDescription: "Unexpected response body received"))) = result {} else {
             XCTFail("Unexpected result: \(result)")

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignUpResponseValidatorTests.swift
@@ -51,7 +51,7 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
 
     func test_whenSignUpStartSuccessResponseDoesNotContainsTokenOrRedirect_it_returns_unexpectedError() {
         let response: Result<MSALNativeAuthSignUpStartResponse, Error> = .success(
-            .init(continuationToken: nil, challengeType: .otp)
+            .init(continuationToken: nil, challengeType: .oob)
         )
 
         let result = sut.validate(response, with: context)
@@ -292,21 +292,6 @@ final class MSALNativeAuthSignUpResponseValidatorTests: XCTestCase {
             challengeChannel: "email",
             continuationToken: nil,
             codeLength: nil)
-        )
-
-        let result = sut.validate(response, with: context)
-        XCTAssertEqual(result, .unexpectedError(.init(errorDescription: "Unexpected response body received")))
-    }
-
-    func test_whenSignUpChallengeSuccessResponseContainsValidAttributesAndOTP_it_returns_unexpectedError() {
-        let response: Result<MSALNativeAuthSignUpChallengeResponse, Error> = .success(.init(
-            challengeType: .otp,
-            bindingMethod: nil,
-            interval: nil,
-            challengeTargetLabel: "challenge-type-label",
-            challengeChannel: nil,
-            continuationToken: "token",
-            codeLength: 6)
         )
 
         let result = sut.validate(response, with: context)

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationConfigTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationConfigTest.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import MSAL
+
+final class MSALNativeAuthPublicClientApplicationConfigTest: XCTestCase {
+ 
+    func test_convertChallengeTypes() {
+        let internalChallengeTypes: [MSALNativeAuthInternalChallengeType] = [.password, .oob]
+        let result = MSALNativeAuthPublicClientApplicationConfig.convertChallengeTypes(internalChallengeTypes)
+        XCTAssertEqual(result, [.password, .OOB])
+    }
+    
+    func test_convertCapabilities() {
+        let internalCapabilities: [MSALNativeAuthInternalCapability] = [.mfaRequired, .registrationRequired]
+        let result = MSALNativeAuthPublicClientApplicationConfig.convertCapabilities(internalCapabilities)
+        XCTAssertEqual(result, [.mfaRequired, .registrationRequired])
+    }
+}

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -50,7 +50,6 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             controllerFactory: controllerFactoryMock,
             cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [], 
             configuration: MSALPublicClientApplicationConfig(
                 clientId: "",
                 redirectUri: "",
@@ -59,19 +58,16 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         )
         
         authority = try! MSALCIAMAuthority(url: authorityURL!)
-        configuration = try! MSALNativeAuthInternalConfiguration(clientId: clientId, authority: authority!, challengeTypes: [.oob, .password], redirectUri: nil)
+        configuration = try! MSALNativeAuthInternalConfiguration(clientId: clientId, authority: authority!, challengeTypes: [.OOB, .password], capabilities: nil, redirectUri: nil)
         contextMock = .init(correlationId: .init(uuidString: correlationId.uuidString)!)
     }
 
-    func testInit_whenPassingB2CAuthority_itShouldThrowError() throws {
-        let b2cAuthority = try MSALB2CAuthority(url: .init(string: "https://login.contoso.com")!)
-        let configuration = MSALPublicClientApplicationConfig(clientId: DEFAULT_TEST_CLIENT_ID, redirectUri: nil, authority: b2cAuthority)
-
-        XCTAssertThrowsError(try MSALNativeAuthPublicClientApplication(configuration: configuration, challengeTypes: [.password]))
-    }
-
     func testInit_whenPassingNilRedirectUri_itShouldNotThrowError() {
-        XCTAssertNoThrow(try MSALNativeAuthPublicClientApplication(clientId: "genericClient", tenantSubdomain: "genericTenenat", challengeTypes: [.OOB]))
+        guard let config = try? MSALNativeAuthPublicClientApplicationConfig(clientId: "genericClient", tenantSubdomain: "genericTenenat", challengeTypes: [.OOB]) else {
+            XCTFail("Error not expected to occur")
+            return
+        }
+        XCTAssertNoThrow(try MSALNativeAuthPublicClientApplication(nativeAuthConfiguration: config))
     }
 
     func testInit_nativeAuthCacheAccessor_itShouldUseConfigFromSuperclass() {
@@ -1183,7 +1179,6 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             controllerFactory: controllerFactory,
             cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
             configuration: MSALPublicClientApplicationConfig(
                 clientId: "",
                 redirectUri: "",
@@ -1295,7 +1290,6 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             controllerFactory: controllerFactory,
             cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
             configuration: MSALPublicClientApplicationConfig(
                 clientId: "",
                 redirectUri: "",
@@ -1397,7 +1391,6 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             controllerFactory: controllerFactory,
             cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
             configuration: MSALPublicClientApplicationConfig(
                 clientId: "",
                 redirectUri: "",
@@ -1495,7 +1488,6 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             controllerFactory: controllerFactory,
             cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
             configuration: MSALPublicClientApplicationConfig(
                 clientId: "",
                 redirectUri: "",
@@ -1603,7 +1595,6 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             controllerFactory: controllerFactory,
             cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
             configuration: MSALPublicClientApplicationConfig(
                 clientId: "",
                 redirectUri: "",
@@ -1724,7 +1715,6 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             controllerFactory: controllerFactory,
             cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
             configuration: MSALPublicClientApplicationConfig(
                 clientId: "",
                 redirectUri: "",
@@ -1837,7 +1827,6 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             controllerFactory: controllerFactory,
             cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
             configuration: MSALPublicClientApplicationConfig(
                 clientId: "",
                 redirectUri: "",
@@ -1939,7 +1928,6 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             controllerFactory: controllerFactory,
             cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
             configuration: MSALPublicClientApplicationConfig(
                 clientId: "",
                 redirectUri: "",
@@ -2037,7 +2025,6 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             controllerFactory: controllerFactory,
             cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
             configuration: MSALPublicClientApplicationConfig(
                 clientId: "",
                 redirectUri: "",
@@ -2145,7 +2132,6 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             controllerFactory: controllerFactory,
             cacheAccessorFactory: cacheAccessorFactoryMock,
             inputValidator: MSALNativeAuthInputValidator(),
-            internalChallengeTypes: [],
             configuration: MSALPublicClientApplicationConfig(
                 clientId: "",
                 redirectUri: "",

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -40,7 +40,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
     private let authorityURL = URL(string: "https://microsoft.com")
     
     private var authority: MSALCIAMAuthority!
-    private var configuration : MSALNativeAuthConfiguration!
+    private var configuration : MSALNativeAuthInternalConfiguration!
     private var contextMock: MSALNativeAuthRequestContext!
     
     override func setUp() {
@@ -59,7 +59,7 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
         )
         
         authority = try! MSALCIAMAuthority(url: authorityURL!)
-        configuration = try! MSALNativeAuthConfiguration(clientId: clientId, authority: authority!, challengeTypes: [.oob, .password], redirectUri: nil)
+        configuration = try! MSALNativeAuthInternalConfiguration(clientId: clientId, authority: authority!, challengeTypes: [.oob, .password], redirectUri: nil)
         contextMock = .init(correlationId: .init(uuidString: correlationId.uuidString)!)
     }
 

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -197,7 +197,7 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let factory = MSALNativeAuthSilentTokenProviderFactoryConfigTester()
         factory.expectedBypassRedirectURIValidation = false
         let correlationId = UUID()
-        let configuration = try! MSALNativeAuthConfiguration (
+        let configuration = try! MSALNativeAuthInternalConfiguration (
             clientId: DEFAULT_TEST_CLIENT_ID,
             authority: try! .init(
                 url: URL(string: DEFAULT_TEST_AUTHORITY)!
@@ -230,7 +230,7 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let factory = MSALNativeAuthSilentTokenProviderFactoryConfigTester()
         factory.expectedBypassRedirectURIValidation = true
         let correlationId = UUID()
-        let configuration = try! MSALNativeAuthConfiguration (
+        let configuration = try! MSALNativeAuthInternalConfiguration (
             clientId: DEFAULT_TEST_CLIENT_ID,
             authority: try! .init(
                 url: URL(string: DEFAULT_TEST_AUTHORITY)!
@@ -355,7 +355,7 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let factory = MSALNativeAuthSilentTokenProviderFactoryConfigTester()
         factory.expectedBypassRedirectURIValidation = false
         let correlationId = UUID()
-        let configuration = try! MSALNativeAuthConfiguration (
+        let configuration = try! MSALNativeAuthInternalConfiguration (
             clientId: DEFAULT_TEST_CLIENT_ID,
             authority: try! .init(
                 url: URL(string: DEFAULT_TEST_AUTHORITY)!
@@ -389,7 +389,7 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
         let factory = MSALNativeAuthSilentTokenProviderFactoryConfigTester()
         factory.expectedBypassRedirectURIValidation = true
         let correlationId = UUID()
-        let configuration = try! MSALNativeAuthConfiguration (
+        let configuration = try! MSALNativeAuthInternalConfiguration (
             clientId: DEFAULT_TEST_CLIENT_ID,
             authority: try! .init(
                 url: URL(string: DEFAULT_TEST_AUTHORITY)!

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthUserAccountResultTests.swift
@@ -202,7 +202,7 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
             authority: try! .init(
                 url: URL(string: DEFAULT_TEST_AUTHORITY)!
             ),
-            challengeTypes: [.redirect], redirectUri: "contoso.com"
+            challengeTypes: [.OOB], capabilities: nil, redirectUri: "contoso.com"
         )
         sut = MSALNativeAuthUserAccountResult(
             account: account!,
@@ -235,7 +235,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
             authority: try! .init(
                 url: URL(string: DEFAULT_TEST_AUTHORITY)!
             ),
-            challengeTypes: [.redirect],
+            challengeTypes: [.OOB],
+            capabilities: nil,
             redirectUri: nil
         )
         sut = MSALNativeAuthUserAccountResult(
@@ -360,7 +361,7 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
             authority: try! .init(
                 url: URL(string: DEFAULT_TEST_AUTHORITY)!
             ),
-            challengeTypes: [.redirect], redirectUri: "contoso.com"
+            challengeTypes: [.OOB], capabilities: nil, redirectUri: "contoso.com"
         )
         sut = MSALNativeAuthUserAccountResult(
             account: account!,
@@ -394,7 +395,8 @@ class MSALNativeAuthUserAccountResultTests: XCTestCase {
             authority: try! .init(
                 url: URL(string: DEFAULT_TEST_AUTHORITY)!
             ),
-            challengeTypes: [.redirect],
+            challengeTypes: [.OOB],
+            capabilities: nil,
             redirectUri: nil
         )
         sut = MSALNativeAuthUserAccountResult(


### PR DESCRIPTION
## Proposed changes

This PR contains:
- New public parameter "capabilities"
- Send this parameter in /initiate and /start endpoints

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


