### PR TITLE
[patch] [engg]: Revert changes to use token provided by GitHub

### DIFF
--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   issues: write
   contents: read
+  models: read
 
 env:
   # ---- Behavior toggles ----
@@ -71,7 +72,7 @@ jobs:
         id: ai
         if: steps.gate.outputs.should == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_COPILOT_PAT_MODELS }} 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
           GH_MODELS_MODEL: ${{ env.MODELS_MODEL }}
           ISSUE_TITLE_JSON: ${{ toJSON(github.event.issue.title) }} 
           ISSUE_BODY_JSON: ${{ toJSON(github.event.issue.body || '') }}


### PR DESCRIPTION
## Proposed changes

This reverts PR https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/2864

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

This pull request makes minor updates to the GitHub Actions workflow for AI-powered issue auto-replies. The changes primarily adjust permissions and update the authentication token used in the workflow.

* Workflow permissions update:
  * Added the `models: read` permission to the workflow, allowing access to GitHub's models API.

* Authentication token update:
  * Changed the token used for authentication from `GH_COPILOT_PAT_MODELS` to the default `GITHUB_TOKEN`, simplifying credential management.