### PR TITLE
MSAL: Add device token model classes and public API definitions (Part 1)

### DIFF
--- a/MSAL/src/MSALDeviceTokenParameters.m
+++ b/MSAL/src/MSALDeviceTokenParameters.m
@@ -1,4 +1,3 @@
-//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -17,33 +16,36 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-//
-//------------------------------------------------------------------------------
 
-#import "MSALResult.h"
 
-@class MSIDTokenResult;
-@protocol MSALAuthenticationSchemeProtocol;
-@protocol MSALAuthenticationSchemeProtocolInternal;
-@class MSIDDevicePopManager;
+#import <Foundation/Foundation.h>
+#import "MSALDeviceTokenParameters.h"
+#import "MSIDCacheAccessor.h"
 
-@interface MSALResult (Internal)
+@implementation MSALDeviceTokenParameters
 
-@property (atomic, readonly) NSString *refreshToken;
+- (instancetype)initWithResource:(NSString *)resource
+                          scopes:(nullable NSArray<NSString *> *)scopes
+                     forTenantId:(NSString *)tenantId
+{
+    if ([NSString msidIsStringNilOrBlank:resource])
+    {
+        return nil;
+    }
+    
+    self = [super initWithScopes:scopes ?: @[]];
+    if (self)
+    {
+        _tenantId = tenantId;
+        _resource = resource;
+    }
+    return self;
+}
 
-+ (MSALResult *)resultWithMSIDTokenResult:(MSIDTokenResult *)tokenResult
-                                authority:(MSALAuthority *)authority
-                               authScheme:(id<MSALAuthenticationSchemeProtocol, MSALAuthenticationSchemeProtocolInternal>)authScheme
-                               popManager:(MSIDDevicePopManager *)popManager
-                                    error:(NSError **)error;
-
-+ (MSALResult *)resultForDeviceTokenResult:(MSIDTokenResult *)tokenResult
-                                 authority:(MSALAuthority *)authority
-                                     error:(NSError **)error;
 
 @end

--- a/MSAL/src/MSALDeviceTokenResult.h
+++ b/MSAL/src/MSALDeviceTokenResult.h
@@ -1,0 +1,70 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@class MSALAuthority;
+@class MSIDTokenResult;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALDeviceTokenResult : NSObject
+
+/**
+ The access token returned with the device token result.
+ */
+@property (atomic, readonly, nonnull) NSString *accessToken;
+
+/**
+ Additional device information returned with the device token result.
+ */
+@property (atomic, readonly, nullable) NSString *deviceInformation;
+
+/**
+ The expiration date of the access token.
+ */
+@property (atomic, readonly, nullable) NSDate *expiresOn;
+
+/**
+ The scopes returned with the device token result.
+ */
+@property (atomic, readonly, nonnull) NSArray<NSString *> *scopes;
+
+/**
+ The authority associated with the device token result.
+ */
+@property (atomic, readonly, nullable) MSALAuthority *authority;
+
+- (nonnull instancetype)initWithAccessToken:(nonnull NSString *)accessToken
+                          deviceInformation:(nullable NSString *)deviceInformation
+                                  expiresOn:(nullable NSDate *)expiresOn
+                                     scopes:(nonnull NSArray<NSString *> *)scopes
+                                  authority:(nullable MSALAuthority *)authority;
+
++ (MSALDeviceTokenResult *)resultForDeviceTokenResult:(MSIDTokenResult *)tokenResult
+                                                error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/MSALDeviceTokenResult.m
+++ b/MSAL/src/MSALDeviceTokenResult.m
@@ -1,0 +1,106 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.  
+
+#import "MSALDeviceTokenResult.h"
+#import "MSIDAuthority.h"
+#import "MSALAADAuthority.h"
+
+@implementation MSALDeviceTokenResult
+
+- (nonnull instancetype)initWithAccessToken:(nonnull NSString *)accessToken
+                          deviceInformation:(nullable NSString *)deviceInformation
+                                  expiresOn:(nullable NSDate *)expiresOn
+                                     scopes:(nonnull NSArray<NSString *> *)scopes
+                                  authority:(nullable MSALAuthority *)authority
+{
+    self = [super init];
+    if (self)
+    {
+        _accessToken = accessToken;
+        _deviceInformation = deviceInformation;
+        _expiresOn = expiresOn;
+        _scopes = scopes;
+        _authority = authority;
+    }
+    return self;
+}
+
++ (MSALDeviceTokenResult *)resultForDeviceTokenResult:(MSIDTokenResult *)tokenResult
+                                                error:(NSError **)error
+{
+    if (!tokenResult)
+    {
+        MSIDFillAndLogError(error, MSIDErrorInternal, @"Nil token result provided", nil);
+        return nil;
+    }
+    
+    if (tokenResult.refreshToken)
+    {
+        MSIDFillAndLogError(error, MSIDErrorServerInvalidResponse, @"Unexpected refresh token found in device token result", nil);
+        return nil;
+    }
+    
+    if (![NSString msidIsStringNilOrBlank:tokenResult.rawIdToken])
+    {
+        MSIDFillAndLogError(error, MSIDErrorServerInvalidResponse, @"Unexpected id token found in device token result", nil);
+        return nil;
+    }
+    
+    NSString *resultAccessToken = @"";
+    NSArray *resultScopes = @[];
+    
+    if (![NSString msidIsStringNilOrBlank:tokenResult.accessToken.accessToken])
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Parsing result access token");
+        resultAccessToken = tokenResult.accessToken.accessToken;
+        resultScopes = [tokenResult.accessToken.scopes array];
+    }
+    else
+    {
+        MSIDFillAndLogError(error, MSIDErrorServerInvalidResponse, @"Access token missing in device token result", nil);
+        return nil;
+    }
+    
+    NSError *authorityError;
+    MSALAADAuthority *aadAuthority = [[MSALAADAuthority alloc] initWithURL:tokenResult.authority.url error:&authorityError];
+    
+    if (!aadAuthority)
+    {
+        MSID_LOG_WITH_CTX_PII(MSIDLogLevelWarning, nil, @"Invalid authority, error %@", MSID_PII_LOG_MASKABLE(authorityError));
+        
+        if (error) *error = authorityError;
+        
+        return nil;
+    }
+    
+    NSString *deviceInformationJwt = tokenResult.tokenResponse.additionalServerInfo[@"device_info"];
+    
+    return [[MSALDeviceTokenResult alloc] initWithAccessToken:resultAccessToken
+                                            deviceInformation:deviceInformationJwt
+                                                    expiresOn:tokenResult.accessToken.expiresOn
+                                                       scopes:resultScopes
+                                                    authority:aadAuthority];
+}
+
+@end

