### PR TITLE
[minor][feature]: Add caller-provided keys for AT PoP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [TBD]
+* Add `MSALExternalKeyPair` and an additive AT PoP authentication-scheme initializer for caller-owned RSA keys.
+* Update IdentityCore with external RSA key validation and injected PoP manager support.
+
 ## [2.14.1]
 * Hotfix release for redirect looping and telemetry missing for browser handoff
 

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -89,8 +89,10 @@
 		0D96DB3C27850F0F00DEAF87 /* MSALWipeCacheForAllAccountsConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D96DB2E27850E1300DEAF87 /* MSALWipeCacheForAllAccountsConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0D96DB3D27850F1100DEAF87 /* MSALWipeCacheForAllAccountsConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D96DB2E27850E1300DEAF87 /* MSALWipeCacheForAllAccountsConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0D96DB3E27850F1200DEAF87 /* MSALWipeCacheForAllAccountsConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D96DB2E27850E1300DEAF87 /* MSALWipeCacheForAllAccountsConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0DE4AC5F9DDB90C2F4BFA8E8 /* MSALExternalKeyPairTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C3F28C277941E85614DB60AC /* MSALExternalKeyPairTests.m */; };
 		12E2160B2D11D3920000F44C /* AuthorityURLFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E2160A2D11D3920000F44C /* AuthorityURLFormat.swift */; };
 		12E2160C2D11D3920000F44C /* AuthorityURLFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E2160A2D11D3920000F44C /* AuthorityURLFormat.swift */; };
+		1AE6006BC97F627E8E94B07C /* MSALExternalKeyPair.h in Headers */ = {isa = PBXBuildFile; fileRef = C80780758A4E248897963095 /* MSALExternalKeyPair.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1E04572324BD5A7D00444756 /* MSALCacheItemDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E04572024BD5A7D00444756 /* MSALCacheItemDetailViewController.m */; };
 		1E06CD6524D116F800E3D0E5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A206371FC510B500755A51 /* Security.framework */; };
 		1E1A2E042256D12F001009ED /* MSALTestAppSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = D61A64B01E5AAC5C0086D120 /* MSALTestAppSettings.m */; };
@@ -393,6 +395,7 @@
 		31A0E8B0B69F886271896E3E /* RetryExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AAD919E560052DA700D2DA /* RetryExecutor.swift */; };
 		38880DF423280C5900688C24 /* MSALPublicClientApplicationConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B1D35D22EA4797000954AF /* MSALPublicClientApplicationConfig.m */; };
 		38880DF523280C5A00688C24 /* MSALPublicClientApplicationConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B1D35D22EA4797000954AF /* MSALPublicClientApplicationConfig.m */; };
+		5759D66144CC92A16A2BBA84 /* MSALExternalKeyPair.h in Headers */ = {isa = PBXBuildFile; fileRef = C80780758A4E248897963095 /* MSALExternalKeyPair.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		583BFD0F24DC8E670035B901 /* MSALRedirectUriVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = B21E07B0210E542C007E3A3C /* MSALRedirectUriVerifier.m */; };
 		583BFD1024DC8EE80035B901 /* MSALRedirectUriVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = B21E07B0210E542C007E3A3C /* MSALRedirectUriVerifier.m */; };
 		583BFD1624DDF9B10035B901 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 583BFD1524DDF9B10035B901 /* Launch Screen.storyboard */; };
@@ -567,6 +570,7 @@
 		A0274CDE24B54C8900BD198D /* MSALDevicePopManagerUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = A0274CD724B54A4E00BD198D /* MSALDevicePopManagerUtil.m */; };
 		A09AAFC324C00B3600C324DE /* MSALAuthenticationSchemeProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E3658A6247F2BB60044A072 /* MSALAuthenticationSchemeProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A09AAFC424C00B3700C324DE /* MSALAuthenticationSchemeProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E3658A6247F2BB60044A072 /* MSALAuthenticationSchemeProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A40FD500991B8AF1A611AE7A /* MSALExternalKeyPair.m in Sources */ = {isa = PBXBuildFile; fileRef = E3D6DF8D0582D8A2ABBE60AC /* MSALExternalKeyPair.m */; };
 		AE64B3751432B2A8DD6C7FAB /* MailTMConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B4CF9C872C00B3E5FD2C40 /* MailTMConstants.swift */; };
 		B203459521AF77FB00B221AA /* MSALRedirectUri.h in Headers */ = {isa = PBXBuildFile; fileRef = B203459221AF77FB00B221AA /* MSALRedirectUri.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B203459621AF77FB00B221AA /* MSALRedirectUri.m in Sources */ = {isa = PBXBuildFile; fileRef = B203459321AF77FB00B221AA /* MSALRedirectUri.m */; };
@@ -966,6 +970,10 @@
 		B2FBB3DA28F72A5700A3591C /* MSALWPJMetaData+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2FBB3D228F72A5700A3591C /* MSALWPJMetaData+Internal.h */; };
 		B2FBB3DB28F72A5700A3591C /* MSALWPJMetaData+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2FBB3D228F72A5700A3591C /* MSALWPJMetaData+Internal.h */; };
 		B2FE601B20E5BB5800502BA6 /* MSAL.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D65A6F431E3FD30A00C69FBA /* MSAL.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B3C048E5B7504CA04BE59E21 /* MSALExternalKeyPairTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C3F28C277941E85614DB60AC /* MSALExternalKeyPairTests.m */; };
+		B70FBB945F58638CB8488349 /* MSALExternalKeyPair.m in Sources */ = {isa = PBXBuildFile; fileRef = E3D6DF8D0582D8A2ABBE60AC /* MSALExternalKeyPair.m */; };
+		CA7959DF5D62E1756F8C2440 /* MSALExternalKeyPair.m in Sources */ = {isa = PBXBuildFile; fileRef = E3D6DF8D0582D8A2ABBE60AC /* MSALExternalKeyPair.m */; };
+		CB53AE75EED32902E5709ED8 /* MSALExternalKeyPair.h in Headers */ = {isa = PBXBuildFile; fileRef = C80780758A4E248897963095 /* MSALExternalKeyPair.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D61A64941E5AA7D60086D120 /* MSALTestAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D61A64801E5AA7C60086D120 /* MSALTestAppDelegate.m */; };
 		D61A64951E5AA7D60086D120 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D61A64811E5AA7C60086D120 /* main.m */; };
 		D61A64A91E5AABC50086D120 /* MSALTestAppAcquireTokenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D61A649D1E5AABC50086D120 /* MSALTestAppAcquireTokenViewController.m */; };
@@ -1549,6 +1557,7 @@
 		DEFE87722CA6BC91009D11DC /* MSALNativeAuthUserAccountEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE876F2CA6BC91009D11DC /* MSALNativeAuthUserAccountEndToEndTests.swift */; };
 		DEFE87732CA6BC91009D11DC /* CredentialsDelegateSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE876E2CA6BC91009D11DC /* CredentialsDelegateSpies.swift */; };
 		DEFE87742CA6BC91009D11DC /* MSALNativeAuthUserAccountEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFE876F2CA6BC91009D11DC /* MSALNativeAuthUserAccountEndToEndTests.swift */; };
+		E1302AF4B4EB42EE88DC3DD0 /* MSALExternalKeyPair.h in Headers */ = {isa = PBXBuildFile; fileRef = C80780758A4E248897963095 /* MSALExternalKeyPair.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E2025CC92B2A182200E32871 /* MSALNativeAuthSubErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2025CC82B2A182200E32871 /* MSALNativeAuthSubErrorCode.swift */; };
 		E2025D202B2B8EEA00E32871 /* MSALNativeAuthSubErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2025D1F2B2B8EEA00E32871 /* MSALNativeAuthSubErrorCodeTests.swift */; };
 		E205D62E29B783FF003887BC /* MSALNativeAuthInternalConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E205D62D29B783FF003887BC /* MSALNativeAuthInternalConfiguration.swift */; };
@@ -1677,6 +1686,7 @@
 		E2F626B32A781CE300C4A303 /* SignInDelegatesSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F626B22A781CE300C4A303 /* SignInDelegatesSpies.swift */; };
 		E2F890052B755355001FBC7C /* MSALNativeAuthUnknownCaseProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F890042B755355001FBC7C /* MSALNativeAuthUnknownCaseProtocol.swift */; };
 		E2F8900E2B75546A001FBC7C /* MSALNativeAuthUnknownCaseProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F8900D2B75546A001FBC7C /* MSALNativeAuthUnknownCaseProtocolTests.swift */; };
