### PR TITLE
Merge release 2.8.2 into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.8.2]
+* Support POP and claims in browser core
+
 ## [2.8.1]
 * Update target device/OS when generating documentation.
 

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MSAL"
-  s.version      = "2.8.1"
+  s.version      = "2.8.2"
   s.summary      = "Microsoft Authentication Library (MSAL) for iOS"
   s.description  = <<-DESC
                    The MSAL library for iOS gives your app the ability to begin using the Microsoft Cloud by supporting Microsoft Azure Active Directory and Microsoft Accounts in a converged experience using industry standard OAuth2 and OpenID Connect. The library also supports Microsoft Azure B2C for those using our hosted identity management service.

--- a/MSAL/resources/ios/Info.plist
+++ b/MSAL/resources/ios/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.8.1</string>
+	<string>2.8.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MSAL/resources/mac/Info.plist
+++ b/MSAL/resources/mac/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.8.1</string>
+	<string>2.8.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/MSAL/src/MSAL_Internal.h
+++ b/MSAL/src/MSAL_Internal.h
@@ -27,7 +27,7 @@
 
 #define MSAL_VER_HIGH       2
 #define MSAL_VER_LOW        8
-#define MSAL_VER_PATCH      1
+#define MSAL_VER_PATCH      2
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,6 @@ let package = Package(
           targets: ["MSAL"]),
   ],
   targets: [
-      .binaryTarget(name: "MSAL", url: "https://github.com/AzureAD/microsoft-authentication-library-for-objc/releases/download/2.8.1/MSAL.zip", checksum: "d45018483cfbf42210a6a88212da66fe47de21e7f8441837ee5613ef1ae5644d")
+      .binaryTarget(name: "MSAL", url: "https://github.com/AzureAD/microsoft-authentication-library-for-objc/releases/download/2.8.2/MSAL.zip", checksum: "525c9a6a7c4ed04ff647455835eec5e576136107b83f9168fedc6a1362659c35")
   ]
 )


### PR DESCRIPTION
## Proposed changes

Merge release 2.8.2 into dev

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

This pull request updates the MSAL library to version 2.8.2 and documents the new support for POP and claims in the browser core. The version bump is reflected consistently across the project files, and the binary target URL and checksum are updated for the new release.

Version update and release notes:

* Bumped MSAL version to 2.8.2 in `MSAL.podspec`, `MSAL/resources/ios/Info.plist`, `MSAL/resources/mac/Info.plist`, and `MSAL/src/MSAL_Internal.h`. [[1]](diffhunk://#diff-1a5b3570495c49f8afe25a38921fbc7c1ddbeb40537c9b4eea597367d2f8f4b9L3-R3) [[2]](diffhunk://#diff-288fc2093da9df47b9f238729aeb2d3cfbde02e3f8c24a089aa56e86947b5893L18-R18) [[3]](diffhunk://#diff-58de2c92a2d46e227feaa87a9f3b78b5793446e88355a7b50ebe0d77de6b9b82L18-R18) [[4]](diffhunk://#diff-b9c2aa156bd945646bd3ce45bf5272bc25355cf5e8c696ed2f94297bad1efddaL30-R30)
* Updated the Swift Package Manager binary target URL and checksum in `Package.swift` to point to the 2.8.2 release.

Documentation:

* Added a changelog entry for version 2.8.2, noting support for POP and claims in browser core.