### PR TITLE
Native auth: add new SDK error when authentication method is blocked

### DIFF
--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -476,7 +476,11 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .jitAuthMethodsSelectionRequired(_, _):
             let error = MFASubmitChallengeError(type: .generalError, correlationId: context.correlationId())
-            MSALNativeAuthLogger.log(level: .error, context: context, format: "SignIn: received unexpected strong authentication method registration API result")
+            MSALNativeAuthLogger.log(
+                level: .error,
+                context: context,
+                format: "SignIn: received unexpected strong authentication method registration API result"
+            )
             self.stopTelemetryEvent(event, context: context, error: error)
             return .init(.error(error: error, newState: nil), correlationId: context.correlationId())
         case .error(let error, let newState):

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorCodes.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorCodes.swift
@@ -30,4 +30,5 @@ enum MSALNativeAuthESTSApiErrorCodes: Int {
     case invalidRequestParameter = 90100
     case resetPasswordRequired = 50142
     case invalidVerificationContact = 901001
+    case authMethodBlocked = 550024
 }

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
@@ -47,6 +47,8 @@ enum MSALNativeAuthErrorMessage {
     static let unexpectedChallengeType = "Unexpected challenge type"
     static let refreshTokenMFARequiredError = "Multi-factor authentication is required, which can't be fulfilled as part of this flow. Please sign out and perform a new sign in operation. More information: "
     static let passwordResetRequired = "User password change is required, which can't be fulfilled as part of this flow. Please reset the password and perform a new sign in operation. More information: "
+    static let authMethodBlocked = "The server blocked the strong authentication method. Try contacting customer support to seek assistance. More information: "
+    static let verificationContactBlocked = "The server blocked the verification contact provided. Try using another email or phone number, or select an alternative authentication method. More information: "
 }
 
 // swiftlint:enable line_length