+		E62567EF33E72E0B4509174B /* MSALExternalKeyPair.m in Sources */ = {isa = PBXBuildFile; fileRef = E3D6DF8D0582D8A2ABBE60AC /* MSALExternalKeyPair.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2214,6 +2224,7 @@
 		28FDC4A52A38C00900E38BE1 /* SignInAfterSignUpDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAfterSignUpDelegate.swift; sourceTree = "<group>"; };
 		28FDC4A82A38C0D000E38BE1 /* SignInAfterSignUpError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInAfterSignUpError.swift; sourceTree = "<group>"; };
 		28FDC4AB2A38D7D200E38BE1 /* MSALNativeAuthSignInControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInControllerMock.swift; sourceTree = "<group>"; };
+		453E3A3F201A3A625ABBB060 /* MSALExternalKeyPair+Internal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "MSALExternalKeyPair+Internal.h"; sourceTree = "<group>"; };
 		475F1413DA1D76D5EF31F4EC /* MailTMHTTPClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MailTMHTTPClient.swift; sourceTree = "<group>"; };
 		49AAD919E560052DA700D2DA /* RetryExecutor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RetryExecutor.swift; sourceTree = "<group>"; };
 		583BFD1524DDF9B10035B901 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
@@ -2484,6 +2495,8 @@
 		B2F4572F211C0B5C00818910 /* MSALBaseAADUITest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSALBaseAADUITest.h; sourceTree = "<group>"; };
 		B2F45744211E41C100818910 /* MSALB2CInteractiveTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSALB2CInteractiveTests.m; sourceTree = "<group>"; };
 		B2FBB3D228F72A5700A3591C /* MSALWPJMetaData+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSALWPJMetaData+Internal.h"; sourceTree = "<group>"; };
+		C3F28C277941E85614DB60AC /* MSALExternalKeyPairTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MSALExternalKeyPairTests.m; sourceTree = "<group>"; };
+		C80780758A4E248897963095 /* MSALExternalKeyPair.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = MSALExternalKeyPair.h; sourceTree = "<group>"; };
 		C8B4CF9C872C00B3E5FD2C40 /* MailTMConstants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MailTMConstants.swift; sourceTree = "<group>"; };
 		D61A63F11E5979200086D120 /* MSALResult+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MSALResult+Internal.h"; sourceTree = "<group>"; };
 		D61A64331E5A29580086D120 /* MSAL Test App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MSAL Test App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2867,6 +2880,7 @@
 		E2F626B22A781CE300C4A303 /* SignInDelegatesSpies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInDelegatesSpies.swift; sourceTree = "<group>"; };
 		E2F890042B755355001FBC7C /* MSALNativeAuthUnknownCaseProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthUnknownCaseProtocol.swift; sourceTree = "<group>"; };
 		E2F8900D2B75546A001FBC7C /* MSALNativeAuthUnknownCaseProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthUnknownCaseProtocolTests.swift; sourceTree = "<group>"; };
+		E3D6DF8D0582D8A2ABBE60AC /* MSALExternalKeyPair.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = MSALExternalKeyPair.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -4103,6 +4117,8 @@
 				23014D4425672DF9005E12F2 /* MSALAuthenticationSchemePop+Internal.h */,
 				9B839A0F2A4D7CF600BCC6F6 /* MSAL.docc */,
 				7233F0882F885D05009C9602 /* MSALDeviceTokenParameters.m */,
+				E3D6DF8D0582D8A2ABBE60AC /* MSALExternalKeyPair.m */,
+				453E3A3F201A3A625ABBB060 /* MSALExternalKeyPair+Internal.h */,
 			);
 			path = src;
 			sourceTree = "<group>";
@@ -4148,6 +4164,7 @@
 				9DA6473528EC2FF10014F44F /* MSALWPJMetaData.h */,
 				1EE776BC246C98D300F7EBFC /* MSALAuthenticationSchemeBearer.h */,
 				1EE776C2246C98E700F7EBFC /* MSALAuthenticationSchemePop.h */,
+				C80780758A4E248897963095 /* MSALExternalKeyPair.h */,
 			);
 			path = public;
 			sourceTree = "<group>";
@@ -4231,6 +4248,7 @@
 				B2725EAB22BF2759009B454A /* MSALExternalAccountHandlerTests.m */,
 				B2725EB422BF2774009B454A /* MSALPublicClientApplicationAccountUpdateTests.m */,
 				B253153A23DD717900432133 /* MSALDeviceInfoProviderTests.m */,
+				C3F28C277941E85614DB60AC /* MSALExternalKeyPairTests.m */,
 			);
 			path = unit;
 			sourceTree = "<group>";
@@ -5394,6 +5412,7 @@
 				B273D098226E855F005A7BB4 /* MSALRedirectUri+Internal.h in Headers */,
 				B273D07C226E84EA005A7BB4 /* MSALDefinitions.h in Headers */,
 				04A6B5C32269375E0035C7C2 /* MSALPublicClientApplication+Internal.h in Headers */,
+				5759D66144CC92A16A2BBA84 /* MSALExternalKeyPair.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5491,6 +5510,7 @@
 				2343CC092576C2F7002D405A /* MSALParameters.h in Headers */,
 				04A6B5BC226937490035C7C2 /* MSALAccountId+Internal.h in Headers */,
 				B273D0C5226E85AE005A7BB4 /* MSALCacheConfig+Internal.h in Headers */,
+				CB53AE75EED32902E5709ED8 /* MSALExternalKeyPair.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5604,6 +5624,7 @@
 				23014D192567233A005E12F2 /* MSALAuthenticationSchemeProtocolInternal.h in Headers */,
 				B203459D21AFA1FB00B221AA /* MSALRedirectUri+Internal.h in Headers */,
 				B253151923DD607600432133 /* MSALDeviceInformation.h in Headers */,
+				E1302AF4B4EB42EE88DC3DD0 /* MSALExternalKeyPair.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5710,6 +5731,7 @@
 				963377C0211E14C600943EE0 /* MSALWebviewType_Internal.h in Headers */,
 				B203459E21AFA1FB00B221AA /* MSALRedirectUri+Internal.h in Headers */,
 				DE8DC56E2C6622D200534E8F /* MSALNativeAuthChallengeTypes.h in Headers */,
+				1AE6006BC97F627E8E94B07C /* MSALExternalKeyPair.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6635,6 +6657,7 @@
 				04A6B5C5226937620035C7C2 /* MSALPublicClientApplication.m in Sources */,
 				04A6B5DE226937AA0035C7C2 /* MSALAccountsProvider.m in Sources */,
 				B273D0C9226E85C5005A7BB4 /* MSALCacheConfig.m in Sources */,
+				E62567EF33E72E0B4509174B /* MSALExternalKeyPair.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6699,6 +6722,7 @@
 				7248CF9C2F9AF2F90038E238 /* MSALDeviceTokenResult.m in Sources */,
 				DE9244DF2A31E1D500C0389F /* MSALCIAMOauth2Provider.m in Sources */,
 				B273D0C8226E85C4005A7BB4 /* MSALCacheConfig.m in Sources */,
+				CA7959DF5D62E1756F8C2440 /* MSALExternalKeyPair.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7174,6 +7198,7 @@
 				E2EFAD162A70300B00D6C3DE /* MSALNativeAuthControllerTelemetryWrapper.swift in Sources */,
 				285F58542C5BA33B00F4EFA4 /* MSALNativeAuthSignInIntrospectRequestParameters.swift in Sources */,
 				28DE70D629FAC16700EB75AA /* MSALNativeAuthSignInResponseValidator.swift in Sources */,
+				A40FD500991B8AF1A611AE7A /* MSALExternalKeyPair.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7462,6 +7487,7 @@
 				DE8DC4612C66219600534E8F /* SignUpResults.swift in Sources */,
 				DE8DC4972C6621A600534E8F /* SignInAfterResetPasswordDelegate.swift in Sources */,
 				DE8DC4512C66218900534E8F /* MSALNativeAuthInternalError.swift in Sources */,
+				B70FBB945F58638CB8488349 /* MSALExternalKeyPair.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7652,6 +7678,7 @@
 				9BD2765B2A0E7E7D00FBD033 /* ResetPasswordCodeSentStateTests.swift in Sources */,
 				E2F626B32A781CE300C4A303 /* SignInDelegatesSpies.swift in Sources */,
 				E22427EA2B065EAE0006C55E /* SignUpVerifyCodeDelegateDispatcherTests.swift in Sources */,
+				0DE4AC5F9DDB90C2F4BFA8E8 /* MSALExternalKeyPairTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7830,6 +7857,7 @@
 				28FB1BB62E0AF1F90065B784 /* MSALNativeAuthPublicClientApplicationConfigObjCTest.m in Sources */,
 				289E44BA2C9D843F00F6B9D7 /* MFARequestChallengeErrorTests.swift in Sources */,
 				DE8DC56C2C66221C00534E8F /* MSALNativeLoggingTests.swift in Sources */,
