### PR TITLE
[minor] [engg]: AI triage – add label trigger, retry on 429, concurrency guard

### DIFF
--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -110,14 +110,28 @@ jobs:
                       --arg user "$USER_PROMPT" \
                 '{model:$m, messages:[{role:"system",content:$sys},{role:"user",content:$user}]}')
 
-          # Call GitHub Models Chat Completions API
-          HTTP_CODE=$(curl -sSL -X POST -w "%{http_code}" -o response.json \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Content-Type: application/json" \
-            https://models.github.ai/inference/chat/completions \
-            -d "$REQ")
+          # Call GitHub Models Chat Completions API (retry once on 429)
+          MAX_ATTEMPTS=2
+          for (( attempt=1; attempt<=MAX_ATTEMPTS; attempt++ )); do
+            HTTP_CODE=$(curl -sSL -X POST -w "%{http_code}" -o response.json -D headers.txt \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -H "Content-Type: application/json" \
+              https://models.github.ai/inference/chat/completions \
+              -d "$REQ")
+
+            if [[ "$HTTP_CODE" != "429" ]] || [[ $attempt -eq $MAX_ATTEMPTS ]]; then
+              break
+            fi
+
+            RETRY_AFTER=$(grep -i '^retry-after:' headers.txt | tr -dc '0-9')
+            WAIT=${RETRY_AFTER:-30}
+            (( WAIT > 60 )) && WAIT=60
+            echo "Rate limited (429). Retrying in ${WAIT}s (attempt ${attempt}/${MAX_ATTEMPTS})..."
+            sleep "$WAIT"
+          done
+          rm -f headers.txt
 
           if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
             echo "::error::API request failed with status $HTTP_CODE"

--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -3,7 +3,7 @@ name: AI auto-reply to new issues
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 permissions:
   issues: write
@@ -13,6 +13,7 @@ permissions:
 env:
   # ---- Behavior toggles ----
   REQUIRED_LABEL: ""                         # e.g., "needs-triage" to only reply when present
+  TARGET_FOR_AI_TRIAGE_LABEL: "target-ai-triage"  # label to call triage bot to review the issue and decide whether to reply
   BLOCK_LABELS: "automation failure,security,vulnerability,no-ai,do-not-reply"
   DRY_RUN: "false"
   MODELS_MODEL: "openai/gpt-5"
@@ -20,6 +21,9 @@ env:
 jobs:
   ai_autoreply:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ai-reply-${{ github.event.issue.number }}
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -66,7 +70,14 @@ jobs:
               core.setOutput('should','false'); return;
             }
 
-            core.setOutput('should','true');
+            // Run on opened issues or issues with label added that matches TARGET_FOR_AI_TRIAGE_LABEL
+            const targetLabel = (process.env.TARGET_FOR_AI_TRIAGE_LABEL || '').trim().toLowerCase();
+            if (context.payload.action === 'opened' || 
+               (context.payload.action === 'labeled' && context.payload.label?.name?.toLowerCase() === targetLabel)) {
+              core.setOutput('should','true'); return;
+            }
+
+            core.setOutput('should','false');
 
       - name: Generate AI reply (GitHub Models)
         id: ai
@@ -135,6 +146,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           DRY_RUN: ${{ env.DRY_RUN }}
+          TARGET_FOR_AI_TRIAGE_LABEL: ${{ env.TARGET_FOR_AI_TRIAGE_LABEL }}
         with:
           script: |
             const body = `${{ steps.ai.outputs.text }}` || '';
@@ -165,4 +177,16 @@ jobs:
               });
             } catch (e) {
               core.warning('Could not add AI-replied label (create it first).');
+            }
+
+            // Remove the trigger label if it was used
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: process.env.TARGET_FOR_AI_TRIAGE_LABEL
+              });
+            } catch(e) {
+              // Label wasn't present, ignore
             }


### PR DESCRIPTION
## Proposed changes

Enhances the AI auto-reply workflow (`.github/workflows/ai-issues-auto-reply.yml`) with three improvements:

1. **Label-based trigger** – The workflow now also fires on the `labeled` event. Adding the `target-ai-triage` label to any issue triggers the AI triage bot, useful for retrying on old issues.
2. **Retry on 429** – The GitHub Models API call now retries once on HTTP 429 (rate limit), respecting the `Retry-After` header (capped at 60 s, default 30 s).
3. **Concurrency guard** – Added a `concurrency` group keyed by issue number to prevent duplicate AI replies from racing past the gate check.
4. **Bug fix** – `TARGET_FOR_AI_TRIAGE_LABEL` env var is now passed to the "Post reply" step so the trigger label is properly removed after replying.

## Type of change

- [x] Engineering change

## Risk

- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
