### PR TITLE
[Patch][Bugfix]: Fix CocoaPods validation by adding missing IdentityCore imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ TBD
 * Adding Get Device Token API for shared device mode #2980
 * Improve UI tests performance #2981
 * Close cookies popup in automation tests #2985
+* Fix CocoaPods validation by adding missing IdentityCore imports for Get Device Token API #2994
 
 ## [2.11.0]:
 * Rename file on disk to match Xcode #2909

--- a/MSAL/src/MSALDeviceTokenResult.m
+++ b/MSAL/src/MSALDeviceTokenResult.m
@@ -25,6 +25,9 @@
 #import "MSALDeviceTokenResult.h"
 #import "MSIDAuthority.h"
 #import "MSALAADAuthority.h"
+#import "MSIDTokenResult.h"
+#import "MSIDAccessToken.h"
+#import "MSIDTokenResponse.h"
 
 @implementation MSALDeviceTokenResult
 

--- a/MSAL/src/MSALPublicClientApplication.m
+++ b/MSAL/src/MSALPublicClientApplication.m
@@ -120,6 +120,7 @@
 #import "MSALDeviceTokenResult.h"
 #import "MSALDeviceTokenResult+Internal.h"
 #import "MSALDeviceInformation.h"
+#import "MSIDAuthenticationScheme.h"
 
 @interface MSALPublicClientApplication()
 {

--- a/MSAL/src/instance/MSALDeviceInfoProvider.h
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.h
@@ -27,6 +27,7 @@
 
 #import <Foundation/Foundation.h>
 #import "MSALSSOExtensionRequestHandler.h"
+#import "MSIDConstants.h"
 
 @class MSIDRequestParameters;
 @class MSALDeviceTokenParameters;

--- a/MSAL/src/instance/MSALDeviceInfoProvider.m
+++ b/MSAL/src/instance/MSALDeviceInfoProvider.m
@@ -39,6 +39,8 @@
 #import "MSIDRegistrationInformation.h"
 #import "MSIDDeviceTokenGrantRequest.h"
 #import "MSIDDeviceTokenResponseHandler.h"
+#import "MSIDAuthority.h"
+#import "MSIDOauth2Factory.h"
 
 @implementation MSALDeviceInfoProvider
 


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [x] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

## Proposed changes

Fixes the `cocoapods_lib_lint` section of the **MSAL Objc Automations** pipeline (`azure_pipelines/automation.yml`), which fails for both the `STATIC_LIBRARY` and `DYNAMIC_LIBRARY` matrix legs.

The Get Device Token API introduced in #2980 used several `MSID*` classes concretely (`alloc/init`, property access, class messages) while relying only on forward declarations / transitive imports. The regular Xcode build was tolerant of this, but the stricter `pod lib lint` environment surfaced the missing imports, e.g.:

```
MSAL/src/MSALPublicClientApplication.m:1631:52: error: receiver
'MSIDAuthenticationScheme' for class message is a forward declaration
```

This PR adds the missing concrete imports so `pod lib lint` succeeds for both static and dynamic builds:

- `MSAL/src/MSALPublicClientApplication.m` — `#import "MSIDAuthenticationScheme.h"`
- `MSAL/src/instance/MSALDeviceInfoProvider.h` — `#import "MSIDConstants.h"` (for the `MSIDRequestCompletionBlock` typedef)
- `MSAL/src/instance/MSALDeviceInfoProvider.m` — `#import "MSIDAuthority.h"`, `#import "MSIDOauth2Factory.h"`
- `MSAL/src/MSALDeviceTokenResult.m` — `#import "MSIDTokenResult.h"`, `#import "MSIDAccessToken.h"`, `#import "MSIDTokenResponse.h"`

No behavioral change — imports only.

### Verification

- `pod lib lint --fail-fast --allow-warnings --use-static-frameworks` → **MSAL passed validation**
- `pod lib lint --fail-fast --allow-warnings` (dynamic) → **MSAL passed validation**
- `./build.py --targets iosFramework` → build + unit tests succeeded

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. Header-only additions, no behavior change.

## Additional information

CHANGELOG: added an entry under the existing `TBD` section (the `#PR_NUMBER` placeholder will be back-filled once this PR receives its number).
