### PR TITLE
[minor][feature]: Add Delos and GovSG cloud support to MSAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 TBD
+* Add Delos and GovSG sovereign cloud environments in `MSALAADAuthority`. (#3598387)
 * Adding Get Device Token API for shared device mode #2980
 * Improve UI tests performance #2981
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 TBD
-* Add Delos and GovSG sovereign cloud environments in `MSALAADAuthority`. (#3598387)
+* Add Delos and GovSG sovereign cloud environments in `MSALAADAuthority`. (#2984)
 * Adding Get Device Token API for shared device mode #2980
 * Improve UI tests performance #2981
 

--- a/MSAL/src/instance/MSALAADAuthority.m
+++ b/MSAL/src/instance/MSALAADAuthority.m
@@ -135,6 +135,10 @@
             return @"login.microsoftonline.us";
         case MSALAzureFranceCloudInstance:
             return @"login.sovcloud-identity.fr";
+        case MSALAzureDelosCloudInstance:
+            return @"login.sovcloud-identity.de";
+        case MSALAzureGovSGCloudInstance:
+            return @"login.sovcloud-identity.sg";
 
         default:
             return nil;

--- a/MSAL/src/public/MSALAADAuthority.h
+++ b/MSAL/src/public/MSALAADAuthority.h
@@ -95,7 +95,17 @@ typedef NS_ENUM(NSInteger, MSALAzureCloudInstance)
     /**
      Microsoft France sovereign cloud. Maps to https://login.sovcloud-identity.fr
     */
-    MSALAzureFranceCloudInstance
+    MSALAzureFranceCloudInstance,
+
+    /**
+    Germany sovereign cloud (Delos). Maps to https://login.sovcloud-identity.de
+    */
+    MSALAzureDelosCloudInstance,
+
+    /**
+    Singapore sovereign cloud (GovSG). Maps to https://login.sovcloud-identity.sg
+    */
+    MSALAzureGovSGCloudInstance
 };
 
 /**

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -200,12 +200,12 @@ typedef NS_ENUM(NSInteger, MSALError)
     MSALErrorInsufficientDeviceStrength          = -50007,
     
     /**
-     * MDM enrollment has completed. Retry the token request to proceed.
+     * MDM enrollment completed during authentication. Retry the token request to continue with the enrolled device.
      */
     MSALErrorMDMEnrollmentCompletedNeedsRetry    = -50008,
     
     /**
-     Error thrown when oauth error = MSIDServerInvalidRequest and error code = 50142 (SecureChangePasswordDueToConditionalAccess)
+     Error thrown when OAuth error = MSIDServerInvalidRequest and error code = 50142 (SecureChangePasswordDueToConditionalAccess).
      */
     MSALErrorServerInvalidRequestResetPasswordRequired = -50142,
 };

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -199,10 +199,14 @@ typedef NS_ENUM(NSInteger, MSALError)
      */
     MSALErrorInsufficientDeviceStrength          = -50007,
     
-    /** MDM enrollment completed during authentication. Retry the token request to continue with the enrolled device. */
+    /**
+     * MDM enrollment completed during authentication. Retry the token request to continue with the enrolled device.
+     */
     MSALErrorMDMEnrollmentCompletedNeedsRetry    = -50008,
     
-    /** Error thrown when OAuth error = MSIDServerInvalidRequest and error code = 50142 (SecureChangePasswordDueToConditionalAccess). */
+    /**
+     Error thrown when OAuth error = MSIDServerInvalidRequest and error code = 50142 (SecureChangePasswordDueToConditionalAccess).
+     */
     MSALErrorServerInvalidRequestResetPasswordRequired = -50142,
 };
 

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -199,14 +199,10 @@ typedef NS_ENUM(NSInteger, MSALError)
      */
     MSALErrorInsufficientDeviceStrength          = -50007,
     
