### PR TITLE
[patch][engg]: Migrate MSAL iOS sample apps to UIScene lifecycle

### DIFF
--- a/Samples/ios/SampleApp/SampleAppiOS.xcodeproj/project.pbxproj
+++ b/Samples/ios/SampleApp/SampleAppiOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		D62CF4A71E9595EC006C0217 /* MSAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D62CF4981E9595CE006C0217 /* MSAL.framework */; };
 		D6AEBD6D1E92DBB300C31082 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D6AEBD6C1E92DBB300C31082 /* main.m */; };
 		D6AEBD701E92DBB300C31082 /* SampleAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D6AEBD6F1E92DBB300C31082 /* SampleAppDelegate.m */; };
+		A1B2C3D40001000000000001 /* SampleSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40002000000000001 /* SampleSceneDelegate.m */; };
 		D6AEBD781E92DBB300C31082 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D6AEBD771E92DBB300C31082 /* Assets.xcassets */; };
 		D6AEBD7B1E92DBB300C31082 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D6AEBD791E92DBB300C31082 /* LaunchScreen.storyboard */; };
 		D6B58A471EB177E8000B3A5F /* SampleCalendarUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D6B58A461EB177E8000B3A5F /* SampleCalendarUtil.m */; };
@@ -132,6 +133,8 @@
 		D6AEBD6C1E92DBB300C31082 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		D6AEBD6E1E92DBB300C31082 /* SampleAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SampleAppDelegate.h; sourceTree = "<group>"; };
 		D6AEBD6F1E92DBB300C31082 /* SampleAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SampleAppDelegate.m; sourceTree = "<group>"; };
+		A1B2C3D40003000000000001 /* SampleSceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SampleSceneDelegate.h; sourceTree = "<group>"; };
+		A1B2C3D40002000000000001 /* SampleSceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SampleSceneDelegate.m; sourceTree = "<group>"; };
 		D6AEBD771E92DBB300C31082 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D6AEBD7A1E92DBB300C31082 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D6AEBD7C1E92DBB300C31082 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -194,6 +197,8 @@
 				B221CF0820C4859C002F5E94 /* SampleAppiOS.entitlements */,
 				D6AEBD6E1E92DBB300C31082 /* SampleAppDelegate.h */,
 				D6AEBD6F1E92DBB300C31082 /* SampleAppDelegate.m */,
+				A1B2C3D40003000000000001 /* SampleSceneDelegate.h */,
+				A1B2C3D40002000000000001 /* SampleSceneDelegate.m */,
 				D6AEBD771E92DBB300C31082 /* Assets.xcassets */,
 				D6AEBD791E92DBB300C31082 /* LaunchScreen.storyboard */,
 				D6AEBD7C1E92DBB300C31082 /* Info.plist */,
@@ -377,6 +382,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D6AEBD701E92DBB300C31082 /* SampleAppDelegate.m in Sources */,
+				A1B2C3D40001000000000001 /* SampleSceneDelegate.m in Sources */,
 				D611E3341E95CE4800BA782C /* SampleBaseViewController.m in Sources */,
 				D6BFE3DF1EB6B0BE00F2B7E8 /* SampleGraphRequest.m in Sources */,
 				D6B58A471EB177E8000B3A5F /* SampleCalendarUtil.m in Sources */,

--- a/Samples/ios/SampleApp/SampleAppiOS/Info.plist
+++ b/Samples/ios/SampleApp/SampleAppiOS/Info.plist
@@ -35,6 +35,23 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SampleSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Samples/ios/SampleApp/SampleAppiOS/SampleAppDelegate.m
+++ b/Samples/ios/SampleApp/SampleAppiOS/SampleAppDelegate.m
@@ -47,12 +47,17 @@
     // The MSAL Logger should be set as early as possible in the app launch sequence, before any MSAL
     // requests are made.
     [SampleMSALUtil setup];
