### PR TITLE
[patch][bugfix]: Merge main back to dev after hotfix 2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.14.1]
+* Hotfix release for redirect looping and telemetry missing for browser handoff
+
 ## [2.14.0]
 * Update IdentityCore submodule to 1.26.0 to pull in CommonCore telemetry, macOS XPC reliability, and security hardening (common core #1897 telemetry, #1886 device-token, #1889 CBA, canPerform, xpc-errors, watchdog, flight-race, string-hardening, reqCnf, UX-callbacks, PRT, cloud-host)
 

--- a/MSAL.podspec
+++ b/MSAL.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MSAL"
-  s.version      = "2.14.0"
+  s.version      = "2.14.1"
   s.summary      = "Microsoft Authentication Library (MSAL) for iOS"
   s.description  = <<-DESC
                    The MSAL library for iOS gives your app the ability to begin using the Microsoft Cloud by supporting Microsoft Azure Active Directory and Microsoft Accounts in a converged experience using industry standard OAuth2 and OpenID Connect. The library also supports Microsoft Azure B2C for those using our hosted identity management service.

--- a/MSAL/resources/ios/Info.plist
+++ b/MSAL/resources/ios/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.14.0</string>
+	<string>2.14.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/MSAL/resources/mac/Info.plist
+++ b/MSAL/resources/mac/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.14.0</string>
+	<string>2.14.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/MSAL/src/MSAL_Internal.h
+++ b/MSAL/src/MSAL_Internal.h
@@ -27,7 +27,7 @@
 
 #define MSAL_VER_HIGH       2
 #define MSAL_VER_LOW        14
-#define MSAL_VER_PATCH      0
+#define MSAL_VER_PATCH      1
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,6 @@ let package = Package(
           targets: ["MSAL"]),
   ],
   targets: [
-      .binaryTarget(name: "MSAL", url: "https://github.com/AzureAD/microsoft-authentication-library-for-objc/releases/download/2.14.0/MSAL.zip", checksum: "5053c4c48a01d30c1cff3a59660f7d2971174ea3e9c91192f5bf2c4e636d9535")
+      .binaryTarget(name: "MSAL", url: "https://github.com/AzureAD/microsoft-authentication-library-for-objc/releases/download/2.14.1/MSAL.zip", checksum: "0803af46b932a498d1f0d9ca46288466fa833cb3cb8d5383434de2218824f98c")
   ]
 )


### PR DESCRIPTION
## PR Checklist (must be completed before review)

- [ ] All tests pass locally
- [x] PR size is <= 500 LOC per PR Size Check policy
- [x] PR is independently mergeable (no hidden dependencies)
- [ ] Appropriate reviewers are assigned
- [ ] PR reviewed by code owner (required if Copilot-generated)
- [ ] SME or Senior IC assigned where required

## Proposed changes

Merge `main` back into `dev` after the 2.14.1 hotfix release. This carries all 5 commits currently present on `main` but not `dev`, including the IdentityCore 1.26.1 submodule update and the redirect-looping and telemetry-loss fix.

The merge is intentionally opened directly from `main` so all release and hotfix commits are preserved.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [x] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios.
- [x] Medium – Errors could cause regression of 1 or more scenarios.
- [ ] Small – No issues are expected.

## Additional information

Includes [hotfix PR #3063](https://github.com/AzureAD/microsoft-authentication-library-for-objc/pull/3063), tagged as `2.14.1`, and the IdentityCore hotfix from [common-core PR #1920](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/1920).