### PR TITLE
Use MSALAuthority instead of MSALCIAMAuthority on Native auth config init

### DIFF
--- a/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
+++ b/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
@@ -34,9 +34,9 @@ public final class MSALNativeAuthPublicClientApplicationConfig: MSALPublicClient
     /// Initialize a MSALNativeAuthPublicClientApplicationConfig.
     /// - Parameters:
     ///   - clientId: The client ID of the application, this should come from the app developer portal.
-    ///   - authority: The target CIAM authority.
+    ///   - authority: The target authority.
     ///   - challengeTypes: The set of challenge types that this application can support as an ``MSALNativeAuthChallengeTypes`` optionset
-    public init(clientId: String, authority: MSALCIAMAuthority, challengeTypes: MSALNativeAuthChallengeTypes) {
+    public init(clientId: String, authority: MSALAuthority, challengeTypes: MSALNativeAuthChallengeTypes) {
         self.challengeTypes = challengeTypes
         // calling the init without nestedAuthBrokerClientId and nestedAuthBrokerRedirectUri result in an error
         super.init(clientId: clientId, redirectUri: nil, authority: authority, nestedAuthBrokerClientId: nil, nestedAuthBrokerRedirectUri: nil)


### PR DESCRIPTION
## Proposed changes

Do not restrict the MSALNativeAuthPublicClientApplicationConfig on using only CIAMAuthority. This can open new development in the future.

## Type of change

- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
