### PR TITLE
Update CODEOWNERS file - MSAL.h

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,11 +2,12 @@
 # Unless a later match takes precedence, these users will be requested
 # for review whenever someone opens a pull request.
 *       @AzureAD/AppleIdentityTeam
-# @AzureAD/AppleIdentityTeam and @AzureAD/MSAL-ObjC-CIAM will be the co-owners of MSAL.project, CHANGELOG.md, Package.swift and all files under azure_pipelines
+# @AzureAD/AppleIdentityTeam and @AzureAD/MSAL-ObjC-CIAM will be the co-owners of the following files:
 /MSAL/MSAL.xcodeproj/project.pbxproj @AzureAD/AppleIdentityTeam @AzureAD/MSAL-ObjC-CIAM
 CHANGELOG.md @AzureAD/AppleIdentityTeam @AzureAD/MSAL-ObjC-CIAM
 /azure_pipelines/ @AzureAD/AppleIdentityTeam @AzureAD/MSAL-ObjC-CIAM
 /Package.swift @AzureAD/AppleIdentityTeam @AzureAD/MSAL-ObjC-CIAM
+/MSAL/src/public/MSAL.h @AzureAD/AppleIdentityTeam @AzureAD/MSAL-ObjC-CIAM
 # @AzureAD/MSAL-ObjC-CIAM owns any files in the */native_auth
 # directories, subdirectories and other files related to native auth.
 /MSAL/module.modulemap @AzureAD/MSAL-ObjC-CIAM


### PR DESCRIPTION
## Proposed changes

Add MSAL.h file to be co-owned by AppleIdentityTeam and MSAL-ObjC-CIAM team. CIAM team will update this file when we add new public class for Objective-C

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

