### PR TITLE
[iOS SDK] Update integration tests to use access_denied

### DIFF
--- a/MSAL/test/integration/native_auth/requests/jit/MSALNativeAuthJITChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/jit/MSALNativeAuthJITChallengeIntegrationTests.swift
@@ -94,7 +94,7 @@ class MSALNativeAuthJITChallengeIntegrationTests: MSALNativeAuthIntegrationBaseT
         try await perform_testFail(
             endpoint: .jitChallenge,
             response: .authMethodBlocked,
-            expectedError: Error(error: .invalidRequest, errorDescription: "AADSTS550024: Configuring multi-factor authentication method is blocked. Trace ID: 48dc1336-6096-4167-ae1d-5bf3baa40400 Correlation ID: dbbcff90-8ad6-497f-aabb-73cc05ffdbdd Timestamp: 2025-10-07 12:59:45Z", errorCodes: [550024], errorURI: nil, innerErrors: nil)
+            expectedError: Error(error: .accessDenied, errorDescription: "AADSTS550024: Configuring multi-factor authentication method is blocked. Trace ID: 48dc1336-6096-4167-ae1d-5bf3baa40400 Correlation ID: dbbcff90-8ad6-497f-aabb-73cc05ffdbdd Timestamp: 2025-10-07 12:59:45Z", errorCodes: [550024], errorURI: nil, innerErrors: nil)
         )
     }
     

--- a/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
+++ b/MSAL/test/integration/native_auth/requests/sign_in/MSALNativeAuthSignInChallengeIntegrationTests.swift
@@ -110,7 +110,7 @@ class MSALNativeAuthSignInChallengeIntegrationTests: MSALNativeAuthIntegrationBa
         try await perform_testFail(
             endpoint: .signInChallenge,
             response: .authMethodBlocked,
-            expectedError: Error(error: .invalidRequest, errorDescription: "AADSTS550024: Configuring multi-factor authentication method is blocked. Trace ID: 48dc1336-6096-4167-ae1d-5bf3baa40400 Correlation ID: dbbcff90-8ad6-497f-aabb-73cc05ffdbdd Timestamp: 2025-10-07 12:59:45Z", errorCodes: [550024], errorURI: nil, innerErrors: nil)
+            expectedError: Error(error: .accessDenied, errorDescription: "AADSTS550024: Configuring multi-factor authentication method is blocked. Trace ID: 48dc1336-6096-4167-ae1d-5bf3baa40400 Correlation ID: dbbcff90-8ad6-497f-aabb-73cc05ffdbdd Timestamp: 2025-10-07 12:59:45Z", errorCodes: [550024], errorURI: nil, innerErrors: nil)
         )
     }
 


### PR DESCRIPTION
## Proposed changes

Mock API got updated to use new/proper response from API and current tests need to be updated also

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

