### PR TITLE
Hotfix 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.8.1]
+* Update target device/OS when generating documentation.
+
 ## [2.8.0]
 * Native auth: use slice config when refreshing access token #2813
 

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -13,7 +13,7 @@ cp README.md docs.temp/
 
 echo -e "Generating MSAL documentation"
 # Generate Swift SourceKitten output
-sourcekitten doc -- -workspace MSAL.xcworkspace -scheme "MSAL (iOS Framework)" -configuration Debug RUN_CLANG_STATIC_ANALYZER=NO -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.4' > docs.temp/swiftDoc.json
+sourcekitten doc -- -workspace MSAL.xcworkspace -scheme "MSAL (iOS Framework)" -configuration Debug RUN_CLANG_STATIC_ANALYZER=NO -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' > docs.temp/swiftDoc.json
 
 # Generate Objective-C SourceKitten output
 cd docs.temp


### PR DESCRIPTION
## Proposed changes

This pull request updates the documentation generation process to target a newer device and OS version, and documents this update in the changelog.

Documentation generation updates:

* Updated the `build_docs.sh` script to use `iPhone 17` with `iOS 26.2` as the target device/OS when generating Swift documentation, instead of `iPhone 14` with `iOS 16.4`.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [x] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