-    /**
-     * MDM enrollment completed during authentication. Retry the token request to continue with the enrolled device.
-     */
+    /** MDM enrollment completed during authentication. Retry the token request to continue with the enrolled device. */
     MSALErrorMDMEnrollmentCompletedNeedsRetry    = -50008,
     
-    /**
-     Error thrown when OAuth error = MSIDServerInvalidRequest and error code = 50142 (SecureChangePasswordDueToConditionalAccess).
-     */
+    /** Error thrown when OAuth error = MSIDServerInvalidRequest and error code = 50142 (SecureChangePasswordDueToConditionalAccess). */
     MSALErrorServerInvalidRequestResetPasswordRequired = -50142,
 };
 

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -200,12 +200,12 @@ typedef NS_ENUM(NSInteger, MSALError)
     MSALErrorInsufficientDeviceStrength          = -50007,
     
     /**
-     * MDM enrollment completed during authentication. Retry the token request to continue with the enrolled device.
+     MDM enrollment has completed. Retry the token request to proceed.
      */
     MSALErrorMDMEnrollmentCompletedNeedsRetry    = -50008,
     
     /**
-     Error thrown when OAuth error = MSIDServerInvalidRequest and error code = 50142 (SecureChangePasswordDueToConditionalAccess).
+     Error thrown when oauth error = MSIDServerInvalidRequest and error code = 50142 (SecureChangePasswordDueToConditionalAccess)
      */
     MSALErrorServerInvalidRequestResetPasswordRequired = -50142,
 };

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -200,7 +200,7 @@ typedef NS_ENUM(NSInteger, MSALError)
     MSALErrorInsufficientDeviceStrength          = -50007,
     
     /**
-     MDM enrollment has completed. Retry the token request to proceed.
+     * MDM enrollment has completed. Retry the token request to proceed.
      */
     MSALErrorMDMEnrollmentCompletedNeedsRetry    = -50008,
     

--- a/MSAL/test/unit/MSALAADAuthorityTests.m
+++ b/MSAL/test/unit/MSALAADAuthorityTests.m
@@ -177,6 +177,176 @@
     XCTAssertEqualObjects(authority.url.absoluteString, @"https://login.sovcloud-identity.fr/common");
 }
 
