### PR TITLE
[patch] [bugfix]: Send claims in Native Auth V2 sign-in

### DIFF
--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowContinuationState.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowContinuationState.swift
@@ -46,6 +46,8 @@ struct MSALNativeAuthFlowContinuationState {
     /// Scopes (caller-requested merged with the default OIDC scopes) to request on the final
     /// `/token` exchange. Threaded through every step.
     let scopes: [String]
+    /// Claims request JSON to include in the final `/token` exchange.
+    let claimsRequestJson: String?
     /// Values supplied by the app at sign-up start (keyed by attribute id, e.g. "email"/"password")
     /// that the SDK submits automatically when the server issues a `collectAttributes` request for
     /// them. Deliberately kept internal so the app never sees them again; must never be logged or
@@ -66,6 +68,7 @@ struct MSALNativeAuthFlowContinuationState {
         codeLength: Int? = nil,
         authMethods: [MSALAuthMethod] = [],
         scopes: [String] = [],
+        claimsRequestJson: String? = nil,
         signUpAutofillValues: [String: Any]? = nil,
         signUpAutofillSubmittedIds: Set<String> = []
     ) {
@@ -77,6 +80,7 @@ struct MSALNativeAuthFlowContinuationState {
         self.codeLength = codeLength
         self.authMethods = authMethods
         self.scopes = scopes
+        self.claimsRequestJson = claimsRequestJson
         self.signUpAutofillValues = signUpAutofillValues
         self.signUpAutofillSubmittedIds = signUpAutofillSubmittedIds
     }

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -126,6 +126,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         : .telemetryApiIdV2SignInWithCodeStart
         let event = makeAndStartTelemetryEvent(id: apiId, context: context)
         let scopes = joinScopes(parameters.scopes)
+        let claimsRequestJson = parameters.claimsRequest?.jsonString()
 
         // Authorization challenge (expects 401 + continuation token + sign_in link).
         let authorizationChallenge = await performAuthorizeChallengeStart(flowScenario: flowScenario, apiId: apiId, context: context)
@@ -184,6 +185,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 flowScenario: flowScenario,
                 username: parameters.username,
                 scopes: scopes,
+                claimsRequestJson: claimsRequestJson,
                 apiId: apiId,
                 event: event,
                 context: context
@@ -203,6 +205,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 flowScenario: flowScenario,
                 username: parameters.username,
                 scopes: scopes,
+                claimsRequestJson: claimsRequestJson,
                 apiId: apiId,
                 event: event,
                 context: context
@@ -214,6 +217,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             flowScenario: flowScenario,
             username: parameters.username,
             scopes: scopes,
+            claimsRequestJson: claimsRequestJson,
             apiId: apiId,
             event: event,
             context: context,
@@ -308,6 +312,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 flowScenario: continuation.flowScenario,
                 username: continuation.username,
                 scopes: continuation.scopes,
+                claimsRequestJson: continuation.claimsRequestJson,
                 apiId: apiId,
                 event: event,
                 context: context,
@@ -331,6 +336,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 flowScenario: continuation.flowScenario,
                 username: continuation.username,
                 scopes: continuation.scopes,
+                claimsRequestJson: continuation.claimsRequestJson,
                 apiId: .telemetryApiIdV2ResetPasswordSubmitCode,
                 event: event,
                 context: context,
@@ -373,6 +379,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             flowScenario: continuation.flowScenario,
             username: continuation.username,
             scopes: continuation.scopes,
+            claimsRequestJson: continuation.claimsRequestJson,
             apiId: .telemetryApiIdV2SignInSubmitPassword,
             event: event,
             context: context,
@@ -458,6 +465,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             continuationToken: completionToken,
             username: continuation.username,
             scopes: continuation.scopes,
+            claimsRequestJson: continuation.claimsRequestJson,
             apiId: .telemetryApiIdV2ResetPasswordSubmit,
             event: event,
             context: context
@@ -491,6 +499,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             flowScenario: continuation.flowScenario,
             username: continuation.username,
             scopes: continuation.scopes,
+            claimsRequestJson: continuation.claimsRequestJson,
             apiId: .telemetryApiIdV2SignUpSubmitAttributes,
             event: event,
             context: context,
@@ -539,6 +548,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 flowScenario: continuation.flowScenario,
                 username: continuation.username,
                 scopes: continuation.scopes,
+                claimsRequestJson: continuation.claimsRequestJson,
                 apiId: .telemetryApiIdV2JITChallenge,
                 event: event,
                 context: context
@@ -572,6 +582,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 flowScenario: continuation.flowScenario,
                 username: continuation.username,
                 scopes: continuation.scopes,
+                claimsRequestJson: continuation.claimsRequestJson,
                 apiId: .telemetryApiIdV2MFAGetAuthMethods,
                 event: event,
                 context: context,
@@ -628,6 +639,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             flowScenario: continuation.flowScenario,
             username: continuation.username,
             scopes: continuation.scopes,
+            claimsRequestJson: continuation.claimsRequestJson,
             apiId: .telemetryApiIdV2MFASubmitChallenge,
             event: event,
             context: context,
@@ -662,6 +674,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             flowScenario: continuation.flowScenario,
             username: continuation.username,
             scopes: continuation.scopes,
+            claimsRequestJson: continuation.claimsRequestJson,
             apiId: .telemetryApiIdV2ResetPasswordResendCode,
             event: event,
             context: context,
@@ -726,6 +739,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         flowScenario: MSALNativeAuthFlowScenario,
         username: String?,
         scopes: [String],
+        claimsRequestJson: String? = nil,
         apiId: MSALNativeAuthTelemetryApiId,
         event: MSIDTelemetryAPIEvent?,
         context: MSALNativeAuthRequestContext,
@@ -742,6 +756,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 continuationToken: token,
                 username: username,
                 scopes: scopes,
+                claimsRequestJson: claimsRequestJson,
                 apiId: apiId,
                 event: event,
                 context: context
@@ -755,6 +770,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 sentToHint: sentTo.isEmpty ? fallbackHint : sentTo,
                 codeLength: codeLength,
                 scopes: scopes,
+                claimsRequestJson: claimsRequestJson,
                 signUpAutofillValues: signUpAutofillValues,
                 signUpAutofillSubmittedIds: signUpAutofillSubmittedIds
             )
@@ -771,6 +787,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 links: [.verify: verifyHref],
                 username: username,
                 scopes: scopes,
+                claimsRequestJson: claimsRequestJson,
                 signUpAutofillValues: signUpAutofillValues,
                 signUpAutofillSubmittedIds: signUpAutofillSubmittedIds
             )