+				B3C048E5B7504CA04BE59E21 /* MSALExternalKeyPairTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MSAL/src/MSALAuthenticationSchemePop.m
+++ b/MSAL/src/MSALAuthenticationSchemePop.m
@@ -33,6 +33,7 @@
 #import "MSIDAccessToken.h"
 #import "MSIDDefaultTokenCacheAccessor.h"
 #import "MSIDAssymetricKeyPair.h"
+#import "MSALExternalKeyPair+Internal.h"
 
 static NSString *keyDelimiter = @" ";
 
@@ -42,6 +43,8 @@ static NSString *keyDelimiter = @" ";
 @property (nonatomic) NSURL *requestUrl;
 @property (nonatomic) NSString *nonce;
 @property (nonatomic) NSDictionary *additionalParameters;
+@property (nonatomic) MSALExternalKeyPair *externalKeyPair;
+@property (nonatomic) MSIDDevicePopManager *externalPopManager;
 
 @end
 
@@ -52,6 +55,19 @@ static NSString *keyDelimiter = @" ";
                              nonce:(NSString *)nonce
               additionalParameters:(NSDictionary *)additionalParameters
 {
+    return [self initWithHttpMethod:httpMethod
+                        requestUrl:requestUrl
+                             nonce:nonce
+              additionalParameters:additionalParameters
+                   externalKeyPair:nil];
+}
+
+- (instancetype)initWithHttpMethod:(MSALHttpMethod)httpMethod
+                        requestUrl:(NSURL *)requestUrl
+                             nonce:(NSString *)nonce
+              additionalParameters:(NSDictionary *)additionalParameters
+                   externalKeyPair:(nullable MSALExternalKeyPair *)externalKeyPair
+{
     self = [super init];
     if (self)
     {
@@ -60,6 +76,11 @@ static NSString *keyDelimiter = @" ";
         _requestUrl = requestUrl;
         _nonce = nonce ? nonce : [[NSUUID new] UUIDString];
         _additionalParameters = additionalParameters ? additionalParameters : [NSDictionary new];
+        _externalKeyPair = externalKeyPair;
+        if (externalKeyPair)
+        {
+            _externalPopManager = [[MSIDDevicePopManager alloc] initWithExternalKeyPair:externalKeyPair.msidKeyPair];
+        }
     }
 
     return self;
@@ -79,6 +100,7 @@ static NSString *keyDelimiter = @" ";
 
 - (NSDictionary *)getSchemeParameters:(MSIDDevicePopManager *)popManager
 {
+    popManager = self.externalPopManager ?: popManager;
     NSMutableDictionary *schemeParams = [NSMutableDictionary new];
     NSString *requestConf = popManager.keyPair.jsonWebKey;
     if (requestConf)
@@ -104,6 +126,7 @@ static NSString *keyDelimiter = @" ";
 
 - (nullable NSString *)getClientAccessToken:(MSIDAccessToken *)accessToken popManager:(nullable MSIDDevicePopManager *)popManager error:(NSError **)error
 {
+    popManager = self.externalPopManager ?: popManager;
     NSString *signedAccessToken = [popManager createSignedAccessToken:accessToken.accessToken
                                                            httpMethod:MSALParameterStringForHttpMethod(self.httpMethod)
                                                            requestUrl:self.requestUrl.absoluteString

--- a/MSAL/src/MSALAuthenticationSchemePop.m
+++ b/MSAL/src/MSALAuthenticationSchemePop.m
@@ -43,8 +43,8 @@ static NSString *keyDelimiter = @" ";
 @property (nonatomic) NSURL *requestUrl;
 @property (nonatomic) NSString *nonce;
 @property (nonatomic) NSDictionary *additionalParameters;
-@property (nonatomic) MSALExternalKeyPair *externalKeyPair;
-@property (nonatomic) MSIDDevicePopManager *externalPopManager;
+@property (nonatomic, nullable) MSALExternalKeyPair *externalKeyPair;
+@property (nonatomic, nullable) MSIDDevicePopManager *externalPopManager;
 
 @end
 
@@ -52,8 +52,8 @@ static NSString *keyDelimiter = @" ";
 
 - (instancetype)initWithHttpMethod:(MSALHttpMethod)httpMethod
                         requestUrl:(NSURL *)requestUrl
-                             nonce:(NSString *)nonce
-              additionalParameters:(NSDictionary *)additionalParameters
+                             nonce:(nullable NSString *)nonce
+              additionalParameters:(nullable NSDictionary *)additionalParameters
 {
     return [self initWithHttpMethod:httpMethod
                         requestUrl:requestUrl
@@ -64,8 +64,8 @@ static NSString *keyDelimiter = @" ";
 
 - (instancetype)initWithHttpMethod:(MSALHttpMethod)httpMethod
                         requestUrl:(NSURL *)requestUrl
-                             nonce:(NSString *)nonce
-              additionalParameters:(NSDictionary *)additionalParameters
+                             nonce:(nullable NSString *)nonce
+              additionalParameters:(nullable NSDictionary *)additionalParameters
                    externalKeyPair:(nullable MSALExternalKeyPair *)externalKeyPair
 {
     self = [super init];
@@ -100,9 +100,9 @@ static NSString *keyDelimiter = @" ";
 
 - (NSDictionary *)getSchemeParameters:(MSIDDevicePopManager *)popManager
 {
-    popManager = self.externalPopManager ?: popManager;
+    MSIDDevicePopManager *manager = self.externalPopManager ?: popManager;
     NSMutableDictionary *schemeParams = [NSMutableDictionary new];
-    NSString *requestConf = popManager.keyPair.jsonWebKey;
+    NSString *requestConf = manager.keyPair.jsonWebKey;
     if (requestConf)
     {
         [schemeParams setObject:MSALParameterStringForAuthScheme(self.scheme) forKey:MSID_OAUTH2_TOKEN_TYPE];
@@ -130,12 +130,12 @@ static NSString *keyDelimiter = @" ";
 
 - (nullable NSString *)getClientAccessToken:(MSIDAccessToken *)accessToken popManager:(nullable MSIDDevicePopManager *)popManager error:(NSError **)error
 {
-    popManager = self.externalPopManager ?: popManager;
-    NSString *signedAccessToken = [popManager createSignedAccessToken:accessToken.accessToken
-                                                           httpMethod:MSALParameterStringForHttpMethod(self.httpMethod)
-                                                           requestUrl:self.requestUrl.absoluteString
-                                                                nonce:self.nonce
-                                                                error:error];
+    MSIDDevicePopManager *manager = self.externalPopManager ?: popManager;
+    NSString *signedAccessToken = [manager createSignedAccessToken:accessToken.accessToken
+                                                        httpMethod:MSALParameterStringForHttpMethod(self.httpMethod)
+                                                        requestUrl:self.requestUrl.absoluteString
+                                                             nonce:self.nonce
+                                                             error:error];
     
     if (!signedAccessToken)
     {

--- a/MSAL/src/MSALAuthenticationSchemePop.m
+++ b/MSAL/src/MSALAuthenticationSchemePop.m
@@ -62,11 +62,11 @@ static NSString *keyDelimiter = @" ";
                    externalKeyPair:nil];
 }
 
-- (instancetype)initWithHttpMethod:(MSALHttpMethod)httpMethod
-                        requestUrl:(NSURL *)requestUrl
-                             nonce:(nullable NSString *)nonce
-              additionalParameters:(nullable NSDictionary *)additionalParameters
-                   externalKeyPair:(nullable MSALExternalKeyPair *)externalKeyPair
+- (nullable instancetype)initWithHttpMethod:(MSALHttpMethod)httpMethod
+                                  requestUrl:(NSURL *)requestUrl
+                                       nonce:(nullable NSString *)nonce
+                        additionalParameters:(nullable NSDictionary *)additionalParameters
+                             externalKeyPair:(nullable MSALExternalKeyPair *)externalKeyPair
 {
     self = [super init];
     if (self)
@@ -76,10 +76,19 @@ static NSString *keyDelimiter = @" ";
         _requestUrl = requestUrl;
         _nonce = nonce ? nonce : [[NSUUID new] UUIDString];
         _additionalParameters = additionalParameters ? additionalParameters : [NSDictionary new];
-        _externalKeyPair = externalKeyPair;
         if (externalKeyPair)
         {
-            _externalPopManager = [[MSIDDevicePopManager alloc] initWithExternalKeyPair:externalKeyPair.msidKeyPair];
+            NSError *externalManagerError = nil;
+            _externalPopManager = [[MSIDDevicePopManager alloc] initWithExternalKeyPair:externalKeyPair.msidKeyPair
+                                                                                context:nil
+                                                                                  error:&externalManagerError];
+            if (!_externalPopManager)
+            {
+                MSID_LOG_WITH_CTX(MSIDLogLevelError, nil, @"Failed to initialize external AT PoP manager: %@", externalManagerError);
+                return nil;
+            }
+
+            _externalKeyPair = externalKeyPair;
         }
     }
 
@@ -107,7 +116,7 @@ static NSString *keyDelimiter = @" ";
     {
         [schemeParams setObject:MSALParameterStringForAuthScheme(self.scheme) forKey:MSID_OAUTH2_TOKEN_TYPE];
         [schemeParams setObject:requestConf forKey:MSID_OAUTH2_REQUEST_CONFIRMATION];
-        if (self.externalKeyPair)
+        if (manager == self.externalPopManager)
         {
             [schemeParams setObject:@"1" forKey:MSID_OAUTH2_EXTERNAL_KEY_POP];
         }

--- a/MSAL/src/MSALAuthenticationSchemePop.m
+++ b/MSAL/src/MSALAuthenticationSchemePop.m
@@ -107,6 +107,10 @@ static NSString *keyDelimiter = @" ";
     {
         [schemeParams setObject:MSALParameterStringForAuthScheme(self.scheme) forKey:MSID_OAUTH2_TOKEN_TYPE];
         [schemeParams setObject:requestConf forKey:MSID_OAUTH2_REQUEST_CONFIRMATION];
+        if (self.externalKeyPair)
+        {
+            [schemeParams setObject:@"1" forKey:MSID_OAUTH2_EXTERNAL_KEY_POP];
+        }
     }
     else
     {

--- a/MSAL/src/MSALError.m
+++ b/MSAL/src/MSALError.m
@@ -32,6 +32,7 @@ NSString *MSALOAuthErrorKey = @"MSALOAuthErrorKey";
 NSString *MSALOAuthSubErrorKey = @"MSALOAuthSubErrorKey";
 NSString *MSALOAuthSubErrorDescriptionKey = @"MSALOAuthSubErrorDescriptionKey";
 NSString *MSALErrorDescriptionKey = @"MSALErrorDescriptionKey";
+NSString *MSALExternalKeyPairFailureReasonKey = @"MSALExternalKeyPairFailureReasonKey";
 NSString *MSALSTSErrorCodesKey = @"MSALSTSErrorCodesKey";
 NSString *MSALInternalErrorCodeKey = @"MSALInternalErrorCodeKey";
 NSString *MSALHTTPHeadersKey = @"MSALHTTPHeadersKey";

--- a/MSAL/src/MSALExternalKeyPair+Internal.h
+++ b/MSAL/src/MSALExternalKeyPair+Internal.h
@@ -5,6 +5,24 @@
 //
 // This code is licensed under the MIT License.
 //
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 //------------------------------------------------------------------------------
 
 #import "MSALExternalKeyPair.h"

--- a/MSAL/src/MSALExternalKeyPair+Internal.h
+++ b/MSAL/src/MSALExternalKeyPair+Internal.h
@@ -1,0 +1,22 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALExternalKeyPair.h"
+
+@class MSIDAssymetricKeyPair;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSALExternalKeyPair ()
+
+@property (nonatomic) MSIDAssymetricKeyPair *msidKeyPair;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/MSALExternalKeyPair.m
+++ b/MSAL/src/MSALExternalKeyPair.m
@@ -5,6 +5,24 @@
 //
 // This code is licensed under the MIT License.
 //
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 //------------------------------------------------------------------------------
 
 #import "MSALExternalKeyPair+Internal.h"
@@ -14,11 +32,40 @@
 
 NSString *const MSALExternalKeyPairFailureReasonKey = @"MSALExternalKeyPairFailureReasonKey";
 
+static MSALExternalKeyPairFailureReason MSALFailureReasonFromMSIDReason(MSIDExternalKeyPairValidationFailureReason reason)
+{
+    switch (reason)
+    {
+        case MSIDExternalKeyPairValidationFailureReasonUnsupportedKeyType:
+            return MSALExternalKeyPairFailureReasonUnsupportedKeyType;
+
+        case MSIDExternalKeyPairValidationFailureReasonKeySizeTooSmall:
+            return MSALExternalKeyPairFailureReasonKeySizeTooSmall;
+
+        case MSIDExternalKeyPairValidationFailureReasonInvalidKeyClass:
+            return MSALExternalKeyPairFailureReasonInvalidKeyClass;
+
+        case MSIDExternalKeyPairValidationFailureReasonNotSigningCapable:
+            return MSALExternalKeyPairFailureReasonNotSigningCapable;
+
+        case MSIDExternalKeyPairValidationFailureReasonKeyPairMismatch:
+            return MSALExternalKeyPairFailureReasonKeyPairMismatch;
+
+        case MSIDExternalKeyPairValidationFailureReasonPublicKeySerializationFailed:
+            return MSALExternalKeyPairFailureReasonPublicKeySerializationFailed;
+
+        case MSIDExternalKeyPairValidationFailureReasonNone:
+        case MSIDExternalKeyPairValidationFailureReasonInvalidKeyHandle:
+        default:
+            return MSALExternalKeyPairFailureReasonInvalidKeyHandle;
+    }
+}
+
 @implementation MSALExternalKeyPair
 
-- (instancetype)initWithPrivateKey:(SecKeyRef)privateKey
-                         publicKey:(SecKeyRef)publicKey
-                             error:(NSError *__autoreleasing *)error
+- (nullable instancetype)initWithPrivateKey:(SecKeyRef)privateKey
+                                  publicKey:(SecKeyRef)publicKey
+                                      error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     MSIDExternalKeyPairValidationFailureReason validationReason = MSIDExternalKeyPairValidationFailureReasonNone;
     NSError *validationError = nil;
@@ -36,7 +83,7 @@ NSString *const MSALExternalKeyPairFailureReasonKey = @"MSALExternalKeyPairFailu
                                          code:MSALErrorInvalidExternalKeyPair
                                      userInfo:@{
                                          MSALErrorDescriptionKey : description,
-                                         MSALExternalKeyPairFailureReasonKey : @([self msalFailureReasonFromMSIDReason:validationReason])
+                                         MSALExternalKeyPairFailureReasonKey : @(MSALFailureReasonFromMSIDReason(validationReason))
                                      }];
         }
 
@@ -71,35 +118,6 @@ NSString *const MSALExternalKeyPairFailureReasonKey = @"MSALExternalKeyPairFailu
 - (NSString *)keyId
 {
     return self.msidKeyPair.kid;
-}
-
-- (MSALExternalKeyPairFailureReason)msalFailureReasonFromMSIDReason:(MSIDExternalKeyPairValidationFailureReason)reason
-{
-    switch (reason)
-    {
-        case MSIDExternalKeyPairValidationFailureReasonUnsupportedKeyType:
-            return MSALExternalKeyPairFailureReasonUnsupportedKeyType;
-
-        case MSIDExternalKeyPairValidationFailureReasonKeySizeTooSmall:
-            return MSALExternalKeyPairFailureReasonKeySizeTooSmall;
-
-        case MSIDExternalKeyPairValidationFailureReasonInvalidKeyClass:
-            return MSALExternalKeyPairFailureReasonInvalidKeyClass;
-
-        case MSIDExternalKeyPairValidationFailureReasonNotSigningCapable:
-            return MSALExternalKeyPairFailureReasonNotSigningCapable;
-
-        case MSIDExternalKeyPairValidationFailureReasonKeyPairMismatch:
-            return MSALExternalKeyPairFailureReasonKeyPairMismatch;
-
-        case MSIDExternalKeyPairValidationFailureReasonPublicKeySerializationFailed:
-            return MSALExternalKeyPairFailureReasonPublicKeySerializationFailed;
-
-        case MSIDExternalKeyPairValidationFailureReasonNone:
-        case MSIDExternalKeyPairValidationFailureReasonInvalidKeyHandle:
-        default:
-            return MSALExternalKeyPairFailureReasonInvalidKeyHandle;
-    }
 }
 
 @end

--- a/MSAL/src/MSALExternalKeyPair.m
+++ b/MSAL/src/MSALExternalKeyPair.m
@@ -1,0 +1,104 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+//------------------------------------------------------------------------------
+
+#import "MSALExternalKeyPair+Internal.h"
+#import "MSALError.h"
+#import "MSIDAssymetricKeyPair.h"
+#import "MSIDKeyOperationUtil.h"
+
+NSString *const MSALExternalKeyPairFailureReasonKey = @"MSALExternalKeyPairFailureReasonKey";
+
+@implementation MSALExternalKeyPair
+
+- (instancetype)initWithPrivateKey:(SecKeyRef)privateKey
+                         publicKey:(SecKeyRef)publicKey
+                             error:(NSError *__autoreleasing *)error
+{
+    MSIDExternalKeyPairValidationFailureReason validationReason = MSIDExternalKeyPairValidationFailureReasonNone;
+    NSError *validationError = nil;
+    BOOL valid = [[MSIDKeyOperationUtil sharedInstance] validateExternalRSAKeyPair:privateKey
+                                                                         publicKey:publicKey
+                                                                     failureReason:&validationReason
+                                                                             error:&validationError];
+    if (!valid)
+    {
+        if (error)
+        {
+            NSString *description = validationError.localizedDescription ?: @"Invalid external AT PoP key pair.";
+            *error = [NSError errorWithDomain:MSALErrorDomain
+                                         code:MSALErrorInvalidExternalKeyPair
+                                     userInfo:@{
+                                         MSALErrorDescriptionKey : description,
+                                         MSALExternalKeyPairFailureReasonKey : @([self msalFailureReasonFromMSIDReason:validationReason])
+                                     }];
+        }
+
+        return nil;
+    }
+
+    self = [super init];
+    if (self)
+    {
+        _msidKeyPair = [[MSIDAssymetricKeyPair alloc] initWithPrivateKey:privateKey
+                                                               publicKey:publicKey
+                                                          privateKeyDict:[NSDictionary new]];
+        if (!_msidKeyPair || !_msidKeyPair.kid)
+        {
+            if (error)
+            {
+                *error = [NSError errorWithDomain:MSALErrorDomain
+                                             code:MSALErrorInvalidExternalKeyPair
+                                         userInfo:@{
+                                             MSALErrorDescriptionKey : @"Unable to derive a public key thumbprint.",
+                                             MSALExternalKeyPairFailureReasonKey : @(MSALExternalKeyPairFailureReasonPublicKeySerializationFailed)
+                                         }];
+            }
+
+            return nil;
+        }
+    }
+
+    return self;
+}
+
+- (NSString *)keyId
+{
+    return self.msidKeyPair.kid;
+}
+
+- (MSALExternalKeyPairFailureReason)msalFailureReasonFromMSIDReason:(MSIDExternalKeyPairValidationFailureReason)reason
+{
+    switch (reason)
+    {
+        case MSIDExternalKeyPairValidationFailureReasonUnsupportedKeyType:
+            return MSALExternalKeyPairFailureReasonUnsupportedKeyType;
+
+        case MSIDExternalKeyPairValidationFailureReasonKeySizeTooSmall:
+            return MSALExternalKeyPairFailureReasonKeySizeTooSmall;
+
+        case MSIDExternalKeyPairValidationFailureReasonInvalidKeyClass:
+            return MSALExternalKeyPairFailureReasonInvalidKeyClass;
+
+        case MSIDExternalKeyPairValidationFailureReasonNotSigningCapable:
+            return MSALExternalKeyPairFailureReasonNotSigningCapable;
+
+        case MSIDExternalKeyPairValidationFailureReasonKeyPairMismatch:
+            return MSALExternalKeyPairFailureReasonKeyPairMismatch;
+
+        case MSIDExternalKeyPairValidationFailureReasonPublicKeySerializationFailed:
+            return MSALExternalKeyPairFailureReasonPublicKeySerializationFailed;
+
+        case MSIDExternalKeyPairValidationFailureReasonNone:
+        case MSIDExternalKeyPairValidationFailureReasonInvalidKeyHandle:
+        default:
+            return MSALExternalKeyPairFailureReasonInvalidKeyHandle;
+    }
+}
+
+@end

--- a/MSAL/src/MSALExternalKeyPair.m
+++ b/MSAL/src/MSALExternalKeyPair.m
@@ -30,12 +30,16 @@
 #import "MSIDAssymetricKeyPair.h"
 #import "MSIDKeyOperationUtil.h"
 
-NSString *const MSALExternalKeyPairFailureReasonKey = @"MSALExternalKeyPairFailureReasonKey";
-
 static MSALExternalKeyPairFailureReason MSALFailureReasonFromMSIDReason(MSIDExternalKeyPairValidationFailureReason reason)
 {
     switch (reason)
     {
+        case MSIDExternalKeyPairValidationFailureReasonNone:
+            return MSALExternalKeyPairFailureReasonUnknown;
+
+        case MSIDExternalKeyPairValidationFailureReasonInvalidKeyHandle:
+            return MSALExternalKeyPairFailureReasonInvalidKeyHandle;
+
         case MSIDExternalKeyPairValidationFailureReasonUnsupportedKeyType:
             return MSALExternalKeyPairFailureReasonUnsupportedKeyType;
 
@@ -54,17 +58,17 @@ static MSALExternalKeyPairFailureReason MSALFailureReasonFromMSIDReason(MSIDExte
         case MSIDExternalKeyPairValidationFailureReasonPublicKeySerializationFailed:
             return MSALExternalKeyPairFailureReasonPublicKeySerializationFailed;
 
-        case MSIDExternalKeyPairValidationFailureReasonNone:
-        case MSIDExternalKeyPairValidationFailureReasonInvalidKeyHandle:
-        default:
-            return MSALExternalKeyPairFailureReasonInvalidKeyHandle;
+        case MSIDExternalKeyPairValidationFailureReasonPublicKeyDerivationFailed:
+            return MSALExternalKeyPairFailureReasonPublicKeyDerivationFailed;
     }
+
+    return MSALExternalKeyPairFailureReasonUnknown;
 }
 
 @implementation MSALExternalKeyPair
 
-- (nullable instancetype)initWithPrivateKey:(SecKeyRef)privateKey
-                                  publicKey:(SecKeyRef)publicKey
+- (nullable instancetype)initWithPrivateKey:(SecKeyRef _Nullable)privateKey
+                                  publicKey:(SecKeyRef _Nullable)publicKey
                                       error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     MSIDExternalKeyPairValidationFailureReason validationReason = MSIDExternalKeyPairValidationFailureReasonNone;
@@ -79,12 +83,18 @@ static MSALExternalKeyPairFailureReason MSALFailureReasonFromMSIDReason(MSIDExte
         if (error)
         {
             NSString *description = validationError.localizedDescription ?: @"Invalid external AT PoP key pair.";
+            NSMutableDictionary *userInfo = [@{
+                MSALErrorDescriptionKey : description,
+                MSALExternalKeyPairFailureReasonKey : @(MSALFailureReasonFromMSIDReason(validationReason))
+            } mutableCopy];
+            if (validationError)
+            {
+                userInfo[NSUnderlyingErrorKey] = validationError;
+            }
+
             *error = [NSError errorWithDomain:MSALErrorDomain
                                          code:MSALErrorInvalidExternalKeyPair
-                                     userInfo:@{
-                                         MSALErrorDescriptionKey : description,
-                                         MSALExternalKeyPairFailureReasonKey : @(MSALFailureReasonFromMSIDReason(validationReason))
-                                     }];
+                                     userInfo:userInfo];
         }
 
         return nil;
@@ -93,6 +103,7 @@ static MSALExternalKeyPairFailureReason MSALFailureReasonFromMSIDReason(MSIDExte
     self = [super init];
     if (self)
     {
+        // Caller-owned keys do not have MSAL keychain lookup metadata.
         _msidKeyPair = [[MSIDAssymetricKeyPair alloc] initWithPrivateKey:privateKey
                                                                publicKey:publicKey
                                                           privateKeyDict:[NSDictionary new]];

--- a/MSAL/src/MSALExternalKeyPair.m
+++ b/MSAL/src/MSALExternalKeyPair.m
@@ -25,6 +25,7 @@ NSString *const MSALExternalKeyPairFailureReasonKey = @"MSALExternalKeyPairFailu
     BOOL valid = [[MSIDKeyOperationUtil sharedInstance] validateExternalRSAKeyPair:privateKey
                                                                          publicKey:publicKey
                                                                      failureReason:&validationReason
+                                                                           context:nil
                                                                              error:&validationError];
     if (!valid)
     {

--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -84,6 +84,7 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALWPJMetaData.h>
 #import <MSAL/MSALAuthenticationSchemeBearer.h>
 #import <MSAL/MSALAuthenticationSchemePop.h>
+#import <MSAL/MSALExternalKeyPair.h>
 #import <MSAL/MSALAuthenticationSchemeProtocol.h>
 #import <MSAL/MSALHttpMethod.h>
 #import <MSAL/MSALCIAMAuthority.h>

--- a/MSAL/src/public/MSALAuthenticationSchemePop.h
+++ b/MSAL/src/public/MSALAuthenticationSchemePop.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MSALAuthenticationSchemePop : NSObject<MSALAuthenticationSchemeProtocol>
 
 @property (nonatomic, readonly) MSALAuthScheme scheme;
+@property (nonatomic, readonly, nullable) MSALExternalKeyPair *externalKeyPair;
 
 - (instancetype)initWithHttpMethod:(MSALHttpMethod)httpMethod
                         requestUrl:(NSURL *)requestUrl
@@ -45,8 +46,6 @@ NS_ASSUME_NONNULL_BEGIN
                              nonce:(nullable NSString *)nonce
               additionalParameters:(nullable NSDictionary *)additionalParameters
                    externalKeyPair:(nullable MSALExternalKeyPair *)externalKeyPair;
-
-@property (nonatomic, readonly, nullable) MSALExternalKeyPair *externalKeyPair;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/MSAL/src/public/MSALAuthenticationSchemePop.h
+++ b/MSAL/src/public/MSALAuthenticationSchemePop.h
@@ -41,11 +41,18 @@ NS_ASSUME_NONNULL_BEGIN
                              nonce:(nullable NSString *)nonce
               additionalParameters:(nullable NSDictionary *)additionalParameters;
 
-- (instancetype)initWithHttpMethod:(MSALHttpMethod)httpMethod
-                        requestUrl:(NSURL *)requestUrl
-                             nonce:(nullable NSString *)nonce
-              additionalParameters:(nullable NSDictionary *)additionalParameters
-                   externalKeyPair:(nullable MSALExternalKeyPair *)externalKeyPair;
+/**
+ Initializes an AT PoP authentication scheme with an optional caller-owned key pair.
+
+ Pass nil to use MSAL's device PoP key. The caller is responsible for creating, storing,
+ rotating, and deleting an external key pair. Supply the same external key pair on later
+ silent requests so cached PoP tokens can be matched by their key identifier.
+ */
+- (nullable instancetype)initWithHttpMethod:(MSALHttpMethod)httpMethod
+                                  requestUrl:(NSURL *)requestUrl
+                                       nonce:(nullable NSString *)nonce
+                        additionalParameters:(nullable NSDictionary *)additionalParameters
+                             externalKeyPair:(nullable MSALExternalKeyPair *)externalKeyPair NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/MSAL/src/public/MSALAuthenticationSchemePop.h
+++ b/MSAL/src/public/MSALAuthenticationSchemePop.h
@@ -27,6 +27,8 @@
 
 #import "MSALAuthenticationSchemeProtocol.h"
 
