### PR TITLE
MSAL: Update project infrastructure for device token API (Part 0 - Base)

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -162,8 +162,6 @@
 		2328074128BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2328073F28BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h */; };
 		2328074228BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2328073F28BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h */; };
 		2328074328BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2328073F28BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h */; };
-		232D168C2F35A48A002EE257 /* MSALNativeAuthRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232D16842F35A486002EE257 /* MSALNativeAuthRequestInterceptor.swift */; };
-		232D168D2F35A48A002EE257 /* MSALNativeAuthRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232D16842F35A486002EE257 /* MSALNativeAuthRequestInterceptor.swift */; };
 		232D614B2248484C00260C42 /* MSALClaimsRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 232D61482248484C00260C42 /* MSALClaimsRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		232D614C2248484C00260C42 /* MSALClaimsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 232D61492248484C00260C42 /* MSALClaimsRequest.m */; };
 		232D614D2248484C00260C42 /* MSALClaimsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 232D61492248484C00260C42 /* MSALClaimsRequest.m */; };
@@ -403,6 +401,22 @@
 		609AF9332256BD0C00E2978D /* MSALAccountsProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 609AF9322256BD0C00E2978D /* MSALAccountsProviderTests.m */; };
 		6525115A29CD84A000D3B876 /* MSALPublicClientApplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D673F07C1E4AAB0D0018BA91 /* MSALPublicClientApplicationTests.m */; };
 		6577FFC829CC2E4B003235A6 /* MSALDeviceInfoProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B253153A23DD717900432133 /* MSALDeviceInfoProviderTests.m */; };