@@ -785,6 +802,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 links: [.update: updateHref],
                 username: username,
                 scopes: scopes,
+                claimsRequestJson: claimsRequestJson,
                 signUpAutofillValues: signUpAutofillValues,
                 signUpAutofillSubmittedIds: signUpAutofillSubmittedIds
             )
@@ -819,6 +837,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                     links: [.submitAttributes: submitHref],
                     username: username,
                     scopes: scopes,
+                    claimsRequestJson: claimsRequestJson,
                     signUpAutofillValues: signUpAutofillValues,
                     signUpAutofillSubmittedIds: signUpAutofillSubmittedIds.union(autoIds)
                 )
@@ -831,6 +850,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 links: [.submitAttributes: submitHref],
                 username: username,
                 scopes: scopes,
+                claimsRequestJson: claimsRequestJson,
                 signUpAutofillValues: signUpAutofillValues,
                 signUpAutofillSubmittedIds: signUpAutofillSubmittedIds
             )
@@ -850,6 +870,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 authMethods: authMethods,
                 methodLinks: methodLinks,
                 scopes: scopes,
+                claimsRequestJson: claimsRequestJson,
                 signUpAutofillValues: signUpAutofillValues,
                 signUpAutofillSubmittedIds: signUpAutofillSubmittedIds
             )