+@class MSALExternalKeyPair;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MSALAuthenticationSchemePop : NSObject<MSALAuthenticationSchemeProtocol>
@@ -37,6 +39,14 @@ NS_ASSUME_NONNULL_BEGIN
                         requestUrl:(NSURL *)requestUrl
                              nonce:(nullable NSString *)nonce
               additionalParameters:(nullable NSDictionary *)additionalParameters;
+
+- (instancetype)initWithHttpMethod:(MSALHttpMethod)httpMethod
+                        requestUrl:(NSURL *)requestUrl
+                             nonce:(nullable NSString *)nonce
+              additionalParameters:(nullable NSDictionary *)additionalParameters
+                   externalKeyPair:(nullable MSALExternalKeyPair *)externalKeyPair;
+
+@property (nonatomic, readonly, nullable) MSALExternalKeyPair *externalKeyPair;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -198,6 +198,12 @@ typedef NS_ENUM(NSInteger, MSALError)
      Workplacejoin migrate device registration is required to proceed.
      */
     MSALErrorInsufficientDeviceStrength          = -50007,
+
+    /**
+     The caller-provided AT PoP key pair is invalid or unsupported.
+     Inspect MSALExternalKeyPairFailureReasonKey for the validation category.
+     */
+    MSALErrorInvalidExternalKeyPair               = -50100,
     
     /**
      MDM enrollment has completed. Retry the token request to proceed.

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -68,6 +68,11 @@ extern NSString *MSALOAuthSubErrorDescriptionKey;
 extern NSString *MSALErrorDescriptionKey;
 
 /**
+ External key-pair validation failure reason returned with MSALErrorInvalidExternalKeyPair.
+ */
+extern NSString *MSALExternalKeyPairFailureReasonKey;
+
+/**
     A list of STS-specific error codes returned by the service that can help in diagnostics. Note that error codes can change and should
     not be relied upon for any error handling logic.
  */

