### PR TITLE
[iOS SDK] Reinstate  Private Preview warnings for MFA and JIT

### DIFF
--- a/MSAL/src/native_auth/public/state_machine/state/JITStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/JITStates+Internal.swift
@@ -26,6 +26,7 @@ extension RegisterStrongAuthBaseState {
     func requestChallengeInternal(authMethod: MSALAuthMethod,
                                   verificationContact: String?) async -> MSALNativeAuthJITControlling.JITRequestChallengeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        MSALNativeAuthLogger.log(level: .warning, context: context, format: MSALNativeAuthLogMessage.privatePreviewLog)
         MSALNativeAuthLogger.log(level: .info, context: context, format: "RegisterStrongAuth, Request Challenge")
         return await controller.requestJITChallenge(continuationToken: continuationToken,
                                                     authMethod: authMethod,
@@ -38,6 +39,7 @@ extension RegisterStrongAuthVerificationRequiredState {
 
     func submitChallengeInternal(challenge: String) async -> MSALNativeAuthJITControlling.JITSubmitChallengeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        MSALNativeAuthLogger.log(level: .warning, context: context, format: MSALNativeAuthLogMessage.privatePreviewLog)
         MSALNativeAuthLogger.log(level: .info, context: context, format: "RegisterStrongAuth, Submit Challenge")
         guard inputValidator.isInputValid(challenge) else {
             MSALNativeAuthLogger.log(level: .error, context: context, format: "RegisterStrongAuth, invalid challenge")

--- a/MSAL/src/native_auth/public/state_machine/state/JITStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/JITStates.swift
@@ -63,6 +63,7 @@ public class RegisterStrongAuthBaseState: MSALNativeAuthBaseState {
 public class RegisterStrongAuthState: RegisterStrongAuthBaseState {
 
     /// Requests the server to send the challenge to the default authentication method.
+    /// - Warning: ⚠️  this API is experimental. It may be changed in the future without notice. Do not use in production applications.
     /// - Parameters:
     ///  - parameters: Parameters used to challenge an authentication method
     ///  - delegate: Delegate that receives callbacks for the operation.
@@ -90,6 +91,7 @@ public class RegisterStrongAuthVerificationRequiredState: RegisterStrongAuthBase
     }
 
     /// Submits the challenge to verify the authentication method selected.
+    /// - Warning: ⚠️  this API is experimental. It may be changed in the future without notice. Do not use in production applications.
     /// - Parameters:
     ///  - challenge: Verification challenge that the user supplies.
     ///  - delegate: Delegate that receives callbacks for the operation.
@@ -107,6 +109,7 @@ public class RegisterStrongAuthVerificationRequiredState: RegisterStrongAuthBase
     }
 
     /// Requests the server to send the challenge to the default authentication method.
+    /// - Warning: ⚠️  this API is experimental. It may be changed in the future without notice. Do not use in production applications.
     /// - Parameters:
     ///  - parameters: Parameters used to challenge an authentication method
     ///  - delegate: Delegate that receives callbacks for the operation.

--- a/MSAL/src/native_auth/public/state_machine/state/MFAStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/MFAStates+Internal.swift
@@ -27,6 +27,7 @@ import Foundation
 extension MFABaseState {
     func requestChallengeInternal(authMethod: MSALAuthMethod?) async -> MSALNativeAuthMFAControlling.MFARequestChallengeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        MSALNativeAuthLogger.log(level: .warning, context: context, format: MSALNativeAuthLogMessage.privatePreviewLog)
         MSALNativeAuthLogger.log(level: .info, context: context, format: "MFA, request challenge")
         return await controller.requestChallenge(
             continuationToken: continuationToken,
@@ -41,6 +42,7 @@ extension MFABaseState {
 extension MFARequiredState {
     func getAuthMethodsInternal() async -> MSALNativeAuthMFAControlling.MFAGetAuthMethodsControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        MSALNativeAuthLogger.log(level: .warning, context: context, format: MSALNativeAuthLogMessage.privatePreviewLog)
         MSALNativeAuthLogger.log(level: .info, context: context, format: "MFA, get authentication methods")
         return await controller.getAuthMethods(
             continuationToken: continuationToken,
@@ -52,6 +54,7 @@ extension MFARequiredState {
 
     func submitChallengeInternal(challenge: String) async -> MSALNativeAuthMFAControlling.MFASubmitChallengeControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
+        MSALNativeAuthLogger.log(level: .warning, context: context, format: MSALNativeAuthLogMessage.privatePreviewLog)
         MSALNativeAuthLogger.log(level: .info, context: context, format: "MFA, submit challenge")
         guard inputValidator.isInputValid(challenge) else {
             MSALNativeAuthLogger.log(level: .error, context: context, format: "MFA, invalid challenge")

--- a/MSAL/src/native_auth/public/state_machine/state/MFAStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/MFAStates.swift
@@ -73,6 +73,7 @@ import Foundation
 public class AwaitingMFAState: MFABaseState {
 
     /// Requests the server to send the challenge to the default authentication method.
+    /// - Warning: ⚠️  this API is experimental. It may be changed in the future without notice. Do not use in production applications.
     /// - Parameter delegate: Delegate that receives callbacks for the operation.
     public func requestChallenge(delegate: MFARequestChallengeDelegate) {
         baseRequestChallenge(authMethod: nil, delegate: delegate)
@@ -102,6 +103,7 @@ public class MFARequiredState: MFABaseState {
     }
 
     /// Requests the server to send the challenge to the specified auth method or the default one.
+    /// - Warning: ⚠️  this API is experimental. It may be changed in the future without notice. Do not use in production applications.
     /// - Parameters:
     ///   - authMethod: Optional. The authentication method you want to use for sending the challenge
     ///   - delegate: Delegate that receives callbacks for the operation.
@@ -110,6 +112,7 @@ public class MFARequiredState: MFABaseState {
     }
 
     /// Requests the available MFA authentication methods.
+    /// - Warning: ⚠️  this API is experimental. It may be changed in the future without notice. Do not use in production applications.
     /// - Parameter delegate: Delegate that receives callbacks for the operation.
     public func getAuthMethods(delegate: MFAGetAuthMethodsDelegate) {
         Task {
@@ -129,6 +132,7 @@ public class MFARequiredState: MFABaseState {
     }
 
     /// Submits the MFA challenge to the server for verification.
+    /// - Warning: ⚠️  this API is experimental. It may be changed in the future without notice. Do not use in production applications.
     /// - Parameters:
     ///   - challenge: Verification challenge that the user supplies.
     ///   - delegate: Delegate that receives callbacks for the operation.


### PR DESCRIPTION
## Proposed changes

Added back the warnings for Private Preview removed from MFA and JIT

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [x] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

