### PR TITLE
[minor][engg]: Add CocoaPods bootstrap to broker submodule check (Mac)

### DIFF
--- a/azure_pipelines/broker_submodule_check.yml
+++ b/azure_pipelines/broker_submodule_check.yml
@@ -141,7 +141,9 @@ jobs:
       workingDirectory: $(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker
       targetType: 'inline'
       script: |
-        git config --global http.https://office.visualstudio.com/.extraheader "AUTHORIZATION: bearer $(aadToken)"
+        GIT_CONFIG_COUNT=1 \
+        GIT_CONFIG_KEY_0=http.https://office.visualstudio.com/.extraheader \
+        GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer $(aadToken)" \
         pod install
     retryCountOnTaskFailure: 1
 

--- a/azure_pipelines/broker_submodule_check.yml
+++ b/azure_pipelines/broker_submodule_check.yml
@@ -137,13 +137,15 @@ jobs:
   - task: Bash@3
     displayName: 'Install CocoaPods dependencies'
     condition: eq(variables['target'], 'mac_library')
+    env:
+      AAD_TOKEN: $(aadToken)
     inputs:
       workingDirectory: $(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker
       targetType: 'inline'
       script: |
         GIT_CONFIG_COUNT=1 \
         GIT_CONFIG_KEY_0=http.https://office.visualstudio.com/.extraheader \
-        GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer $(aadToken)" \
+        GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer $AAD_TOKEN" \
         pod install
     retryCountOnTaskFailure: 1
 

--- a/azure_pipelines/broker_submodule_check.yml
+++ b/azure_pipelines/broker_submodule_check.yml
@@ -126,7 +126,25 @@ jobs:
       script: |
         cd azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Frameworks/WorkplaceJoin-for-iOS
         git submodule update --init --recursive Frameworks/microsoft-authentication-library-for-objc
-        
+
+  - task: Cache@2
+    displayName: 'Cache CocoaPods'
+    condition: eq(variables['target'], 'mac_library')
+    inputs:
+      key: 'cocoapods | "$(Agent.OS)" | azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Podfile.lock'
+      path: '$(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker/Pods'
+
+  - task: Bash@3
+    displayName: 'Install CocoaPods dependencies'
+    condition: eq(variables['target'], 'mac_library')
+    inputs:
+      workingDirectory: $(Pipeline.Workspace)/s/azure-activedirectory-tokenbroker-for-objc/ADAuthenticationBroker
+      targetType: 'inline'
+      script: |
+        git config --global http.https://office.visualstudio.com/.extraheader "AUTHORIZATION: bearer $(aadToken)"
+        pod install
+    retryCountOnTaskFailure: 1
+
   - script: 'gem uninstall xcpretty -I --version 0.4.0'
     displayName: 'Uninstall xcpretty v0.4.0'
 


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [x] Appropriate reviewers are assigned
- [x] PR reviewed by code owner (required if Copilot-generated)
- [x] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH] [tests]: add coverage`

## Proposed changes

The broker workspace now references ADAuthenticationBroker/Pods/Pods.xcodeproj after Broker PR #2343 added a Podfile (PowerLiftKit consumed by the MicrosoftSingleSignOnForMac scheme). Without 'pod install' the workspace reference dangles and the Mac validation of MicrosoftSingleSignOnForMac fails.

Mirror the cache + pod install block from the broker's apple-broker-ci.yml. Gated on target=mac_library so iOS validation is unaffected. Reuses the existing AuthSdkResourceManager aadToken already set up earlier in this pipeline for NGC submodule auth.
## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