+		7233F07F2F885A4A009C9602 /* MSALDeviceTokenParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 7233F07E2F885A4A009C9602 /* MSALDeviceTokenParameters.h */; };
+		7233F0802F885A4A009C9602 /* MSALDeviceTokenParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 7233F07E2F885A4A009C9602 /* MSALDeviceTokenParameters.h */; };
+		7233F0812F885A4A009C9602 /* MSALDeviceTokenParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 7233F07E2F885A4A009C9602 /* MSALDeviceTokenParameters.h */; };
+		7233F0822F885A4A009C9602 /* MSALDeviceTokenParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 7233F07E2F885A4A009C9602 /* MSALDeviceTokenParameters.h */; };
+		7233F0892F885D05009C9602 /* MSALDeviceTokenParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7233F0882F885D05009C9602 /* MSALDeviceTokenParameters.m */; };
+		7233F08A2F885D05009C9602 /* MSALDeviceTokenParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7233F0882F885D05009C9602 /* MSALDeviceTokenParameters.m */; };
+		7233F08B2F885D05009C9602 /* MSALDeviceTokenParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7233F0882F885D05009C9602 /* MSALDeviceTokenParameters.m */; };
+		7233F08C2F885D05009C9602 /* MSALDeviceTokenParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 7233F0882F885D05009C9602 /* MSALDeviceTokenParameters.m */; };
+		7248CF962F9AF2F30038E238 /* MSALDeviceTokenResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 7248CF8E2F9AF2E90038E238 /* MSALDeviceTokenResult.h */; };
+		7248CF972F9AF2F30038E238 /* MSALDeviceTokenResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 7248CF8E2F9AF2E90038E238 /* MSALDeviceTokenResult.h */; };
+		7248CF982F9AF2F30038E238 /* MSALDeviceTokenResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 7248CF8E2F9AF2E90038E238 /* MSALDeviceTokenResult.h */; };
+		7248CF992F9AF2F30038E238 /* MSALDeviceTokenResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 7248CF8E2F9AF2E90038E238 /* MSALDeviceTokenResult.h */; };
+		7248CF9B2F9AF2F90038E238 /* MSALDeviceTokenResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 7248CF9A2F9AF2F80038E238 /* MSALDeviceTokenResult.m */; };
+		7248CF9C2F9AF2F90038E238 /* MSALDeviceTokenResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 7248CF9A2F9AF2F80038E238 /* MSALDeviceTokenResult.m */; };
+		7248CF9D2F9AF2F90038E238 /* MSALDeviceTokenResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 7248CF9A2F9AF2F80038E238 /* MSALDeviceTokenResult.m */; };
+		7248CF9E2F9AF2F90038E238 /* MSALDeviceTokenResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 7248CF9A2F9AF2F80038E238 /* MSALDeviceTokenResult.m */; };
 		886F515829CCA50300F09471 /* MSALCIAMAuthority.h in Headers */ = {isa = PBXBuildFile; fileRef = 886F515729CCA50300F09471 /* MSALCIAMAuthority.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		886F515929CCA50300F09471 /* MSALCIAMAuthority.h in Headers */ = {isa = PBXBuildFile; fileRef = 886F515729CCA50300F09471 /* MSALCIAMAuthority.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		886F515A29CCA50300F09471 /* MSALCIAMAuthority.h in Headers */ = {isa = PBXBuildFile; fileRef = 886F515729CCA50300F09471 /* MSALCIAMAuthority.h */; };
@@ -2046,7 +2060,6 @@
 		231CE9DD1FEC684C00E95D3E /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		231CE9E01FECBD4600E95D3E /* unit-test-host.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "unit-test-host.entitlements"; sourceTree = "<group>"; };
 		2328073F28BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSALAccountEnumerationParameters+Private.h"; sourceTree = "<group>"; };
-		232D16842F35A486002EE257 /* MSALNativeAuthRequestInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRequestInterceptor.swift; sourceTree = "<group>"; };
 		232D61482248484C00260C42 /* MSALClaimsRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALClaimsRequest.h; sourceTree = "<group>"; };
 		232D61492248484C00260C42 /* MSALClaimsRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALClaimsRequest.m; sourceTree = "<group>"; };
 		232D615A22485B4600260C42 /* MSALIndividualClaimRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALIndividualClaimRequest.h; sourceTree = "<group>"; };
@@ -2192,6 +2205,10 @@
 		609AF9322256BD0C00E2978D /* MSALAccountsProviderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALAccountsProviderTests.m; sourceTree = "<group>"; };
 		609AF958225B348900E2978D /* MSALTenantProfile+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MSALTenantProfile+Internal.h"; sourceTree = "<group>"; };
 		60DEF15A1E67756800966664 /* MSAL Test App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = "MSAL Test App.entitlements"; path = "../../../../MSAL Test App.entitlements"; sourceTree = "<group>"; };
+		7233F07E2F885A4A009C9602 /* MSALDeviceTokenParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALDeviceTokenParameters.h; sourceTree = "<group>"; };
+		7233F0882F885D05009C9602 /* MSALDeviceTokenParameters.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALDeviceTokenParameters.m; sourceTree = "<group>"; };
+		7248CF8E2F9AF2E90038E238 /* MSALDeviceTokenResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALDeviceTokenResult.h; sourceTree = "<group>"; };
+		7248CF9A2F9AF2F80038E238 /* MSALDeviceTokenResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALDeviceTokenResult.m; sourceTree = "<group>"; };
 		886F515729CCA50300F09471 /* MSALCIAMAuthority.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALCIAMAuthority.h; sourceTree = "<group>"; };
 		886F516329CCA58900F09471 /* MSALCIAMAuthority.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALCIAMAuthority.m; sourceTree = "<group>"; };
 		88A25ED229E7185B00066311 /* MSALCIAMAuthorityTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALCIAMAuthorityTests.m; sourceTree = "<group>"; };
@@ -3372,7 +3389,6 @@
 		28E9B7762DE7276000A162EA /* configuration */ = {
 			isa = PBXGroup;
 			children = (
-				232D16842F35A486002EE257 /* MSALNativeAuthRequestInterceptor.swift */,
 				28E9B7772DE7276C00A162EA /* MSALNativeAuthPublicClientApplicationConfig.swift */,
 			);
 			path = configuration;
@@ -3998,6 +4014,8 @@
 		D65A6F671E3FF3D900C69FBA /* src */ = {
 			isa = PBXGroup;
 			children = (
+				7248CF9A2F9AF2F80038E238 /* MSALDeviceTokenResult.m */,
+				7248CF8E2F9AF2E90038E238 /* MSALDeviceTokenResult.h */,
 				E2AA770B292F972500113F04 /* native_auth */,
 				94E876C91E492D2800FB96ED /* instance */,
 				D65A6F7E1E3FF3D900C69FBA /* public */,
@@ -4057,6 +4075,7 @@
 				23014D4F25672E53005E12F2 /* MSALAuthenticationSchemeBearer+Internal.h */,
 				23014D4425672DF9005E12F2 /* MSALAuthenticationSchemePop+Internal.h */,
 				9B839A0F2A4D7CF600BCC6F6 /* MSAL.docc */,
+				7233F0882F885D05009C9602 /* MSALDeviceTokenParameters.m */,
 			);
 			path = src;
 			sourceTree = "<group>";
@@ -4064,6 +4083,7 @@
 		D65A6F7E1E3FF3D900C69FBA /* public */ = {
 			isa = PBXGroup;
 			children = (
+				7233F07E2F885A4A009C9602 /* MSALDeviceTokenParameters.h */,
 				1E3658A6247F2BB60044A072 /* MSALAuthenticationSchemeProtocol.h */,
 				1E72193724773D1B00AB9B67 /* MSALHttpMethod.h */,
 				9627C7B8225432690028A859 /* configuration */,
@@ -5265,6 +5285,7 @@
 				B2D47899230E3DFB005AE186 /* MSALExternalAccountProviding.h in Headers */,
 				B273D0E9226E85FB005A7BB4 /* MSALResult+Internal.h in Headers */,
 				B273D084226E8515005A7BB4 /* MSALSilentTokenParameters.h in Headers */,
+				7248CF962F9AF2F30038E238 /* MSALDeviceTokenResult.h in Headers */,
 				B273D06E226E84BD005A7BB4 /* MSALPublicClientApplicationConfig.h in Headers */,
 				886F515B29CCA50300F09471 /* MSALCIAMAuthority.h in Headers */,
 				B2D4789B230E3E01005AE186 /* MSALSerializedADALCacheProvider.h in Headers */,
@@ -5329,6 +5350,7 @@
 				B2D478B7230E3E8E005AE186 /* MSALSerializedADALCacheProvider+Internal.h in Headers */,
 				04A6B5B62269370E0035C7C2 /* MSALWebviewType_Internal.h in Headers */,
 				B273D0BE226E85A5005A7BB4 /* MSALGlobalConfig+Internal.h in Headers */,
+				7233F0822F885A4A009C9602 /* MSALDeviceTokenParameters.h in Headers */,
 				B2D478A6230E3E57005AE186 /* MSALTelemetryEventsObservingProxy.h in Headers */,
 				2328074328BC175C000306A9 /* MSALAccountEnumerationParameters+Private.h in Headers */,
 				B273D0A2226E8574005A7BB4 /* MSALIndividualClaimRequest+Internal.h in Headers */,
@@ -5360,6 +5382,7 @@
 				886F515A29CCA50300F09471 /* MSALCIAMAuthority.h in Headers */,
 				238A362D22EA3EB700F08167 /* MSALWebviewParameters.h in Headers */,
 				B2D4789A230E3E00005AE186 /* MSALSerializedADALCacheProvider.h in Headers */,
+				7248CF972F9AF2F30038E238 /* MSALDeviceTokenResult.h in Headers */,
 				1E5319BA24A51DDE007BCF30 /* MSALAuthenticationSchemeBearer.h in Headers */,
 				B273D071226E84C9005A7BB4 /* MSALSliceConfig.h in Headers */,
 				B2D478A0230E3E40005AE186 /* MSALAccountEnumerationParameters.h in Headers */,
@@ -5367,6 +5390,7 @@
 				B2D478AE230E3E88005AE186 /* MSALLegacySharedAccount.h in Headers */,
 				04A6B5D0226937810035C7C2 /* MSALRedirectUriVerifier.h in Headers */,
 				04A6B6142269383C0035C7C2 /* MSALOauth2ProviderFactory.h in Headers */,
+				7233F0812F885A4A009C9602 /* MSALDeviceTokenParameters.h in Headers */,
 				B273D0B2226E858A005A7BB4 /* MSALErrorConverter.h in Headers */,
 				B273D0BF226E85A6005A7BB4 /* MSALGlobalConfig+Internal.h in Headers */,
 				B273D067226E84BD005A7BB4 /* MSALPublicClientApplicationConfig.h in Headers */,
@@ -5499,6 +5523,7 @@
 				DE9244D82A31E1D500C0389F /* MSALCIAMOauth2Provider.h in Headers */,
 				96CF95252268FD0500D97374 /* MSALB2CAuthority.h in Headers */,
 				289C1D892DE73181009EEBEA /* MSALNativeAuthCapabilities.h in Headers */,
+				7248CF982F9AF2F30038E238 /* MSALDeviceTokenResult.h in Headers */,
 				B26756CA22921C5B000F01D7 /* MSALB2COauth2Provider.h in Headers */,
 				96CF95172268FD0400D97374 /* MSALSliceConfig.h in Headers */,
 				B227037122A4BA3600030ADC /* MSALLegacySharedAccountsProvider.h in Headers */,
@@ -5517,6 +5542,7 @@
 				2342584B20649A9800621AFE /* MSALAccount+Internal.h in Headers */,
 				B26756D522921CC4000F01D7 /* MSALOauth2Provider+Internal.h in Headers */,
 				96CF95322268FD0500D97374 /* MSALJsonDeserializable.h in Headers */,
+				7233F0802F885A4A009C9602 /* MSALDeviceTokenParameters.h in Headers */,
 				96CF95202268FD0400D97374 /* MSALResult.h in Headers */,
 				96CF95182268FD0400D97374 /* MSALCacheConfig.h in Headers */,
 				B29A56A5228262770023F5E6 /* MSALExternalAccountProviding.h in Headers */,
@@ -5602,6 +5628,7 @@
 				B273D0D2226E85D0005A7BB4 /* MSALTelemetryConfig+Internal.h in Headers */,
 				B28BBD342211DC7D00F51723 /* MSALPublicClientStatusNotifications.h in Headers */,
 				232D68DD223DBA0700594BBD /* MSALInteractiveTokenParameters.h in Headers */,
+				7248CF992F9AF2F30038E238 /* MSALDeviceTokenResult.h in Headers */,
 				DE9244D92A31E1D500C0389F /* MSALCIAMOauth2Provider.h in Headers */,
 				B26756C522921C42000F01D7 /* MSALAADOauth2Provider.h in Headers */,
 				B2FBB3DB28F72A5700A3591C /* MSALWPJMetaData+Internal.h in Headers */,
@@ -5646,6 +5673,7 @@
 				B273D0C0226E85A7005A7BB4 /* MSALGlobalConfig+Internal.h in Headers */,
 				0D96DB3C27850F0F00DEAF87 /* MSALWipeCacheForAllAccountsConfig.h in Headers */,
 				963377C0211E14C600943EE0 /* MSALWebviewType_Internal.h in Headers */,
+				7233F07F2F885A4A009C9602 /* MSALDeviceTokenParameters.h in Headers */,
 				B203459E21AFA1FB00B221AA /* MSALRedirectUri+Internal.h in Headers */,
 				DE8DC56E2C6622D200534E8F /* MSALNativeAuthChallengeTypes.h in Headers */,
 			);
@@ -6016,11 +6044,12 @@
 				TargetAttributes = {
 					04A6B57A226921890035C7C2 = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1410;
+						LastSwiftMigration = 2630;
 						ProvisioningStyle = Automatic;
 					};
 					04A6B59B2269286F0035C7C2 = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 2630;
 						ProvisioningStyle = Automatic;
 					};
 					1E614BD922558D8300EBF62F = {
@@ -6529,6 +6558,7 @@
 				04A6B60F226938340035C7C2 /* MSALADFSAuthority.m in Sources */,
 				886F516629CCA58900F09471 /* MSALCIAMAuthority.m in Sources */,
 				B273D0F0226E8609005A7BB4 /* MSALTokenParameters.m in Sources */,
+				7233F08A2F885D05009C9602 /* MSALDeviceTokenParameters.m in Sources */,
 				B2D478AB230E3E84005AE186 /* MSALLegacySharedADALAccount.m in Sources */,
 				B273D0F1226E860B005A7BB4 /* MSALInteractiveTokenParameters.m in Sources */,
 				04A6B5B5226937080035C7C2 /* MSALWebviewType.m in Sources */,
@@ -6561,6 +6591,7 @@
 				DE9244DE2A31E1D500C0389F /* MSALCIAMOauth2Provider.m in Sources */,
 				B2D478AD230E3E88005AE186 /* MSALLegacySharedMSAAccount.m in Sources */,
 				B273D0EA226E85FF005A7BB4 /* MSALPublicClientStatusNotifications.m in Sources */,
+				7248CF9D2F9AF2F90038E238 /* MSALDeviceTokenResult.m in Sources */,
 				B273D0D5226E85D3005A7BB4 /* MSALTelemetryConfig.m in Sources */,
 				04A6B60C226938300035C7C2 /* MSALB2CAuthority.m in Sources */,
 				B2D478B1230E3E88005AE186 /* MSALLegacySharedAccountFactory.m in Sources */,
@@ -6627,11 +6658,13 @@
 				B2D478C4230E3EC4005AE186 /* MSALAccountEnumerationParameters.m in Sources */,
 				04A6B60D226938310035C7C2 /* MSALB2CAuthority.m in Sources */,
 				04A6B5CA226937700035C7C2 /* MSALError.m in Sources */,
+				7233F0892F885D05009C9602 /* MSALDeviceTokenParameters.m in Sources */,
 				B2D4788F230E3DD6005AE186 /* MSALOauth2Provider.m in Sources */,
 				1E5319C924A51FCF007BCF30 /* MSALHttpMethod.m in Sources */,
 				B273D0F4226E860D005A7BB4 /* MSALSilentTokenParameters.m in Sources */,
 				04A6B5C4226937610035C7C2 /* MSALPublicClientApplication.m in Sources */,
 				04A6B5DD226937AA0035C7C2 /* MSALAccountsProvider.m in Sources */,
+				7248CF9C2F9AF2F90038E238 /* MSALDeviceTokenResult.m in Sources */,
 				DE9244DF2A31E1D500C0389F /* MSALCIAMOauth2Provider.m in Sources */,
 				B273D0C8226E85C4005A7BB4 /* MSALCacheConfig.m in Sources */,
 			);
@@ -6852,6 +6885,7 @@
 				D61F5BCA1E59359900912CB8 /* MSALFramework.m in Sources */,
 				28FDC4A62A38C00900E38BE1 /* SignInAfterSignUpDelegate.swift in Sources */,
 				28DCD0B429D73BCE00C4601E /* ResetPasswordDelegates.swift in Sources */,
+				7248CF9B2F9AF2F90038E238 /* MSALDeviceTokenResult.m in Sources */,
 				B26756DB22922375000F01D7 /* MSALOauth2Authority.m in Sources */,
 				96B5E6E82256D174002232F9 /* MSALLoggerConfig.m in Sources */,
 				DEF9D999296EC848006CB384 /* MSALNativeAuthOperationTypes.swift in Sources */,
@@ -6910,6 +6944,7 @@
 				6077D4A922498D87001798A2 /* MSALTenantProfile.m in Sources */,
 				9B9D05E82B4FFBEC00024E6E /* MSALNativeAuthCacheAccessorFactory.swift in Sources */,
 				A0274CD824B54A4E00BD198D /* MSALDevicePopManagerUtil.m in Sources */,
+				7233F08B2F885D05009C9602 /* MSALDeviceTokenParameters.m in Sources */,
 				DE9245122A38736600C0389F /* CredentialsDelegates.swift in Sources */,
 				B223B0C022ADFACB00FB8713 /* MSALLegacySharedAccount.m in Sources */,
 				E2EFACFE2A69915100D6C3DE /* SignInResults.swift in Sources */,
@@ -7035,7 +7070,6 @@
 				E22427DE2B05981A0006C55E /* SignInAfterSignUpDelegateDispatcher.swift in Sources */,
 				E22427DB2B0594670006C55E /* CredentialsDelegateDispatcher.swift in Sources */,
 				289D138D2DF336390008CB1A /* MSALNativeAuthGenericError.swift in Sources */,
-				232D168C2F35A48A002EE257 /* MSALNativeAuthRequestInterceptor.swift in Sources */,
 				28D811ED2C760303002BE1AA /* MSALNativeAuthMFAControlling.swift in Sources */,
 				B26756C622921C42000F01D7 /* MSALAADOauth2Provider.m in Sources */,
 				DEE34F12D170B71C00BC302A /* MSALNativeAuthResetPasswordStartRequestParameters.swift in Sources */,
@@ -7158,6 +7192,7 @@
 				D69ADB1C1E50531300952049 /* MSALPromptType.m in Sources */,
 				233E96FE22653EFC007FCE2A /* MSALTelemetryEventsObservingProxy.m in Sources */,
 				DE8DC4752C66219E00534E8F /* MSALNativeAuthRequiredAttribute.swift in Sources */,
+				7248CF9E2F9AF2F90038E238 /* MSALDeviceTokenResult.m in Sources */,
 				DE8DC4ED2C6621D300534E8F /* MSALNativeAuthInternalChallengeType.swift in Sources */,
 				DE8DC46A2C66219600534E8F /* MSALNativeAuthControllerTelemetryWrapper.swift in Sources */,
 				DE8DC4A72C6621B100534E8F /* MSALNativeAuthCustomErrorSerializer.swift in Sources */,
@@ -7220,6 +7255,7 @@
 				28E9B7792DE7276F00A162EA /* MSALNativeAuthPublicClientApplicationConfig.swift in Sources */,
 				96B5E6E32256D166002232F9 /* MSALTelemetryConfig.m in Sources */,
 				DE8DC45B2C66219600534E8F /* MSALNativeAuthSignUpController.swift in Sources */,
+				7233F08C2F885D05009C9602 /* MSALDeviceTokenParameters.m in Sources */,
 				DE8DC4E22C6621D000534E8F /* MSALNativeAuthResetPasswordStartOauth2ErrorCode.swift in Sources */,
 				B29A56BB228266B40023F5E6 /* MSALSerializedADALCacheProvider.m in Sources */,
 				DE8DC4AC2C6621B400534E8F /* MSALNativeAuthSignUpContinueRequestParameters.swift in Sources */,
@@ -7312,7 +7348,6 @@
 				94E876CE1E492D6000FB96ED /* MSALAuthority.m in Sources */,
 				DE8DC4DB2C6621CC00534E8F /* MSALNativeAuthSignUpStartResponseError.swift in Sources */,
 				289D138E2DF336390008CB1A /* MSALNativeAuthGenericError.swift in Sources */,
-				232D168D2F35A48A002EE257 /* MSALNativeAuthRequestInterceptor.swift in Sources */,
 				DE8DC4E52C6621D000534E8F /* MSALNativeAuthResetPasswordContinueResponseError.swift in Sources */,
 				DE8974092DA52BE800C67203 /* MSALNativeAuthJITIntrospectOauth2ErrorCode.swift in Sources */,
 				DE89740A2DA52BE800C67203 /* MSALNativeAuthJITContinueOauth2ErrorCode.swift in Sources */,
@@ -8041,11 +8076,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 04A6B585226921CD0035C7C2 /* msal__static__lib__mac.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "MSAL (macOS Static Library)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -8053,17 +8091,18 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 04A6B585226921CD0035C7C2 /* msal__static__lib__mac.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "MSAL (macOS Static Library)";
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
 		1E614BEC22558D8300EBF62F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -8137,7 +8176,6 @@
 		1E614BED22558D8300EBF62F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -8208,7 +8246,6 @@
 		28CED2EE2C21E0F9004320D1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -8284,7 +8321,6 @@
 		28CED2EF2C21E0F9004320D1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -8355,7 +8391,6 @@
 		28D1D57329BF62E900CE75F4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -8431,7 +8466,6 @@
 		28D1D57429BF62E900CE75F4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -8665,7 +8699,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 962E37A51E720B7E00DE71FE /* msal__automation_app__ios.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_ENTITLEMENTS = test/automation/ios/MSALAutomation.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -8688,7 +8721,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 962E37A51E720B7E00DE71FE /* msal__automation_app__ios.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_ENTITLEMENTS = test/automation/ios/MSALAutomation.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -8839,7 +8871,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B2BB73962112C4B3000EA4C5 /* msal__ui_test__ios.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -8909,7 +8940,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B2BB73962112C4B3000EA4C5 /* msal__ui_test__ios.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -8977,7 +9007,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B2BB73962112C4B3000EA4C5 /* msal__ui_test__ios.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -9048,7 +9077,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B2BB73962112C4B3000EA4C5 /* msal__ui_test__ios.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -9116,7 +9144,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D61A64661E5AA6B40086D120 /* msal__test_app__ios.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
 				CODE_SIGN_ENTITLEMENTS = "MSAL Test App.entitlements";
@@ -9146,7 +9173,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D61A64661E5AA6B40086D120 /* msal__test_app__ios.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
 				CODE_SIGN_ENTITLEMENTS = "MSAL Test App.entitlements";
@@ -9276,7 +9302,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D65A6FE91E40002800C69FBA /* msal__unit_test__ios.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
@@ -9310,7 +9335,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D65A6FE91E40002800C69FBA /* msal__unit_test__ios.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
@@ -9342,7 +9366,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D65A6FEC1E40002800C69FBA /* msal__unit_test__mac.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -9365,7 +9388,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D65A6FEC1E40002800C69FBA /* msal__unit_test__mac.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";


### PR DESCRIPTION
## Summary

Updates Xcode project file (`project.pbxproj`) and IdentityCore submodule pointer to support the new device token API.

The submodule update brings in:
- `MSIDDeviceTokenGrantRequest` — network request for device token grant
- `MSIDDeviceTokenResponseHandler` — response handler for device token responses
- `MSIDKeyVault*` providers

## ⚠️ Merge this PR first. All other split PRs depend on it.

## Related PRs
This PR is part of a split from `ameyapat/add-get-device-token-api` (3 parts):
- **Base (Part 0): This PR (#2973)** — Project infrastructure changes ⚠️ Merge first
- Part 1: #2974 — Device token model classes
- Part 2: #2975 — getDeviceToken API integration

## Files Changed
- `MSAL/MSAL.xcodeproj/project.pbxproj`
- `MSAL/IdentityCore` (submodule pointer)