### PR TITLE
Make public capabilities not optional to make it visible to Objecitve-C

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -386,6 +386,8 @@
 		28F8D29F2D8C6C3A005084FA /* MSALNativeAuthRegisterStrongAuthVerificationRequiredResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F8D29D2D8C6C37005084FA /* MSALNativeAuthRegisterStrongAuthVerificationRequiredResult.swift */; };
 		28F8D2A12D8C7A4F005084FA /* RegisterStrongAuthSubmitChallengeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F8D2A02D8C7A49005084FA /* RegisterStrongAuthSubmitChallengeError.swift */; };
 		28F8D2A22D8C7A4F005084FA /* RegisterStrongAuthSubmitChallengeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F8D2A02D8C7A49005084FA /* RegisterStrongAuthSubmitChallengeError.swift */; };
+		28FB1BB62E0AF1F90065B784 /* MSALNativeAuthPublicClientApplicationConfigObjCTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 28FB1BB52E0AF1F90065B784 /* MSALNativeAuthPublicClientApplicationConfigObjCTest.m */; };
+		28FB1BB72E0AF1F90065B784 /* MSALNativeAuthPublicClientApplicationConfigObjCTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 28FB1BB52E0AF1F90065B784 /* MSALNativeAuthPublicClientApplicationConfigObjCTest.m */; };
 		28FDC49C2A38BFA900E38BE1 /* SignInAfterSignUpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FDC49B2A38BFA900E38BE1 /* SignInAfterSignUpState.swift */; };
 		28FDC4A62A38C00900E38BE1 /* SignInAfterSignUpDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FDC4A52A38C00900E38BE1 /* SignInAfterSignUpDelegate.swift */; };
 		28FDC4A92A38C0D100E38BE1 /* SignInAfterSignUpError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FDC4A82A38C0D000E38BE1 /* SignInAfterSignUpError.swift */; };
@@ -2183,6 +2185,7 @@
 		28F8D2992D8C6612005084FA /* RegisterStrongAuthChallengeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterStrongAuthChallengeError.swift; sourceTree = "<group>"; };
 		28F8D29D2D8C6C37005084FA /* MSALNativeAuthRegisterStrongAuthVerificationRequiredResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRegisterStrongAuthVerificationRequiredResult.swift; sourceTree = "<group>"; };
 		28F8D2A02D8C7A49005084FA /* RegisterStrongAuthSubmitChallengeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterStrongAuthSubmitChallengeError.swift; sourceTree = "<group>"; };
+		28FB1BB52E0AF1F90065B784 /* MSALNativeAuthPublicClientApplicationConfigObjCTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALNativeAuthPublicClientApplicationConfigObjCTest.m; sourceTree = "<group>"; };
 		28FDC49B2A38BFA900E38BE1 /* SignInAfterSignUpState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAfterSignUpState.swift; sourceTree = "<group>"; };
 		28FDC4A52A38C00900E38BE1 /* SignInAfterSignUpDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAfterSignUpDelegate.swift; sourceTree = "<group>"; };
 		28FDC4A82A38C0D000E38BE1 /* SignInAfterSignUpError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAfterSignUpError.swift; sourceTree = "<group>"; };
@@ -3095,6 +3098,7 @@
 				E2CD2E3F29FBE957009F8FFA /* state_machine */,
 				287F64F22981A00400ED90BD /* MSALNativeAuthPublicClientApplicationTest.swift */,
 				289C1D912DE8D059009EEBEA /* MSALNativeAuthPublicClientApplicationConfigTest.swift */,
+				28FB1BB52E0AF1F90065B784 /* MSALNativeAuthPublicClientApplicationConfigObjCTest.m */,
 				DE87DE692A39E80B0032BF9E /* MSALNativeAuthUserAccountResultTests.swift */,
 			);
 			path = public;
@@ -7458,6 +7462,7 @@
 				E22952682A1A4FCB00EDD58C /* MSALNativeAuthSignUpResponseValidatorTests.swift in Sources */,
 				289E44B92C9D843F00F6B9D7 /* MFARequestChallengeErrorTests.swift in Sources */,
 				E286E2DD2A1BAEA800666DD0 /* MSALNativeAuthSignUpControllerTests.swift in Sources */,
+				28FB1BB72E0AF1F90065B784 /* MSALNativeAuthPublicClientApplicationConfigObjCTest.m in Sources */,
 				B2725EC522BF4865009B454A /* MSALMockExternalAccountHandler.m in Sources */,
 				E2C190772B20DF4300095534 /* SignInAfterResetPasswordErrorTests.swift in Sources */,
 				9BD2765F2A0E81CE00FBD033 /* ResetPasswordRequiredStateTests.swift in Sources */,
