### PR TITLE
Automation - Try again tapping the 'Done' button with a bigger offset

### DIFF
--- a/MSAL/test/automation/tests/MSALBaseUITest.m
+++ b/MSAL/test/automation/tests/MSALBaseUITest.m
@@ -241,6 +241,10 @@ static MSIDTestConfigurationProvider *s_confProvider;
             
             __auto_type coordinate = [firstButton coordinateWithNormalizedOffset:CGVectorMake(0, 0)];
             [coordinate tap];
+            
+            // Try again with a bigger offset, sometimes the first one doesn't work
+            coordinate = [firstButton coordinateWithNormalizedOffset:CGVectorMake(1, 1)];
+            [coordinate tap];
         }
         else
         {


### PR DESCRIPTION
## Proposed changes

This pull request makes a minor improvement to the `closeAuthUIUsingWebViewType:` method in `MSALBaseUITest.m` to increase the reliability of UI automation tests when tapping a button.

UI Automation Reliability:

* Adds a second tap on the `firstButton` using a larger offset (`CGVectorMake(1, 1)`) if the initial tap at `(0, 0)` does not work, improving the robustness of UI automation for closing the authentication UI.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

