### PR TITLE
[minor] [engg]: Bump IdentityCore to include DI foundation (#1810/#1838/#1809)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 TBD
-* Update IdentityCore submodule to pull in DI foundation (AzureAD/microsoft-authentication-library-common-for-objc#1810 WPJ, AzureAD/microsoft-authentication-library-common-for-objc#1838 hardening, AzureAD/microsoft-authentication-library-common-for-objc#1809 throttling)
+* Update IdentityCore submodule to pull in DI foundation (common core #1810 WPJ, #1838 hardening, #1809 throttling)
 * Add Delos and GovSG sovereign cloud environments in `MSALAADAuthority`. (#2984)
 * Adding Get Device Token API for shared device mode #2980
 * Improve UI tests performance #2981

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 TBD
-* Update IdentityCore submodule to pull in DI foundation (CC #1810 WPJ, #1838 hardening, #1809 throttling)
+* Update IdentityCore submodule to pull in DI foundation (AzureAD/microsoft-authentication-library-common-for-objc#1810 WPJ, AzureAD/microsoft-authentication-library-common-for-objc#1838 hardening, AzureAD/microsoft-authentication-library-common-for-objc#1809 throttling)
 * Add Delos and GovSG sovereign cloud environments in `MSALAADAuthority`. (#2984)
 * Adding Get Device Token API for shared device mode #2980
 * Improve UI tests performance #2981

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 TBD
+* Update IdentityCore submodule to pull in DI foundation (CC #1810 WPJ, #1838 hardening, #1809 throttling)
 * Add Delos and GovSG sovereign cloud environments in `MSALAADAuthority`. (#2984)
 * Adding Get Device Token API for shared device mode #2980
 * Improve UI tests performance #2981


### PR DESCRIPTION
## Summary
Routine Common Core submodule bump. Advances `MSAL/IdentityCore` from `ce438cc1e` → `00ab949b4` to pull in the next batch of `MSIDDIContainer` dependency-injection seams (the container itself, CC #1807, was already included in the prior pin).

## Common Core PRs pulled in
- **CC #1810** — Route `MSIDWorkPlaceJoinUtil` through `MSIDDIContainer` (WPJ seam)
- **CC #1838** — Harden `MSIDDIContainer` (thread-safety + protocol conformance check)
- **CC #1809** — Route `MSIDThrottlingService` through `MSIDDIContainer` (throttling seam)

Plus a handful of unrelated commits that landed on CC `dev` between the two pins (visionOS build fix #1840, pop/recCnf fix #1832, Mobile Onboarding navigation #1817, etc.) — see `git diff --submodule=log` in the diff for the full list.

## ADO
- Related to: PBI **3571651**, Task **3612431**
- ADO link: https://dev.azure.com/IdentityDivision/Engineering/_workitems/edit/3612431

## Downstream
The broker pointer bump that consumes this MSAL change is tracked in **Task 3612430** and will land in a separate PR.

## Validation
Local build/test skipped — relying on PR CI. No source changes; only the submodule pointer and a CHANGELOG entry are modified.

— Authored by Forge/Coder
