### PR TITLE
Native auth: update auth method blocked error handling

### DIFF
--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorCodes.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthESTSApiErrorCodes.swift
@@ -30,5 +30,4 @@ enum MSALNativeAuthESTSApiErrorCodes: Int {
     case invalidRequestParameter = 90100
     case resetPasswordRequired = 50142
     case invalidVerificationContact = 901001
-    case authMethodBlocked = 550024
 }

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthSubErrorCode.swift
@@ -36,6 +36,7 @@ enum MSALNativeAuthSubErrorCode: String, Decodable, Equatable, MSALNativeAuthUnk
     case introspectRequired = "introspect_required"
     case mfaRequired = "mfa_required"
     case jitRequired = "registration_required"
+    case providerBlockedByRep = "provider_blocked_by_rep"
     case unknown
 
     var isAnyPasswordError: Bool {
@@ -52,6 +53,7 @@ enum MSALNativeAuthSubErrorCode: String, Decodable, Equatable, MSALNativeAuthUnk
              .introspectRequired,
              .mfaRequired,
              .jitRequired,
+             .providerBlockedByRep,
              .unknown:
             return false
         }

--- a/MSAL/src/native_auth/network/errors/jit/MSALNativeAuthJITChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/jit/MSALNativeAuthJITChallengeOauth2ErrorCode.swift
@@ -26,5 +26,6 @@ import Foundation
 
 enum MSALNativeAuthJITChallengeOauth2ErrorCode: String, Decodable, MSALNativeAuthUnknownCaseProtocol {
     case invalidRequest = "invalid_request"
+    case accessDenied = "access_denied"
     case unknown
 }