--- a/MSAL/src/MSALResult.m
+++ b/MSAL/src/MSALResult.m
@@ -44,6 +44,7 @@
 #import "MSIDDevicePopManager.h"
 #import "MSALAuthenticationSchemeProtocol.h"
 #import "MSALAuthenticationSchemeProtocolInternal.h"
+#import "MSALDeviceTokenResult.h"
 
 @interface MSALResult()
 
@@ -164,6 +165,62 @@
                              authority:authority
                          correlationId:tokenResult.correlationId
                             authScheme:authScheme];
+}
+
++ (MSALDeviceTokenResult *)resultForDeviceTokenResult:(MSIDTokenResult *)tokenResult
+                                            authority:(MSALAuthority *)authority
+                                                error:(NSError **)error
+{
+    if (!tokenResult)
+    {
+        MSIDFillAndLogError(error, MSIDErrorInternal, @"Nil token result provided", nil);
+        return nil;
+    }
+    
+    if (tokenResult.refreshToken)
+    {
+        MSIDFillAndLogError(error, MSIDErrorServerInvalidResponse, @"Unexpected refresh token found in device token result", nil);
+        return nil;
+    }
+    
+    if (![NSString msidIsStringNilOrBlank:tokenResult.rawIdToken])
+    {
+        MSIDFillAndLogError(error, MSIDErrorServerInvalidResponse, @"Unexpected id token found in device token result", nil);
+        return nil;
+    }
+    
+    NSString *resultAccessToken = @"";
+    NSArray *resultScopes = @[];
+    
+    if (![NSString msidIsStringNilOrBlank:tokenResult.accessToken.accessToken])
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"Parsing result access token");
+        resultAccessToken = tokenResult.accessToken.accessToken;
+        resultScopes = [tokenResult.accessToken.scopes array];
+    }
+    else
+    {
+        MSID_LOG_WITH_CTX(MSIDLogLevelInfo, nil, @"[Device Token] Access token missing in token result");
+        return nil;
+    }
+    MSALResult *baseResult =  [self resultWithAccessToken:resultAccessToken
+                                             refreshToken:nil
+                                                expiresOn:tokenResult.accessToken.expiresOn
+                                  isExtendedLifetimeToken:tokenResult.extendedLifeTimeToken
+                                            tenantProfile:nil
+                                                  account:nil
+                                                  idToken:nil
+                                                   scopes:resultScopes
+                                                authority:nil
+                                            correlationId:tokenResult.correlationId
+                                               authScheme:nil];
+    MSALDeviceTokenResult *deviceTokenResult = [[MSALDeviceTokenResult alloc] initWithAccessToken:baseResult.accessToken
+                                                                                deviceInformation:tokenResult.tokenResponse.additionalServerInfo[@"device_info"]
+                                                                                        expiresOn:tokenResult.accessToken.expiresOn
+                                                                                           scopes:resultScopes
+                                                                                        authority:authority];
+    
+    return deviceTokenResult;
 }
 
 @end