-    
-    UIWindow* window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+
+    // Window and root view controller are set up by SampleSceneDelegate in the UIScene lifecycle.
+    return YES;
+}
+
+- (void)installRootIntoWindow:(UIWindow *)window
+{
     self.window = window;
-    
+
     _rootController = [UIViewController new];
-    
+
     if ([[SampleMSALUtil sharedUtil] currentAccount:nil])
     {
         [self setCurrentViewController:[SampleMainViewController sharedViewController]];
@@ -61,12 +66,10 @@
     {
         [self setCurrentViewController:[SampleLoginViewController sharedViewController]];
     }
-    
+
     [window setRootViewController:_rootController];
     [window setBackgroundColor:[UIColor whiteColor]];
     [window makeKeyAndVisible];
-    
-    return YES;
 }
 
 - (BOOL)application:(UIApplication *)app

--- a/Samples/ios/SampleApp/SampleAppiOS/SampleAppDelegate.m
+++ b/Samples/ios/SampleApp/SampleAppiOS/SampleAppDelegate.m
@@ -25,8 +25,6 @@
 //
 //------------------------------------------------------------------------------
 
-#import <MSAL/MSAL.h>
-
 #import "SampleAppDelegate.h"
 #import "SampleMSALUtil.h"
 #import "SampleMainViewController.h"
@@ -70,17 +68,6 @@
     [window setRootViewController:_rootController];
     [window setBackgroundColor:[UIColor whiteColor]];
     [window makeKeyAndVisible];
-}
-
-- (BOOL)application:(UIApplication *)app
-            openURL:(NSURL *)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
-{
-    if ([MSALPublicClientApplication handleMSALResponse:url sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]])
-    {
-        NSLog(@"This URL is handled by MSAL");
-    }
-    return YES;
 }
 
 + (void)setCurrentViewController:(SampleBaseViewController *)viewController

--- a/Samples/ios/SampleApp/SampleAppiOS/SampleSceneDelegate.h
+++ b/Samples/ios/SampleApp/SampleAppiOS/SampleSceneDelegate.h
@@ -27,16 +27,8 @@
 
 #import <UIKit/UIKit.h>
 
-@interface SampleAppDelegate : UIResponder <UIApplicationDelegate>
+@interface SampleSceneDelegate : UIResponder <UIWindowSceneDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 
-+ (void)setCurrentViewController:(UIViewController *)viewController;
-
-// Creates the root view controller, selects the initial (login vs main) controller based on the
-// current account, and installs it into the provided window. Called from the scene delegate under
-// the UIScene lifecycle so the VC-swap state stays owned by the app delegate.
-- (void)installRootIntoWindow:(UIWindow *)window;
-
 @end
-

--- a/Samples/ios/SampleApp/SampleAppiOS/SampleSceneDelegate.m
+++ b/Samples/ios/SampleApp/SampleAppiOS/SampleSceneDelegate.m
@@ -1,0 +1,73 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import <MSAL/MSAL.h>
+
+#import "SampleSceneDelegate.h"
+#import "SampleAppDelegate.h"
+
+@implementation SampleSceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+    (void)session;
+
+    if (![scene isKindOfClass:[UIWindowScene class]])
+    {
+        return;
+    }
+
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    UIWindow *window = [[UIWindow alloc] initWithWindowScene:windowScene];
+    self.window = window;
+
+    // The app delegate owns the root controller / current controller VC-swap state, so let it
+    // install its root into this scene's window. External callers reach that state through
+    // [[UIApplication sharedApplication] delegate], so it must stay on the app delegate.
+    SampleAppDelegate *appDelegate = (SampleAppDelegate *)[[UIApplication sharedApplication] delegate];
+    [appDelegate installRootIntoWindow:window];
+
+    if (connectionOptions.URLContexts.count > 0)
+    {
+        [self scene:scene openURLContexts:connectionOptions.URLContexts];
+    }
+}
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+{
+    (void)scene;
+
+    for (UIOpenURLContext *context in URLContexts)
+    {
+        if ([MSALPublicClientApplication handleMSALResponse:context.URL sourceApplication:context.options.sourceApplication])
+        {
+            NSLog(@"This URL is handled by MSAL");
+        }
+    }
+}
+
+@end