--- a/MSAL/src/native_auth/network/errors/jit/MSALNativeAuthJITChallengeResponseError.swift
+++ b/MSAL/src/native_auth/network/errors/jit/MSALNativeAuthJITChallengeResponseError.swift
@@ -31,6 +31,7 @@ struct MSALNativeAuthJITChallengeResponseError: MSALNativeAuthResponseError {
     let errorCodes: [Int]?
     let errorURI: String?
     let innerErrors: [MSALNativeAuthInnerError]?
+    let subError: MSALNativeAuthSubErrorCode?
     var correlationId: UUID?
 
     enum CodingKeys: String, CodingKey {
@@ -39,6 +40,7 @@ struct MSALNativeAuthJITChallengeResponseError: MSALNativeAuthResponseError {
         case errorCodes = "error_codes"
         case errorURI = "error_uri"
         case innerErrors = "inner_errors"
+        case subError = "suberror"
         case correlationId
     }
 
@@ -48,6 +50,7 @@ struct MSALNativeAuthJITChallengeResponseError: MSALNativeAuthResponseError {
         errorCodes: [Int]? = nil,
         errorURI: String? = nil,
         innerErrors: [MSALNativeAuthInnerError]? = nil,
+        subError: MSALNativeAuthSubErrorCode? = nil,
         correlationId: UUID? = nil
     ) {
         self.error = error
@@ -55,6 +58,7 @@ struct MSALNativeAuthJITChallengeResponseError: MSALNativeAuthResponseError {
         self.errorCodes = errorCodes
         self.errorURI = errorURI
         self.innerErrors = innerErrors
+        self.subError = subError
         self.correlationId = correlationId
     }
 }

--- a/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeOauth2ErrorCode.swift
+++ b/MSAL/src/native_auth/network/errors/sign_in/MSALNativeAuthSignInChallengeOauth2ErrorCode.swift
@@ -30,5 +30,6 @@ enum MSALNativeAuthSignInChallengeOauth2ErrorCode: String, Decodable, MSALNative
     case invalidGrant = "invalid_grant"
     case expiredToken = "expired_token"
     case unsupportedChallengeType = "unsupported_challenge_type"
+    case accessDenied = "access_denied"
     case unknown
 }

--- a/MSAL/src/native_auth/network/responses/validator/jit/MSALNativeAuthJITResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/jit/MSALNativeAuthJITResponseValidator.swift
@@ -170,8 +170,8 @@ final class MSALNativeAuthJITResponseValidator: MSALNativeAuthJITResponseValidat
     private func handleFailedJITChallengeResult(
         error: MSALNativeAuthJITChallengeResponseError) -> MSALNativeAuthJITChallengeValidatedResponse {
             switch error.error {
-            case .invalidRequest:
-                if error.errorCodes?.contains(MSALNativeAuthESTSApiErrorCodes.authMethodBlocked.rawValue) == true {
+            case .accessDenied:
+                if error.subError == .providerBlockedByRep {
                     let customErrorDescription = MSALNativeAuthErrorMessage.verificationContactBlocked + (error.errorDescription ?? "")
                     return .error(.verificationContactBlocked(
                         MSALNativeAuthJITChallengeResponseError(
@@ -182,7 +182,11 @@ final class MSALNativeAuthJITResponseValidator: MSALNativeAuthJITResponseValidat
                             innerErrors: error.innerErrors,
                             correlationId: error.correlationId
                         )))
-                } else if error.errorCodes?.contains(MSALNativeAuthESTSApiErrorCodes.invalidVerificationContact.rawValue) == true {
+                } else {
+                    return .error(.unexpectedError(error))
+                }
+            case .invalidRequest:
+                if error.errorCodes?.contains(MSALNativeAuthESTSApiErrorCodes.invalidVerificationContact.rawValue) == true {
                     return .error(.invalidVerificationContact(error))
                 } else {
                     return .error(.unexpectedError(error))

--- a/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_in/MSALNativeAuthSignInResponseValidator.swift
@@ -173,8 +173,8 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
     private func handleFailedSignInChallengeResult(
         error: MSALNativeAuthSignInChallengeResponseError) -> MSALNativeAuthSignInChallengeValidatedResponse {
             switch error.error {
-            case .invalidRequest:
-                if error.errorCodes?.contains(MSALNativeAuthESTSApiErrorCodes.authMethodBlocked.rawValue) == true {
+            case .accessDenied:
+                if error.subError == .providerBlockedByRep {
                     let customErrorDescription = MSALNativeAuthErrorMessage.authMethodBlocked + (error.errorDescription ?? "")
                     return .error(.authMethodBlocked(
                         MSALNativeAuthSignInChallengeResponseError(
@@ -187,8 +187,10 @@ final class MSALNativeAuthSignInResponseValidator: MSALNativeAuthSignInResponseV
                             correlationId: error.correlationId
                         )))
                 } else {
-                    return .error(.invalidRequest(error))
+                    return .error(.unexpectedError(error))
                 }
+            case .invalidRequest:
+                return .error(.invalidRequest(error))
             case .unauthorizedClient:
                 return .error(.unauthorizedClient(error))
             case .invalidGrant:

--- a/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/sign_up/MSALNativeAuthSignUpResponseValidator.swift
@@ -265,6 +265,7 @@ final class MSALNativeAuthSignUpResponseValidator: MSALNativeAuthSignUpResponseV
         case .unknown,
             .introspectRequired,
             .mfaRequired,
+            .providerBlockedByRep,
             .jitRequired:
             return .unexpectedError(apiError)
         }

--- a/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
+++ b/MSAL/src/native_auth/network/responses/validator/token/MSALNativeAuthTokenResponseValidator.swift
@@ -233,7 +233,6 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
         case .userNotHaveAPassword,
              .invalidRequestParameter,
              .resetPasswordRequired,
-             .authMethodBlocked,
              .invalidVerificationContact:
             return .generalError(apiError)
         }
@@ -249,7 +248,6 @@ final class MSALNativeAuthTokenResponseValidator: MSALNativeAuthTokenResponseVal
             .userNotHaveAPassword,
             .invalidRequestParameter,
             .resetPasswordRequired,
-            .authMethodBlocked,
             .invalidVerificationContact:
             return .invalidRequest(apiError)
         }

--- a/MSAL/test/integration/native_auth/requests/jit/MSALNativeAuthJITChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/jit/MSALNativeAuthJITChallengeIntegrationTests.swift
@@ -94,7 +94,7 @@ class MSALNativeAuthJITChallengeIntegrationTests: MSALNativeAuthIntegrationBaseT
         try await perform_testFail(
             endpoint: .jitChallenge,
             response: .authMethodBlocked,
-            expectedError: Error(error: .invalidRequest, errorDescription: "AADSTS550024: Configuring multi-factor authentication method is blocked. Trace ID: ebec4d3c-253c-4668-aa73-7528f2140100 Correlation ID: f71d0f39-4412-44d3-a715-3e82508bf368 Timestamp: 2025-09-25 14:53:26Z", errorCodes: [550024], errorURI: nil, innerErrors: nil)
+            expectedError: Error(error: .invalidRequest, errorDescription: "AADSTS550024: Configuring multi-factor authentication method is blocked. Trace ID: 48dc1336-6096-4167-ae1d-5bf3baa40400 Correlation ID: dbbcff90-8ad6-497f-aabb-73cc05ffdbdd Timestamp: 2025-10-07 12:59:45Z", errorCodes: [550024], errorURI: nil, innerErrors: nil)
         )
     }
     

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
@@ -110,7 +110,7 @@ class MSALNativeAuthSignInChallengeIntegrationTests: MSALNativeAuthIntegrationBa
         try await perform_testFail(
             endpoint: .signInChallenge,
             response: .authMethodBlocked,
-            expectedError: Error(error: .invalidRequest, errorDescription: "AADSTS550024: Configuring multi-factor authentication method is blocked. Trace ID: ebec4d3c-253c-4668-aa73-7528f2140100 Correlation ID: f71d0f39-4412-44d3-a715-3e82508bf368 Timestamp: 2025-09-25 14:53:26Z", errorCodes: [550024], errorURI: nil, innerErrors: nil)
+            expectedError: Error(error: .invalidRequest, errorDescription: "AADSTS550024: Configuring multi-factor authentication method is blocked. Trace ID: 48dc1336-6096-4167-ae1d-5bf3baa40400 Correlation ID: dbbcff90-8ad6-497f-aabb-73cc05ffdbdd Timestamp: 2025-10-07 12:59:45Z", errorCodes: [550024], errorURI: nil, innerErrors: nil)
         )
     }
 

--- a/MSAL/test/unit/native_auth/controllers/MSALNativeAuthJITControllerTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/MSALNativeAuthJITControllerTests.swift
@@ -223,7 +223,7 @@ class MSALNativeAuthJITControllerTests: MSALNativeAuthTestCase {
 
         jitRequestProviderMock.mockChallengeRequestFunc(MSALNativeAuthHTTPRequestMock.prepareMockRequest())
         jitRequestProviderMock.expectedContext = expectedContext
-        jitResponseValidatorMock.challengeValidatedResponse = .error(.verificationContactBlocked(.init(error: .invalidRequest, errorCodes: [MSALNativeAuthESTSApiErrorCodes.authMethodBlocked.rawValue])))
+        jitResponseValidatorMock.challengeValidatedResponse = .error(.verificationContactBlocked(.init(error: .accessDenied, subError: .providerBlockedByRep)))
 
         let result = await sut.requestJITChallenge(continuationToken: "continuationToken", authMethod: authMethod, verificationContact: "", context: expectedContext)
 

--- a/MSAL/test/unit/native_auth/network/errors/MSALNativeAuthSubErrorCodeTests.swift
+++ b/MSAL/test/unit/native_auth/network/errors/MSALNativeAuthSubErrorCodeTests.swift
@@ -29,7 +29,7 @@ final class MSALNativeAuthSubErrorCodeTests: XCTestCase {
     private typealias sut = MSALNativeAuthSubErrorCode
 
     func test_allCases() {
-        XCTAssertEqual(sut.allCases.count, 12)
+        XCTAssertEqual(sut.allCases.count, 13)
     }
 
     func test_passwordTooWeak() {
@@ -74,5 +74,9 @@ final class MSALNativeAuthSubErrorCodeTests: XCTestCase {
 
     func test_jitRequiredValue() {
         XCTAssertEqual(sut.jitRequired.rawValue, "registration_required")
+    }
+    
+    func test_providerBlockedByRep() {
+        XCTAssertEqual(sut.providerBlockedByRep.rawValue, "provider_blocked_by_rep")
     }
 }

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthJITResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthJITResponseValidatorTests.swift
@@ -93,7 +93,7 @@ final class MSALNativeAuthJITResponseValidatorTests: XCTestCase {
     
     func test_whenChallengeTypeInvalidRequestWithCorrectErrorCode_validationShouldReturnBlockedVerificationContact() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let challengeErrorResponse = MSALNativeAuthJITChallengeResponseError(error: .invalidRequest, errorCodes: [550024])
+        let challengeErrorResponse = MSALNativeAuthJITChallengeResponseError(error: .accessDenied, errorCodes: [550024], subError: .providerBlockedByRep)
         let result = sut.validateChallenge(context: context, result: .failure(challengeErrorResponse))
         if case .error(.verificationContactBlocked) = result {} else {
             XCTFail("Unexpected result: \(result)")

--- a/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTests.swift
+++ b/MSAL/test/unit/native_auth/network/responses/validator/MSALNativeAuthSignInResponseValidatorTests.swift
@@ -53,7 +53,7 @@ final class MSALNativeAuthSignInResponseValidatorTests: MSALNativeAuthTestCase {
     
     func test_whenChallengeTypeInvalidRequestWithCorrectErrorCode_validationShouldReturnBlockedAuthMethod() {
         let context = MSALNativeAuthRequestContext(correlationId: defaultUUID)
-        let challengeErrorResponse = MSALNativeAuthSignInChallengeResponseError(error: .invalidRequest, errorCodes: [550024])
+        let challengeErrorResponse = MSALNativeAuthSignInChallengeResponseError(error: .accessDenied, errorCodes: [550024], subError: .providerBlockedByRep)
         let result = sut.validateChallenge(context: context, result: .failure(challengeErrorResponse))
         if case .error(.authMethodBlocked) = result {} else {
             XCTFail("Unexpected result: \(result)")


### PR DESCRIPTION
## Proposed changes

Update auth method blocked error handling. Use suberror instead of error codes

## Type of change

- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