@@ -867,6 +888,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 authMethods: authMethods,
                 methodLinks: methodLinks,
                 scopes: scopes,
+                claimsRequestJson: claimsRequestJson,
                 signUpAutofillValues: signUpAutofillValues,
                 signUpAutofillSubmittedIds: signUpAutofillSubmittedIds
             )
@@ -883,6 +905,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 sentToHint: sentTo.isEmpty ? fallbackHint : sentTo,
                 codeLength: codeLength,
                 scopes: scopes,
+                claimsRequestJson: claimsRequestJson,
                 signUpAutofillValues: signUpAutofillValues,
                 signUpAutofillSubmittedIds: signUpAutofillSubmittedIds
             )
@@ -917,6 +940,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         continuationToken: String,
         username: String?,
         scopes: [String],
+        claimsRequestJson: String?,
         apiId: MSALNativeAuthTelemetryApiId,
         event: MSIDTelemetryAPIEvent?,
         context: MSALNativeAuthRequestContext
@@ -931,7 +955,13 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             return failure(codeResult, event: event, context: context, scenario: flowScenario)
         }
 
-        let tokenResponseResult = await performTokenExchange(code: code, scopes: scopes, apiId: apiId, context: context)
+        let tokenResponseResult = await performTokenExchange(
+            code: code,
+            scopes: scopes,
+            claimsRequestJson: claimsRequestJson,
+            apiId: apiId,
+            context: context
+        )
         switch tokenResponseResult {
         case .success(let tokenResponse):
             do {
@@ -962,12 +992,19 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
     private func performTokenExchange(
         code: String,
         scopes: [String],
+        claimsRequestJson: String?,
         apiId: MSALNativeAuthTelemetryApiId,
         context: MSALNativeAuthRequestContext
     ) async -> Result<MSIDTokenResponse, Error> {
         let request: MSIDHttpRequest
         do {
-            request = try requestProvider.token(code: code, scopes: scopes, apiId: apiId, context: context)
+            request = try requestProvider.token(
+                code: code,
+                scopes: scopes,
+                claimsRequestJson: claimsRequestJson,
+                apiId: apiId,
+                context: context
+            )
         } catch {
             return .failure(error)
         }
@@ -1025,6 +1062,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         authMethods: [MSALAuthMethod] = [],
         methodLinks: [String: String] = [:],
         scopes: [String] = [],
+        claimsRequestJson: String? = nil,
         signUpAutofillValues: [String: Any]? = nil,
         signUpAutofillSubmittedIds: Set<String> = []
     ) -> MSALNativeAuthFlowInternalState {
@@ -1049,6 +1087,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             codeLength: codeLength,
             authMethods: authMethods,
             scopes: scopes,
+            claimsRequestJson: claimsRequestJson,
             signUpAutofillValues: signUpAutofillValues,
             signUpAutofillSubmittedIds: signUpAutofillSubmittedIds
         )

--- a/MSAL/src/native_auth/network/v2/MSALNativeAuthV2RequestProvider.swift
+++ b/MSAL/src/native_auth/network/v2/MSALNativeAuthV2RequestProvider.swift
@@ -129,6 +129,26 @@ protocol MSALNativeAuthV2RequestProviding {
                apiId: MSALNativeAuthTelemetryApiId,
                context: MSALNativeAuthRequestContext
     ) throws -> MSIDHttpRequest
+
+    /// Token exchange with an optional claims request.
+    func token(code: String,
+               scopes: [String],
+               claimsRequestJson: String?,
+               apiId: MSALNativeAuthTelemetryApiId,
+               context: MSALNativeAuthRequestContext
+    ) throws -> MSIDHttpRequest
+}
+
+extension MSALNativeAuthV2RequestProviding {
+
+    func token(code: String,
+               scopes: [String],
+               claimsRequestJson: String?,
+               apiId: MSALNativeAuthTelemetryApiId,
+               context: MSALNativeAuthRequestContext
+    ) throws -> MSIDHttpRequest {
+        return try token(code: code, scopes: scopes, apiId: apiId, context: context)
+    }
 }
 
 final class MSALNativeAuthV2RequestProvider: MSALNativeAuthV2RequestProviding {
@@ -341,11 +361,27 @@ final class MSALNativeAuthV2RequestProvider: MSALNativeAuthV2RequestProviding {
                apiId: MSALNativeAuthTelemetryApiId,
                context: MSALNativeAuthRequestContext
     ) throws -> MSIDHttpRequest {
+        return try token(
+            code: code,
+            scopes: scopes,
+            claimsRequestJson: nil,
+            apiId: apiId,
+            context: context
+        )
+    }
+
+    func token(code: String,
+               scopes: [String],
+               claimsRequestJson: String?,
+               apiId: MSALNativeAuthTelemetryApiId,
+               context: MSALNativeAuthRequestContext
+    ) throws -> MSIDHttpRequest {
         return try configurator.configure(parameters: MSALNativeAuthV2TokenParameters(
             context: context,
             clientId: config.clientId,
             code: code,
             scopes: scopes,
+            claimsRequestJson: claimsRequestJson,
             apiId: apiId
         ))
     }

--- a/MSAL/src/native_auth/network/v2/parameters/MSALNativeAuthV2TokenParameters.swift
+++ b/MSAL/src/native_auth/network/v2/parameters/MSALNativeAuthV2TokenParameters.swift
@@ -30,10 +30,27 @@ struct MSALNativeAuthV2TokenParameters: MSALNativeAuthV2Requestable {
     let clientId: String
     let code: String
     let scopes: [String]
+    let claimsRequestJson: String?
     let apiId: MSALNativeAuthTelemetryApiId
     let encoding: MSALNativeAuthUrlRequestEncoding = .wwwFormUrlEncoded
     let operationType: MSALNativeAuthOperationType = MSALNativeAuthV2OperationType.token.rawValue
     let expectsRawJSONResponse = true
+
+    init(
+        context: MSALNativeAuthRequestContext,
+        clientId: String,
+        code: String,
+        scopes: [String],
+        claimsRequestJson: String? = nil,
+        apiId: MSALNativeAuthTelemetryApiId
+    ) {
+        self.context = context
+        self.clientId = clientId
+        self.code = code
+        self.scopes = scopes
+        self.claimsRequestJson = claimsRequestJson
+        self.apiId = apiId
+    }
 
     var body: [AnyHashable: Any] {
         var form: [AnyHashable: Any] = [
@@ -44,6 +61,9 @@ struct MSALNativeAuthV2TokenParameters: MSALNativeAuthV2Requestable {
         ]
         if !scopes.isEmpty {
             form[MSALNativeAuthRequestParametersKey.scope.rawValue] = scopes.joined(separator: " ")
+        }
+        if let claimsRequestJson = claimsRequestJson {
+            form[MSALNativeAuthRequestParametersKey.claims.rawValue] = claimsRequestJson
         }
         return form
     }


### PR DESCRIPTION
## Summary

Propagate `MSALNativeAuthSignInParameters.claimsRequest` through Native Auth V2 sign-in continuation states and include it as the `claims` form field in the final `/token` request.

The propagation covers immediate completion and resumed OTP, password, MFA, JIT registration, and resend paths while preserving compatibility for existing request-provider conformers.

## How to validate

- Start a V2 Native Auth sign-in with a claims request.
- Complete the applicable sign-in challenge.
- Verify the final `/token` request contains the serialized `claims` field.
- Verify sign-in without a claims request omits the field.

## Notes

Builds and tests were not run per request.