--- a/MSAL/src/public/MSALError.h
+++ b/MSAL/src/public/MSALError.h
@@ -198,17 +198,17 @@ typedef NS_ENUM(NSInteger, MSALError)
      Workplacejoin migrate device registration is required to proceed.
      */
     MSALErrorInsufficientDeviceStrength          = -50007,
-
-    /**
-     The caller-provided AT PoP key pair is invalid or unsupported.
-     Inspect MSALExternalKeyPairFailureReasonKey for the validation category.
-     */
-    MSALErrorInvalidExternalKeyPair               = -50100,
     
     /**
      MDM enrollment has completed. Retry the token request to proceed.
      */
     MSALErrorMDMEnrollmentCompletedNeedsRetry    = -50008,
+
+    /**
+     The caller-provided AT PoP key pair is invalid or unsupported.
+     Inspect MSALExternalKeyPairFailureReasonKey for the validation category.
+     */
+    MSALErrorInvalidExternalKeyPair              = -50009,
     
     /**
      Error thrown when oauth error = MSIDServerInvalidRequest and error code = 50142 (SecureChangePasswordDueToConditionalAccess)

--- a/MSAL/src/public/MSALExternalKeyPair.h
+++ b/MSAL/src/public/MSALExternalKeyPair.h
@@ -1,0 +1,51 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+//------------------------------------------------------------------------------
+
+#import <Foundation/Foundation.h>
+#import <Security/Security.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, MSALExternalKeyPairFailureReason)
+{
+    MSALExternalKeyPairFailureReasonInvalidKeyHandle = 1,
+    MSALExternalKeyPairFailureReasonUnsupportedKeyType,
+    MSALExternalKeyPairFailureReasonKeySizeTooSmall,
+    MSALExternalKeyPairFailureReasonInvalidKeyClass,
+    MSALExternalKeyPairFailureReasonNotSigningCapable,
+    MSALExternalKeyPairFailureReasonKeyPairMismatch,
+    MSALExternalKeyPairFailureReasonPublicKeySerializationFailed
+};
+
+extern NSString *const MSALExternalKeyPairFailureReasonKey;
+
+/**
+ A caller-owned RSA key pair supplied to MSAL for Access Token Proof-of-Possession.
+
+ MSAL retains the key handles for the lifetime of this object. The caller remains
+ responsible for creating, storing, rotating, and deleting the underlying keys.
+ MSAL never exports or persists the private key material.
+ */
+@interface MSALExternalKeyPair : NSObject
+
+- (nullable instancetype)initWithPrivateKey:(SecKeyRef)privateKey
+                                  publicKey:(SecKeyRef)publicKey
+                                      error:(NSError * _Nullable __autoreleasing * _Nullable)error NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+/**
+ RFC 7638 thumbprint of the public key used for the access token confirmation claim.
+ */
+@property (nonatomic, readonly) NSString *keyId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MSAL/src/public/MSALExternalKeyPair.h
+++ b/MSAL/src/public/MSALExternalKeyPair.h
@@ -32,16 +32,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, MSALExternalKeyPairFailureReason)
 {
-    MSALExternalKeyPairFailureReasonInvalidKeyHandle = 1,
+    MSALExternalKeyPairFailureReasonUnknown = 0,
+    MSALExternalKeyPairFailureReasonInvalidKeyHandle,
     MSALExternalKeyPairFailureReasonUnsupportedKeyType,
     MSALExternalKeyPairFailureReasonKeySizeTooSmall,
     MSALExternalKeyPairFailureReasonInvalidKeyClass,
     MSALExternalKeyPairFailureReasonNotSigningCapable,
     MSALExternalKeyPairFailureReasonKeyPairMismatch,
-    MSALExternalKeyPairFailureReasonPublicKeySerializationFailed
+    MSALExternalKeyPairFailureReasonPublicKeySerializationFailed,
+    MSALExternalKeyPairFailureReasonPublicKeyDerivationFailed
 };
