### PR TITLE
feat: PR size check — exclude comment lines from count

### DIFF
--- a/.github/workflows/pr-size-check-reusable.yml
+++ b/.github/workflows/pr-size-check-reusable.yml
@@ -68,9 +68,62 @@ jobs:
             // Thrown values are not guaranteed to be Error instances in JS.
             const errMsg = e => e instanceof Error ? e.message : String(e);
 
+            // ── Comment detection helpers ─────────────────────────────────
+            // Returns true if a line of code (trimmed) is purely a comment.
+            // Supports: // , /* , */ , * (block continuation), # , <!-- -->
+            function isCommentLine(line) {
+              const trimmed = line.trim();
+              if (trimmed === '') return true; // blank lines don't count
+              // C-style single-line comments
+              if (trimmed.startsWith('//')) return true;
+              // Shell/Python-style comments — but NOT preprocessor directives
+              // (#include, #import, #define, #if, #ifdef, #ifndef, #pragma, #endif, #else, #elif, #error, #warning, #region, #endregion)
+              if (trimmed.startsWith('#')) {
+                const afterHash = trimmed.substring(1).trimStart();
+                const preprocessorKeywords = [
+                  'include', 'import', 'define', 'undef', 'if', 'ifdef',
+                  'ifndef', 'else', 'elif', 'endif', 'pragma', 'error',
+                  'warning', 'line', 'region', 'endregion'
+                ];
+                const isPreprocessor = preprocessorKeywords.some(kw =>
+                  afterHash === kw || afterHash.startsWith(kw + ' ') || afterHash.startsWith(kw + '\t')
+                );
+                if (!isPreprocessor) return true;
+              }
+              // C-style block comment patterns
+              if (trimmed.startsWith('/*')) return true;
+              if (trimmed.startsWith('*/')) return true;
+              if (trimmed.startsWith('*') && !trimmed.startsWith('*/')) {
+                // Block comment continuation line (e.g., " * some doc")
+                if (trimmed === '*' || trimmed.startsWith('* ') || trimmed.startsWith('*\t')) return true;
+              }
+              // HTML/XML comments
+              if (trimmed.startsWith('<!--')) return true;
+              if (trimmed.endsWith('-->') && !trimmed.includes('<!--')) return true;
+              return false;
+            }
+
+            // Count non-comment changed lines from a patch string.
+            // Patch lines starting with + or - (but not +++ or ---) are changes.
+            function countNonCommentLines(patch) {
+              if (!patch) return { additions: 0, deletions: 0 };
+              const lines = patch.split('\n');
+              let additions = 0;
+              let deletions = 0;
+              for (const line of lines) {
+                if (line.startsWith('+++') || line.startsWith('---')) continue;
+                if (line.startsWith('+')) {
+                  const content = line.substring(1);
+                  if (!isCommentLine(content)) additions++;
+                } else if (line.startsWith('-')) {
+                  const content = line.substring(1);
+                  if (!isCommentLine(content)) deletions++;
+                }
+              }
+              return { additions, deletions };
+            }
+
             // ── Guard: must be called from a pull_request workflow ────────
