### PR TITLE
Harden SPM integration test to guard visionOS slices

### DIFF
--- a/azure_pipelines/pr-validation.yml
+++ b/azure_pipelines/pr-validation.yml
@@ -265,7 +265,9 @@ jobs:
         inputs:
           targetType: 'inline'
           script: |
-            sh spm-integration-test.sh "${BRANCH_NAME}"
+            # visionOS slices are validated in visionos-validation.yml (which installs
+            # the visionOS SDK). This fast PR job does not, so skip them here.
+            sh spm-integration-test.sh "${BRANCH_NAME}" --skip-visionos
         continueOnError: false
 
       - task: Bash@3

--- a/spm-integration-test.sh
+++ b/spm-integration-test.sh
@@ -1,5 +1,10 @@
 BRANCH_NAME="$1"
-INCLUDE_VISIONOS=false
+# visionOS device + simulator slices are included by default so the published
+# xcframework never ships out of sync with Package.swift's .visionOS() platform.
+# Use --skip-visionos on fast paths (e.g. regular PR validation) that do not have
+# the visionOS SDK installed. --include-visionos is kept as a no-op alias for
+# backward compatibility with existing callers.
+INCLUDE_VISIONOS=true
 SKIP_SAMPLE_APP=false
 
 # Parse optional flags
@@ -7,6 +12,9 @@ for arg in "$@"; do
   case $arg in
     --include-visionos)
       INCLUDE_VISIONOS=true
+      ;;
+    --skip-visionos)
+      INCLUDE_VISIONOS=false
       ;;
     --skip-sample-app)
       SKIP_SAMPLE_APP=true
@@ -35,10 +43,42 @@ if [ "$INCLUDE_VISIONOS" = true ]; then
   xcodebuild -sdk xros -configuration Release -workspace MSAL.xcworkspace -scheme "MSAL (iOS Framework)" archive SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES -archivePath archive/visionOS CODE_SIGNING_ALLOWED=NO -quiet > build.log 2>&1
   XCFRAMEWORK_ARGS="$XCFRAMEWORK_ARGS -framework archive/visionOSSimulator.xcarchive/Products/Library/Frameworks/MSAL.framework -framework archive/visionOS.xcarchive/Products/Library/Frameworks/MSAL.framework"
 else
-  echo "Skipping visionOS (use --include-visionos to include)"
+  echo "Skipping visionOS (use default, or pass --include-visionos, to include; --skip-visionos to opt out)"
 fi
 
 xcodebuild -create-xcframework $XCFRAMEWORK_ARGS -output framework/MSAL.xcframework > build.log 2>&1
+
+if [ "$INCLUDE_VISIONOS" = true ]; then
+  echo "Verifying visionOS slices are present in MSAL.xcframework"
+  python3 - <<'PY'
+import plistlib, sys
+
+plist_path = "framework/MSAL.xcframework/Info.plist"
+with open(plist_path, "rb") as f:
+    info = plistlib.load(f)
+
+libraries = info.get("AvailableLibraries", [])
+
+def has_slice(platform, simulator):
+    for lib in libraries:
+        is_sim = lib.get("SupportedPlatformVariant") == "simulator"
+        if lib.get("SupportedPlatform") == platform and is_sim == simulator:
+            return True
+    return False
+
+missing = []
+if not has_slice("xros", False):
+    missing.append("visionOS device (xros)")
+if not has_slice("xros", True):
+    missing.append("visionOS simulator (xros-simulator)")
+
+if missing:
+    sys.stderr.write("** ERROR: MSAL.xcframework is missing required slices: " + ", ".join(missing) + " **\n")
+    sys.exit(1)
+
+print("Verified visionOS device + simulator slices are present in MSAL.xcframework")
+PY
+fi
 
 echo "Creating MSAL.zip"
 zip -r MSAL.zip framework/MSAL.xcframework -y -v

