### PR TITLE
Expose MSALResourceTenantIdKey for guest/MTO MAM (AB#3673092)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [2.13.0]
+* Expose `MSALResourceTenantIdKey` in error userInfo so client apps can enroll with the Intune MAM SDK against the correct resource tenant for guest / multi-tenant organization (MTO) scenarios.
 * Update IdentityCore submodule to pull in DI foundation (common core #1810 WPJ, #1838 hardening, #1809 throttling)
 * Migrating MSAL automation pipeline to ACES shared pool.
 

--- a/MSAL/src/MSALError.m
+++ b/MSAL/src/MSALError.m
@@ -43,4 +43,5 @@ NSString *MSALInvalidResultKey = @"MSALInvalidResultKey";
 NSString *MSALDisplayableUserIdKey = @"MSALDisplayableUserIdKey";
 NSString *MSALBrokerVersionKey = @"MSALBrokerVersionKey";
 NSString *MSALHomeAccountIdKey = @"MSALHomeAccountIdKey";
+NSString *MSALResourceTenantIdKey = @"MSALResourceTenantIdKey";
 NSString *MSALThrottlingCacheHitKey = @"MSALThrottlingCacheHitKey";

--- a/MSAL/src/MSALErrorConverter.m
+++ b/MSAL/src/MSALErrorConverter.m
@@ -160,6 +160,7 @@ static NSSet *s_recoverableErrorCode;
                              MSIDUserDisplayableIdkey: MSALDisplayableUserIdKey,
                              MSIDBrokerVersionKey: MSALBrokerVersionKey,
                              MSIDHomeAccountIdkey: MSALHomeAccountIdKey,
+                             MSIDResourceTenantIdKey: MSALResourceTenantIdKey,
                              MSIDThrottlingCacheHitKey: MSALThrottlingCacheHitKey
                              };
     

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -132,6 +132,14 @@ extern NSString *MSALBrokerVersionKey;
 extern NSString *MSALHomeAccountIdKey;
 
 /**
+ Resource tenant id for the particular error if available. Populated for guest / multi-tenant
+ organization (MTO) scenarios where the resource tenant differs from the user's home tenant
+ (for example when a protection policy is required). Client apps can use this value to enroll
+ with the Intune MAM SDK against the correct resource tenant.
+ */
+extern NSString *MSALResourceTenantIdKey;
+
+/**
  Error domain that MSAL uses for authentication related errors. 
  */
 extern NSString *MSALErrorDomain;

--- a/MSAL/test/unit/MSALErrorConverterTests.m
+++ b/MSAL/test/unit/MSALErrorConverterTests.m
@@ -128,6 +128,27 @@
     XCTAssertEqualObjects(msalError.userInfo[MSALSTSErrorCodesKey], stsErrorCodes);
 }
 
+- (void)testErrorConversion_whenResourceTenantIdPresent_shouldMapToMSALResourceTenantIdKey {
+    NSString *resourceTenantId = @"7a8b9c0d-1234-5678-90ab-cdef12345678";
+
+    NSError *msalError = [MSALErrorConverter errorWithDomain:MSIDErrorDomain
+                                                        code:MSIDErrorServerProtectionPoliciesRequired
+                                            errorDescription:@"protection policy required"
+                                                  oauthError:nil
+                                                    subError:nil
+                                             underlyingError:nil
+                                               correlationId:[NSUUID UUID]
+                                                    userInfo:@{MSIDResourceTenantIdKey : resourceTenantId}
+                                              classifyErrors:YES
+                                          msalOauth2Provider:nil
+                                                  authScheme:[MSALAuthenticationSchemeBearer new]
+                                                  popManager:nil];
+
+    XCTAssertNotNil(msalError);
+    XCTAssertEqualObjects(msalError.userInfo[MSALResourceTenantIdKey], resourceTenantId);
+    XCTAssertNil(msalError.userInfo[MSIDResourceTenantIdKey]);
+}
+
 - (void)testErrorConversion_ErrorCodesAreAlsoRetrievedFromUnderlyingError_ErrorShouldBeParsedCorrectly {
     NSArray<NSNumber *> *stsErrorCodes = @[@123];
     NSError *underlyingError = [NSError errorWithDomain:NSOSStatusErrorDomain code:errSecItemNotFound userInfo:@{MSIDSTSErrorCodesKey : stsErrorCodes}];


### PR DESCRIPTION
## Work item
[AB#3673092](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3673092) — MSAL layer of the Guest/MTO cross-tenant MAM fix.

## Summary
Exposes the resource tenant id from protection-policy-required broker errors to client apps (e.g. Teams) so they can enroll with the Intune MAM SDK against the correct resource tenant in guest / multi-tenant organization (MTO) scenarios.

## Changes
- MSALError.h/.m: new public MSALResourceTenantIdKey error userInfo constant.
- MSALErrorConverter.m: map the broker MSIDResourceTenantIdKey onto MSALResourceTenantIdKey so it surfaces in the public NSError userInfo.
- Unit test for the key mapping.

## Testing
MSALErrorConverterTests pass (20 tests, 0 failures).

## Dependencies
Requires the CommonCore change that defines MSIDResourceTenantIdKey and maps resource_tenant_id from broker responses:
- CommonCore — AzureAD/microsoft-authentication-library-common-for-objc `antonio_alwan/mto_resource_tenant_enrollment` (#1873)

Part of the broker-side fix:
- Broker — AzureAD/azure-activedirectory-tokenbroker-for-objc `antonio_alwan/mto_guest_mam_resource_tenant`
