### PR TITLE
[minor] [bugfix]: Fix Swift 6 actor-isolation crash for all public callback typedefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 TBD
+* Fix Swift 6 runtime crash (EXC_BREAKPOINT) when MSAL callbacks are invoked on background threads by adding NS_SWIFT_SENDABLE and NS_SWIFT_NONISOLATED to all public block typedefs #2474
 * Add changes in podspec to support swift files added in common-core #2846
 * Add a property in MSAL global config allowing 1st party apps to opt into using bound app refresh tokens #2896
 * Add error handling for MSALErrorServerInvalidRequestResetPasswordRequired, error code mapping for STS error 50142 (SecureChangePasswordDueToConditionalAccess) #2867

--- a/MSAL/src/public/MSALDefinitions.h
+++ b/MSAL/src/public/MSALDefinitions.h
@@ -272,7 +272,7 @@ typedef void (^MSALWPJMetaDataCompletionBlock)(MSALWPJMetaData * _Nullable msalP
                          logger.
  
  */
-typedef void (^MSALLogCallback)(MSALLogLevel level, NSString * _Nullable message, BOOL containsPII);
+typedef void (NS_SWIFT_SENDABLE NS_SWIFT_NONISOLATED ^MSALLogCallback)(MSALLogLevel level, NSString * _Nullable message, BOOL containsPII);
 
 /**
  MSAL telemetry callback.

--- a/MSAL/src/public/MSALDefinitions.h
+++ b/MSAL/src/public/MSALDefinitions.h
@@ -234,32 +234,32 @@ typedef NS_ENUM(NSUInteger, MSALXpcMode)
     @param result       Represents information returned to the application after a successful interactive or silent token acquisition. See `MSALResult` for more information.
     @param error         Provides information about error that prevented MSAL from getting a token. See `MSALError` for possible errors.
  */
-typedef void (^MSALCompletionBlock)(MSALResult * _Nullable result, NSError * _Nullable error);
+typedef void (NS_SWIFT_SENDABLE NS_SWIFT_NONISOLATED ^MSALCompletionBlock)(MSALResult * _Nullable result, NSError * _Nullable error);
 
 /**
     The completion block that will be called when accounts are loaded, or MSAL encountered an error.
  */
-typedef void (^MSALAccountsCompletionBlock)(NSArray<MSALAccount *> * _Nullable accounts, NSError * _Nullable error);
+typedef void (NS_SWIFT_SENDABLE NS_SWIFT_NONISOLATED ^MSALAccountsCompletionBlock)(NSArray<MSALAccount *> * _Nullable accounts, NSError * _Nullable error);
 
 /**
     The completion block that will be called when current account is loaded, or MSAL encountered an error.
  */
-typedef void (^MSALCurrentAccountCompletionBlock)(MSALAccount * _Nullable_result account, MSALAccount * _Nullable_result previousAccount, NSError * _Nullable error);
+typedef void (NS_SWIFT_SENDABLE NS_SWIFT_NONISOLATED ^MSALCurrentAccountCompletionBlock)(MSALAccount * _Nullable_result account, MSALAccount * _Nullable_result previousAccount, NSError * _Nullable error);
 
 /**
     The completion block that will be called when sign out is completed, or MSAL encountered an error.
  */
-typedef void (^MSALSignoutCompletionBlock)(BOOL success, NSError * _Nullable error);
+typedef void (NS_SWIFT_SENDABLE NS_SWIFT_NONISOLATED ^MSALSignoutCompletionBlock)(BOOL success, NSError * _Nullable error);
 
 /**
    The completion block that will be called when MSAL has finished reading device state, or MSAL encountered an error.
 */
-typedef void (^MSALDeviceInformationCompletionBlock)(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error);
+typedef void (NS_SWIFT_SENDABLE NS_SWIFT_NONISOLATED ^MSALDeviceInformationCompletionBlock)(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error);
 
 /**
    The completion block that will be called when MSAL has finished reading device state, or MSAL encountered an error.
 */
-typedef void (^MSALWPJMetaDataCompletionBlock)(MSALWPJMetaData * _Nullable msalPJMetaDataInformation, NSError * _Nullable error);
+typedef void (NS_SWIFT_SENDABLE NS_SWIFT_NONISOLATED ^MSALWPJMetaDataCompletionBlock)(MSALWPJMetaData * _Nullable msalPJMetaDataInformation, NSError * _Nullable error);
 
 /**
  The block that returns a MSAL log message.
@@ -279,7 +279,7 @@ typedef void (NS_SWIFT_SENDABLE NS_SWIFT_NONISOLATED ^MSALLogCallback)(MSALLogLe
  
  @param event Aggregated telemetry event.
  */
-typedef void(^MSALTelemetryCallback)(NSDictionary<NSString *, NSString *> * _Nonnull event);
+typedef void (NS_SWIFT_SENDABLE NS_SWIFT_NONISOLATED ^MSALTelemetryCallback)(NSDictionary<NSString *, NSString *> * _Nonnull event);
 
 #endif /* MSALConstants_h */
 


### PR DESCRIPTION
## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

## Proposed changes

This pull request annotates **all public block typedefs** in `MSALDefinitions.h` with `NS_SWIFT_SENDABLE` and `NS_SWIFT_NONISOLATED` to fix Swift 6 runtime crashes (`EXC_BREAKPOINT` / `SIGTRAP`) caused by actor-isolation checks when callbacks are invoked on background threads.

### Root cause

In Swift 6, closures defined in `@MainActor` contexts (e.g., SwiftUI `App` structs) inherit `@MainActor` isolation. When MSAL invokes these callbacks on background threads (logger serial queue, network completion, etc.), the Swift 6 runtime asserts the closure is on the main thread and crashes with `dispatch_assert_queue_fail`.

### Changes

- **`MSALDefinitions.h`**: Added `NS_SWIFT_SENDABLE NS_SWIFT_NONISOLATED` to all 8 public block typedefs:
  - `MSALCompletionBlock` (acquireToken/acquireTokenSilent)
  - `MSALAccountsCompletionBlock`
  - `MSALCurrentAccountCompletionBlock`
  - `MSALSignoutCompletionBlock`
  - `MSALDeviceInformationCompletionBlock`
  - `MSALWPJMetaDataCompletionBlock`
  - `MSALLogCallback`
  - `MSALTelemetryCallback`
- **IdentityCore submodule**: Updated to include matching `MSIDLogCallback` annotation (PR AzureAD/microsoft-authentication-library-common-for-objc#1761)
- **CHANGELOG.md**: Added entry for this fix

### Impact

- **Swift 6 users**: Fixes runtime crashes with no code changes needed on their side
- **Swift 5 users**: Zero impact — `NS_SWIFT_SENDABLE` and `NS_SWIFT_NONISOLATED` are compiler import hints that Swift 5 effectively ignores
- **Source compatibility**: `@Sendable` annotation may produce new compile-time warnings for callers capturing non-Sendable state, but this is preferable to runtime crashes

Fixes #2474

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High
- [x] Medium – Errors could cause regression of 1 or more scenarios.
- [ ] Small