### PR TITLE
[2.14.1] Hotfix release : redirect looping and telemetry loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.14.1]
+* Hotfix release for redirect looping and telemetry missing for browser handoff
+
 ## [2.14.0]
 * Update IdentityCore submodule to 1.26.0 to pull in CommonCore telemetry, macOS XPC reliability, and security hardening (common core #1897 telemetry, #1886 device-token, #1889 CBA, canPerform, xpc-errors, watchdog, flight-race, string-hardening, reqCnf, UX-callbacks, PRT, cloud-host)
 


### PR DESCRIPTION

Bump IdentityCore to hotfix/1.26.1 (cdde3e08f), which carries the browser hand-off error differentiation and the redirect-looping/telemetry-loss hotfix (common core #1918). Add the 2.14.1 changelog entry.

## PR Checklist (must be completed before review)

- [ ] All tests pass locally
- [ ] PR size is <= 500 LOC per PR Size Check policy
- [ ] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH] [tests]: add coverage`

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