+#pragma mark - Delos Sovereign Cloud
+
+- (void)testInitWithCloudInstance_Delos_MyOrg_NilTenant_shouldReturnError
+{
+    NSError *error = nil;
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithCloudInstance:MSALAzureDelosCloudInstance
+                                                                     audienceType:MSALAzureADMyOrgOnlyAudience
+                                                                        rawTenant:nil
+                                                                            error:&error];
+
+    XCTAssertNil(authority);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSALErrorDomain);
+    XCTAssertEqual(error.code, MSALErrorInternal);
+    XCTAssertEqual([error.userInfo[MSALInternalErrorCodeKey] integerValue], MSALInternalErrorInvalidParameter);
+    XCTAssertEqualObjects(error.userInfo[MSALErrorDescriptionKey], @"Invalid MSALAudienceType provided. You must provide rawTenant when using MSALAzureADMyOrgOnlyAudience.");
+}
+
+- (void)testInitWithCloudInstance_Delos_MyOrg_NonNilTenant_shouldReturnAuthority
+{
+    NSError *error = nil;
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithCloudInstance:MSALAzureDelosCloudInstance
+                                                                     audienceType:MSALAzureADMyOrgOnlyAudience
+                                                                        rawTenant:@"contoso.de"
+                                                                            error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(authority);
+    XCTAssertEqualObjects(authority.url.absoluteString, @"https://login.sovcloud-identity.de/contoso.de");
+}
+
+- (void)testInitWithCloudInstance_Delos_Common_NilTenant_shouldReturnAuthority
+{
+    NSError *error = nil;
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithCloudInstance:MSALAzureDelosCloudInstance
+                                                                     audienceType:MSALAzureADAndPersonalMicrosoftAccountAudience
+                                                                        rawTenant:nil
+                                                                            error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(authority);
+    XCTAssertEqualObjects(authority.url.absoluteString, @"https://login.sovcloud-identity.de/common");
+}
+
+- (void)testInitWithCloudInstance_Delos_Common_NonNilTenant_shouldReturnError
+{
+    NSError *error = nil;
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithCloudInstance:MSALAzureDelosCloudInstance
+                                                                     audienceType:MSALAzureADAndPersonalMicrosoftAccountAudience
+                                                                        rawTenant:@"contoso.de"
+                                                                            error:&error];
+
+    XCTAssertNil(authority);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSALErrorDomain);
+    XCTAssertEqual(error.code, MSALErrorInternal);
+    XCTAssertEqual([error.userInfo[MSALInternalErrorCodeKey] integerValue], MSALInternalErrorInvalidParameter);
+    XCTAssertEqualObjects(error.userInfo[MSALErrorDescriptionKey], @"Invalid MSALAudienceType provided. You can only provide rawTenant when using MSALAzureADMyOrgOnlyAudience.");
+}
+
+- (void)testInitWithCloudInstance_Delos_MultipleOrgs_shouldReturnAuthority
+{
+    NSError *error = nil;
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithCloudInstance:MSALAzureDelosCloudInstance
+                                                                     audienceType:MSALAzureADMultipleOrgsAudience
+                                                                        rawTenant:nil
+                                                                            error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(authority);
+    XCTAssertEqualObjects(authority.url.absoluteString, @"https://login.sovcloud-identity.de/organizations");
+}
+
+- (void)testInitWithURL_Delos_shouldReturnAuthority
+{
+    NSError *error = nil;
+    NSURL *delosURL = [NSURL URLWithString:@"https://login.sovcloud-identity.de/common"];
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithURL:delosURL
+                                                                  error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(authority);
+    XCTAssertEqualObjects(authority.url.absoluteString, @"https://login.sovcloud-identity.de/common");
+}
+
+#pragma mark - GovSG Sovereign Cloud
+
+- (void)testInitWithCloudInstance_GovSG_MyOrg_NilTenant_shouldReturnError
+{
+    NSError *error = nil;
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithCloudInstance:MSALAzureGovSGCloudInstance
+                                                                     audienceType:MSALAzureADMyOrgOnlyAudience
+                                                                        rawTenant:nil
+                                                                            error:&error];
+
+    XCTAssertNil(authority);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSALErrorDomain);
+    XCTAssertEqual(error.code, MSALErrorInternal);
+    XCTAssertEqual([error.userInfo[MSALInternalErrorCodeKey] integerValue], MSALInternalErrorInvalidParameter);
+    XCTAssertEqualObjects(error.userInfo[MSALErrorDescriptionKey], @"Invalid MSALAudienceType provided. You must provide rawTenant when using MSALAzureADMyOrgOnlyAudience.");
+}
+
+- (void)testInitWithCloudInstance_GovSG_MyOrg_NonNilTenant_shouldReturnAuthority
+{
+    NSError *error = nil;
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithCloudInstance:MSALAzureGovSGCloudInstance
+                                                                     audienceType:MSALAzureADMyOrgOnlyAudience
+                                                                        rawTenant:@"contoso.sg"
+                                                                            error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(authority);
+    XCTAssertEqualObjects(authority.url.absoluteString, @"https://login.sovcloud-identity.sg/contoso.sg");
+}
+
+- (void)testInitWithCloudInstance_GovSG_Common_NilTenant_shouldReturnAuthority
+{
+    NSError *error = nil;
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithCloudInstance:MSALAzureGovSGCloudInstance
+                                                                     audienceType:MSALAzureADAndPersonalMicrosoftAccountAudience
+                                                                        rawTenant:nil
+                                                                            error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(authority);
+    XCTAssertEqualObjects(authority.url.absoluteString, @"https://login.sovcloud-identity.sg/common");
+}
+
+- (void)testInitWithCloudInstance_GovSG_Common_NonNilTenant_shouldReturnError
+{
+    NSError *error = nil;
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithCloudInstance:MSALAzureGovSGCloudInstance
+                                                                     audienceType:MSALAzureADAndPersonalMicrosoftAccountAudience
+                                                                        rawTenant:@"contoso.sg"
+                                                                            error:&error];
+
+    XCTAssertNil(authority);
+    XCTAssertNotNil(error);
+    XCTAssertEqualObjects(error.domain, MSALErrorDomain);
+    XCTAssertEqual(error.code, MSALErrorInternal);
+    XCTAssertEqual([error.userInfo[MSALInternalErrorCodeKey] integerValue], MSALInternalErrorInvalidParameter);
+    XCTAssertEqualObjects(error.userInfo[MSALErrorDescriptionKey], @"Invalid MSALAudienceType provided. You can only provide rawTenant when using MSALAzureADMyOrgOnlyAudience.");
+}
+
+- (void)testInitWithCloudInstance_GovSG_MultipleOrgs_shouldReturnAuthority
+{
+    NSError *error = nil;
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithCloudInstance:MSALAzureGovSGCloudInstance
+                                                                     audienceType:MSALAzureADMultipleOrgsAudience
+                                                                        rawTenant:nil
+                                                                            error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(authority);
+    XCTAssertEqualObjects(authority.url.absoluteString, @"https://login.sovcloud-identity.sg/organizations");
+}
+
+- (void)testInitWithURL_GovSG_shouldReturnAuthority
+{
+    NSError *error = nil;
+    NSURL *govSGURL = [NSURL URLWithString:@"https://login.sovcloud-identity.sg/common"];
+    MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithURL:govSGURL
+                                                                  error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(authority);
+    XCTAssertEqualObjects(authority.url.absoluteString, @"https://login.sovcloud-identity.sg/common");
+}
+
 #pragma mark - Regression: all MSALAzureCloudInstance values produce a non-nil environment
 
 - (void)testEnvironmentFromCloudInstance_allKnownCasesReturnNonNilEnvironment
