### PR TITLE
Add getDeviceToken public API and provider implementation

### DIFF
--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -115,6 +115,10 @@
 #if TARGET_OS_IPHONE
 #import "MSIDBartFeatureUtil.h"
 #endif
+#import "MSALDeviceTokenParameters.h"
+#import "MSALAADOauth2Provider.h"
+#import "MSALDeviceTokenResult.h"
+#import "MSALDeviceInformation.h"
 
 @interface MSALPublicClientApplication()
 {
@@ -754,7 +758,7 @@
     msidParams.currentRequestTelemetry.schemaVersion = HTTP_REQUEST_TELEMETRY_SCHEMA_VERSION;
     msidParams.currentRequestTelemetry.apiId = [msidParams.telemetryApiId integerValue];
     msidParams.currentRequestTelemetry.tokenCacheRefreshType = parameters.forceRefresh ? TokenCacheRefreshTypeForceRefresh : TokenCacheRefreshTypeNoCacheLookupInvolved;
-    msidParams.allowUsingLocalCachedRtWhenSsoExtFailed = parameters.allowUsingLocalCachedRtWhenSsoExtFailed;    
+    msidParams.allowUsingLocalCachedRtWhenSsoExtFailed = parameters.allowUsingLocalCachedRtWhenSsoExtFailed;
     msidParams.forceRefresh = parameters.forceRefresh;
     
     // Nested auth protocol
@@ -1533,6 +1537,136 @@
     
     MSALDeviceInfoProvider *deviceInfoProvider = [MSALDeviceInfoProvider new];
     [deviceInfoProvider wpjMetaDataDeviceInfoWithRequestParameters:requestParams tenantId:tenantId completionBlock:block];
+}
+
+- (void)getDeviceTokenForSharedDeviceWithResource:(nonnull NSString *)resource
+                                           scopes:(nullable NSArray<NSString *> *)scopes
+                                   completionBlock:(nonnull MSALDeviceTokenResultCompletionBlock)completionBlock
+{
+    if (!resource)
+    {
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"Resource parameter is required to get device token for shared device.", nil, nil, nil, nil, nil, YES);
+        if (completionBlock)
+        {
+            completionBlock(nil, error);
+        }
+        return;
+    }
+    
+    if (!completionBlock)
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelWarning, nil, @"getDeviceTokenForSharedDeviceWithResource called without a completion block.");
+        return;
+    }
+    
+    [self getDeviceInformationWithParameters:nil
+                             completionBlock:^(MSALDeviceInformation * _Nullable deviceInformation, NSError * _Nullable error)
+    {
+        if (!deviceInformation)
+        {
+            // Unable to get device information, return error
+            if (!error)
+            {
+                error = MSIDCreateError(MSIDErrorDomain, MSALErrorWorkplaceJoinRequired, @"Failed to retrieve device information for shared device. No error was returned from the device info provider.", nil, nil, nil, nil, nil, YES);
+            }
+            if (completionBlock)
+            {
+                completionBlock(nil, error);
+            }
+            return;
+        }
+        
+        if (deviceInformation.deviceMode != MSALDeviceModeShared)
+        {
+            // Device is not in shared mode, return error
+            NSError *modeError = MSIDCreateError(MSIDErrorDomain, MSALInternalErrorInvalidParameter, @"Device is not in shared mode. Device token for shared device cannot be retrieved.", nil, nil, nil, nil, nil, YES);
+            if (completionBlock)
+            {
+                completionBlock(nil, modeError);
+            }
+            return;
+        }
+        
+        // Initializing parameters with nil tenantId to get device token for primary registration.
+        MSALDeviceTokenParameters *parameters = [[MSALDeviceTokenParameters alloc] initWithResource:resource
+                                                                                             scopes:scopes
+                                                                                        forTenantId:nil];
+        // Device is in shared mode, proceed to get device token
+        [self getDeviceTokenWithParameters:parameters completionBlock:completionBlock];
+    }];
+}
+
+- (void)getDeviceTokenWithParameters:(nonnull MSALDeviceTokenParameters *)parameters
+                     completionBlock:(nonnull MSALDeviceTokenResultCompletionBlock)completionBlock
+{
+    if (!parameters)
+    {
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"Request parameters are required to get device token", nil, nil, nil, nil, nil, YES);
+        if (completionBlock)
+        {
+            completionBlock(nil, error);
+        }
+        return;
+    }
+    
+    NSError *requestParamsError;
+    MSIDAuthenticationScheme *bearerAuthScheme = [[MSIDAuthenticationScheme alloc] initWithSchemeParameters:@{}];
+    MSIDRequestParameters *requestParams = [[MSIDRequestParameters alloc] initWithAuthority:self.internalConfig.authority.msidAuthority
+                                                                                 authScheme:bearerAuthScheme
+                                                                                redirectUri:self.internalConfig.verifiedRedirectUri.url.absoluteString
+                                                                                   clientId:self.internalConfig.clientId
+                                                                                     scopes:[[NSOrderedSet alloc] initWithArray:parameters.scopes copyItems:YES]
+                                                                                 oidcScopes:nil
+                                                                              correlationId:parameters.correlationId
+                                                                             telemetryApiId:nil
+                                                                        intuneAppIdentifier:[[NSBundle mainBundle] bundleIdentifier]
+                                                                                requestType:MSIDRequestLocalType
+                                                                                      error:&requestParamsError];
+
+    __auto_type block = ^(MSALDeviceTokenResult *result, NSError *msidError, id<MSIDRequestContext> context)
+    {
+        NSError *msalError = [MSALErrorConverter msalErrorFromMsidError:msidError classifyErrors:YES msalOauth2Provider:self.msalOauth2Provider correlationId:context.correlationId authScheme:parameters.authenticationScheme popManager:self.popManager];
+        if (!completionBlock) return;
+        
+        if (parameters.completionBlockQueue)
+        {
+            dispatch_async(parameters.completionBlockQueue, ^{
+                completionBlock(result, msalError);
+            });
+        }
+        else
+        {
+            completionBlock(result, msalError);
+        }
+    };
+    
+    if (!parameters.tenantId)
+    {
+        block(nil, MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"tenantId is required to get device token", nil, nil, nil, nil, nil, YES), nil);
+        return;
+    }
+    
+    if (!parameters.resource)
+    {
+        block(nil, MSIDCreateError(MSIDErrorDomain, MSIDErrorInvalidDeveloperParameter, @"resource is required to get device token", nil, nil, nil, nil, nil, YES), nil);
+        return;
+    }
+    
+    if (!requestParams)
+    {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, requestParams, @"getDeviceTokenWithParameters: Error when creating requestParams: %@", requestParamsError);
+        block(nil, requestParamsError, nil);
+        return;
+    }
+    
+    MSALDeviceInfoProvider *deviceInfoProvider = [MSALDeviceInfoProvider new];
+    [deviceInfoProvider deviceTokenWithRequestParameters:requestParams
+                                   deviceTokenParameters:parameters
+                                         completionBlock:^(MSIDTokenResult * _Nullable result, NSError * _Nullable error)
+    {
+        MSALDeviceTokenResult *msalResult = [MSALDeviceTokenResult resultForDeviceTokenResult:result error:&error];
+        block(msalResult, error, requestParams);
+    }];
 }
 
 - (BOOL)isCompatibleAADBrokerAvailable

