### PR TITLE
[patch] [tests]: Enable ResetPasswordV2 end-to-end tests

### DIFF
--- a/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordV2EndToEndTests.swift
+++ b/MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordV2EndToEndTests.swift
@@ -39,8 +39,6 @@ final class MSALNativeAuthResetPasswordV2EndToEndTests: MSALNativeAuthEndToEndBa
     // SSPR – happy path: start → code required → new password required → sign in → flow completed (tokens).
     @MainActor
     func test_resetPasswordV2_succeeds() async throws {
-        throw XCTSkip("SSPRV2 requires a test slice. Disable this test until api is in prod.")
-        
         guard let sut = initialisePublicClientApplication(customAuthorityURLFormat: .tenantSubdomainTenantId),
               let username = retrieveUsernameForResetPassword()
         else {
@@ -84,8 +82,6 @@ final class MSALNativeAuthResetPasswordV2EndToEndTests: MSALNativeAuthEndToEndBa
     // SSPR – submit an invalid code first, then recover with a valid code and complete the flow.
     @MainActor
     func test_resetPasswordV2_invalidCode_thenValidCode_succeeds() async throws {
-        throw XCTSkip("SSPRV2 requires a test slice. Disable this test until api is in prod.")
-        
         guard let sut = initialisePublicClientApplication(customAuthorityURLFormat: .tenantSubdomainTenantId),
               let username = retrieveUsernameForResetPassword()
         else {
@@ -145,8 +141,6 @@ final class MSALNativeAuthResetPasswordV2EndToEndTests: MSALNativeAuthEndToEndBa
     // SSPR – the new password being set doesn't meet the complexity requirements set on the portal.
     @MainActor
     func test_resetPasswordV2_passwordComplexity_error() async throws {
-        throw XCTSkip("SSPRV2 requires a test slice. Disable this test until api is in prod.")
-        
         guard let sut = initialisePublicClientApplication(customAuthorityURLFormat: .tenantSubdomainTenantId),
               let username = retrieveUsernameForResetPassword()
         else {
@@ -193,8 +187,6 @@ final class MSALNativeAuthResetPasswordV2EndToEndTests: MSALNativeAuthEndToEndBa
     // SSPR – resend email OTP.
     @MainActor
     func test_resetPasswordV2_resendCode_succeeds() async throws {
-        throw XCTSkip("SSPRV2 requires a test slice. Disable this test until api is in prod.")
-
         guard let sut = initialisePublicClientApplication(customAuthorityURLFormat: .tenantSubdomainTenantId),
               let username = retrieveUsernameForResetPassword()
         else {
@@ -258,8 +250,6 @@ final class MSALNativeAuthResetPasswordV2EndToEndTests: MSALNativeAuthEndToEndBa
     // SSPR – email is not found in records.
     @MainActor
     func test_resetPasswordV2_emailNotFound_error() async throws {
-        throw XCTSkip("SSPRV2 requires a test slice. Disable this test until api is in prod.")
-        
         guard let sut = initialisePublicClientApplication(customAuthorityURLFormat: .tenantSubdomainTenantId) else {
             XCTFail("Missing information")
             return


### PR DESCRIPTION
## Summary

- remove the obsolete test-slice skips from `MSALNativeAuthResetPasswordV2EndToEndTests`
- enable all five ResetPasswordV2 end-to-end scenarios against the production API

## Validation

- `xcrun swiftc -parse MSAL/test/integration/native_auth/end_to_end/reset_password/MSALNativeAuthResetPasswordV2EndToEndTests.swift`
- `git diff --check`
- end-to-end execution requires CI-provisioned test configuration