--- a/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		9622AAC71ECA75FC0052B975 /* SampleLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9622AAC61ECA75FC0052B975 /* SampleLoginViewController.swift */; };
 		966165671ECA79ED00E3E365 /* SampleMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966165661ECA79ED00E3E365 /* SampleMainViewController.swift */; };
 		96672D9A1EC7912C00878AC5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96672D991EC7912C00878AC5 /* AppDelegate.swift */; };
+		A1B2C3D40010000000000002 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40011000000000002 /* SceneDelegate.swift */; };
 		96672D9F1EC7912C00878AC5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 96672D9D1EC7912C00878AC5 /* Main.storyboard */; };
 		96672DA11EC7912C00878AC5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 96672DA01EC7912C00878AC5 /* Assets.xcassets */; };
 		96672DA41EC7912C00878AC5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 96672DA21EC7912C00878AC5 /* LaunchScreen.storyboard */; };
@@ -146,6 +147,7 @@
 		966165661ECA79ED00E3E365 /* SampleMainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleMainViewController.swift; sourceTree = "<group>"; };
 		96672D961EC7912C00878AC5 /* SampleAppiOS-Swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SampleAppiOS-Swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		96672D991EC7912C00878AC5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A1B2C3D40011000000000002 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		96672D9E1EC7912C00878AC5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		96672DA01EC7912C00878AC5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		96672DA31EC7912C00878AC5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 			children = (
 				B221CEFE20C4856D002F5E94 /* SampleAppiOS-Swift.entitlements */,
 				96672D991EC7912C00878AC5 /* AppDelegate.swift */,
+				A1B2C3D40011000000000002 /* SceneDelegate.swift */,
 				9622AAC41ECA3D900052B975 /* SampleAppErrors.swift */,
 				96672DC61EC7919500878AC5 /* Authentication */,
 				96672DCA1EC791FA00878AC5 /* Graph */,
@@ -462,6 +465,7 @@
 				9622AAC51ECA3D900052B975 /* SampleAppErrors.swift in Sources */,
 				9622AAC31ECA30B50052B975 /* SampleCalendarEvent.swift in Sources */,
 				96672D9A1EC7912C00878AC5 /* AppDelegate.swift in Sources */,
+				A1B2C3D40010000000000002 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/AppDelegate.swift
+++ b/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/AppDelegate.swift
@@ -43,14 +43,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Window and root view controller are set up by SceneDelegate in the UIScene lifecycle.
         return true
     }
-
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        // This is for SafariViewController only.
-        if MSALPublicClientApplication.handleMSALResponse(url, sourceApplication: options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String) == true {
-            print("This URL is handled by MSAL")
-        }
-        return true
-    }
 }
 
 extension AppDelegate {

--- a/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/AppDelegate.swift
+++ b/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/AppDelegate.swift
@@ -40,20 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // requests are made.
         SampleMSALAuthentication.shared.setup()
         
-        self.window = UIWindow(frame: UIScreen.main.bounds)
-        
-        let initialViewController: UIViewController
-        do {
-            try SampleMSALAuthentication.shared.currentAccount()
-            initialViewController = mainVC()
-            
-        } catch {
-            initialViewController = loginVC()
-        }
-        
-        self.window?.rootViewController = initialViewController
-        self.window?.makeKeyAndVisible()
-        
+        // Window and root view controller are set up by SceneDelegate in the UIScene lifecycle.
         return true
     }
 

