### PR TITLE
Code Review Feedback: ameyapat/add-get-device-token-api

### DIFF
--- a/MSAL/src/MSALDeviceTokenResult.h
+++ b/MSAL/src/MSALDeviceTokenResult.h
@@ -22,6 +22,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#import <Foundation/Foundation.h>
+
+@class MSALAuthority;
+@class MSIDTokenResult;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MSALDeviceTokenResult : NSObject

--- a/MSAL/src/instance/MSALDeviceInfoProvider.m
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.m
@@ -33,7 +33,6 @@
 #import "MSALDeviceInformation+Internal.h"
 #import "MSALWPJMetaData+Internal.h"
 #import "MSALDeviceTokenParameters.h"
-#import "MSALDeviceTokenParameters.h"
 
 #import "MSIDWorkPlaceJoinConstants.h"
 #import "MSIDWorkPlaceJoinUtil.h"


### PR DESCRIPTION
## Code Review Summary

**Branch reviewed:** `ameyapat/add-get-device-token-api` vs `dev`

### Findings: 15 issues (4 Critical, 9 Warnings, 2 Suggestions)

#### Critical
1. **`getDeviceTokenForSharedDeviceWithResource` always fails** — passes nil tenantId to init that rejects nil, making the shared device flow non-functional
2. **Original network error overwritten** — `resultForDeviceTokenResult:error:` replaces informative network errors with generic message when result is nil
3. **Missing imports in `MSALDeviceTokenResult.h`** — no Foundation import or forward declarations *(fixed in this PR)*
4. **Hardcoded `login.microsoftonline.com`** — breaks sovereign cloud deployments (Azure Gov, China, Germany)

#### Warnings
5. Duplicate import in `MSALDeviceInfoProvider.m` *(fixed in this PR)*
6. Dead code — `MSALResult.resultForDeviceTokenResult:authority:error:` never called + return type mismatch
7. `MSALDeviceTokenParameters.h` not in umbrella header `MSAL.h`
8. `MSALDeviceTokenResult.h` not in `MSAL/src/public/` despite being referenced by public API
9. Properties use `atomic` — inconsistent with codebase (`nonatomic` convention)
10. tenantId nullability mismatch between property (nonnull) and init (nullable)
11. Unused `MSIDCacheAccessor.h` import in `MSALDeviceTokenParameters.m`
12. Parameter validation order suboptimal in `getDeviceTokenWithParameters:`

#### Suggestions
13. Missing braces in submodule `MSIDDeviceTokenGrantRequest.m` (code style violation)
14. No unit tests added for new device token API
15. Log message parameter order inconsistency in `MSALDeviceInfoProvider.m`

### Fixes Applied in This PR
- Removed duplicate `#import "MSALDeviceTokenParameters.h"` in `MSALDeviceInfoProvider.m`
- Added missing `#import <Foundation/Foundation.h>` and `@class` forward declarations in `MSALDeviceTokenResult.h`