### PR TITLE
Migrate Native Auth E2E email OTP retriever from 1secmail to mail.tm & enable SSPR e2e tests

### DIFF
--- a/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
@@ -43,13 +43,17 @@ class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
         #else
         static let resetPasswordUsernameKey = "reset_password_username_macos"
         #endif
+        static let emailProviderPasswordKey = "email_provider_password"
     }
     
     let correlationId = UUID()
     
     static var confFileContent: [String: Any]? = nil
     static var nativeAuthConfFileContent: [String: String]? = nil
-    private let codeRetriever = MSALNativeAuthEmailCodeRetriever()
+    // Shared stateful mail.tm client so markCheckpoint() and the subsequent readOtpCode()
+    // operate on the same instance across a test.
+    private static let sharedEmailClient = MSALNativeAuthEmailCodeRetriever()
+    private var codeRetriever: MSALNativeAuthEmailCodeRetriever { MSALNativeAuthEndToEndBaseTestCase.sharedEmailClient }
     
     override class func setUp() {
         super.setUp()
@@ -128,7 +132,26 @@ class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
     }
 
     func retrieveCodeFor(email: String) async -> String? {
-        return await codeRetriever.retrieveEmailOTPCode(email: email)
+        guard let password = retrieveEmailProviderPassword() else {
+            XCTFail("email_provider_password not found in conf.json")
+            return nil
+        }
+        let connected = await codeRetriever.connectToExistingAccount(address: email, password: password)
+        guard connected else {
+            XCTFail("Could not authenticate with mail.tm for the email specified")
+            return nil
+        }
+        return await codeRetriever.readOtpCode()
+    }
+
+    /// Records a checkpoint on the shared mail.tm client. Call this immediately before triggering an
+    /// action that sends an OTP email so `retrieveCodeFor` ignores older messages.
+    func markEmailCheckpoint() {
+        codeRetriever.markCheckpoint()
+    }
+
+    func retrieveEmailProviderPassword() -> String? {
+        return MSALNativeAuthEndToEndBaseTestCase.nativeAuthConfFileContent?[Constants.emailProviderPasswordKey]
     }
 
     func retrieveUsernameForSignInCode() -> String? {

--- a/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
@@ -50,10 +50,10 @@ class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
     
     static var confFileContent: [String: Any]? = nil
     static var nativeAuthConfFileContent: [String: String]? = nil
-    // Shared stateful mail.tm client so markCheckpoint() and the subsequent readOtpCode()
-    // operate on the same instance across a test.
-    private static let sharedEmailClient = MSALNativeAuthEmailCodeRetriever()
-    private var codeRetriever: MSALNativeAuthEmailCodeRetriever { MSALNativeAuthEndToEndBaseTestCase.sharedEmailClient }
+    // Per-test-case instance so mail.tm state (token, checkpoint) is isolated to a single test's
+    // lifecycle. markCheckpoint() and the subsequent readOtpCode() run on the same instance within
+    // a test, while parallel test runs never share mutable state.
+    private let codeRetriever = MSALNativeAuthEmailCodeRetriever()
     
     override class func setUp() {
         super.setUp()

--- a/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/MSALNativeAuthEndToEndBaseTestCase.swift
@@ -144,8 +144,8 @@ class MSALNativeAuthEndToEndBaseTestCase: XCTestCase {
         return await codeRetriever.readOtpCode()
     }
 
-    /// Records a checkpoint on the shared mail.tm client. Call this immediately before triggering an
-    /// action that sends an OTP email so `retrieveCodeFor` ignores older messages.
+    /// Records a checkpoint on the test-case's mail.tm client. Call this immediately before triggering
+    /// an action that sends an OTP email so `retrieveCodeFor` ignores older messages.
     func markEmailCheckpoint() {
         codeRetriever.markCheckpoint()
     }

--- a/MSAL/test/integration/native_auth/end_to_end/otp_code_retriever/MSALNativeAuthEmailCodeRetriever.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/otp_code_retriever/MSALNativeAuthEmailCodeRetriever.swift
@@ -75,8 +75,9 @@ class MSALNativeAuthEmailCodeRetriever {
     /// Records the current time so `readOtpCode()` ignores messages received earlier.
     /// Call this before triggering the action that sends the OTP email.
     func markCheckpoint() {
-        lastCheckedTime = Date()
-        print("Checkpoint marked at: \(ISO8601DateFormatter().string(from: lastCheckedTime!))")
+        let now = Date()
+        lastCheckedTime = now
+        print("Checkpoint marked at: \(ISO8601DateFormatter().string(from: now))")
     }
 
     // MARK: - mail.tm API
@@ -136,7 +137,7 @@ class MSALNativeAuthEmailCodeRetriever {
             }
             address = finalAddress
             password = requestedPassword
-            print("Account ready: \(finalAddress)")
+            print("Account ready.")
             return finalAddress
         } catch {
             print(error)
@@ -199,7 +200,9 @@ class MSALNativeAuthEmailCodeRetriever {
     }
 
     /// Reads messages (newest checked first), skipping any received at or before the checkpoint,
-    /// and returns the first OTP code found. Clears the checkpoint after a successful read.
+    /// and returns the first OTP code found. On a successful read the checkpoint is advanced to the
+    /// matched message's timestamp so subsequent reads (including retry flows) only consider newer
+    /// messages and never return the same stale OTP again.
     func readOtpCode(maxRetries: Int = 5) async -> String? {
         guard token != nil else {
             print("Call connectToExistingAccount()/login() before reading messages")
@@ -216,7 +219,7 @@ class MSALNativeAuthEmailCodeRetriever {
                         continue
                     }
                     if let code = await getMessageSource(messageId: messageId) {
-                        lastCheckedTime = nil
+                        lastCheckedTime = messageTime
                         return code
                     }
                 }

--- a/MSAL/test/integration/native_auth/end_to_end/otp_code_retriever/MSALNativeAuthEmailCodeRetriever.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/otp_code_retriever/MSALNativeAuthEmailCodeRetriever.swift
@@ -26,7 +26,6 @@ import Foundation
 
 /// Retrieves email OTP codes from the mail.tm disposable-email service (https://docs.mail.tm).
 ///
-/// This is a Swift port of the `MailTmClient` used in the msal-browser NativeAuthSample
 /// E2E tests. mail.tm is a token-based API: an account (address + password) must exist, then a
 /// bearer token is obtained and used to read messages.
 ///

--- a/MSAL/test/integration/native_auth/end_to_end/otp_code_retriever/MSALNativeAuthEmailCodeRetriever.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/otp_code_retriever/MSALNativeAuthEmailCodeRetriever.swift
@@ -26,7 +26,7 @@ import Foundation
 
 /// Retrieves email OTP codes from the mail.tm disposable-email service (https://docs.mail.tm).
 ///
-/// E2E tests. mail.tm is a token-based API: an account (address + password) must exist, then a
+/// mail.tm is a token-based API: an account (address + password) must exist, then a
 /// bearer token is obtained and used to read messages.
 ///
 /// The client is stateful and intended to be shared across a test suite: call `markCheckpoint()`
@@ -284,9 +284,20 @@ class MSALNativeAuthEmailCodeRetriever {
 
     private func messageDate(from message: [String: Any]) -> Date {
         let dateString = (message["updatedAt"] as? String) ?? (message["createdAt"] as? String)
-        guard let dateString = dateString, let date = ISO8601DateFormatter().date(from: dateString) else {
+        guard let dateString = dateString, let date = parseISO8601(dateString) else {
             return .distantPast
         }
         return date
+    }
+
+    /// Parses an ISO 8601 timestamp, tolerating both fractional-seconds (e.g. `...34.391Z`, which
+    /// mail.tm returns) and whole-second forms.
+    private func parseISO8601(_ string: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: string) {
+            return date
+        }
+        return ISO8601DateFormatter().date(from: string)
     }
 }

--- a/MSAL/test/integration/native_auth/end_to_end/otp_code_retriever/MSALNativeAuthEmailCodeRetriever.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/otp_code_retriever/MSALNativeAuthEmailCodeRetriever.swift
@@ -22,112 +22,269 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.  
 
-import XCTest
+import Foundation
 
-class MSALNativeAuthEmailCodeRetriever: XCTestCase {
+/// Retrieves email OTP codes from the mail.tm disposable-email service (https://docs.mail.tm).
+///
+/// This is a Swift port of the `MailTmClient` used in the msal-browser NativeAuthSample
+/// E2E tests. mail.tm is a token-based API: an account (address + password) must exist, then a
+/// bearer token is obtained and used to read messages.
+///
+/// The client is stateful and intended to be shared across a test suite: call `markCheckpoint()`
+/// right before triggering an OTP send, then `readOtpCode()` to fetch the resulting code.
+class MSALNativeAuthEmailCodeRetriever {
 
-    private let baseURLString = "https://www.1secmail.com/api/v1/?action="
-    private let secondsToWait = 4.0
-    private let numberOfRetry = 3
-    private let dateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0) //We ignore the timezone
-        return dateFormatter
-    }()
-    private let maximumSecondsSinceEmailReceive = 5.0
+    private let baseURLString = "https://api.mail.tm"
+    // Progressive delays (seconds) between read attempts, giving the email time to arrive.
+    private let progressiveDelays: [Double] = [10, 20, 30, 40, 50]
 
-    func retrieveEmailOTPCode(email: String) async -> String? {
-        let comps = email.components(separatedBy: "@")
-        guard comps.count == 2 else {
-            XCTFail("Invalid email address")
-            return nil
-        }
-        let local = comps[0]
-        let domain = comps[1]
+    private var address: String?
+    private var password: String?
+    private var token: String?
+    private var domain: String?
+    private var lastCheckedTime: Date?
 
-        guard let lastMessageId = await retrieveLastMessage(local: local, domain: domain, retryCounter: numberOfRetry) else {
-            XCTFail("Something went wrong retrieving the messages for the email specified")
-            return nil
-        }
-        guard let emailOTPCode = await retrieveOTPCodeFromMessage(local: local, domain: domain, messageId: lastMessageId) else {
-            XCTFail("Something went wrong retrieving the OTP code")
-            return nil
-        }
-        return emailOTPCode
+    // MARK: - Factory-style helpers
+
+    /// Connects to an existing mail.tm mailbox by logging in. Returns true on success.
+    @discardableResult
+    func connectToExistingAccount(address: String, password: String) async -> Bool {
+        return await login(address: address, password: password) != nil
     }
-    
+
+    /// Creates a brand-new mail.tm mailbox and authenticates to it. Returns the created address.
+    /// Used by sign-up flows (currently skipped, kept for parity with the JS client).
+    func createAuthenticatedAccount(password: String) async -> String? {
+        guard let created = await createInbox(address: nil, password: password) else {
+            return nil
+        }
+        guard await login(address: created, password: password) != nil else {
+            return nil
+        }
+        return created
+    }
+
+    /// Generates a random address for sign-up flows (does not create the mailbox).
     func generateRandomEmailAddress() -> String {
-        let randomId = UUID().uuidString.prefix(8)
-        return "native-auth-signup-\(randomId)@1secmail.org"
+        let randomId = UUID().uuidString.prefix(8).lowercased()
+        return "native-auth-signup-\(randomId)@mail.tm"
     }
 
-    private func retrieveLastMessage(local: String, domain: String, retryCounter: Int) async -> Int? {
-        guard retryCounter > 0, let url = URL(string: baseURLString + "getMessages&login=\(local)&domain=\(domain)") else {
-            return nil
-        }
-        try? await Task.sleep(nanoseconds: UInt64(secondsToWait * Double(NSEC_PER_SEC)))
-        var request = URLRequest(url: url)
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            
-            let code = (response as? HTTPURLResponse)?.statusCode ?? 0
-            guard let httpResponse = response as? HTTPURLResponse,
-                    httpResponse.statusCode == 200 else {
-                print("Unexpected response from 1secmail: \(code) status code")
-                return nil
-            }
-            guard var dataDictionary = try JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] else {
-                return nil
-            }
-            if dataDictionary.count > 0 {
-                dataDictionary.sort(by: {($0["id"] as? Int ?? 0) > ($1["id"] as? Int ?? 0)})
-                if let emailDateString = dataDictionary.first?["date"] as? String,
-                   let emailDate = dateFormatter.date(from: emailDateString) {
-                    let currentDate = Date()
-                    // Email should be newer than 5 seconds otherwise it could be from previous test
-                    // This retry will help with the delay in receiving the emails
-                    if currentDate.timeIntervalSince1970 - emailDate.timeIntervalSince1970  < maximumSecondsSinceEmailReceive {
-                        print ("Email is for current test, last receive date: \(emailDate) current date: \(currentDate)")
-                        return dataDictionary.first?["id"] as? Int
-                    } else {
-                        print ("Email is from previous tests, last receive date: \(emailDate) current date: \(currentDate)")
-                    }
-                }
-            }
-            // log only for the final retry
-            if (retryCounter == 1) {
-                print("Unexpected behaviour: no email received for the following local: \(local)")
-            }
-            // no emails found, retry
-            return await retrieveLastMessage(local: local, domain: domain, retryCounter: retryCounter - 1)
-        } catch {
-            print(error)
-            return nil
-        }
+    // MARK: - Checkpointing
+
+    /// Records the current time so `readOtpCode()` ignores messages received earlier.
+    /// Call this before triggering the action that sends the OTP email.
+    func markCheckpoint() {
+        lastCheckedTime = Date()
+        print("Checkpoint marked at: \(ISO8601DateFormatter().string(from: lastCheckedTime!))")
     }
 
-    private func retrieveOTPCodeFromMessage(local: String, domain: String, messageId: Int) async -> String? {
-        guard let url = URL(string: baseURLString + "readMessage&login=\(local)&domain=\(domain)&id=\(messageId)") else {
+    // MARK: - mail.tm API
+
+    private func fetchDomain() async -> String? {
+        guard let url = URL(string: baseURLString + "/domains") else {
             return nil
         }
         var request = URLRequest(url: url)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
-
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                 return nil
             }
-            let dataDictionary = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
-            let emailLines = (dataDictionary?["textBody"] as? String)?.components(separatedBy: CharacterSet.newlines) ?? []
-            // return the first line with only numbers, minimum 4 digits.
-            return emailLines.first(where: {$0.range(of: "[0-9]{4,}$", options: .regularExpression, range: nil, locale: nil) != nil })
+            let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+            let members = json?["hydra:member"] as? [[String: Any]]
+            guard let fetched = members?.first?["domain"] as? String else {
+                return nil
+            }
+            domain = fetched
+            print("Fetched domain: \(fetched)")
+            return fetched
         } catch {
             print(error)
             return nil
         }
+    }
+
+    /// Creates a mail.tm inbox. When `address` is nil a random address on the fetched domain is used.
+    private func createInbox(address requestedAddress: String?, password requestedPassword: String) async -> String? {
+        var useAddress = requestedAddress
+        if useAddress == nil {
+            var resolvedDomain = domain
+            if resolvedDomain == nil {
+                resolvedDomain = await fetchDomain()
+            }
+            guard let resolvedDomain = resolvedDomain else {
+                return nil
+            }
+            useAddress = "test\(Int(Date().timeIntervalSince1970 * 1000))@\(resolvedDomain)"
+        }
+        guard let finalAddress = useAddress, let url = URL(string: baseURLString + "/accounts") else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: ["address": finalAddress, "password": requestedPassword])
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            // 201 created, 422 already exists — both mean the mailbox is usable.
+            guard statusCode == 201 || statusCode == 422 else {
+                print("Failed to create mail.tm account: \(statusCode) status code")
+                return nil
+            }
+            address = finalAddress
+            password = requestedPassword
+            print("Account ready: \(finalAddress)")
+            return finalAddress
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+
+    private func login(address loginAddress: String, password loginPassword: String) async -> String? {
+        guard let url = URL(string: baseURLString + "/token") else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: ["address": loginAddress, "password": loginPassword])
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+                print("Failed to get token from mail.tm: \(statusCode) status code")
+                return nil
+            }
+            let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+            guard let receivedToken = json?["token"] as? String else {
+                return nil
+            }
+            token = receivedToken
+            address = loginAddress
+            password = loginPassword
+            print("Authentication token received.")
+            return receivedToken
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+
+    private func getMessageSource(messageId: String) async -> String? {
+        guard let token = token, let url = URL(string: baseURLString + "/sources/\(messageId)") else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                return nil
+            }
+            let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+            guard let source = json?["data"] as? String else {
+                print("'data' field not found in message source response.")
+                return nil
+            }
+            return extractOTPCode(from: source)
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+
+    /// Reads messages (newest checked first), skipping any received at or before the checkpoint,
+    /// and returns the first OTP code found. Clears the checkpoint after a successful read.
+    func readOtpCode(maxRetries: Int = 5) async -> String? {
+        guard token != nil else {
+            print("Call connectToExistingAccount()/login() before reading messages")
+            return nil
+        }
+        for attempt in 1...maxRetries {
+            if let messages = await fetchMessages() {
+                for message in messages {
+                    let messageTime = messageDate(from: message)
+                    if let checkpoint = lastCheckedTime, messageTime <= checkpoint {
+                        continue
+                    }
+                    guard let messageId = message["id"] as? String else {
+                        continue
+                    }
+                    if let code = await getMessageSource(messageId: messageId) {
+                        lastCheckedTime = nil
+                        return code
+                    }
+                }
+            }
+            if attempt < maxRetries {
+                let delay = progressiveDelays[min(attempt - 1, progressiveDelays.count - 1)]
+                try? await Task.sleep(nanoseconds: UInt64(delay * Double(NSEC_PER_SEC)))
+            }
+        }
+        print("Failed to find OTP code after \(maxRetries) attempts")
+        return nil
+    }
+
+    // MARK: - Helpers
+
+    private func fetchMessages() async -> [[String: Any]]? {
+        guard let token = token, let url = URL(string: baseURLString + "/messages?page=1") else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                return nil
+            }
+            let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+            guard var messages = json?["hydra:member"] as? [[String: Any]] else {
+                return nil
+            }
+            // Newest first so the most recent OTP is considered before older ones.
+            messages.sort(by: { messageDate(from: $0) > messageDate(from: $1) })
+            return messages
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+
+    /// Extracts the OTP code from the raw email source.
+    /// Prefers the explicit "Account verification code: <digits>" wording (mirroring the JS client),
+    /// then falls back to the first standalone 4-8 digit sequence.
+    private func extractOTPCode(from source: String) -> String? {
+        if let match = firstMatch(in: source, pattern: "Account verification code:\\s*([0-9]+)", group: 1) {
+            return match
+        }
+        return firstMatch(in: source, pattern: "(?<![0-9])([0-9]{4,8})(?![0-9])", group: 1)
+    }
+
+    private func firstMatch(in text: String, pattern: String, group: Int) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return nil
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range),
+              match.numberOfRanges > group,
+              let matchRange = Range(match.range(at: group), in: text) else {
+            return nil
+        }
+        return String(text[matchRange])
+    }
+
+    private func messageDate(from message: [String: Any]) -> Date {
+        let dateString = (message["updatedAt"] as? String) ?? (message["createdAt"] as? String)
+        guard let dateString = dateString, let date = ISO8601DateFormatter().date(from: dateString) else {
+            return .distantPast
+        }
+        return date
     }
 }

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
@@ -110,8 +110,8 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         let resetPasswordCompletedExp = expectation(description: "reset password completed")
         let resetPasswordRequiredDelegate = ResetPasswordRequiredDelegateSpy(expectation: resetPasswordCompletedExp)
 
