### PR TITLE
[patch][engg]: Adopt UIScene lifecycle in 3 iOS host app targets for iOS 27

### DIFF
--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -470,6 +470,7 @@
 		962E37E01E720E4F00DE71FE /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 962E37D41E720E4F00DE71FE /* Images.xcassets */; };
 		962E37E81E7211D200DE71FE /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 962E37C01E720E4F00DE71FE /* main.m */; };
 		962E37E91E7211D200DE71FE /* MSALAutoAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 962E37CA1E720E4F00DE71FE /* MSALAutoAppDelegate.m */; };
+		8A807F5003F0E7D1CD944C25 /* MSALAutoSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C4D0772330DFCDE35C1128DF /* MSALAutoSceneDelegate.m */; };
 		963377BF211E14C600943EE0 /* MSALWebviewType_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 963377BD211E14C600943EE0 /* MSALWebviewType_Internal.h */; };
 		963377C0211E14C600943EE0 /* MSALWebviewType_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 963377BD211E14C600943EE0 /* MSALWebviewType_Internal.h */; };
 		963377C1211E14C600943EE0 /* MSALWebviewType.m in Sources */ = {isa = PBXBuildFile; fileRef = 963377BE211E14C600943EE0 /* MSALWebviewType.m */; };
@@ -967,6 +968,7 @@
 		B2FBB3DB28F72A5700A3591C /* MSALWPJMetaData+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2FBB3D228F72A5700A3591C /* MSALWPJMetaData+Internal.h */; };
 		B2FE601B20E5BB5800502BA6 /* MSAL.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D65A6F431E3FD30A00C69FBA /* MSAL.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D61A64941E5AA7D60086D120 /* MSALTestAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D61A64801E5AA7C60086D120 /* MSALTestAppDelegate.m */; };
+		FFFA5E722C1971C22037D3DF /* MSALTestAppSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B126A3DA5A48D88A98F08C43 /* MSALTestAppSceneDelegate.m */; };
 		D61A64951E5AA7D60086D120 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D61A64811E5AA7C60086D120 /* main.m */; };
 		D61A64A91E5AABC50086D120 /* MSALTestAppAcquireTokenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D61A649D1E5AABC50086D120 /* MSALTestAppAcquireTokenViewController.m */; };
 		D61A64AA1E5AABC50086D120 /* MSALTestAppAcquireLayoutBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = D61A649F1E5AABC50086D120 /* MSALTestAppAcquireLayoutBuilder.m */; };
@@ -1001,6 +1003,7 @@
 		D67227971EBD10B500F3422A /* MSAL.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D65A6F431E3FD30A00C69FBA /* MSAL.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D67227A31EBD111900F3422A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D67227A21EBD111900F3422A /* main.m */; };
 		D67227A61EBD111900F3422A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D67227A51EBD111900F3422A /* AppDelegate.m */; };
+		6D460DF30E7702343093364C /* MSALUnitTestHostSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C2E64FCABA889B83C81B9A3 /* MSALUnitTestHostSceneDelegate.m */; };
 		D67227A91EBD111900F3422A /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D67227A81EBD111900F3422A /* ViewController.m */; };
 		D67227AC1EBD111900F3422A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D67227AA1EBD111900F3422A /* Main.storyboard */; };
 		D67227AE1EBD111900F3422A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D67227AD1EBD111900F3422A /* Assets.xcassets */; };