--- a/spm-integration-test.sh
+++ b/spm-integration-test.sh
@@ -27,6 +27,11 @@ current_date=$(date +"%Y-%m-%d %H:%M:%S")
 
 set -e
 
+# xcodebuild steps below run with -quiet and redirect output to build.log, so a
+# failure would otherwise exit with no actionable context in the CI log. Dump
+# build.log on any error so the underlying xcodebuild error is visible.
+trap 'echo "** Build step failed. Contents of build.log: **"; cat build.log 2>/dev/null || echo "(build.log not found)"' ERR
+
 # Build framework
 
 echo "Building framework"
@@ -50,6 +55,10 @@ xcodebuild -create-xcframework $XCFRAMEWORK_ARGS -output framework/MSAL.xcframew
 
 if [ "$INCLUDE_VISIONOS" = true ]; then
   echo "Verifying visionOS slices are present in MSAL.xcframework"
+  if [ ! -f framework/MSAL.xcframework/Info.plist ]; then
+    echo "** ERROR: framework/MSAL.xcframework/Info.plist not found; xcframework creation likely failed. See build.log above. **"
+    exit 1
+  fi
   python3 - <<'PY'
 import plistlib, sys
 

--- a/spm-integration-test.sh
+++ b/spm-integration-test.sh
@@ -28,9 +28,19 @@ current_date=$(date +"%Y-%m-%d %H:%M:%S")
 set -e
 
 # xcodebuild steps below run with -quiet and redirect output to build.log, so a
-# failure would otherwise exit with no actionable context in the CI log. Dump
-# build.log on any error so the underlying xcodebuild error is visible.
-trap 'echo "** Build step failed. Contents of build.log: **"; cat build.log 2>/dev/null || echo "(build.log not found)"' ERR
+# failure would otherwise exit with no actionable context in the CI log. On a
+# non-zero exit, dump build.log so the underlying xcodebuild error is visible.
+# This script is invoked via `sh`, so use a POSIX-compatible EXIT trap that
+# checks the status rather than a bash-only ERR trap.
+on_exit()
+{
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        echo "** Build step failed (exit $status). Contents of build.log: **"
+        cat build.log 2>/dev/null || echo "(build.log not found)"
+    fi
+}
+trap on_exit EXIT
 
 # Build framework
 


### PR DESCRIPTION
## Summary

Regression guard for #2809. Makes the visionOS device + simulator slices default-on in the SPM integration test and verifies they are actually present in the built `MSAL.xcframework`, so the published binary can never again silently ship out of sync with `Package.swift`'s `.visionOS(.v1)` platform declaration.

This is a complement to the actual binary fix in the internal OneBranch release pipeline — it protects the GitHub-side CI so the mismatch that caused #2809 cannot regress unnoticed.

## Changes

- **`spm-integration-test.sh`**
  - Default `INCLUDE_VISIONOS=true` (previously `false`).
  - Add `--skip-visionos` opt-out for fast paths that don't install the visionOS SDK. `--include-visionos` is kept as a no-op alias for backward compatibility.
  - After building the xcframework, verify via `plistlib` that both `xros` (device) and `xros-simulator` slices are present in `MSAL.xcframework/Info.plist`, failing the build if either is missing.
- **`azure_pipelines/pr-validation.yml`**
  - Pass `--skip-visionos` on the fast PR job, which does not install the visionOS SDK. visionOS is validated separately in `visionos-validation.yml`.

## Context

`Package.swift` declares `.visionOS(.v1)`, but the released `MSAL.zip` xcframework shipped no visionOS slice, so SPM resolved and then failed at link time (`no library for this platform was found in MSAL.xcframework`). The binary is produced by the internal release pipeline, which is fixed separately; this PR ensures the repo's own CI would catch a missing-slice regression.

## Testing

- `ruby`/shell parse-checked.
- The `plistlib` verification runs only when visionOS is included (i.e., not on the `--skip-visionos` fast PR job).

Related: #2809, #2850