--- a/MSAL/src/native_auth/network/responses/validator/jit/MSALNativeAuthJITResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/jit/MSALNativeAuthJITResponseValidator.swift
@@ -171,12 +171,22 @@ final class MSALNativeAuthJITResponseValidator: MSALNativeAuthJITResponseValidat
         error: MSALNativeAuthJITChallengeResponseError) -> MSALNativeAuthJITChallengeValidatedResponse {
             switch error.error {
             case .invalidRequest:
-                guard let errorCode = error.errorCodes?.first,
-                      let knownErrorCode = MSALNativeAuthESTSApiErrorCodes(rawValue: errorCode),
-                      knownErrorCode == .invalidVerificationContact else {
+                if error.errorCodes?.contains(MSALNativeAuthESTSApiErrorCodes.authMethodBlocked.rawValue) == true {
+                    let customErrorDescription = MSALNativeAuthErrorMessage.verificationContactBlocked + (error.errorDescription ?? "")
+                    return .error(.verificationContactBlocked(
+                        MSALNativeAuthJITChallengeResponseError(
+                            error: error.error,
+                            errorDescription: customErrorDescription,
+                            errorCodes: error.errorCodes,
+                            errorURI: error.errorURI,
+                            innerErrors: error.innerErrors,
+                            correlationId: error.correlationId
+                        )))
+                } else if error.errorCodes?.contains(MSALNativeAuthESTSApiErrorCodes.invalidVerificationContact.rawValue) == true {
+                    return .error(.invalidVerificationContact(error))
+                } else {
                     return .error(.unexpectedError(error))
                 }
-                return .error(.invalidVerificationContact(error))
             case .unknown:
                 return .error(.unexpectedError(error))
             }

--- a/MSAL/src/native_auth/network/responses/validator/jit/validated_response/MSALNativeAuthJITChallengeValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/jit/validated_response/MSALNativeAuthJITChallengeValidatedResponse.swift
@@ -33,6 +33,7 @@ enum MSALNativeAuthJITChallengeValidatedResponse {
 enum MSALNativeAuthJITChallengeValidatedErrorType: Error {
     case redirect(reason: String?)
     case invalidVerificationContact(MSALNativeAuthJITChallengeResponseError)
+    case verificationContactBlocked(MSALNativeAuthJITChallengeResponseError)
     case invalidRequest(MSALNativeAuthJITChallengeResponseError?)
     case unexpectedError(MSALNativeAuthJITChallengeResponseError?)
 
@@ -60,6 +61,14 @@ enum MSALNativeAuthJITChallengeValidatedErrorType: Error {
                 type: .browserRequired,
                 message: reason,
                 correlationId: correlationId
+            )
+        case .verificationContactBlocked(let apiError):
+            return .init(
+                type: .verificationContactBlocked,
+                message: apiError.errorDescription,
+                correlationId: correlationId,
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
             )
         }
     }

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -174,7 +174,21 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
         error: MSALNativeAuthSignInChallengeResponseError) -> MSALNativeAuthSignInChallengeValidatedResponse {
             switch error.error {
             case .invalidRequest:
-                return .error(.invalidRequest(error))
+                if error.errorCodes?.contains(MSALNativeAuthESTSApiErrorCodes.authMethodBlocked.rawValue) == true {
+                    let customErrorDescription = MSALNativeAuthErrorMessage.authMethodBlocked + (error.errorDescription ?? "")
+                    return .error(.authMethodBlocked(
+                        MSALNativeAuthSignInChallengeResponseError(
+                            error: error.error,
+                            errorDescription: customErrorDescription,
+                            errorCodes: error.errorCodes,
+                            errorURI: error.errorURI,
+                            innerErrors: error.innerErrors,
+                            subError: error.subError,
+                            correlationId: error.correlationId
+                        )))
+                } else {
+                    return .error(.invalidRequest(error))
+                }
             case .unauthorizedClient:
                 return .error(.unauthorizedClient(error))
             case .invalidGrant:

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInChallengeValidatedResponse.swift
@@ -39,6 +39,7 @@ enum MSALNativeAuthSignInChallengeValidatedErrorType: Error {
     case unexpectedError(MSALNativeAuthSignInChallengeResponseError?)
     case userNotFound(MSALNativeAuthSignInChallengeResponseError)
     case unsupportedChallengeType(MSALNativeAuthSignInChallengeResponseError)
+    case authMethodBlocked(MSALNativeAuthSignInChallengeResponseError)
 
     func convertToSignInStartError(correlationId: UUID) -> SignInStartError {
         switch self {
@@ -56,6 +57,7 @@ enum MSALNativeAuthSignInChallengeValidatedErrorType: Error {
              .invalidToken(let apiError),
              .unauthorizedClient(let apiError),
              .unsupportedChallengeType(let apiError),
+             .authMethodBlocked(let apiError),
              .invalidRequest(let apiError):
             return .init(
                 type: .generalError,
@@ -84,6 +86,7 @@ enum MSALNativeAuthSignInChallengeValidatedErrorType: Error {
              .invalidToken(let apiError),
              .unauthorizedClient(let apiError),
              .userNotFound(let apiError),
+             .authMethodBlocked(let apiError),
              .unsupportedChallengeType(let apiError):
             return .init(
                 type: .generalError,
@@ -127,6 +130,14 @@ enum MSALNativeAuthSignInChallengeValidatedErrorType: Error {
                 correlationId: correlationId,
                 errorCodes: apiError?.errorCodes ?? [],
                 errorUri: apiError?.errorURI
+            )
+        case .authMethodBlocked(let apiError):
+            return .init(
+                type: .authMethodBlocked,
+                message: apiError.errorDescription,
+                correlationId: correlationId,
+                errorCodes: apiError.errorCodes ?? [],
+                errorUri: apiError.errorURI
             )
         }
     }

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInIntrospectValidatedResponse.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/validated_response/MSALNativeAuthSignInIntrospectValidatedResponse.swift
@@ -58,7 +58,7 @@ enum MSALNativeAuthSignInIntrospectValidatedErrorType: Error {
             )
         }
     }
-    
+
     func convertToPasswordRequiredError(correlationId: UUID) -> PasswordRequiredError {
         switch self {
         case .redirect(let reason):

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -233,6 +233,7 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
         case .userNotHaveAPassword,
              .invalidRequestParameter,
              .resetPasswordRequired,
+             .authMethodBlocked,
              .invalidVerificationContact:
             return .generalError(apiError)
         }
@@ -248,6 +249,7 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
             .userNotHaveAPassword,
             .invalidRequestParameter,
             .resetPasswordRequired,
+            .authMethodBlocked,
             .invalidVerificationContact:
             return .invalidRequest(apiError)
         }

--- a/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterSignUpDelegateDispatcher.swift
+++ b/MSAL/src/native_auth/public/state_machine/delegate_dispatcher/SignInAfterSignUpDelegateDispatcher.swift
@@ -39,7 +39,7 @@ final class SignInAfterSignUpDelegateDispatcher: DelegateDispatcher<SignInAfterS
             await delegate.onSignInAfterSignUpError(error: error)
         }
     }
-    
+
     func dispatchAwaitingMFA(authMethods: [MSALAuthMethod], newState: AwaitingMFAState, correlationId: UUID) async {
         if let onSignInAwaitingMFA = delegate.onSignInAwaitingMFA {
             telemetryUpdate?(.success(()))

--- a/MSAL/src/native_auth/public/state_machine/error/MFARequestChallengeError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/MFARequestChallengeError.swift
@@ -26,4 +26,43 @@ import Foundation
 
 /// Class that defines the structure and type of a MFARequestChallengeError
 @objcMembers
-public class MFARequestChallengeError: MSALNativeAuthGenericError { }
+public class MFARequestChallengeError: MSALNativeAuthError {
+    enum ErrorType: CaseIterable {
+        case authMethodBlocked
+        case browserRequired
+        case generalError
+    }
+
+    let type: ErrorType
+
+    init(type: ErrorType, message: String? = nil, correlationId: UUID, errorCodes: [Int] = [], errorUri: String? = nil) {
+        self.type = type
+        super.init(message: message, correlationId: correlationId, errorCodes: errorCodes, errorUri: errorUri)
+    }
+
+    /// Describes why an error occurred and provides more information about the error.
+    public override var errorDescription: String? {
+        if let description = super.errorDescription {
+            return description
+        }
+
+        switch type {
+        case .authMethodBlocked:
+            return MSALNativeAuthErrorMessage.authMethodBlocked
+        case .generalError:
+            return MSALNativeAuthErrorMessage.generalError
+        case .browserRequired:
+            return MSALNativeAuthErrorMessage.browserRequired
+        }
+    }
+
+    /// Returns `true` when the strong authentication method selected has been blocked. Reach out to customer support  to seek assistance.
+    public var isAuthMethodBlocked: Bool {
+        return type == .authMethodBlocked
+    }
+
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/error/RegisterStrongAuthChallengeError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/RegisterStrongAuthChallengeError.swift
@@ -29,6 +29,7 @@ public class RegisterStrongAuthChallengeError: MSALNativeAuthError {
     enum ErrorType: CaseIterable {
         case browserRequired
         case invalidInput
+        case verificationContactBlocked
         case generalError
     }
 
@@ -52,11 +53,23 @@ public class RegisterStrongAuthChallengeError: MSALNativeAuthError {
             return MSALNativeAuthErrorMessage.invalidInput
         case .generalError:
             return MSALNativeAuthErrorMessage.generalError
+        case .verificationContactBlocked:
+            return MSALNativeAuthErrorMessage.verificationContactBlocked
         }
     }
 
     /// Returns `true` when the input introduced is not valid.
     public var isInvalidInput: Bool {
         return type == .invalidInput
+    }
+
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
+    }
+
+    /// Returns `true` when the verification contact provided has been blocked. Try using another email or phone number, or select an alternative authentication method.
+    public var isVerificationContactBlocked: Bool {
+        return type == .verificationContactBlocked
     }
 }

--- a/MSAL/src/native_auth/public/state_machine/error/RegisterStrongAuthSubmitChallengeError.swift
+++ b/MSAL/src/native_auth/public/state_machine/error/RegisterStrongAuthSubmitChallengeError.swift
@@ -59,4 +59,9 @@ public class RegisterStrongAuthSubmitChallengeError: MSALNativeAuthError {
     public var isInvalidChallenge: Bool {
         return type == .invalidChallenge
     }
+
+    /// Returns `true` if a browser is required to continue the operation.
+    public var isBrowserRequired: Bool {
+        return type == .browserRequired
+    }
 }

--- a/MSAL/test/integration/native_auth/common/Model.swift
+++ b/MSAL/test/integration/native_auth/common/Model.swift
@@ -105,6 +105,7 @@ enum MockAPIResponse: String {
     case registraionInvalidChallengeTarget = "RegistraionInvalidChallengeTarget"
     case serverError = "ServerError"
     case accessDenied = "AccessDenied"
+    case authMethodBlocked = "AuthMethodBlocked"
 }
 
 // MARK: request body

--- a/MSAL/test/integration/native_auth/requests/jit/MSALNativeAuthJITChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/jit/MSALNativeAuthJITChallengeIntegrationTests.swift
@@ -90,6 +90,14 @@ class MSALNativeAuthJITChallengeIntegrationTests: MSALNativeAuthIntegrationBaseT
         )
     }
     
+    func test_failRequest_BlockedVerificationContact() async throws {
+        try await perform_testFail(
+            endpoint: .jitChallenge,
+            response: .authMethodBlocked,
+            expectedError: Error(error: .invalidRequest, errorDescription: "AADSTS550024: Configuring multi-factor authentication method is blocked. Trace ID: ebec4d3c-253c-4668-aa73-7528f2140100 Correlation ID: f71d0f39-4412-44d3-a715-3e82508bf368 Timestamp: 2025-09-25 14:53:26Z", errorCodes: [550024], errorURI: nil, innerErrors: nil)
+        )
+    }
+    
     func test_failRequest_expiredToken() async throws {
         try await perform_testFail(
             endpoint: .jitChallenge,

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
@@ -105,6 +105,14 @@ class MSALNativeAuthSignInChallengeIntegrationTests: MSALNativeAuthIntegrationBa
             expectedError: Error(error: .invalidRequest, errorDescription: nil, errorCodes: [55000], errorURI: nil, innerErrors: nil)
         )
     }
+    
+    func test_failRequest_BlockedVerificationContact() async throws {
+        try await perform_testFail(
+            endpoint: .signInChallenge,
+            response: .authMethodBlocked,
+            expectedError: Error(error: .invalidRequest, errorDescription: "AADSTS550024: Configuring multi-factor authentication method is blocked. Trace ID: ebec4d3c-253c-4668-aa73-7528f2140100 Correlation ID: f71d0f39-4412-44d3-a715-3e82508bf368 Timestamp: 2025-09-25 14:53:26Z", errorCodes: [550024], errorURI: nil, innerErrors: nil)
+        )
+    }
 
     func test_failRequest_expiredToken() async throws {
         try await perform_testFail(

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthJITResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthJITResponseValidatorTests.swift
@@ -82,11 +82,20 @@ final class MSALNativeAuthJITResponseValidatorTests: XCTestCase {
 
     // MARK: challenge API tests
 
-    func test_whenChallengeTypeInvalidRequest_validationShouldReturnInvalidVerificationContact() {
+    func test_whenChallengeTypeInvalidRequestWithCorrectErrorCode_validationShouldReturnInvalidVerificationContact() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let challengeErrorResponse = MSALNativeAuthJITChallengeResponseError(error: .invalidRequest, errorCodes: [901001])
         let result = sut.validateChallenge(context: context, result: .failure(challengeErrorResponse))
         if case .error(.invalidVerificationContact) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
+    func test_whenChallengeTypeInvalidRequestWithCorrectErrorCode_validationShouldReturnBlockedVerificationContact() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let challengeErrorResponse = MSALNativeAuthJITChallengeResponseError(error: .invalidRequest, errorCodes: [550024])
+        let result = sut.validateChallenge(context: context, result: .failure(challengeErrorResponse))
+        if case .error(.verificationContactBlocked) = result {} else {
             XCTFail("Unexpected result: \(result)")
         }
     }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTests.swift
@@ -51,6 +51,15 @@ final class MSALNativeAuthSignInResponseValidatorTests: MSALNativeAuthTestCase {
         }
     }
     
+    func test_whenChallengeTypeInvalidRequestWithCorrectErrorCode_validationShouldReturnBlockedAuthMethod() {
+        let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
+        let challengeErrorResponse = MSALNativeAuthSignInChallengeResponseError(error: .invalidRequest, errorCodes: [550024])
+        let result = sut.validateChallenge(context: context, result: .failure(challengeErrorResponse))
+        if case .error(.authMethodBlocked) = result {} else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
+    
     func test_whenChallengeTypePassword_validationShouldReturnPasswordRequired() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
         let continuationToken = "continuationToken"

--- a/MSAL/test/unit/native_auth/public/error/MFARequestChallengeErrorTests.swift
+++ b/MSAL/test/unit/native_auth/public/error/MFARequestChallengeErrorTests.swift
@@ -20,7 +20,7 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.  
+// THE SOFTWARE.
 
 import XCTest
 @testable import MSAL
@@ -30,7 +30,7 @@ final class MFARequestChallengeErrorTests: XCTestCase {
     private var sut: MFARequestChallengeError!
 
     func test_totalCases() {
-        XCTAssertEqual(MFARequestChallengeError.ErrorType.allCases.count, 2)
+        XCTAssertEqual(MFARequestChallengeError.ErrorType.allCases.count, 3)
     }
 
     func test_customErrorDescription() {
@@ -42,12 +42,14 @@ final class MFARequestChallengeErrorTests: XCTestCase {
     func test_defaultErrorDescription() {
         let sut: [MFARequestChallengeError] = [
             .init(type: .browserRequired, correlationId: .init()),
-            .init(type: .generalError, correlationId: .init())
+            .init(type: .generalError, correlationId: .init()),
+            .init(type: .authMethodBlocked, correlationId: .init())
         ]
 
         let expectedDescriptions = [
             MSALNativeAuthErrorMessage.browserRequired,
-            MSALNativeAuthErrorMessage.generalError
+            MSALNativeAuthErrorMessage.generalError,
+            MSALNativeAuthErrorMessage.authMethodBlocked
         ]
 
         let errorDescriptions = sut.map { $0.errorDescription }
@@ -60,5 +62,10 @@ final class MFARequestChallengeErrorTests: XCTestCase {
     func test_isBrowserRequired() {
         sut = .init(type: .browserRequired, correlationId: .init())
         XCTAssertTrue(sut.isBrowserRequired)
+    }
+    
+    func test_isAuthMethodBlocked() {
+        sut = .init(type: .authMethodBlocked, correlationId: .init())
+        XCTAssertTrue(sut.isAuthMethodBlocked)
     }
 }


### PR DESCRIPTION
## Proposed changes

Add new SDK error when authentication method is blocked

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