--- a/MSAL/src/public/MSALDefinitions.h
+++ b/MSAL/src/public/MSALDefinitions.h
@@ -29,6 +29,7 @@
 #define MSALDefinitions_h
 
 @class MSALResult;
+@class MSALDeviceTokenResult;
 @class MSALAccount;
 @class MSALDeviceInformation;
 @class MSALWPJMetaData;
@@ -260,6 +261,13 @@ typedef void (^MSALDeviceInformationCompletionBlock)(MSALDeviceInformation * _Nu
    The completion block that will be called when MSAL has finished reading device state, or MSAL encountered an error.
 */
 typedef void (^MSALWPJMetaDataCompletionBlock)(MSALWPJMetaData * _Nullable msalPJMetaDataInformation, NSError * _Nullable error);
+
+/**
+    The block that gets invoked after MSAL has finished getting a device associated token and device information returned by server.
+    @param result       Represents information returned to the application after a successful device token acquisition. See `MSALDeviceTokenResult` for more information.
+    @param error         Provides information about error that prevented MSAL from getting a token. See `MSALError` for possible errors.
+ */
+typedef void (^MSALDeviceTokenResultCompletionBlock)(MSALDeviceTokenResult * _Nullable result, NSError * _Nullable error);
 
 /**
  The block that returns a MSAL log message.

--- a/MSAL/src/public/MSALDeviceTokenParameters.h
+++ b/MSAL/src/public/MSALDeviceTokenParameters.h
@@ -1,0 +1,56 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "MSALTokenParameters.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Token parameters to be used when MSAL is getting a token for a device. The resulting token won't have a user identity associated with it.
+ */
+@interface MSALDeviceTokenParameters : MSALTokenParameters
+
+- (instancetype)initWithScopes:(NSArray<NSString *> *)scopes NS_UNAVAILABLE;
+
+@property (nonatomic, readonly, nullable) NSString *tenantId;
+@property (nonatomic, readonly) NSString *resource;
+
+#pragma mark - Constructing MSALDeviceTokenParameters
+
+/**
+ Initialize a MSALDeviceTokenParameters with a resource and optional scopes.
+
+ @param resource    The resource for which the token is requested. Resources MUST have a property set in MSODS permitting device_tokens to be issued for that resource.
+ @param scopes      Permissions you want included in the access token received
+                    in the result in the completionBlock. Not all scopes are
+                    guaranteed to be included in the access token returned. Can be nil.
+ @param tenantId    The tenant identifier. If not specified, the primary registration on the device will be used to get device token.
+ */
+- (instancetype)initWithResource:(NSString *)resource
+                          scopes:(nullable NSArray<NSString *> *)scopes
+                     forTenantId:(nullable NSString *)tenantId;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Summary

Adds new model classes for the device token API:

- **`MSALDeviceTokenParameters`** — Public parameter class for requesting device tokens. Requires a resource, accepts optional scopes and tenant ID.
- **`MSALDeviceTokenResult`** — Result object containing access token, device information, expiry, scopes, and authority.
- **`MSALDeviceTokenResultCompletionBlock`** — Completion block typedef added to `MSALDefinitions.h`.
- **`MSALResult+Internal`** — Adds `resultForDeviceTokenResult:authority:error:` factory method for converting `MSIDTokenResult` to `MSALDeviceTokenResult`.

## Merge Order
Depends on base PR #2973. Merge the base first, then retarget this PR to `dev`.

## Related PRs
This PR is part of a split from `ameyapat/add-get-device-token-api` (3 parts):
- Base (Part 0): #2973 — Project infrastructure changes ⚠️ Merge first
- **Part 1: This PR (#2974)** — Device token model classes
- Part 2: #2975 — getDeviceToken API integration

## Files Changed
- `MSAL/src/public/MSALDeviceTokenParameters.h` (new)
- `MSAL/src/MSALDeviceTokenParameters.m` (new)
- `MSAL/src/MSALDeviceTokenResult.h` (new)
- `MSAL/src/MSALDeviceTokenResult.m` (new)
- `MSAL/src/public/MSALDefinitions.h` (modified)
- `MSAL/src/MSALResult+Internal.h` (modified)
- `MSAL/src/MSALResult.m` (modified)