@@ -7758,6 +7763,7 @@
 				DE8DC5202C6621F500534E8F /* ResetPasswordStartDelegateDispatcherTests.swift in Sources */,
 				DE8DC55C2C66221700534E8F /* MSALNativeAuthResetPasswordStartRequestParametersTest.swift in Sources */,
 				28EE651C2C8B0FF500015F90 /* MSALNativeAuthMFAControllerTests.swift in Sources */,
+				28FB1BB62E0AF1F90065B784 /* MSALNativeAuthPublicClientApplicationConfigObjCTest.m in Sources */,
 				289E44BA2C9D843F00F6B9D7 /* MFARequestChallengeErrorTests.swift in Sources */,
 				DE8DC56C2C66221C00534E8F /* MSALNativeLoggingTests.swift in Sources */,
 			);

--- a/MSAL/src/native_auth/configuration/MSALNativeAuthInternalConfiguration.swift
+++ b/MSAL/src/native_auth/configuration/MSALNativeAuthInternalConfiguration.swift
@@ -77,7 +77,7 @@ struct MSALNativeAuthInternalConfiguration {
     private static func getInternalCapabilities(
         _ capabilities: MSALNativeAuthCapabilities?
     ) -> [MSALNativeAuthInternalCapability]? {
-        guard let capabilities else { return nil }
+        guard let capabilities, !capabilities.isEmpty else { return nil }
         var internalCapabilities: [MSALNativeAuthInternalCapability] = []
 
         if capabilities.contains(.mfaRequired) {

--- a/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
+++ b/MSAL/src/native_auth/public/configuration/MSALNativeAuthPublicClientApplicationConfig.swift
@@ -29,7 +29,7 @@ public final class MSALNativeAuthPublicClientApplicationConfig: MSALPublicClient
     let challengeTypes: MSALNativeAuthChallengeTypes
 
     /** The set of capabilities that this application can support as an ``MSALNativeAuthCapabilities`` optionset */
-    public var capabilities: MSALNativeAuthCapabilities?
+    public var capabilities: MSALNativeAuthCapabilities = []
 
     /// Initialize a MSALNativeAuthPublicClientApplicationConfig.
     /// - Parameters:

--- a/MSAL/src/native_auth/public/state_machine/result/MSALNativeAuthUserAccountResult+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/result/MSALNativeAuthUserAccountResult+Internal.swift
@@ -51,7 +51,7 @@ extension MSALNativeAuthUserAccountResult {
             challengeTypes: challengeTypes
         )
         config.bypassRedirectURIValidation = configuration.redirectUri == nil
-        config.capabilities = capabilities
+        config.capabilities = capabilities ?? []
 
         guard let silentTokenProvider = try? silentTokenProviderFactory.makeSilentTokenProvider(configuration: config)
         else {

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationConfigObjCTest.m
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationConfigObjCTest.m
@@ -1,10 +1,26 @@
 //
-//  MSALNativeAuthPublicClientApplicationConfigObjCTest.m
-//  MSAL
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
 //
-//  Created by daniloraspa on 24/06/2025.
-//  Copyright © 2025 Microsoft. All rights reserved.
+// This code is licensed under the MIT License.
 //
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #import <XCTest/XCTest.h>
 #import <MSAL/MSAL.h>

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationConfigObjCTest.m
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationConfigObjCTest.m
@@ -1,0 +1,24 @@
+//
+//  MSALNativeAuthPublicClientApplicationConfigObjCTest.m
+//  MSAL
+//
+//  Created by daniloraspa on 24/06/2025.
+//  Copyright © 2025 Microsoft. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <MSAL/MSAL.h>
+
+@interface MSALNativeAuthPublicClientApplicationConfigObjCTest : XCTestCase
+
+@end
+
+@implementation MSALNativeAuthPublicClientApplicationConfigObjCTest
+
+- (void)test_capabilitiesVisibility {
+    NSError *error = nil;
+    MSALNativeAuthPublicClientApplicationConfig *config = [[MSALNativeAuthPublicClientApplicationConfig alloc] initWithClientId:@"clientId" tenantSubdomain:@"tenantSubdomain" challengeTypes:MSALNativeAuthChallengeTypeOOB error:&error];
+    config.capabilities = MSALNativeAuthCapabilityMFARequired;
+}
+
+@end


### PR DESCRIPTION
## Proposed changes

Make the public capabilities not optional to make it visible to Objective-C. Keeping the internal capabilities as optional. Internal capabilities will be set to nil if the capabilities list is empty.

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