@@ -190,6 +360,8 @@
         @(MSALAzureGermanyCloudInstance),
         @(MSALAzureUsGovernmentCloudInstance),
         @(MSALAzureFranceCloudInstance),
+        @(MSALAzureDelosCloudInstance),
+        @(MSALAzureGovSGCloudInstance),
     ];
 
     for (NSNumber *instanceNumber in allInstances)
@@ -207,9 +379,9 @@
     }
 }
 
-- (void)testInitWithCloudInstance_Germany_unchangedAfterFranceAddition
+- (void)testInitWithCloudInstance_Germany_unchangedAfterSovereignAdditions
 {
-    // Regression: adding France must not alter Germany behaviour.
+    // Regression: adding France/Delos/GovSG must not alter Germany behaviour.
     NSError *error = nil;
     MSALAADAuthority *authority = [[MSALAADAuthority alloc] initWithCloudInstance:MSALAzureGermanyCloudInstance
                                                                      audienceType:MSALAzureADMultipleOrgsAudience


### PR DESCRIPTION
## Summary
- add Delos and GovSG cloud instances to MSALAADAuthority
- map the new cloud instances to their sovereign login hosts
- extend MSALAADAuthority unit coverage for Delos and GovSG
- update the nested IdentityCore submodule to trust the new hosts

## Validation
- xcodebuild test -workspace MSAL.xcworkspace -scheme 'MSAL (iOS Framework)' -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO -only-testing:'MSAL iOS Unit Tests/MSALAADAuthorityTests' -only-testing:'IdentityCoreTests iOS/MSIDAADAuthorityTests'

## Dependency
- IdentityCore PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1813

— Authored by Forge/Coder