### PR TITLE
Add visionOS platform to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "MSAL",
   platforms: [
-        .macOS(.v11),.iOS(.v16)
+        .macOS(.v11),.iOS(.v16),.visionOS(v2)
   ],
   products: [
       .library(


### PR DESCRIPTION
## Proposed changes

Add support for visionOS platform to Package.swift (as binary already supports it).

## Type of change

- [ ] Feature work
- [x] Bug fix
- [x] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)