-        let uniquePassword = "1"
-        newPasswordRequiredState?.submitPassword(password: uniquePassword, delegate: resetPasswordRequiredDelegate)
+        let invalidPassword = "1"
+        newPasswordRequiredState?.submitPassword(password: invalidPassword, delegate: resetPasswordRequiredDelegate)
 
         await fulfillment(of: [resetPasswordCompletedExp])
         XCTAssertTrue(resetPasswordRequiredDelegate.onResetPasswordRequiredErrorCalled)

--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordEndToEndTests.swift
@@ -31,8 +31,6 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
     private let codeRetryCount = 3
 
     func test_resetPassword_withoutAutomaticSignIn_succeeds() async throws {
-        throw XCTSkip("Retrieving OTP failure")
-        
         guard let sut = initialisePublicClientApplication(),
               let username = retrieveUsernameForResetPassword()
         else {
@@ -41,6 +39,8 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         }
         let codeRequiredExp = expectation(description: "code required")
         let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        markEmailCheckpoint()
 
         let param = MSALNativeAuthResetPasswordParameters(username: username)
         sut.resetPassword(parameters: param, delegate: resetPasswordStartDelegate)
@@ -75,8 +75,6 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         
     // User Case 3.1.3. SSPR – New password being set doesn’t meet password complexity requirements set on portal
     func test_resetPassword_passwordComplexity_error() async throws {
-        throw XCTSkip("Retrieving OTP failure")
-        
         guard let sut = initialisePublicClientApplication(),
               let username = retrieveUsernameForResetPassword()
         else {
@@ -85,6 +83,8 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         }
         let codeRequiredExp = expectation(description: "code required")
         let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        markEmailCheckpoint()
 
         let param = MSALNativeAuthResetPasswordParameters(username: username)
         sut.resetPassword(parameters: param, delegate: resetPasswordStartDelegate)
@@ -110,7 +110,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         let resetPasswordCompletedExp = expectation(description: "reset password completed")
         let resetPasswordRequiredDelegate = ResetPasswordRequiredDelegateSpy(expectation: resetPasswordCompletedExp)
 
-        let uniquePassword = "INVALID_PASSWORD"
+        let uniquePassword = "1"
         newPasswordRequiredState?.submitPassword(password: uniquePassword, delegate: resetPasswordRequiredDelegate)
 
         await fulfillment(of: [resetPasswordCompletedExp])
@@ -120,8 +120,6 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
     
     // User Case 3.1.4 SSPR - Resend email OTP
     func test_resetPassword_resendCode_succeeds() async throws {
-        throw XCTSkip("Retrieving OTP failure")
-        
         guard let sut = initialisePublicClientApplication(),
               let username = retrieveUsernameForResetPassword()
         else {
@@ -130,6 +128,8 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         }
         let codeRequiredExp = expectation(description: "code required")
         let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        markEmailCheckpoint()
 
         let param = MSALNativeAuthResetPasswordParameters(username: username)
         sut.resetPassword(parameters: param, delegate: resetPasswordStartDelegate)
@@ -153,6 +153,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         let resetPasswordResendCodeDelegate = ResetPasswordResendCodeDelegateSpy(expectation: resendCodeRequiredExp)
         
         // Call resend code method
+        markEmailCheckpoint()
         resetPasswordStartDelegate.newState?.resendCode(delegate: resetPasswordResendCodeDelegate)
         
         await fulfillment(of: [resendCodeRequiredExp])
@@ -278,8 +279,6 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
 
     // SSPR - with automatic sign in
     func test_resetPassword_withAutomaticSignIn_succeeds() async throws {
-        throw XCTSkip("Retrieving OTP failure")
-        
         guard let sut = initialisePublicClientApplication(),
               let username = retrieveUsernameForResetPassword()
         else {
@@ -288,6 +287,8 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         }
         let codeRequiredExp = expectation(description: "code required")
         let resetPasswordStartDelegate = ResetPasswordStartDelegateSpy(expectation: codeRequiredExp)
+
+        markEmailCheckpoint()
 
         let param = MSALNativeAuthResetPasswordParameters(username: username)
         sut.resetPassword(parameters: param, delegate: resetPasswordStartDelegate)
@@ -339,7 +340,7 @@ final class MSALNativeAuthResetPasswordEndToEndTests: MSALNativeAuthEndToEndBase
         XCTAssertNotNil(signInAfterResetPasswordDelegate.result?.account.accountClaims)
     }
 
-    // This method tries to fetch a code from 1secmail API and submit it
+    // This method tries to fetch a code from the email provider (mail.tm) and submit it
     private func retrieveAndSubmitCode(resetPasswordStartDelegate: ResetPasswordStartDelegateSpy, username: String, retries: Int) async -> ResetPasswordRequiredState? {
         let passwordRequiredExp = expectation(description: "password required")
         let resetPasswordVerifyDelegate = ResetPasswordVerifyCodeDelegateSpy(expectation: passwordRequiredExp)


### PR DESCRIPTION
## Summary
Ports the disposable-email OTP retriever used by the **Native Auth end-to-end integration tests** from **1secmail** to **mail.tm**.

mail.tm is a token-based API: an existing mailbox (address + password) is authenticated via `POST /token`, then messages are read with a bearer token and the verification code is extracted from the message source.

## Changes
- **`MSALNativeAuthEmailCodeRetriever.swift`** — rewritten against `https://api.mail.tm` (login, read messages, extract OTP, optional inbox creation). Adds `markCheckpoint()` / `readOtpCode()` with a progressive-delay read strategy.
- **`MSALNativeAuthEndToEndBaseTestCase.swift`** — uses a shared stateful email client so `markCheckpoint()` and the subsequent `readOtpCode()` operate on the same instance; reads the mailbox password from a new conf key `email_provider_password`; adds `markEmailCheckpoint()`.
- **`MSALNativeAuthResetPasswordEndToEndTests.swift`** — checkpoints before triggering OTP sends so a reused mailbox ignores stale codes.

## Notes
- **Test-only** integration changes; no library or public API is affected.
- Requires a new key **`email_provider_password`** in the (non-repo) `conf.json` for the E2E tests to run in CI.
- Branched cleanly off `dev`; unrelated in-progress work on `native-auth-v2` is not included.