@@ -2268,6 +2271,8 @@
 		962E37C01E720E4F00DE71FE /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		962E37C91E720E4F00DE71FE /* MSALAutoAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSALAutoAppDelegate.h; sourceTree = "<group>"; };
 		962E37CA1E720E4F00DE71FE /* MSALAutoAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSALAutoAppDelegate.m; sourceTree = "<group>"; };
+		AE021827A2124B0D0045FA58 /* MSALAutoSceneDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSALAutoSceneDelegate.h; sourceTree = "<group>"; };
+		C4D0772330DFCDE35C1128DF /* MSALAutoSceneDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSALAutoSceneDelegate.m; sourceTree = "<group>"; };
 		962E37D41E720E4F00DE71FE /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		962E37D51E720E4F00DE71FE /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		963377BD211E14C600943EE0 /* MSALWebviewType_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALWebviewType_Internal.h; sourceTree = "<group>"; };
@@ -2491,6 +2496,8 @@
 		D61A64671E5AA6BE0086D120 /* msal__test_app__mac.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = msal__test_app__mac.xcconfig; sourceTree = "<group>"; };
 		D61A647F1E5AA7C60086D120 /* MSALTestAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALTestAppDelegate.h; sourceTree = "<group>"; };
 		D61A64801E5AA7C60086D120 /* MSALTestAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALTestAppDelegate.m; sourceTree = "<group>"; };
+		2892B11ECB69F44FBC67D7AB /* MSALTestAppSceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALTestAppSceneDelegate.h; sourceTree = "<group>"; };
+		B126A3DA5A48D88A98F08C43 /* MSALTestAppSceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALTestAppSceneDelegate.m; sourceTree = "<group>"; };
 		D61A64811E5AA7C60086D120 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		D61A64881E5AA7C60086D120 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D61A649D1E5AABC50086D120 /* MSALTestAppAcquireTokenViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSALTestAppAcquireTokenViewController.m; sourceTree = "<group>"; };
@@ -2550,6 +2557,8 @@
 		D67227A21EBD111900F3422A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		D67227A41EBD111900F3422A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		D67227A51EBD111900F3422A /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		11720179ACE90EABBE79EEF4 /* MSALUnitTestHostSceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALUnitTestHostSceneDelegate.h; sourceTree = "<group>"; };
+		9C2E64FCABA889B83C81B9A3 /* MSALUnitTestHostSceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALUnitTestHostSceneDelegate.m; sourceTree = "<group>"; };
 		D67227A71EBD111900F3422A /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		D67227A81EBD111900F3422A /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 		D67227AB1EBD111900F3422A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -3581,6 +3590,8 @@
 				B21FA9EF22063EC800806B68 /* MainAutomation.storyboard */,
 				962E37C91E720E4F00DE71FE /* MSALAutoAppDelegate.h */,
 				962E37CA1E720E4F00DE71FE /* MSALAutoAppDelegate.m */,
+				AE021827A2124B0D0045FA58 /* MSALAutoSceneDelegate.h */,
+				C4D0772330DFCDE35C1128DF /* MSALAutoSceneDelegate.m */,
 				962E37D31E720E4F00DE71FE /* resources */,
 			);
 			path = ios;
@@ -3945,6 +3956,8 @@
 				D61A64811E5AA7C60086D120 /* main.m */,
 				D61A647F1E5AA7C60086D120 /* MSALTestAppDelegate.h */,
 				D61A64801E5AA7C60086D120 /* MSALTestAppDelegate.m */,
+				2892B11ECB69F44FBC67D7AB /* MSALTestAppSceneDelegate.h */,
+				B126A3DA5A48D88A98F08C43 /* MSALTestAppSceneDelegate.m */,
 				D61A649E1E5AABC50086D120 /* MSALTestAppAcquireLayoutBuilder.h */,
 				D61A649F1E5AABC50086D120 /* MSALTestAppAcquireLayoutBuilder.m */,
 				D61A64A01E5AABC50086D120 /* MSALTestAppAcquireTokenViewController.h */,