-
-extern NSString *const MSALExternalKeyPairFailureReasonKey;
 
 /**
  A caller-owned RSA key pair supplied to MSAL for Access Token Proof-of-Possession.
@@ -52,8 +52,8 @@ extern NSString *const MSALExternalKeyPairFailureReasonKey;
  */
 @interface MSALExternalKeyPair : NSObject
 
-- (nullable instancetype)initWithPrivateKey:(SecKeyRef)privateKey
-                                  publicKey:(SecKeyRef)publicKey
+- (nullable instancetype)initWithPrivateKey:(SecKeyRef _Nullable)privateKey
+                                  publicKey:(SecKeyRef _Nullable)publicKey
                                       error:(NSError * _Nullable __autoreleasing * _Nullable)error NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/MSAL/src/public/MSALExternalKeyPair.h
+++ b/MSAL/src/public/MSALExternalKeyPair.h
@@ -30,16 +30,39 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ Reason an external Access Token Proof-of-Possession key pair was rejected.
+
+ Read from `MSALExternalKeyPairFailureReasonKey` in the `userInfo` of an
+ `MSALErrorInvalidExternalKeyPair` error.
+ */
 typedef NS_ENUM(NSInteger, MSALExternalKeyPairFailureReason)
 {
+    /** No reason was recorded, or the `userInfo` key was absent. */
     MSALExternalKeyPairFailureReasonUnknown = 0,
+
+    /** A key handle was NULL, or its attributes could not be read. */
     MSALExternalKeyPairFailureReasonInvalidKeyHandle,
+
+    /** A key was not RSA. Elliptic curve keys, including Secure Enclave keys, are not supported. */
     MSALExternalKeyPairFailureReasonUnsupportedKeyType,
+
+    /** A key was smaller than the 2048-bit minimum. */
     MSALExternalKeyPairFailureReasonKeySizeTooSmall,
+
+    /** The supplied keys were not one private key and one public key. */
     MSALExternalKeyPairFailureReasonInvalidKeyClass,
+
+    /** The private key cannot sign, or the public key cannot verify, using RS256. */
     MSALExternalKeyPairFailureReasonNotSigningCapable,
+
+    /** The public key does not correspond to the private key, or their sizes differ. */
     MSALExternalKeyPairFailureReasonKeyPairMismatch,
+
+    /** The public key could not be exported, so no thumbprint could be computed. */
     MSALExternalKeyPairFailureReasonPublicKeySerializationFailed,
+
+    /** The public key could not be derived from the private key. */
     MSALExternalKeyPairFailureReasonPublicKeyDerivationFailed
 };
 
@@ -52,6 +75,32 @@ typedef NS_ENUM(NSInteger, MSALExternalKeyPairFailureReason)
  */
 @interface MSALExternalKeyPair : NSObject
 
+/**
+ Validates a caller-owned RSA key pair and, on success, retains both key handles.
+
+ The key pair must satisfy all of the following, otherwise initialization fails:
+
+ - Both handles are non-NULL and their attributes are readable.
+ - Both keys are RSA. Elliptic curve keys, including Secure Enclave keys, are rejected.
+ - One key is a private key and the other is a public key.
+ - Both keys are at least 2048 bits and are of equal size.
+ - The private key supports RS256 signing and the public key supports RS256 verification.
+ - The public key can be exported, so that its RFC 7638 thumbprint can be computed.
+ - The public key derived from the private key matches the supplied public key.
+
+ Validation is non-interactive: it never signs a challenge, so it does not trigger a
+ biometric or user-presence prompt. It fails closed. If the public key cannot be derived
+ from the private key, the pair is rejected rather than accepted on weaker evidence.
+
+ @param privateKey Caller-owned RSA private key. Retained for the lifetime of the returned object.
+ @param publicKey Caller-owned RSA public key matching `privateKey`. Retained for the lifetime of the returned object.
+ @param error On failure, an `NSError` in `MSALErrorDomain` with code `MSALErrorInvalidExternalKeyPair`.
+        Its `userInfo` contains `MSALExternalKeyPairFailureReasonKey`, holding a boxed
+        `MSALExternalKeyPairFailureReason`, and, when validation produced one, the originating
+        error under `NSUnderlyingErrorKey`.
+
+ @return An initialized object, or `nil` if the key pair failed validation.
+ */
 - (nullable instancetype)initWithPrivateKey:(SecKeyRef _Nullable)privateKey
                                   publicKey:(SecKeyRef _Nullable)publicKey
                                       error:(NSError * _Nullable __autoreleasing * _Nullable)error NS_DESIGNATED_INITIALIZER;

--- a/MSAL/src/public/MSALExternalKeyPair.h
+++ b/MSAL/src/public/MSALExternalKeyPair.h
@@ -5,6 +5,24 @@
 //
 // This code is licensed under the MIT License.
 //
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 //------------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>

--- a/MSAL/test/unit/MSALAuthSchemeTests.m
+++ b/MSAL/test/unit/MSALAuthSchemeTests.m
@@ -41,6 +41,7 @@
 #import "MSIDAssymetricKeyKeychainGenerator.h"
 #import "MSIDAssymetricKeyLookupAttributes.h"
 #import "MSIDAssymetricKeyPair.h"
+#import "NSData+MSIDExtensions.h"
 #if !TARGET_OS_IPHONE
 #import "MSIDAssymetricKeyLoginKeychainGenerator.h"
 #endif
@@ -189,6 +190,7 @@
     NSString *requestConfirmation = schemeParameters[MSID_OAUTH2_REQUEST_CONFIRMATION];
     NSString *decodedConfirmation = [requestConfirmation msidBase64UrlDecode];
     XCTAssertTrue([decodedConfirmation containsString:externalKeyPair.keyId]);
+    XCTAssertEqualObjects(schemeParameters[MSID_OAUTH2_EXTERNAL_KEY_POP], @"1");
 
     MSIDAccessTokenWithAuthScheme *accessToken = [self populatePopMSIDAccessToken];
     NSString *signedAccessToken = [authScheme getClientAccessToken:accessToken popManager:defaultManager error:&error];
@@ -199,6 +201,17 @@
     XCTAssertEqual(segments.count, 3);
     NSString *decodedHeader = [segments[0] msidBase64UrlDecode];
     XCTAssertTrue([decodedHeader containsString:externalKeyPair.keyId]);
+
+    NSData *signedData = [[NSString stringWithFormat:@"%@.%@", segments[0], segments[1]] dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *signature = [NSData msidDataFromBase64UrlEncodedString:segments[2]];
+    CFErrorRef verificationError = NULL;
+    BOOL signatureValid = SecKeyVerifySignature(publicKey,
+                                                kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256,
+                                                (__bridge CFDataRef)signedData,
+                                                (__bridge CFDataRef)signature,
+                                                &verificationError);
+    XCTAssertTrue(signatureValid);
+    XCTAssertEqual(verificationError, NULL);
 
     CFRelease(publicKey);
     CFRelease(privateKey);

--- a/MSAL/test/unit/MSALAuthSchemeTests.m
+++ b/MSAL/test/unit/MSALAuthSchemeTests.m
@@ -212,6 +212,10 @@
                                                 &verificationError);
     XCTAssertTrue(signatureValid);
     XCTAssertEqual(verificationError, NULL);
+    if (verificationError)
+    {
+        CFRelease(verificationError);
+    }
 
     CFRelease(publicKey);
     CFRelease(privateKey);
@@ -276,6 +280,11 @@
     SecKeyRef privateKey = SecKeyCreateRandomKey((__bridge CFDictionaryRef)attributes, &error);
     XCTAssertNotEqual(privateKey, NULL);
     XCTAssertEqual(error, NULL);
+    if (error)
+    {
+        CFRelease(error);
+    }
+
     return privateKey;
 }
 

--- a/MSAL/test/unit/MSALAuthSchemeTests.m
+++ b/MSAL/test/unit/MSALAuthSchemeTests.m
@@ -50,6 +50,7 @@
 #import "MSIDMacKeychainTokenCache.h"
 #import "MSALDevicePopManagerUtil.h"
 #import "MSALExternalKeyPair.h"
+#import "MSALExternalKeyPair+Internal.h"
 #import "NSString+MSIDExtensions.h"
 
 @interface MSALAuthSchemeTests : XCTestCase
@@ -57,6 +58,12 @@
 @end
 
 @implementation MSALAuthSchemeTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.continueAfterFailure = NO;