--- a/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/Info.plist
+++ b/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/Info.plist
@@ -22,6 +22,23 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SceneDelegate.swift
+++ b/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SceneDelegate.swift
@@ -1,0 +1,69 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+import UIKit
+import MSAL
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+
+        let window = UIWindow(windowScene: windowScene)
+        self.window = window
+
+        // Keep the app delegate's window reference pointing at the active scene window so the
+        // existing showMainVC()/showLoginVC() call sites continue to swap the root controller.
+        let appDelegate = UIApplication.shared.delegate as? AppDelegate
+        appDelegate?.window = window
+
+        let initialViewController: UIViewController
+        do {
+            try SampleMSALAuthentication.shared.currentAccount()
+            initialViewController = appDelegate?.mainVC() ?? UIViewController()
+        } catch {
+            initialViewController = appDelegate?.loginVC() ?? UIViewController()
+        }
+
+        window.rootViewController = initialViewController
+        window.makeKeyAndVisible()
+
+        if !connectionOptions.urlContexts.isEmpty {
+            self.scene(scene, openURLContexts: connectionOptions.urlContexts)
+        }
+    }
+
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        for context in URLContexts {
+            if MSALPublicClientApplication.handleMSALResponse(context.url, sourceApplication: context.options.sourceApplication) == true {
+                print("This URL is handled by MSAL")
+            }
+        }
+    }
+}

--- a/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SceneDelegate.swift
+++ b/Samples/ios/SampleAppiOS-Swift/SampleAppiOS-Swift/SceneDelegate.swift
@@ -33,22 +33,26 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        guard let windowScene = scene as? UIWindowScene else { return }
+        guard let windowScene = scene as? UIWindowScene,
+              let appDelegate = UIApplication.shared.delegate as? AppDelegate
+        else {
+            assertionFailure("SceneDelegate: expected a UIWindowScene and an AppDelegate instance")
+            return
+        }
 
         let window = UIWindow(windowScene: windowScene)
         self.window = window
 
         // Keep the app delegate's window reference pointing at the active scene window so the
         // existing showMainVC()/showLoginVC() call sites continue to swap the root controller.
-        let appDelegate = UIApplication.shared.delegate as? AppDelegate
-        appDelegate?.window = window
+        appDelegate.window = window
 
         let initialViewController: UIViewController
         do {
             try SampleMSALAuthentication.shared.currentAccount()
-            initialViewController = appDelegate?.mainVC() ?? UIViewController()
+            initialViewController = appDelegate.mainVC()
         } catch {
-            initialViewController = appDelegate?.loginVC() ?? UIViewController()
+            initialViewController = appDelegate.loginVC()
         }
 
         window.rootViewController = initialViewController


### PR DESCRIPTION
## Summary

Migrates the two MSAL iOS sample apps (`SampleAppiOS` ObjC and `SampleAppiOS-Swift`) to the UIScene-based lifecycle, required for apps built with the iOS 27.0 SDK. Apps linked against the 27.0 SDK without UIScene adoption crash on launch.

## Changes

**Both apps**
- Added `UIApplicationSceneManifest` to `Info.plist` — `UIApplicationSupportsMultipleScenes = NO`, single `UIWindowSceneSessionRoleApplication` configuration named `Default Configuration`, and no `UISceneStoryboardFile` — the window is created in code.
  - Note: the Swift sample's view controllers still come from `Main.storyboard` via `AppDelegate.mainVC()` / `loginVC()`. Only the window is code-created there. The ObjC sample is fully code-built.
- Added a scene delegate that creates the window from the `UIWindowScene` and installs the root view controller.
- Moved MSAL redirect-URL handling from the app delegate's `application:openURL:options:` to `scene:openURLContexts:` on the scene delegate, and removed the now-dead app-delegate handlers.

**ObjC (`SampleAppiOS`)**
- New `SampleSceneDelegate.{h,m}`.
- `SampleAppDelegate` keeps `_rootController` / `_currentController` and `+/-setCurrentViewController:`; the scene delegate calls a new `-installRootIntoWindow:` to build the hierarchy. Existing callers reaching the app delegate via `[[UIApplication sharedApplication] delegate]` are unchanged.

**Swift (`SampleAppiOS-Swift`)**
- New `SceneDelegate.swift`.
- The scene delegate assigns the scene's window to `AppDelegate.window`, so the existing `showMainVC()` / `showLoginVC()` root-swapping continues to work unchanged.

## Verification

- Both apps: `** BUILD SUCCEEDED **` on `iPhone 17, OS=27.0` (Xcode 26.6).
- Both apps install and launch on the iOS 27.0 simulator and stay alive under the scene lifecycle.
- No changes outside `Samples/ios`. No submodule pointer changes.