@@ -4277,6 +4290,8 @@
 			children = (
 				D67227A41EBD111900F3422A /* AppDelegate.h */,
 				D67227A51EBD111900F3422A /* AppDelegate.m */,
+				11720179ACE90EABBE79EEF4 /* MSALUnitTestHostSceneDelegate.h */,
+				9C2E64FCABA889B83C81B9A3 /* MSALUnitTestHostSceneDelegate.m */,
 				D67227A71EBD111900F3422A /* ViewController.h */,
 				D67227A81EBD111900F3422A /* ViewController.m */,
 				D67227AA1EBD111900F3422A /* Main.storyboard */,
@@ -6797,6 +6812,7 @@
 				962E37E81E7211D200DE71FE /* main.m in Sources */,
 				B25F1BC41EC3E44500474D1B /* MSALResult+Automation.m in Sources */,
 				962E37E91E7211D200DE71FE /* MSALAutoAppDelegate.m in Sources */,
+				8A807F5003F0E7D1CD944C25 /* MSALAutoSceneDelegate.m in Sources */,
 				B25F1BBB1EC3DB3200474D1B /* MSIDTokenCacheItem+Automation.m in Sources */,
 				B25A439621C35A90000B3DD4 /* MSALAutomationAcquireTokenSilentAction.m in Sources */,
 				B25A39ED21C4CACE00213A62 /* MSALAutomationReadAccountsAction.m in Sources */,
@@ -6866,6 +6882,7 @@
 				D61A64951E5AA7D60086D120 /* main.m in Sources */,
 				B2AD634A1EA5663800EFEEF1 /* MSALTestAppTelemetryViewController.m in Sources */,
 				D61A64941E5AA7D60086D120 /* MSALTestAppDelegate.m in Sources */,
+				FFFA5E722C1971C22037D3DF /* MSALTestAppSceneDelegate.m in Sources */,
 				1EB7ABD621262C420058C7E0 /* MSALTestAppAuthorityTypeViewController.m in Sources */,
 				D61A64B11E5AAC5C0086D120 /* MSALTestAppSettings.m in Sources */,
 				D659D4EF1E64BEA3007FBCF7 /* MSALTestAppSettingViewController.m in Sources */,
@@ -7839,6 +7856,7 @@
 			files = (
 				D67227A91EBD111900F3422A /* ViewController.m in Sources */,
 				D67227A61EBD111900F3422A /* AppDelegate.m in Sources */,
+				6D460DF30E7702343093364C /* MSALUnitTestHostSceneDelegate.m in Sources */,
 				D67227A31EBD111900F3422A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MSAL/test/app/ios/MSALTestAppDelegate.h
+++ b/MSAL/test/app/ios/MSALTestAppDelegate.h
@@ -29,6 +29,4 @@
 
 @interface MSALTestAppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (strong, nonatomic) UIWindow *window;
-
 @end

--- a/MSAL/test/app/ios/MSALTestAppDelegate.m
+++ b/MSAL/test/app/ios/MSALTestAppDelegate.m
@@ -28,16 +28,9 @@
 #import "MSALTestAppDelegate.h"
 #import "MSALTestAppSettings.h"
 
-#import "MSALTestAppAcquireTokenViewController.h"
-#import "MSALTestAppCacheViewController.h"
-#import "MSALTestAppLogViewController.h"
-#import "MSALTestAppSettingsViewController.h"
 #import "MSALPublicClientApplication.h"
 
 @implementation MSALTestAppDelegate
-{
-    UITabBarController* _tabBar;
-}
 
 /*
 - (BOOL)application:(UIApplication *)application
@@ -52,43 +45,10 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+    // Window and root view controller are set up by MSALTestAppSceneDelegate in the UIScene lifecycle.
     (void)application;
     (void)launchOptions;
-    UIWindow* window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-    [window setTintColor:[UIColor colorWithRed:118.0/255.0 green:44.0/255.0 blue:144.0/255.0 alpha:1.0]];
-    self.window = window;
-    
-    _tabBar = [UITabBarController new];
-    
-    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"MSALTestAppAcquireTokenViewController" bundle:nil];
-    MSALTestAppAcquireTokenViewController *tokenController = [storyboard instantiateViewControllerWithIdentifier:@"MSALTestAppAcquireTokenViewController"];
-    UINavigationController* tokenNavController = [[UINavigationController alloc] initWithRootViewController:tokenController];
-    tokenNavController.tabBarItem = tokenController.tabBarItem;
-    tokenNavController.navigationBar.hidden = YES;
-    [_tabBar addChildViewController:tokenNavController];
-    
-    // Settings controller is contained in a navigation controller
-    MSALTestAppSettingsViewController* settingsController = [MSALTestAppSettingsViewController new];
-    
-    UINavigationController* navController = [[UINavigationController alloc] initWithRootViewController:settingsController];
-    navController.navigationBar.hidden = YES;
-    navController.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Settings"
-                                                             image:[UIImage imageNamed:@"Settings"]
-                                                               tag:0];
-    [_tabBar addChildViewController:navController];
-    
-    MSALTestAppCacheViewController* cacheController = [MSALTestAppCacheViewController new];
-    UINavigationController* cacheNavController = [[UINavigationController alloc] initWithRootViewController:cacheController];
-    cacheNavController.tabBarItem = cacheController.tabBarItem;
-    cacheController.navigationItem.title = @"MSAL Credentials";
-    [_tabBar addChildViewController:cacheNavController];
-    MSALTestAppLogViewController* logController = [MSALTestAppLogViewController new];
-    [_tabBar addChildViewController:logController];
-    
-    [window setRootViewController:_tabBar];
-    [window setBackgroundColor:[UIColor whiteColor]];
-    [window makeKeyAndVisible];
-    
+
     return YES;
 }
 							

--- a/MSAL/test/app/ios/MSALTestAppSceneDelegate.h
+++ b/MSAL/test/app/ios/MSALTestAppSceneDelegate.h
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <UIKit/UIKit.h>
+
+@interface MSALTestAppSceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/MSAL/test/app/ios/MSALTestAppSceneDelegate.m
+++ b/MSAL/test/app/ios/MSALTestAppSceneDelegate.m
@@ -1,0 +1,110 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALTestAppSceneDelegate.h"
+#import "MSALTestAppAcquireTokenViewController.h"
+#import "MSALTestAppCacheViewController.h"
+#import "MSALTestAppLogViewController.h"
+#import "MSALTestAppSettingsViewController.h"
+
+@implementation MSALTestAppSceneDelegate
+{
+    UITabBarController* _tabBar;
+}
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+    (void)session;
+    (void)connectionOptions;
+
+    if (![scene isKindOfClass:[UIWindowScene class]])
+    {
+        return;
+    }
+
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    UIWindow* window = [[UIWindow alloc] initWithWindowScene:windowScene];
+    [window setTintColor:[UIColor colorWithRed:118.0/255.0 green:44.0/255.0 blue:144.0/255.0 alpha:1.0]];
+    self.window = window;
+
+    _tabBar = [UITabBarController new];
+
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"MSALTestAppAcquireTokenViewController" bundle:nil];
+    MSALTestAppAcquireTokenViewController *tokenController = [storyboard instantiateViewControllerWithIdentifier:@"MSALTestAppAcquireTokenViewController"];
+    UINavigationController* tokenNavController = [[UINavigationController alloc] initWithRootViewController:tokenController];
+    tokenNavController.tabBarItem = tokenController.tabBarItem;
+    tokenNavController.navigationBar.hidden = YES;
+    [_tabBar addChildViewController:tokenNavController];
+
+    // Settings controller is contained in a navigation controller
+    MSALTestAppSettingsViewController* settingsController = [MSALTestAppSettingsViewController new];
+
+    UINavigationController* navController = [[UINavigationController alloc] initWithRootViewController:settingsController];
+    navController.navigationBar.hidden = YES;
+    navController.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Settings"
+                                                             image:[UIImage imageNamed:@"Settings"]
+                                                               tag:0];
+    [_tabBar addChildViewController:navController];
+
+    MSALTestAppCacheViewController* cacheController = [MSALTestAppCacheViewController new];
+    UINavigationController* cacheNavController = [[UINavigationController alloc] initWithRootViewController:cacheController];
+    cacheNavController.tabBarItem = cacheController.tabBarItem;
+    cacheController.navigationItem.title = @"MSAL Credentials";
+    [_tabBar addChildViewController:cacheNavController];
+    MSALTestAppLogViewController* logController = [MSALTestAppLogViewController new];
+    [_tabBar addChildViewController:logController];
+
+    [window setRootViewController:_tabBar];
+    [window setBackgroundColor:[UIColor whiteColor]];
+    [window makeKeyAndVisible];
+}
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+{
+    (void)scene;
+
+    id<UIApplicationDelegate> appDelegate = UIApplication.sharedApplication.delegate;
+
+    if (![appDelegate respondsToSelector:@selector(application:openURL:options:)])
+    {
+        return;
+    }
+
+    for (UIOpenURLContext *context in URLContexts)
+    {
+        NSMutableDictionary<UIApplicationOpenURLOptionsKey, id> *options = [NSMutableDictionary new];
+
+        if (context.options.sourceApplication)
+        {
+            options[UIApplicationOpenURLOptionsSourceApplicationKey] = context.options.sourceApplication;
+        }
+
+        [appDelegate application:UIApplication.sharedApplication openURL:context.URL options:options];
+    }
+}
+
+@end

--- a/MSAL/test/app/ios/MSALTestAppSceneDelegate.m
+++ b/MSAL/test/app/ios/MSALTestAppSceneDelegate.m
@@ -39,7 +39,6 @@
 - (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
 {
     (void)session;
-    (void)connectionOptions;
 
     if (![scene isKindOfClass:[UIWindowScene class]])
     {
@@ -81,6 +80,11 @@
     [window setRootViewController:_tabBar];
     [window setBackgroundColor:[UIColor whiteColor]];
     [window makeKeyAndVisible];
+
+    if (connectionOptions.URLContexts.count > 0)
+    {
+        [self scene:scene openURLContexts:connectionOptions.URLContexts];
+    }
 }
 
 - (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts

--- a/MSAL/test/app/ios/resources/Info.plist
+++ b/MSAL/test/app/ios/resources/Info.plist
@@ -47,6 +47,23 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>Launch Screen</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>MSALTestAppSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/MSAL/test/automation/ios/MSALAutoAppDelegate.h
+++ b/MSAL/test/automation/ios/MSALAutoAppDelegate.h
@@ -29,6 +29,4 @@
 
 @interface MSALAutoAppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (strong, nonatomic) UIWindow *window;
-
 @end

--- a/MSAL/test/automation/ios/MSALAutoSceneDelegate.h
+++ b/MSAL/test/automation/ios/MSALAutoSceneDelegate.h
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <UIKit/UIKit.h>
+
+@interface MSALAutoSceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/MSAL/test/automation/ios/MSALAutoSceneDelegate.m
+++ b/MSAL/test/automation/ios/MSALAutoSceneDelegate.m
@@ -34,7 +34,11 @@
     // The root view controller is provided by the storyboard (UISceneStoryboardFile).
     (void)scene;
     (void)session;
-    (void)connectionOptions;
+
+    if (connectionOptions.URLContexts.count > 0)
+    {
+        [self scene:scene openURLContexts:connectionOptions.URLContexts];
+    }
 }
 
 - (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts

--- a/MSAL/test/automation/ios/MSALAutoSceneDelegate.m
+++ b/MSAL/test/automation/ios/MSALAutoSceneDelegate.m
@@ -1,0 +1,64 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALAutoSceneDelegate.h"
+
+@implementation MSALAutoSceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+    // The root view controller is provided by the storyboard (UISceneStoryboardFile).
+    (void)scene;
+    (void)session;
+    (void)connectionOptions;
+}
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+{
+    (void)scene;
+
+    id<UIApplicationDelegate> appDelegate = UIApplication.sharedApplication.delegate;
+
+    if (![appDelegate respondsToSelector:@selector(application:openURL:options:)])
+    {
+        return;
+    }
+
+    for (UIOpenURLContext *context in URLContexts)
+    {
+        NSMutableDictionary<UIApplicationOpenURLOptionsKey, id> *options = [NSMutableDictionary new];
+
+        if (context.options.sourceApplication)
+        {
+            options[UIApplicationOpenURLOptionsSourceApplicationKey] = context.options.sourceApplication;
+        }
+
+        [appDelegate application:UIApplication.sharedApplication openURL:context.URL options:options];
+    }
+}
+
+@end

--- a/MSAL/test/automation/ios/resources/Info.plist
+++ b/MSAL/test/automation/ios/resources/Info.plist
@@ -54,8 +54,25 @@
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>Launch Screen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>MainAutomation</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>MSALAutoSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>MainAutomation</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/MSAL/test/unit/ios/unit-test-host/AppDelegate.h
+++ b/MSAL/test/unit/ios/unit-test-host/AppDelegate.h
@@ -29,8 +29,6 @@
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (strong, nonatomic) UIWindow *window;
-
 
 @end
 

--- a/MSAL/test/unit/ios/unit-test-host/Info.plist
+++ b/MSAL/test/unit/ios/unit-test-host/Info.plist
@@ -24,8 +24,25 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>MSALUnitTestHostSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/MSAL/test/unit/ios/unit-test-host/MSALUnitTestHostSceneDelegate.h
+++ b/MSAL/test/unit/ios/unit-test-host/MSALUnitTestHostSceneDelegate.h
@@ -1,0 +1,34 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <UIKit/UIKit.h>
+
+@interface MSALUnitTestHostSceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/MSAL/test/unit/ios/unit-test-host/MSALUnitTestHostSceneDelegate.m
+++ b/MSAL/test/unit/ios/unit-test-host/MSALUnitTestHostSceneDelegate.m
@@ -1,0 +1,40 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALUnitTestHostSceneDelegate.h"
+
+@implementation MSALUnitTestHostSceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+    // The root view controller is provided by the storyboard (UISceneStoryboardFile).
+    (void)scene;
+    (void)session;
+    (void)connectionOptions;
+}
+
+@end


### PR DESCRIPTION
Migrate the unit-test-host, MSAL Test Automation (iOS), and MSAL Test App (iOS) targets to the UIScene lifecycle for iOS 27 SDK readiness. Each target gets its own scene delegate class and scene manifest entry:

- unit-test-host: MSALUnitTestHostSceneDelegate (storyboard-driven).
- MSAL Test Automation (iOS): MSALAutoSceneDelegate, forwards scene:openURLContexts: to the app delegate so MSAL redirect completion works.
- MSAL Test App (iOS): MSALTestAppSceneDelegate owns the programmatic UITabBarController window (moved out of didFinishLaunchingWithOptions) and forwards scene:openURLContexts:.

Source-only migration; not built.

## PR Checklist (must be completed before review)

- [ ] All tests pass locally
- [ ] PR size is <= 500 LOC per PR Size Check policy
- [ ] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## PR Title Format

**Required Format:** `[Keyword1] [Keyword2]: Description`

- **Keyword1:** `major`, `minor`, or `patch` (case-insensitive)
- **Keyword2:** `feature`, `bugfix`, `engg`, or `tests` (case-insensitive)

**Examples:**
- `[MAJOR] [Feature]: new API`
- `[minor] [bugfix]: fix crash`
- `[PATCH] [tests]: add coverage`

## Proposed changes

Describe what this PR is trying to do.

## Type of change

- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

## Additional information