--- a/MSAL/src/instance/MSALDeviceInfoProvider.h
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.h
@@ -29,6 +29,7 @@
 #import "MSALSSOExtensionRequestHandler.h"
 
 @class MSIDRequestParameters;
+@class MSALDeviceTokenParameters;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -41,6 +42,9 @@ NS_ASSUME_NONNULL_BEGIN
                                           tenantId:(nullable NSString *)tenantId
                                    completionBlock:(MSALWPJMetaDataCompletionBlock)completionBlock;
 
+- (void)deviceTokenWithRequestParameters:(MSIDRequestParameters *)requestParameters
+                   deviceTokenParameters:(nonnull MSALDeviceTokenParameters *)deviceTokenParameters
+                         completionBlock:(MSIDRequestCompletionBlock)completionBlock;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MSAL/src/instance/MSALDeviceInfoProvider.m
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.m
@@ -32,10 +32,13 @@
 #import "MSIDRequestParameters+Broker.h"
 #import "MSALDeviceInformation+Internal.h"
 #import "MSALWPJMetaData+Internal.h"
+#import "MSALDeviceTokenParameters.h"
 
 #import "MSIDWorkPlaceJoinConstants.h"
 #import "MSIDWorkPlaceJoinUtil.h"
 #import "MSIDRegistrationInformation.h"
