### PR TITLE
[bugfix]: Use Swift os(iOS) conditional instead of TARGET_OS_IPHONE in native auth test

### DIFF
--- a/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
+++ b/MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
@@ -547,7 +547,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
         XCTAssertNotNil("x-app-ver")
         XCTAssertNotNil("x-client-OS")
         XCTAssertNotNil("x-client-Ver")
-#if TARGET_OS_IPHONE
+#if os(iOS)
         XCTAssertNotNil("x-client-DM")
 #endif
     }


### PR DESCRIPTION
## Summary

Fixes a Swift preprocessor bug in `MSALNativeAuthRequestConfiguratorTests.swift`. A platform guard used the C/Objective-C macro `TARGET_OS_IPHONE`, which is **not visible to the Swift compiler**. Swift treats it as an undefined build flag that evaluates to `false`, so:

- The compiler emitted: `warning: 'TARGET_OS_*' preprocessor macros are not available in Swift; use 'os(...)' conditionals instead`.
- The guarded assertion silently **never compiled on any platform**, including iOS.

A stricter Xcode/Swift toolchain (or warnings-as-errors in a pipeline) surfaces this as a build failure.

## The fix (surgical, one line)

```diff
-#if TARGET_OS_IPHONE
+#if os(iOS)
         XCTAssertNotNil("x-client-DM")
 #endif
```

This is the only functional change. No reformatting, no unrelated lines touched.

```
MSAL/test/unit/native_auth/network/MSALNativeAuthRequestConfiguratorTests.swift
@@ -547,7 +547,7 @@ final class MSALNativeAuthRequestConfiguratorTests: XCTestCase {
         XCTAssertNotNil("x-app-ver")
         XCTAssertNotNil("x-client-OS")
         XCTAssertNotNil("x-client-Ver")
-#if TARGET_OS_IPHONE
+#if os(iOS)
         XCTAssertNotNil("x-client-DM")
 #endif
```

## Root cause

The line was introduced brand-new in PR #1911 "Native Auth features" (merged 2023-12-11, squash commit `7166bf3455`) as part of a 452-line new test file, and was never modified since.

It went unnoticed because:
1. It is only a **non-fatal warning** — the file compiled fine and CI stayed green.
2. The surrounding `XCTAssertNotNil("x-client-...")` assertions all check **string literals** (always non-nil / no-op), so there was no test signal even when the guarded block was dropped.
3. Buried in a large feature PR, it slipped review.

## Validation

- `./MSAL.xcworkspace` → scheme **`MSAL (iOS Framework)`**, iOS Simulator: `** TEST BUILD SUCCEEDED **` with `CODE_SIGNING_ALLOWED=NO`.
- The `TARGET_OS_*` / "preprocessor macros are not available in Swift" warning is **gone**. Remaining warnings on the file are pre-existing `@_implementationOnly` ones unrelated to this change.
- `MSALNativeAuthRequestConfiguratorTests`: **Executed 16 tests, 0 failures**.
- `git diff --check`: clean.
- Repo-wide scan `grep -rn "TARGET_OS_" --include=*.swift .` on current `dev`: this was the **only** occurrence in any Swift file.

## Follow-up note (out of scope for this PR)

Every assertion in this test method (`XCTAssertNotNil("x-client-OS")`, `x-client-Ver`, `x-client-DM`, etc.) asserts a **hard-coded string literal**, which is always non-nil and therefore tests nothing. This is a separate, pre-existing test-quality smell with a larger blast radius. This PR is intentionally scoped to only the `#if os(iOS)` guard fix; changing the assertion logic would alter test behavior and belongs in its own change.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>