### PR TITLE
Fix crash when deallocating STK reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.4.2]
+* Bug fix to prevent crash when deallocating STK SecKeyRef
+
 ## [2.4.1]
 * Allow cookies in duna resume request (#2732)
 


### PR DESCRIPTION
## Proposed changes

Fix crash when deallocating STK SecKeyRef in MSIDKeyPairWithCert.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