+}
 
 - (void)testBearerInit_shouldReturnAuthBearer_AndAllBearerAttributes
 {
@@ -172,6 +179,7 @@
 {
     SecKeyRef privateKey = [self createRSA2048PrivateKey];
     SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+    XCTAssertNotEqual(publicKey, NULL);
     NSError *error = nil;
     MSALExternalKeyPair *externalKeyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:privateKey
                                                                                  publicKey:publicKey
@@ -200,7 +208,13 @@
     NSArray<NSString *> *segments = [signedAccessToken componentsSeparatedByString:@"."];
     XCTAssertEqual(segments.count, 3);
     NSString *decodedHeader = [segments[0] msidBase64UrlDecode];
-    XCTAssertTrue([decodedHeader containsString:externalKeyPair.keyId]);
+    NSData *headerData = [decodedHeader dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *header = [NSJSONSerialization JSONObjectWithData:headerData options:0 error:&error];
+    XCTAssertNotNil(header);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(header[@"alg"], @"RS256");
+    XCTAssertEqualObjects(header[@"typ"], @"JWT");
+    XCTAssertEqualObjects(header[@"kid"], externalKeyPair.keyId);
 
     NSData *signedData = [[NSString stringWithFormat:@"%@.%@", segments[0], segments[1]] dataUsingEncoding:NSUTF8StringEncoding];
     NSData *signature = [NSData msidDataFromBase64UrlEncodedString:segments[2]];
@@ -217,6 +231,40 @@
         CFRelease(verificationError);
     }
 
+    CFRelease(publicKey);
+    CFRelease(privateKey);
+}
+
+- (void)testDeviceKeyPair_getSchemeParameters_shouldNotSetExternalKeyMarker
+{
+    MSALAuthenticationSchemePop *authScheme = [self generateAuthSchemePopInstance];
+    MSIDDevicePopManager *devicePopManager = [MSALDevicePopManagerUtil test_initWithValidCacheConfig];
+
+    NSDictionary *schemeParameters = [authScheme getSchemeParameters:devicePopManager];
+
+    XCTAssertNil(schemeParameters[MSID_OAUTH2_EXTERNAL_KEY_POP]);
+    XCTAssertEqualObjects(schemeParameters[MSID_OAUTH2_REQUEST_CONFIRMATION], devicePopManager.keyPair.jsonWebKey);
+}
+
+- (void)testExternalKeyPair_whenInternalPairIsMissing_shouldFailInitialization
+{
+    SecKeyRef privateKey = [self createRSA2048PrivateKey];
+    SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+    XCTAssertNotEqual(publicKey, NULL);
+    NSError *error = nil;
+    MSALExternalKeyPair *externalKeyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:privateKey
+                                                                                 publicKey:publicKey
+                                                                                     error:&error];
+    XCTAssertNotNil(externalKeyPair);
+    [externalKeyPair setValue:nil forKey:@"msidKeyPair"];
+
+    MSALAuthenticationSchemePop *authScheme = [[MSALAuthenticationSchemePop alloc] initWithHttpMethod:MSALHttpMethodPOST
+                                                                                           requestUrl:[NSURL URLWithString:@"https://contoso.com/path"]
+                                                                                                nonce:nil
+                                                                                 additionalParameters:nil
+                                                                                      externalKeyPair:externalKeyPair];
+
+    XCTAssertNil(authScheme);
     CFRelease(publicKey);
     CFRelease(privateKey);
 }

--- a/MSAL/test/unit/MSALAuthSchemeTests.m
+++ b/MSAL/test/unit/MSALAuthSchemeTests.m
@@ -48,6 +48,8 @@
 #import "MSIDKeychainTokenCache.h"
 #import "MSIDMacKeychainTokenCache.h"
 #import "MSALDevicePopManagerUtil.h"
+#import "MSALExternalKeyPair.h"
+#import "NSString+MSIDExtensions.h"
 
 @interface MSALAuthSchemeTests : XCTestCase
 
@@ -165,6 +167,43 @@
     XCTAssertTrue([signedAccessToken isEqualToString:msidAccessToken.accessToken]);
 }
 
+- (void)testExternalKeyPair_getSchemeParametersAndSignedToken_ShouldUseExternalKey
+{
+    SecKeyRef privateKey = [self createRSA2048PrivateKey];
+    SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+    NSError *error = nil;
+    MSALExternalKeyPair *externalKeyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:privateKey
+                                                                                 publicKey:publicKey
+                                                                                     error:&error];
+    XCTAssertNotNil(externalKeyPair);
+    XCTAssertNil(error);
+
+    NSURL *requestUrl = [NSURL URLWithString:@"https://signedhttprequest.azurewebsites.net/api/validateSHR"];
+    MSALAuthenticationSchemePop *authScheme = [[MSALAuthenticationSchemePop alloc] initWithHttpMethod:MSALHttpMethodPOST
+                                                                                           requestUrl:requestUrl
+                                                                                                nonce:@"external-key-nonce"
+                                                                                 additionalParameters:nil
+                                                                                      externalKeyPair:externalKeyPair];
+    MSIDDevicePopManager *defaultManager = [MSALDevicePopManagerUtil test_initWithValidCacheConfig];
+    NSDictionary *schemeParameters = [authScheme getSchemeParameters:defaultManager];
+    NSString *requestConfirmation = schemeParameters[MSID_OAUTH2_REQUEST_CONFIRMATION];
+    NSString *decodedConfirmation = [requestConfirmation msidBase64UrlDecode];
+    XCTAssertTrue([decodedConfirmation containsString:externalKeyPair.keyId]);
+
+    MSIDAccessTokenWithAuthScheme *accessToken = [self populatePopMSIDAccessToken];
+    NSString *signedAccessToken = [authScheme getClientAccessToken:accessToken popManager:defaultManager error:&error];
+    XCTAssertNotNil(signedAccessToken);
+    XCTAssertNil(error);
+
+    NSArray<NSString *> *segments = [signedAccessToken componentsSeparatedByString:@"."];
+    XCTAssertEqual(segments.count, 3);
+    NSString *decodedHeader = [segments[0] msidBase64UrlDecode];
+    XCTAssertTrue([decodedHeader containsString:externalKeyPair.keyId]);
+
+    CFRelease(publicKey);
+    CFRelease(privateKey);
+}
+
 - (MSALAuthenticationSchemePop *) generateAuthSchemePopInstance
 {
     MSALAuthenticationSchemePop *authScheme;
@@ -212,6 +251,19 @@
     token.resource = @"target";
     token.enrollmentId = @"enrollmentId";
     return token;
+}
+
+- (SecKeyRef)createRSA2048PrivateKey
+{
+    NSDictionary *attributes = @{
+        (id)kSecAttrKeyType : (id)kSecAttrKeyTypeRSA,
+        (id)kSecAttrKeySizeInBits : @2048
+    };
+    CFErrorRef error = NULL;
+    SecKeyRef privateKey = SecKeyCreateRandomKey((__bridge CFDictionaryRef)attributes, &error);
+    XCTAssertNotEqual(privateKey, NULL);
+    XCTAssertEqual(error, NULL);
+    return privateKey;
 }
 
 @end

--- a/MSAL/test/unit/MSALExternalKeyPairTests.m
+++ b/MSAL/test/unit/MSALExternalKeyPairTests.m
@@ -1,0 +1,121 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+//------------------------------------------------------------------------------
+
+#import <XCTest/XCTest.h>
+#import "MSALExternalKeyPair.h"
+#import "MSALError.h"
+
+@interface MSALExternalKeyPairTests : XCTestCase
+
+@end
+
+@implementation MSALExternalKeyPairTests
+
+- (void)testInitWithValidRSAKeyPair_ShouldReturnKeyPair
+{
+    SecKeyRef privateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeRSA size:@2048];
+    SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+    NSError *error = nil;
+    MSALExternalKeyPair *keyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:privateKey
+                                                                         publicKey:publicKey
+                                                                             error:&error];
+
+    XCTAssertNotNil(keyPair);
+    XCTAssertNotNil(keyPair.keyId);
+    XCTAssertNil(error);
+
+    CFRelease(publicKey);
+    CFRelease(privateKey);
+    XCTAssertNotNil(keyPair.keyId);
+}
+
+- (void)testInitWithEccKeyPair_ShouldReturnUnsupportedKeyType
+{
+    SecKeyRef privateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeECSECPrimeRandom size:@256];
+    SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+    NSError *error = nil;
+    MSALExternalKeyPair *keyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:privateKey
+                                                                         publicKey:publicKey
+                                                                             error:&error];
+
+    XCTAssertNil(keyPair);
+    XCTAssertEqual(error.code, MSALErrorInvalidExternalKeyPair);
+    XCTAssertEqual([error.userInfo[MSALExternalKeyPairFailureReasonKey] integerValue], MSALExternalKeyPairFailureReasonUnsupportedKeyType);
+
+    CFRelease(publicKey);
+    CFRelease(privateKey);
+}
+
+- (void)testInitWithSmallRSAKeyPair_ShouldReturnKeySizeTooSmall
+{
+    SecKeyRef privateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeRSA size:@1024];
+    SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+    NSError *error = nil;
+    MSALExternalKeyPair *keyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:privateKey
+                                                                         publicKey:publicKey
+                                                                             error:&error];
+
+    XCTAssertNil(keyPair);
+    XCTAssertEqual(error.code, MSALErrorInvalidExternalKeyPair);
+    XCTAssertEqual([error.userInfo[MSALExternalKeyPairFailureReasonKey] integerValue], MSALExternalKeyPairFailureReasonKeySizeTooSmall);
+
+    CFRelease(publicKey);
+    CFRelease(privateKey);
+}
+
+- (void)testInitWithMismatchedRSAKeyPair_ShouldReturnKeyPairMismatch
+{
+    SecKeyRef privateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeRSA size:@2048];
+    SecKeyRef otherPrivateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeRSA size:@2048];
+    SecKeyRef otherPublicKey = SecKeyCopyPublicKey(otherPrivateKey);
+    NSError *error = nil;
+    MSALExternalKeyPair *keyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:privateKey
+                                                                         publicKey:otherPublicKey
+                                                                             error:&error];
+
+    XCTAssertNil(keyPair);
+    XCTAssertEqual(error.code, MSALErrorInvalidExternalKeyPair);
+    XCTAssertEqual([error.userInfo[MSALExternalKeyPairFailureReasonKey] integerValue], MSALExternalKeyPairFailureReasonKeyPairMismatch);
+
+    CFRelease(otherPublicKey);
+    CFRelease(otherPrivateKey);
+    CFRelease(privateKey);
+}
+
+- (void)testInitWithPublicKeys_ShouldReturnInvalidKeyClass
+{
+    SecKeyRef privateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeRSA size:@2048];
+    SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+    NSError *error = nil;
+    MSALExternalKeyPair *keyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:publicKey
+                                                                         publicKey:publicKey
+                                                                             error:&error];
+
+    XCTAssertNil(keyPair);
+    XCTAssertEqual(error.code, MSALErrorInvalidExternalKeyPair);
+    XCTAssertEqual([error.userInfo[MSALExternalKeyPairFailureReasonKey] integerValue], MSALExternalKeyPairFailureReasonInvalidKeyClass);
+
+    CFRelease(publicKey);
+    CFRelease(privateKey);
+}
+
+- (SecKeyRef)createPrivateKeyWithType:(CFStringRef)keyType size:(NSNumber *)size
+{
+    NSDictionary *attributes = @{
+        (id)kSecAttrKeyType : (__bridge id)keyType,
+        (id)kSecAttrKeySizeInBits : size
+    };
+    CFErrorRef error = NULL;
+    SecKeyRef privateKey = SecKeyCreateRandomKey((__bridge CFDictionaryRef)attributes, &error);
+    XCTAssertNotEqual(privateKey, NULL);
+    XCTAssertEqual(error, NULL);
+    return privateKey;
+}
+
+@end