+#import "MSIDDeviceTokenGrantRequest.h"
+#import "MSIDDeviceTokenResponseHandler.h"
 
 @implementation MSALDeviceInfoProvider
 
@@ -134,6 +137,72 @@
     
     MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, requestParameters, @"wpjMetaDataDeviceInfo: Completing filling device info for tenant Id: %@ %@", MSID_PII_LOG_MASKABLE(wpjMetaData),  MSID_PII_LOG_MASKABLE(tenantId));
     completionBlock(wpjMetaData, nil);
+}
+
+- (void)deviceTokenWithRequestParameters:(MSIDRequestParameters *)requestParameters
+                   deviceTokenParameters:(nonnull MSALDeviceTokenParameters *)deviceTokenParameters
+                         completionBlock:(MSIDRequestCompletionBlock)completionBlock
+{
+    NSString *tenantId = deviceTokenParameters.tenantId;
+    MSIDWPJKeyPairWithCert *wpjCerts = [MSIDWorkPlaceJoinUtil getWPJKeysWithTenantId:tenantId context:requestParameters];
+    
+    if (!wpjCerts)
+    {
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorWorkplaceJoinRequired, @"Could not find device registration for the requested tenant.", nil, nil, nil, nil, nil, YES);
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, requestParameters, @"deviceTokenWithRequestParameters: No device registration found for tenant Id: %@", MSID_PII_LOG_MASKABLE(tenantId));
+        completionBlock(nil, error);
+        return;
+    }
+    
+    if (!wpjCerts.certificateData)
+    {
+        NSError *error = MSIDCreateError(MSIDErrorDomain, MSIDErrorInternal, @"Could not find certificate for device registration.", nil, nil, nil, nil, nil, YES);
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, requestParameters, @"deviceTokenWithRequestParameters: No certificate found for device registration for tenant Id: %@", MSID_PII_LOG_MASKABLE(tenantId));
+        completionBlock(nil, error);
+        return;
+    }
+    NSURL *endpoint = [requestParameters.authority.url URLByAppendingPathComponent:@"oauth2/token"];
+    NSError *error;
+    
+    // No user is associated to device token, using the first enrollment id from Intune cache for shared device.
+    NSString *enrollmentId = [requestParameters.authority enrollmentIdForHomeAccountId:nil
+                                                                          legacyUserId:nil
+                                                                               context:requestParameters
+                                                                                 error:nil];
+    
+    MSIDDeviceTokenResponseHandler *tokenResponseHandler = [[MSIDDeviceTokenResponseHandler alloc] initWithRequestParameters:requestParameters
+                                                                                                                oauthFactory:[MSIDOauth2Factory new]];
+    
+    MSIDDeviceTokenGrantRequest *deviceTokenRequest = [[MSIDDeviceTokenGrantRequest alloc] initWithEndpoint:endpoint
+                                                                                         requestParameters:requestParameters
+                                                                                                     scopes:requestParameters.allTokenRequestScopes
+                                                                                    registrationInformation:wpjCerts
+                                                                                                   resource:deviceTokenParameters.resource
+                                                                                               enrollmentId:enrollmentId
+                                                                                            extraParameters:nil
+                                                                                                 ssoContext:nil
+                                                                                       tokenResponseHandler:tokenResponseHandler
+                                                                                                      error:&error];
+    if (!deviceTokenRequest)
+    {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, requestParameters, @"deviceTokenWithRequestParameters: Failed to create device token request for tenant Id: %@, error: %@", MSID_PII_LOG_MASKABLE(tenantId), MSID_PII_LOG_MASKABLE(error));
+        completionBlock(nil, error);
+        return;
+    }
+    
+    [deviceTokenRequest executeRequestWithCompletion:^(MSIDTokenResult * _Nullable result, NSError * _Nullable error)
+    {
+        if (!result)
+        {
+            MSID_LOG_WITH_CTX_PII(MSIDLogLevelError, requestParameters, @"deviceTokenWithRequestParameters: Error acquiring device token for tenant Id: %@ %@", MSID_PII_LOG_MASKABLE(error),  MSID_PII_LOG_MASKABLE(tenantId));
+            completionBlock(nil, error);
+            return;
+        }
+        
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelInfo, requestParameters, @"deviceTokenWithRequestParameters: Successfully acquired device token for tenant Id: %@ %@", MSID_PII_LOG_MASKABLE(result),  MSID_PII_LOG_MASKABLE(tenantId));
+        
+        completionBlock(result, nil);
+    }];
 }
 
 @end