-            // Only trust context.payload.pull_request — do NOT fall back to
-            // context.issue.number which could be an issue number, not a PR.
             const pull_number = context.payload.pull_request?.number;
             if (!pull_number) {
               core.setFailed(
@@ -81,8 +134,6 @@ jobs:
             }
 
             // ── Validate max_lines ────────────────────────────────────────
-            // Use Number + isInteger to reject floats like 500.9 which
-            // parseInt would silently truncate to 500.
             const raw = Number(process.env.MAX_LINES);
             if (!Number.isInteger(raw) || raw <= 0) {
               core.setFailed(
@@ -130,8 +181,6 @@ jobs:
             }
 
             // ── Hard limit: fail if PR has more than 300 files ───────────
-            // Only probe for a next page if we filled all MAX_PAGES pages —
-            // avoids a false positive when the PR has exactly 300 files.
             if (files.length === MAX_PAGES * 100) {
               let hasMoreFiles = false;
               try {
@@ -263,8 +312,6 @@ jobs:
               if (isExcluded) {
                 excluded.push(f);
               } else if (f.patch == null && f.changes === 0) {
-                // Binary or submodule — GitHub API returns patch as undefined or null, and 0 changes
-                // This includes additions, modifications, AND removals of binaries.
                 binaryNonExcluded.push(f);
               } else {
                 included.push(f);
@@ -296,17 +343,30 @@ jobs:
               return;
             }
 
-            const totalLines  = included.reduce((sum, f) => sum + f.additions + f.deletions, 0);
+            // ── Count non-comment lines from patch content ────────────────
+            let totalLines = 0;
+            let totalCommentLines = 0;
+            for (const f of included) {
+              const { additions, deletions } = countNonCommentLines(f.patch);
+              const rawTotal = f.additions + f.deletions;
+              const codeTotal = additions + deletions;
+              totalCommentLines += (rawTotal - codeTotal);
+              totalLines += codeTotal;
+              // Store computed values for table display
+              f._codeAdditions = additions;
+              f._codeDeletions = deletions;
+            }
+
             const linesPassed = totalLines <= LIMIT;
             const filesPassed = included.length <= FILE_LIMIT;
             const passed      = linesPassed && filesPassed;
 
             // ── Cap summary table to top N files by changes ───────────────
             const sortedIncluded = [...included].sort(
-              (a, b) => (b.additions + b.deletions) - (a.additions + a.deletions)
+              (a, b) => (b._codeAdditions + b._codeDeletions) - (a._codeAdditions + a._codeDeletions)
             );
             const tableRows = sortedIncluded.slice(0, TABLE_MAX_INCLUDED).map(
-              f => [f.filename, `+${f.additions} / -${f.deletions}`]
+              f => [f.filename, `+${f._codeAdditions} / -${f._codeDeletions}`]
             );
             if (included.length > TABLE_MAX_INCLUDED) {
               tableRows.push([`(+${included.length - TABLE_MAX_INCLUDED} more files…)`, '']);
@@ -330,7 +390,8 @@ jobs:
 
             // ── Build status lines ────────────────────────────────────────
             const statusLines = [];
-            statusLines.push(`**Counted lines changed: ${totalLines} / ${LIMIT}** ${linesPassed ? '✅' : '❌'}`);
+            statusLines.push(`**Counted code lines changed: ${totalLines} / ${LIMIT}** ${linesPassed ? '✅' : '❌'}`);
+            statusLines.push(`**Comment lines excluded: ${totalCommentLines}**`);
             statusLines.push(`**Counted files changed: ${included.length} / ${FILE_LIMIT}** ${filesPassed ? '✅' : '❌'}`);
 
             const statusBlock = passed
@@ -342,7 +403,7 @@ jobs:
               await core.summary
                 .addHeading(`PR Size Check — ${repo}`, 2)
                 .addTable([
-                  [{data: 'File', header: true}, {data: 'Changes (+ / -)', header: true}],
+                  [{data: 'File', header: true}, {data: 'Code Changes (+ / -)', header: true}],
                   ...tableRows
                 ])
                 .addRaw(`\n${statusLines.join('\n')}\n\n`)
@@ -357,15 +418,19 @@ jobs:
             if (!passed) {
               const reasons = [];
               if (!linesPassed) {
-                reasons.push(`${totalLines} lines changed (limit: ${LIMIT})`);
+                reasons.push(`${totalLines} code lines changed (limit: ${LIMIT})`);
               }
               if (!filesPassed) {
                 reasons.push(`${included.length} files changed (limit: ${FILE_LIMIT})`);
               }
               core.setFailed(
                 `❌ PR size exceeds limits: ${reasons.join('; ')}. ` +
+                `Comment lines (${totalCommentLines}) are not counted. ` +
                 `Excluded files are not counted. Please split into smaller PRs.`
               );
             } else {
-              core.info(`✅ PR size OK: ${totalLines} / ${LIMIT} lines, ${included.length} / ${FILE_LIMIT} files.`);
+              core.info(
+                `✅ PR size OK: ${totalLines} / ${LIMIT} code lines, ${included.length} / ${FILE_LIMIT} files. ` +
+                `(${totalCommentLines} comment lines excluded)`
+              );
             }

--- a/.github/workflows/pr-size-check-reusable.yml
+++ b/.github/workflows/pr-size-check-reusable.yml
@@ -79,8 +79,9 @@ jobs:
             // Known limitation: GitHub patches omit unchanged lines between
             // hunks, so block-comment state may be inaccurate if a comment
             // opens in one hunk and closes in omitted context before the
-            // next hunk. This is rare in practice and acceptable for a
-            // heuristic PR size gate — it is not a compiler-grade parser.
+            // next hunk. Also, comment markers inside string literals
+            // (e.g., @"/*") may incorrectly toggle state. Both are rare
+            // in practice and acceptable for a heuristic PR size gate.
             //
             // @param {string|null|undefined} patch - unified diff from GitHub API
             // @param {number} rawAdditions - fallback additions count
@@ -144,8 +145,14 @@ jobs:
                       i += 4;
                       continue;
                     }
-                    // # comment — only when first non-ws char (not preprocessor)
+                    // # comment — only when first non-ws char (not preprocessor/shebang)
                     if (content[i] === '#' && !hasCode) {
+                      // Shebangs (#!/...) are executable directives, not comments
+                      if (i + 1 < len && content[i + 1] === '!') {
+                        hasCode = true;
+                        i++;
+                        continue;
+                      }
                       const rest = content.substring(i + 1).trimStart();
                       const isPreprocessor = PREPROC_KEYWORDS.some(kw => {
                         if (!rest.startsWith(kw)) return false;
@@ -389,12 +396,15 @@ jobs:
             // ── Count non-comment code lines per file ─────────────────────
             let totalLines = 0;
             let totalCommentLines = 0;
+            let fallbackFiles = 0;
             for (const f of included) {
               const result = countCodeLines(f.patch, f.additions, f.deletions);
               const rawTotal = f.additions + f.deletions;
               const codeTotal = result.additions + result.deletions;
               if (!result.fallback) {
                 totalCommentLines += (rawTotal - codeTotal);
+              } else {
+                fallbackFiles++;
               }
               totalLines += codeTotal;
               f._codeAdditions = result.additions;
@@ -436,6 +446,9 @@ jobs:
             const statusLines = [];
             statusLines.push(`**Counted code lines changed: ${totalLines} / ${LIMIT}** ${linesPassed ? '✅' : '❌'}`);
             statusLines.push(`**Comment lines excluded: ${totalCommentLines}**`);
+            if (fallbackFiles > 0) {
+              statusLines.push(`⚠️ ${fallbackFiles} file(s) had patches too large for comment detection — raw counts used.`);
+            }
             statusLines.push(`**Counted files changed: ${included.length} / ${FILE_LIMIT}** ${filesPassed ? '✅' : '❌'}`);
 
             const statusBlock = passed

--- a/.github/workflows/pr-size-check-reusable.yml
+++ b/.github/workflows/pr-size-check-reusable.yml
@@ -76,6 +76,12 @@ jobs:
             // but are not counted — only '+' and '-' lines contribute.
             // Falls back to raw counts when patch is unavailable.
             //
+            // Known limitation: GitHub patches omit unchanged lines between
+            // hunks, so block-comment state may be inaccurate if a comment
+            // opens in one hunk and closes in omitted context before the
+            // next hunk. This is rare in practice and acceptable for a
+            // heuristic PR size gate — it is not a compiler-grade parser.
+            //
             // @param {string|null|undefined} patch - unified diff from GitHub API
             // @param {number} rawAdditions - fallback additions count
             // @param {number} rawDeletions - fallback deletions count

--- a/.github/workflows/pr-size-check-reusable.yml
+++ b/.github/workflows/pr-size-check-reusable.yml
@@ -77,7 +77,6 @@ jobs:
               // C-style single-line comments
               if (trimmed.startsWith('//')) return true;
               // Shell/Python-style comments — but NOT preprocessor directives
-              // (#include, #import, #define, #if, #ifdef, #ifndef, #pragma, #endif, #else, #elif, #error, #warning, #region, #endregion)
               if (trimmed.startsWith('#')) {
                 const afterHash = trimmed.substring(1).trimStart();
                 const preprocessorKeywords = [
@@ -85,33 +84,56 @@ jobs:
                   'ifndef', 'else', 'elif', 'endif', 'pragma', 'error',
                   'warning', 'line', 'region', 'endregion'
                 ];
-                const isPreprocessor = preprocessorKeywords.some(kw =>
-                  afterHash === kw || afterHash.startsWith(kw + ' ') || afterHash.startsWith(kw + '\t')
-                );
+                // Match keyword at word boundary (handles #include<foo> and #include"foo")
+                const isPreprocessor = preprocessorKeywords.some(kw => {
+                  if (!afterHash.startsWith(kw)) return false;
+                  if (afterHash.length === kw.length) return true;
+                  const nextChar = afterHash[kw.length];
+                  // Preprocessor if followed by non-identifier char
+                  return !/[A-Za-z0-9_]/.test(nextChar);
+                });
                 if (!isPreprocessor) return true;
               }
-              // C-style block comment patterns
-              if (trimmed.startsWith('/*')) return true;
-              if (trimmed.startsWith('*/')) return true;
-              if (trimmed.startsWith('*') && !trimmed.startsWith('*/')) {
-                // Block comment continuation line (e.g., " * some doc")
-                if (trimmed === '*' || trimmed.startsWith('* ') || trimmed.startsWith('*\t')) return true;
+              // C-style block comment — only if the ENTIRE line is a comment
+              if (trimmed.startsWith('/*')) {
+                // If line contains closing */ followed by non-whitespace, it has code
+                const closeIdx = trimmed.indexOf('*/', 2);
+                if (closeIdx === -1) return true; // open block, no close on this line
+                const afterClose = trimmed.substring(closeIdx + 2).trim();
+                if (afterClose === '') return true; // line is only /* ... */
+                return false; // code follows after */
               }
+              if (trimmed.startsWith('*/')) {
+                const afterClose = trimmed.substring(2).trim();
+                return afterClose === ''; // only comment-end, no trailing code
+              }
+              if (/^\*(\s|$)/.test(trimmed)) return true; // block comment continuation
               // HTML/XML comments
-              if (trimmed.startsWith('<!--')) return true;
+              if (trimmed.startsWith('<!--')) {
+                const closeIdx = trimmed.indexOf('-->', 4);
+                if (closeIdx === -1) return true;
+                const afterClose = trimmed.substring(closeIdx + 3).trim();
+                return afterClose === '';
+              }
               if (trimmed.endsWith('-->') && !trimmed.includes('<!--')) return true;
               return false;
             }
 
             // Count non-comment changed lines from a patch string.
-            // Patch lines starting with + or - (but not +++ or ---) are changes.
+            // Patch lines starting with + or - are changes; diff headers are
+            // identified by the @@ hunk marker context, not by +++ or --- prefix.
             function countNonCommentLines(patch) {
-              if (!patch) return { additions: 0, deletions: 0 };
+              if (!patch) return null; // signal that patch is missing
               const lines = patch.split('\n');
               let additions = 0;
               let deletions = 0;
+              let inHeader = true; // diff headers come before first @@ hunk
               for (const line of lines) {
-                if (line.startsWith('+++') || line.startsWith('---')) continue;
+                if (line.startsWith('@@')) {
+                  inHeader = false;
+                  continue;
+                }
+                if (inHeader) continue; // skip file-level diff headers (+++ / ---)
                 if (line.startsWith('+')) {
                   const content = line.substring(1);
                   if (!isCommentLine(content)) additions++;
@@ -347,14 +369,20 @@ jobs:
             let totalLines = 0;
             let totalCommentLines = 0;
             for (const f of included) {
-              const { additions, deletions } = countNonCommentLines(f.patch);
-              const rawTotal = f.additions + f.deletions;
-              const codeTotal = additions + deletions;
-              totalCommentLines += (rawTotal - codeTotal);
-              totalLines += codeTotal;
-              // Store computed values for table display
-              f._codeAdditions = additions;
-              f._codeDeletions = deletions;
+              const result = countNonCommentLines(f.patch);
+              if (result === null) {
+                // Patch missing/truncated by GitHub API — fall back to raw counts (treat all as code)
+                totalLines += f.additions + f.deletions;
+                f._codeAdditions = f.additions;
+                f._codeDeletions = f.deletions;
+              } else {
+                const rawTotal = f.additions + f.deletions;
+                const codeTotal = result.additions + result.deletions;
+                totalCommentLines += (rawTotal - codeTotal);
+                totalLines += codeTotal;
+                f._codeAdditions = result.additions;
+                f._codeDeletions = result.deletions;
+              }
             }
 
             const linesPassed = totalLines <= LIMIT;

--- a/.github/workflows/pr-size-check-reusable.yml
+++ b/.github/workflows/pr-size-check-reusable.yml
@@ -68,81 +68,96 @@ jobs:
             // Thrown values are not guaranteed to be Error instances in JS.
             const errMsg = e => e instanceof Error ? e.message : String(e);
 
-            // ── Comment detection helpers ─────────────────────────────────
-            // Returns true if a line of code (trimmed) is purely a comment.
-            // Supports: // , /* , */ , * (block continuation), # , <!-- -->
-            function isCommentLine(line) {
-              const trimmed = line.trim();
-              if (trimmed === '') return true; // blank lines don't count
-              // C-style single-line comments
-              if (trimmed.startsWith('//')) return true;
-              // Shell/Python-style comments — but NOT preprocessor directives
-              if (trimmed.startsWith('#')) {
-                const afterHash = trimmed.substring(1).trimStart();
-                const preprocessorKeywords = [
-                  'include', 'import', 'define', 'undef', 'if', 'ifdef',
-                  'ifndef', 'else', 'elif', 'endif', 'pragma', 'error',
-                  'warning', 'line', 'region', 'endregion'
-                ];
-                // Match keyword at word boundary (handles #include<foo> and #include"foo")
-                const isPreprocessor = preprocessorKeywords.some(kw => {
-                  if (!afterHash.startsWith(kw)) return false;
-                  if (afterHash.length === kw.length) return true;
-                  const nextChar = afterHash[kw.length];
-                  // Preprocessor if followed by non-identifier char
-                  return !/[A-Za-z0-9_]/.test(nextChar);
-                });
-                if (!isPreprocessor) return true;
-              }
-              // C-style block comment — only if the ENTIRE line is a comment
-              if (trimmed.startsWith('/*')) {
-                // If line contains closing */ followed by non-whitespace, it has code
-                const closeIdx = trimmed.indexOf('*/', 2);
-                if (closeIdx === -1) return true; // open block, no close on this line
-                const afterClose = trimmed.substring(closeIdx + 2).trim();
-                if (afterClose === '') return true; // line is only /* ... */
-                return false; // code follows after */
-              }
-              if (trimmed.startsWith('*/')) {
-                const afterClose = trimmed.substring(2).trim();
-                return afterClose === ''; // only comment-end, no trailing code
-              }
-              if (/^\*(\s|$)/.test(trimmed)) return true; // block comment continuation
-              // HTML/XML comments
-              if (trimmed.startsWith('<!--')) {
-                const closeIdx = trimmed.indexOf('-->', 4);
-                if (closeIdx === -1) return true;
-                const afterClose = trimmed.substring(closeIdx + 3).trim();
-                return afterClose === '';
-              }
-              if (trimmed.endsWith('-->') && !trimmed.includes('<!--')) return true;
-              return false;
-            }
+            // ── Count non-comment changed lines using character scanning ──
+            // Uses character-by-character parsing with block-comment state
+            // tracking across lines for accurate multi-line /* */ and <!-- -->
+            // detection. Also handles // and # comments.
+            // Context lines (' ') are scanned to maintain block-comment state
+            // but are not counted — only '+' and '-' lines contribute.
+            // Falls back to raw counts when patch is unavailable.
+            //
+            // @param {string|null|undefined} patch - unified diff from GitHub API
+            // @param {number} rawAdditions - fallback additions count
+            // @param {number} rawDeletions - fallback deletions count
+            // @returns {{ additions: number, deletions: number, fallback: boolean }}
+            function countCodeLines(patch, rawAdditions, rawDeletions) {
+              if (!patch) return { additions: rawAdditions, deletions: rawDeletions, fallback: true };
 
-            // Count non-comment changed lines from a patch string.
-            // Patch lines starting with + or - are changes; diff headers are
-            // identified by the @@ hunk marker context, not by +++ or --- prefix.
-            function countNonCommentLines(patch) {
-              if (!patch) return null; // signal that patch is missing
+              const PREPROC_KEYWORDS = [
+                'include', 'import', 'define', 'undef', 'if', 'ifdef',
+                'ifndef', 'else', 'elif', 'endif', 'pragma', 'error',
+                'warning', 'line', 'region', 'endregion'
+              ];
+
               const lines = patch.split('\n');
+              let inBlockComment = false;
+              let inHtmlComment = false;
               let additions = 0;
               let deletions = 0;
               let inHeader = true; // diff headers come before first @@ hunk
+
               for (const line of lines) {
-                if (line.startsWith('@@')) {
-                  inHeader = false;
-                  continue;
+                if (line.startsWith('@@')) { inHeader = false; continue; }
+                if (inHeader || line.length === 0) continue;
+
+                const prefix = line[0]; // '+', '-', or ' ' (context)
+                const content = line.slice(1);
+                let hasCode = false;
+                let i = 0;
+                const len = content.length;
+
+                while (i < len) {
+                  if (inBlockComment) {
+                    if (content[i] === '*' && i + 1 < len && content[i + 1] === '/') {
+                      inBlockComment = false;
+                      i += 2;
+                    } else {
+                      i++;
+                    }
+                  } else if (inHtmlComment) {
+                    if (content[i] === '-' && i + 2 < len && content[i + 1] === '-' && content[i + 2] === '>') {
+                      inHtmlComment = false;
+                      i += 3;
+                    } else {
+                      i++;
+                    }
+                  } else {
+                    if (/\s/.test(content[i])) { i++; continue; }
+                    // // single-line comment — rest of line is comment
+                    if (content[i] === '/' && i + 1 < len && content[i + 1] === '/') break;
+                    // /* block-comment start
+                    if (content[i] === '/' && i + 1 < len && content[i + 1] === '*') {
+                      inBlockComment = true;
+                      i += 2;
+                      continue;
+                    }
+                    // <!-- HTML/XML comment start
+                    if (content[i] === '<' && i + 3 < len &&
+                        content[i + 1] === '!' && content[i + 2] === '-' && content[i + 3] === '-') {
+                      inHtmlComment = true;
+                      i += 4;
+                      continue;
+                    }
+                    // # comment — only when first non-ws char (not preprocessor)
+                    if (content[i] === '#' && !hasCode) {
+                      const rest = content.substring(i + 1).trimStart();
+                      const isPreprocessor = PREPROC_KEYWORDS.some(kw => {
+                        if (!rest.startsWith(kw)) return false;
+                        if (rest.length === kw.length) return true;
+                        return !/[A-Za-z0-9_]/.test(rest[kw.length]);
+                      });
+                      if (!isPreprocessor) break; // # comment, skip rest of line
+                    }
+                    hasCode = true;
+                    i++;
+                  }
                 }
-                if (inHeader) continue; // skip file-level diff headers (+++ / ---)
-                if (line.startsWith('+')) {
-                  const content = line.substring(1);
-                  if (!isCommentLine(content)) additions++;
-                } else if (line.startsWith('-')) {
-                  const content = line.substring(1);
-                  if (!isCommentLine(content)) deletions++;
-                }
+
+                if (prefix === '+' && hasCode) additions++;
+                else if (prefix === '-' && hasCode) deletions++;
               }
-              return { additions, deletions };
+
+              return { additions, deletions, fallback: false };
             }
 
             // ── Guard: must be called from a pull_request workflow ────────
@@ -365,24 +380,19 @@ jobs:
               return;
             }
 
-            // ── Count non-comment lines from patch content ────────────────
+            // ── Count non-comment code lines per file ─────────────────────
             let totalLines = 0;
             let totalCommentLines = 0;
             for (const f of included) {
-              const result = countNonCommentLines(f.patch);
-              if (result === null) {
-                // Patch missing/truncated by GitHub API — fall back to raw counts (treat all as code)
-                totalLines += f.additions + f.deletions;
-                f._codeAdditions = f.additions;
-                f._codeDeletions = f.deletions;
-              } else {
-                const rawTotal = f.additions + f.deletions;
-                const codeTotal = result.additions + result.deletions;
+              const result = countCodeLines(f.patch, f.additions, f.deletions);
+              const rawTotal = f.additions + f.deletions;
+              const codeTotal = result.additions + result.deletions;
+              if (!result.fallback) {
                 totalCommentLines += (rawTotal - codeTotal);
-                totalLines += codeTotal;
-                f._codeAdditions = result.additions;
-                f._codeDeletions = result.deletions;
               }
+              totalLines += codeTotal;
+              f._codeAdditions = result.additions;
+              f._codeDeletions = result.deletions;
             }
 
             const linesPassed = totalLines <= LIMIT;


### PR DESCRIPTION
## Summary

Updates the reusable PR size check workflow to **not count comment-only lines** toward the line change limit.

### What's excluded:
- `//` single-line comments
- `/* ... */` block comments (including `*` continuation lines)
- `#` shell/Python-style comments (but **not** preprocessor directives like `#include`, `#import`, `#define`)
- Blank/whitespace-only lines

### What's still counted:
- All actual code lines
- Preprocessor directives (`#include`, `#import`, `#define`, `#pragma`, etc.)

### How it works:
Uses the `patch` field from the GitHub API (unified diff format) and parses each `+`/`-` line to determine if it's a comment. No checkout required.

### Summary output now includes:
- **Counted code lines changed: N / 500**
- **Comment lines excluded: N**
- **Counted files changed: N / 30**

---

> ⚠️ This file must be kept identical with the copy in `azure-activedirectory-tokenbroker-for-objc`. A matching PR is open there.