--- a/MSAL/test/unit/MSALExternalKeyPairTests.m
+++ b/MSAL/test/unit/MSALExternalKeyPairTests.m
@@ -5,6 +5,24 @@
 //
 // This code is licensed under the MIT License.
 //
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 //------------------------------------------------------------------------------
 
 #import <XCTest/XCTest.h>
@@ -151,6 +169,11 @@
     SecKeyRef privateKey = SecKeyCreateRandomKey((__bridge CFDictionaryRef)attributes, &error);
     XCTAssertNotEqual(privateKey, NULL);
     XCTAssertEqual(error, NULL);
+    if (error)
+    {
+        CFRelease(error);
+    }
+
     return privateKey;
 }
 

--- a/MSAL/test/unit/MSALExternalKeyPairTests.m
+++ b/MSAL/test/unit/MSALExternalKeyPairTests.m
@@ -17,6 +17,42 @@
 
 @implementation MSALExternalKeyPairTests
 
+- (void)testInitWithNilPrivateKey_ShouldReturnInvalidKeyHandle
+{
+    SecKeyRef privateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeRSA size:@2048];
+    SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+    SecKeyRef nilPrivateKey = NULL;
+    NSError *error = nil;
+
+    MSALExternalKeyPair *keyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:nilPrivateKey
+                                                                         publicKey:publicKey
+                                                                             error:&error];
+
+    XCTAssertNil(keyPair);
+    XCTAssertEqual(error.code, MSALErrorInvalidExternalKeyPair);
+    XCTAssertEqual([error.userInfo[MSALExternalKeyPairFailureReasonKey] integerValue], MSALExternalKeyPairFailureReasonInvalidKeyHandle);
+
+    CFRelease(publicKey);
+    CFRelease(privateKey);
+}
+
+- (void)testInitWithNilPublicKey_ShouldReturnInvalidKeyHandle
+{
+    SecKeyRef privateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeRSA size:@2048];
+    SecKeyRef nilPublicKey = NULL;
+    NSError *error = nil;
+
+    MSALExternalKeyPair *keyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:privateKey
+                                                                         publicKey:nilPublicKey
+                                                                             error:&error];
+
+    XCTAssertNil(keyPair);
+    XCTAssertEqual(error.code, MSALErrorInvalidExternalKeyPair);
+    XCTAssertEqual([error.userInfo[MSALExternalKeyPairFailureReasonKey] integerValue], MSALExternalKeyPairFailureReasonInvalidKeyHandle);
+
+    CFRelease(privateKey);
+}
+
 - (void)testInitWithValidRSAKeyPair_ShouldReturnKeyPair
 {
     SecKeyRef privateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeRSA size:@2048];

--- a/MSAL/test/unit/MSALExternalKeyPairTests.m
+++ b/MSAL/test/unit/MSALExternalKeyPairTests.m
@@ -123,15 +123,6 @@
     }
 }
 
-- (void)testFailureReason_whenMissing_shouldReturnUnknown
-{
-    NSError *error = [NSError errorWithDomain:MSALErrorDomain
-                                         code:MSALErrorInvalidExternalKeyPair
-                                     userInfo:nil];
-
-    XCTAssertEqual([error.userInfo[MSALExternalKeyPairFailureReasonKey] integerValue], MSALExternalKeyPairFailureReasonUnknown);
-}
-
 - (void)testInitWithEccKeyPair_ShouldReturnUnsupportedKeyType
 {
     SecKeyRef privateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeECSECPrimeRandom size:@256];

--- a/MSAL/test/unit/MSALExternalKeyPairTests.m
+++ b/MSAL/test/unit/MSALExternalKeyPairTests.m
@@ -27,7 +27,11 @@
 
 #import <XCTest/XCTest.h>
 #import "MSALExternalKeyPair.h"
+#import "MSALExternalKeyPair+Internal.h"
 #import "MSALError.h"
+#import "MSIDDevicePopManager.h"
+#import "MSIDAssymetricKeyPair.h"
+#import "NSData+MSIDExtensions.h"
 
 @interface MSALExternalKeyPairTests : XCTestCase
 
@@ -35,20 +39,26 @@
 
 @implementation MSALExternalKeyPairTests
 
+- (void)setUp
+{
+    [super setUp];
+    self.continueAfterFailure = NO;
+}
+
 - (void)testInitWithNilPrivateKey_ShouldReturnInvalidKeyHandle
 {
     SecKeyRef privateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeRSA size:@2048];
     SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
-    SecKeyRef nilPrivateKey = NULL;
     NSError *error = nil;
 
-    MSALExternalKeyPair *keyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:nilPrivateKey
+    MSALExternalKeyPair *keyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:NULL
                                                                          publicKey:publicKey
                                                                              error:&error];
 
     XCTAssertNil(keyPair);
     XCTAssertEqual(error.code, MSALErrorInvalidExternalKeyPair);
     XCTAssertEqual([error.userInfo[MSALExternalKeyPairFailureReasonKey] integerValue], MSALExternalKeyPairFailureReasonInvalidKeyHandle);
+    XCTAssertNotNil(error.userInfo[NSUnderlyingErrorKey]);
 
     CFRelease(publicKey);
     CFRelease(privateKey);
@@ -57,11 +67,10 @@
 - (void)testInitWithNilPublicKey_ShouldReturnInvalidKeyHandle
 {
     SecKeyRef privateKey = [self createPrivateKeyWithType:kSecAttrKeyTypeRSA size:@2048];
-    SecKeyRef nilPublicKey = NULL;
     NSError *error = nil;
 
     MSALExternalKeyPair *keyPair = [[MSALExternalKeyPair alloc] initWithPrivateKey:privateKey
-                                                                         publicKey:nilPublicKey
+                                                                         publicKey:NULL
                                                                              error:&error];
 
     XCTAssertNil(keyPair);
@@ -86,7 +95,41 @@
 
     CFRelease(publicKey);
     CFRelease(privateKey);
-    XCTAssertNotNil(keyPair.keyId);
+
+    MSIDDevicePopManager *manager = [[MSIDDevicePopManager alloc] initWithExternalKeyPair:keyPair.msidKeyPair];
+    NSString *signedToken = [manager createSignedAccessToken:@"access-token"
+                                                  httpMethod:@"POST"
+                                                  requestUrl:@"https://contoso.com/path"
+                                                       nonce:@"nonce"
+                                                       error:&error];
+    XCTAssertNotNil(signedToken);
+    XCTAssertNil(error);
+
+    NSArray<NSString *> *segments = [signedToken componentsSeparatedByString:@"."];
+    XCTAssertEqual(segments.count, 3);
+    NSData *signedData = [[NSString stringWithFormat:@"%@.%@", segments[0], segments[1]] dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *signature = [NSData msidDataFromBase64UrlEncodedString:segments[2]];
+    CFErrorRef verificationError = NULL;
+    BOOL signatureValid = SecKeyVerifySignature(keyPair.msidKeyPair.publicKeyRef,
+                                                kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256,
+                                                (__bridge CFDataRef)signedData,
+                                                (__bridge CFDataRef)signature,
+                                                &verificationError);
+    XCTAssertTrue(signatureValid);
+    XCTAssertEqual(verificationError, NULL);
+    if (verificationError)
+    {
+        CFRelease(verificationError);
+    }
+}
+
+- (void)testFailureReason_whenMissing_shouldReturnUnknown
+{
+    NSError *error = [NSError errorWithDomain:MSALErrorDomain
+                                         code:MSALErrorInvalidExternalKeyPair
+                                     userInfo:nil];
+
+    XCTAssertEqual([error.userInfo[MSALExternalKeyPairFailureReasonKey] integerValue], MSALExternalKeyPairFailureReasonUnknown);
 }
 
 - (void)testInitWithEccKeyPair_ShouldReturnUnsupportedKeyType


### PR DESCRIPTION
## Summary

Adds the public MSAL API for caller-provided RSA keys in Access Token Proof-of-Possession flows. MSAL validates and retains the caller-owned key pair, derives `req_cnf` from its public key, signs the SHR with its private key, and marks Broker requests for selective rollout control.

## Key changes

- Add public `MSALExternalKeyPair` with a read-only RFC 7638 `keyId`.
- Add an external-key initializer to `MSALAuthenticationSchemePop`.
- Use the same external key manager for both token binding and SHR signing.
- Add `external_key_pop=1` to scheme parameters for Broker classification.
- Add deterministic validation and cryptographic SHR signature tests.

## Dependency

- CommonCore: AzureAD/microsoft-authentication-library-common-for-objc#1934

## How to validate

- Run `MSALExternalKeyPairTests`.
- Run `MSALAuthSchemeTests`.
- Verify the external SHR signature with the supplied RSA public key.

## Notes

The caller owns key creation, storage, rotation, and deletion. MSAL does not expose or persist private key material.