--- a/MSAL/src/public/MSALPublicClientApplication.h
+++ b/MSAL/src/public/MSALPublicClientApplication.h
@@ -35,6 +35,7 @@
 @class MSALAccountEnumerationParameters;
 @class MSALSignoutParameters;
 @class MSALParameters;
+@class MSALDeviceTokenParameters;
 
 /**
     Representation of OAuth 2.0 Public client application. Create an instance of this class to acquire tokens.
@@ -225,6 +226,22 @@
 - (void)getWPJMetaDataDeviceWithParameters:(nullable MSALParameters *)parameters
                                forTenantId:(nullable NSString *)tenantId
                            completionBlock:(nonnull MSALWPJMetaDataCompletionBlock)completionBlock;
+
+/**
+    For a given tenantId, requests a device token from token service. This access token is not associated to any user but the device.
+    The resource accepting this token, should support device tokens to authenticate device identity.
+ */
+- (void)getDeviceTokenWithParameters:(nonnull MSALDeviceTokenParameters *)parameters
+                     completionBlock:(nonnull MSALDeviceTokenResultCompletionBlock)completionBlock;
+
+/**
+    When the device is a shared device, for a given resource, requests a device token from token service.
+    This access token is not associated to any user but the device.
+    The resource accepting this token, should support device tokens to authenticate device identity.
+ */
+- (void)getDeviceTokenForSharedDeviceWithResource:(nonnull NSString *)resource
+                                           scopes:(nullable NSArray<NSString *> *)scopes
+                                  completionBlock:(nonnull MSALDeviceTokenResultCompletionBlock)completionBlock;
 
 /**
    A boolean indicates if a compatible broker is present in device for AAD requests.


### PR DESCRIPTION
## Summary

Adds the public API surface and internal implementation for device token acquisition:

- **MSALPublicClientApplication.h** — two new public methods:
  - `getDeviceTokenWithParameters:completionBlock:` — request a device token for a given tenant
  - `getDeviceTokenForSharedDeviceWithResource:scopes:completionBlock:` — convenience method for shared devices (validates shared mode first)
- **MSALPublicClientApplication.m** — full implementation including parameter validation, request parameter construction, error conversion, and completion block dispatch
- **MSALDeviceInfoProvider** — new `deviceTokenWithRequestParameters:deviceTokenParameters:completionBlock:` method that handles WPJ certificate lookup, enrollment ID resolution, and executes the `MSIDDeviceTokenGrantRequest`

> **Note:** This PR depends on Part 1 (#2971) which adds the model types and submodule update.

## Related PRs
This PR is part of a split from `ameyapat/add-get-device-token-api` (2 parts):
- **Part 1:** #2971 — Models, definitions, and submodule update
- **Part 2 (this PR):** Public API and provider implementation