### PR TITLE
Native auth SMS OTP MFA - E2E test changes

### DIFF
--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -324,7 +324,6 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         }
     }
 
-    // swiftlint:disable:next function_body_length
     func resendCode(
         continuationToken: String,
         context: MSALNativeAuthRequestContext,
@@ -773,7 +772,7 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
         }
     }
 
-    // swiftlint:disable:next function_body_length cyclomatic_complexity
+    // swiftlint:disable:next function_body_length
     private func handleChallengeResponse(
         _ validatedResponse: MSALNativeAuthSignInChallengeValidatedResponse,
         params: MSALNativeAuthInternalSignInParameters,

--- a/MSAL/src/native_auth/input_validator/MSALNativeAuthInputValidator.swift
+++ b/MSAL/src/native_auth/input_validator/MSALNativeAuthInputValidator.swift
@@ -25,12 +25,15 @@
 import Foundation
 
 protocol MSALNativeAuthInputValidating {
-    func isInputValid(_ input: String) -> Bool
+    func isInputValid(_ input: String?) -> Bool
     func isInputValid(_ input: [Any]) -> Bool
 }
 
 final class MSALNativeAuthInputValidator: MSALNativeAuthInputValidating {
-    func isInputValid(_ input: String) -> Bool {
+    func isInputValid(_ input: String?) -> Bool {
+        guard let input = input else {
+            return false
+        }
         return !input.isEmpty
     }
 

--- a/MSAL/src/native_auth/public/MSALNativeAuthChannelType.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthChannelType.swift
@@ -36,9 +36,9 @@ public class MSALNativeAuthChannelType: NSObject {
         return value.lowercased() == "email"
     }
 
-    /// Returns `true` if the channel is phone.
-    public var isPhoneType: Bool {
-        return value.lowercased() == "phone"
+    /// Returns `true` if the channel is SMS.
+    public var isSMSType: Bool {
+        return value.lowercased() == "sms"
     }
 
     init(value: String) {

--- a/MSAL/src/native_auth/public/state_machine/state/JITStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/JITStates+Internal.swift
@@ -32,7 +32,10 @@ extension RegisterStrongAuthBaseState {
         if authMethod.channelTargetType.isSMSType && !inputValidator.isInputValid(verificationContact) {
             MSALNativeAuthLogger.log(level: .error, context: context, format: "RegisterStrongAuth, Request Challenge - invalid verification contact")
             return .init(
-                .error(error: RegisterStrongAuthChallengeError(type: .invalidInput, correlationId: correlationId), newState: self as? RegisterStrongAuthState),
+                .error(error: RegisterStrongAuthChallengeError(
+                    type: .invalidInput,
+                    correlationId: correlationId
+                ), newState: self as? RegisterStrongAuthState),
                 correlationId: context.correlationId()
             )
         }

--- a/MSAL/src/native_auth/public/state_machine/state/JITStates+Internal.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/JITStates+Internal.swift
@@ -28,6 +28,14 @@ extension RegisterStrongAuthBaseState {
         let context = MSALNativeAuthRequestContext(correlationId: correlationId)
         MSALNativeAuthLogger.log(level: .warning, context: context, format: MSALNativeAuthLogMessage.privatePreviewLog)
         MSALNativeAuthLogger.log(level: .info, context: context, format: "RegisterStrongAuth, Request Challenge")
+        // when SMS auth method is used verification contact can't be nil or empty
+        if authMethod.channelTargetType.isSMSType && !inputValidator.isInputValid(verificationContact) {
+            MSALNativeAuthLogger.log(level: .error, context: context, format: "RegisterStrongAuth, Request Challenge - invalid verification contact")
+            return .init(
+                .error(error: RegisterStrongAuthChallengeError(type: .invalidInput, correlationId: correlationId), newState: self as? RegisterStrongAuthState),
+                correlationId: context.correlationId()
+            )
+        }
         return await controller.requestJITChallenge(continuationToken: continuationToken,
                                                     authMethod: authMethod,
                                                     verificationContact: verificationContact,

--- a/MSAL/src/native_auth/public/state_machine/state/JITStates.swift
+++ b/MSAL/src/native_auth/public/state_machine/state/JITStates.swift
@@ -27,12 +27,15 @@ import Foundation
 @objcMembers
 public class RegisterStrongAuthBaseState: MSALNativeAuthBaseState {
     let controller: MSALNativeAuthJITControlling
+    let inputValidator: MSALNativeAuthInputValidating
 
     init(controller: MSALNativeAuthJITControlling,
+         inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
          continuationToken: String,
          correlationId: UUID
     ) {
         self.controller = controller
+        self.inputValidator = inputValidator
         super.init(continuationToken: continuationToken, correlationId: correlationId)
     }
 
@@ -75,14 +78,10 @@ public class RegisterStrongAuthState: RegisterStrongAuthBaseState {
 @objcMembers
 public class RegisterStrongAuthVerificationRequiredState: RegisterStrongAuthBaseState {
 
-    let inputValidator: MSALNativeAuthInputValidating
-
     init(
-        inputValidator: MSALNativeAuthInputValidating = MSALNativeAuthInputValidator(),
         controller: MSALNativeAuthJITControlling,
         continuationToken: String,
         correlationId: UUID) {
-        self.inputValidator = inputValidator
         super.init(
             controller: controller,
             continuationToken: continuationToken,

--- a/MSAL/test/integration/native_auth/common/Model.swift
+++ b/MSAL/test/integration/native_auth/common/Model.swift
@@ -71,6 +71,7 @@ enum MockAPIResponse: String {
     case authorizationPending = "AuthorizationPending"
     case challengeTypePassword = "ChallengeTypePassword"
     case challengeTypeOOB = "ChallengeTypeOOB"
+    case challengeSuccessSMS = "ChallengeSuccessSMS"
     case unsupportedChallengeType = "UnsupportedChallengeType"
     case challengeTypeRedirect = "ChallengeTypeRedirect"
     case credentialRequired = "CredentialRequired"
@@ -82,6 +83,7 @@ enum MockAPIResponse: String {
     case attributeValidationFailed = "AttributeValidationFailed"
     case invalidContinuationToken = "InvalidContinuationToken"
     case signInIntrospectSuccess = "IntrospectSuccess"
+    case signInIntrospectSMSSuccess = "IntrospectSMSSuccess"
     case mfaRequired = "MFARequired"
     case introspectRequired = "IntrospectRequired"
     case ssprStartSuccess = "SSPRStartSuccess"
@@ -97,6 +99,7 @@ enum MockAPIResponse: String {
     // Typo below on Registraion is expected, on par with Mock API
     case registrationIntrospectSuccess = "RegistraionIntrospectSuccess"
     case registrationChallengeSuccess = "RegistraionChallengeSuccess"
+    case registrationChallengeSMSSuccess = "RegistraionChallengeSMSSuccess"
     case registrationContinueSuccess = "RegistrationContinueSuccess"
     case registrationInvalidOOBValue = "RegistrationInvalidOOBValue"
     case registraionInvalidChallengeTarget = "RegistraionInvalidChallengeTarget"

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInJITEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInJITEndToEndTests.swift
@@ -52,7 +52,7 @@ final class MSALNativeAuthSignInJITEndToEndTests: MSALNativeAuthEndToEndPassword
 
         guard signInDelegateSpy.onSignInStrongAuthMethodRegistrationCalled,
               let strongAuthState = signInDelegateSpy.newStateStrongAuthMethodRegistration,
-              let authMethod = signInDelegateSpy.authMethods?.first else {
+              let authMethod = signInDelegateSpy.authMethods?.first(where: { $0.channelTargetType.isEmailType }) else {
             XCTFail("Sign in failed or strong auth method registration not required")
             return
         }
@@ -97,7 +97,7 @@ final class MSALNativeAuthSignInJITEndToEndTests: MSALNativeAuthEndToEndPassword
 
         guard signInDelegateSpy.onSignInStrongAuthMethodRegistrationCalled,
               let strongAuthState = signInDelegateSpy.newStateStrongAuthMethodRegistration,
-              let authMethod = signInDelegateSpy.authMethods?.first else {
+              let authMethod = signInDelegateSpy.authMethods?.first(where: { $0.channelTargetType.isEmailType }) else {
             XCTFail("Sign in failed or strong auth method registration not required")
             return
         }
@@ -168,7 +168,7 @@ final class MSALNativeAuthSignInJITEndToEndTests: MSALNativeAuthEndToEndPassword
 
         guard signInDelegateSpy.onSignInStrongAuthMethodRegistrationCalled,
               let strongAuthState = signInDelegateSpy.newStateStrongAuthMethodRegistration,
-              let authMethod = signInDelegateSpy.authMethods?.first else {
+              let authMethod = signInDelegateSpy.authMethods?.first(where: { $0.channelTargetType.isEmailType }) else {
             XCTFail("Sign in failed or strong auth method registration not required")
             return
         }
@@ -239,7 +239,7 @@ final class MSALNativeAuthSignInJITEndToEndTests: MSALNativeAuthEndToEndPassword
 
         guard signInDelegateSpy.onSignInStrongAuthMethodRegistrationCalled,
               let strongAuthState = signInDelegateSpy.newStateStrongAuthMethodRegistration,
-              let authMethod = signInDelegateSpy.authMethods?.first else {
+              let authMethod = signInDelegateSpy.authMethods?.first(where: { $0.channelTargetType.isEmailType }) else {
             XCTFail("Sign in failed or strong auth method registration not required")
             return
         }

--- a/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/mfa/MSALNativeAuthSignInWithMFAEndToEndTests.swift
@@ -45,7 +45,11 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         let mfaExpectation = expectation(description: "mfa")
         let mfaDelegateSpy = MFARequestChallengeDelegateSpy(expectation: mfaExpectation)
 
-        result.newAwaitingMFAState.requestChallenge(authMethod: result.authMethods[0], delegate: mfaDelegateSpy)
+        guard let emailAuthMethod = result.authMethods.first(where: { $0.channelTargetType.isEmailType }) else {
+            XCTFail("No email auth method found")
+            return
+        }
+        result.newAwaitingMFAState.requestChallenge(authMethod: emailAuthMethod, delegate: mfaDelegateSpy)
 
         await fulfillment(of: [mfaExpectation])
         
@@ -74,8 +78,7 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         
         let mfaResendChallengeExpectation = expectation(description: "mfa")
         let mfaResendChallengeDelegateSpy = MFARequestChallengeDelegateSpy(expectation: mfaResendChallengeExpectation)
-        
-        result.newAwaitingMFAState.requestChallenge(authMethod: result.authMethods[0], delegate: mfaResendChallengeDelegateSpy)
+        result.newAwaitingMFAState.requestChallenge(authMethod: emailAuthMethod, delegate: mfaResendChallengeDelegateSpy)
 
         await fulfillment(of: [mfaResendChallengeExpectation])
         
@@ -104,8 +107,11 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         // Request to send challenge to the default strong auth method
         let mfaExpectation = expectation(description: "mfa")
         let mfaDelegateSpy = MFARequestChallengeDelegateSpy(expectation: mfaExpectation)
-        
-        result.newAwaitingMFAState.requestChallenge(authMethod: result.authMethods[0], delegate: mfaDelegateSpy)
+        guard let emailAuthMethod = result.authMethods.first(where: { $0.channelTargetType.isEmailType }) else {
+            XCTFail("No email auth method found")
+            return
+        }
+        result.newAwaitingMFAState.requestChallenge(authMethod: emailAuthMethod, delegate: mfaDelegateSpy)
 
         await fulfillment(of: [mfaExpectation])
         
@@ -160,11 +166,15 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         let mfaExpectation = expectation(description: "mfa")
         let mfaDelegateSpy = MFARequestChallengeDelegateSpy(expectation: mfaExpectation)
 
-        awaitingMFAState.requestChallenge(authMethod: authMethods[0], delegate: mfaDelegateSpy)
+        guard let emailAuthMethod = authMethods.first(where: { $0.channelTargetType.isEmailType }) else {
+            XCTFail("No email auth method found")
+            return
+        }
+        awaitingMFAState.requestChallenge(authMethod: emailAuthMethod, delegate: mfaDelegateSpy)
 
         await fulfillment(of: [mfaExpectation])
 
-        guard mfaDelegateSpy.onSelectionRequiredCalled, let mfaRequiredState = mfaDelegateSpy.newStateMFARequired, let authMethod = mfaDelegateSpy.authMethods?.first else {
+        guard mfaDelegateSpy.onSelectionRequiredCalled, let mfaRequiredState = mfaDelegateSpy.newStateMFARequired, let authMethod = mfaDelegateSpy.authMethods?.first(where: { $0.channelTargetType.isEmailType }) else {
             XCTFail("Selection required not triggered")
             return
         }
@@ -258,7 +268,11 @@ final class MSALNativeAuthSignInWithMFAEndToEndTests: MSALNativeAuthEndToEndPass
         let mfaExpectation = expectation(description: "mfa")
         let mfaDelegateSpy = MFARequestChallengeDelegateSpy(expectation: mfaExpectation)
         
-        result.newAwaitingMFAState.requestChallenge(authMethod: result.authMethods[0], delegate: mfaDelegateSpy)
+        guard let emailAuthMethod = result.authMethods.first(where: { $0.channelTargetType.isEmailType }) else {
+            XCTFail("No email auth method found")
+            return
+        }
+        result.newAwaitingMFAState.requestChallenge(authMethod: emailAuthMethod, delegate: mfaDelegateSpy)
 
         await fulfillment(of: [mfaExpectation])
         // browser required is expected here

--- a/MSAL/test/integration/native_auth/requests/jit/MSALNativeAuthJITChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/jit/MSALNativeAuthJITChallengeIntegrationTests.swift
@@ -49,7 +49,7 @@ class MSALNativeAuthJITChallengeIntegrationTests: MSALNativeAuthIntegrationBaseT
         )
     }
 
-    func test_succeedRequest_challengeSuccess() async throws {
+    func test_succeedRequest_challengeSuccessForEmail() async throws {
         try await mockResponse(.registrationChallengeSuccess, endpoint: .jitChallenge)
         let response: MSALNativeAuthJITChallengeResponse? = try await performTestSucceed()
 
@@ -59,6 +59,18 @@ class MSALNativeAuthJITChallengeIntegrationTests: MSALNativeAuthIntegrationBaseT
         XCTAssertTrue(response?.challengeChannel == "email")
         XCTAssertTrue(response?.codeLength == 8)
         XCTAssertNotNil(response?.continuationToken)
+    }
+    
+    func test_succeedRequest_challengeSuccessForSMS() async throws {
+        try await mockResponse(.registrationChallengeSMSSuccess, endpoint: .jitChallenge)
+        let response: MSALNativeAuthJITChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertEqual(response?.challengeType, "oob")
+        XCTAssertEqual(response?.bindingMethod, "prompt")
+        XCTAssertEqual(response?.challengeTarget, "+3538331***")
+        XCTAssertEqual(response?.challengeChannel, "sms")
+        XCTAssertEqual(response?.codeLength, 8)
+        XCTAssertEqual(response?.continuationToken, "Q3JlZGVudGlhbCB0b2tlbiBpcyB0ZXN0")
     }
     
     func test_jitChallenge_returnRedirect() async throws {

--- a/MSAL/test/integration/native_auth/requests/jit/MSALNativeAuthJITIntrospectIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/jit/MSALNativeAuthJITIntrospectIntegrationTests.swift
@@ -49,8 +49,18 @@ class MSALNativeAuthJITIntrospectIntegrationTests: MSALNativeAuthIntegrationBase
         let response: MSALNativeAuthJITIntrospectResponse? = try await performTestSucceed()
 
         XCTAssertNotNil(response?.continuationToken)
-        XCTAssertNotNil(response?.methods)
-        XCTAssertTrue(response!.methods!.count > 0)
+        guard let smsMethod = response?.methods?.first(where: { $0.challengeChannel == "sms"}) else {
+            XCTFail("Expected response to contain SMS method")
+            return
+        }
+        XCTAssertEqual(smsMethod.loginHint, "+35383******")
+        XCTAssertEqual(smsMethod.challengeType, .oob)
+        guard let emailMethod = response?.methods?.first(where: { $0.challengeChannel == "email"}) else {
+            XCTFail("Expected response to contain email method")
+            return
+        }
+        XCTAssertEqual(emailMethod.loginHint, "bar@contoso.com")
+        XCTAssertEqual(emailMethod.challengeType, .oob)
     }
     
     func test_jitIntrospect_returnRedirect() async throws {

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
@@ -60,11 +60,24 @@ class MSALNativeAuthSignInChallengeIntegrationTests: MSALNativeAuthIntegrationBa
         let response: MSALNativeAuthSignInChallengeResponse? = try await performTestSucceed()
 
         XCTAssertTrue(response?.challengeType == .oob)
-        XCTAssertNotNil(response?.continuationToken)
-        XCTAssertNotNil(response?.bindingMethod)
-        XCTAssertNotNil(response?.challengeTargetLabel)
-        XCTAssertNotNil(response?.codeLength)
-        XCTAssertNotNil(response?.interval)
+        XCTAssertEqual(response?.continuationToken, "Q3JlZGVudGlhbCB0b2tlbiBpcyB0ZXN0")
+        XCTAssertEqual(response?.bindingMethod, "prompt")
+        XCTAssertEqual(response?.challengeTargetLabel, "...")
+        XCTAssertEqual(response?.challengeChannel, "email")
+        XCTAssertEqual(response?.codeLength, 6)
+        XCTAssertEqual(response?.interval, 300)
+    }
+    
+    func test_succeedRequest_challengeSuccessSMS() async throws {
+        try await mockResponse(.challengeSuccessSMS, endpoint: .signInChallenge)
+        let response: MSALNativeAuthSignInChallengeResponse? = try await performTestSucceed()
+
+        XCTAssertTrue(response?.challengeType == .oob)
+        XCTAssertEqual(response?.continuationToken, "Q3JlZGVudGlhbCB0b2tlbiBpcyB0ZXN0")
+        XCTAssertEqual(response?.bindingMethod, "prompt")
+        XCTAssertEqual(response?.challengeTargetLabel, "+3538331***")
+        XCTAssertEqual(response?.challengeChannel, "sms")
+        XCTAssertEqual(response?.codeLength, 8)
     }
 
     func test_succeedRequest_challengeTypeRedirect() async throws {

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInIntrospectIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInIntrospectIntegrationTests.swift
@@ -68,6 +68,20 @@ class MSALNativeAuthSignInIntrospectIntegrationTests: MSALNativeAuthIntegrationB
         XCTAssertEqual(firstMethod.challengeType, .oob)
         XCTAssertEqual(firstMethod.loginHint, "**o*@c****so.com")
     }
+    
+    func test_succeedRequest_successfulSMSResult() async throws {
+        try await mockResponse(.signInIntrospectSMSSuccess, endpoint: .signInIntrospect)
+        let response: MSALNativeAuthSignInIntrospectResponse? = try await performTestSucceed()
+
+        XCTAssertNotNil(response?.continuationToken)
+        guard let firstMethod = response?.methods?.first else {
+            return XCTFail("No authentication method returned")
+        }
+        XCTAssertEqual(firstMethod.id, "F37D8C55-BE83-449F-8F99-131F6553871D")
+        XCTAssertEqual(firstMethod.challengeChannel, "sms")
+        XCTAssertEqual(firstMethod.challengeType, .oob)
+        XCTAssertEqual(firstMethod.loginHint, "+3538331***")
+    }
 
     func test_failRequest_invalidRequest() async throws {
         try await perform_testFail(


### PR DESCRIPTION
## Proposed changes

This PR includes changes only to the E2E test suite for the new SMS OTP MFA feature.
The only new SMS-related test checks that an invalid input error is returned when an invalid verification contact is used with the SMS authentication method in the JIT flow.
No additional SMS tests have been added, as there is currently no way to retrieve the SMS content containing the OTP code. Also, sending SMS is more expensive than email, so tests involving sending SMS to a phone number were not included.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [X] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

