### PR TITLE
E2E tests for backward compatibility feature

### DIFF
--- a/MSAL/src/native_auth/controllers/jit/MSALNativeAuthJITController.swift
+++ b/MSAL/src/native_auth/controllers/jit/MSALNativeAuthJITController.swift
@@ -243,6 +243,7 @@ final class MSALNativeAuthJITController: MSALNativeAuthBaseController, MSALNativ
         }
     }
 
+    // swiftlint:disable:next function_body_length
     private func handleSubmitChallengeResponse(
         _ response: MSALNativeAuthJITContinueValidatedResponse,
         continuationToken: String,


### PR DESCRIPTION
## Proposed changes

This PR contains the following E2E tests:
- createUserAndDoNotSendCapabilities_thenBrowserRequiredIsExpected
- signInWithMFANoCapabilities_thenBrowserRequiredIsReturned

Those tests are currently disabled because "backward compatibility" feature is not in production at the moment. We will enable them as soon as the feature will be available. 
## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [X] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

