### PR TITLE
Native Auth V2 (server-driven): sign-up flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #TBD
+* Add Native Auth V2 email OTP + email password sign-up #3093
 * Add Native Auth V2 email OTP sign-in #3085
 * Add SignIn v2 #3079
 

--- a/MSAL/MSAL.xcodeproj/project.pbxproj
+++ b/MSAL/MSAL.xcodeproj/project.pbxproj
@@ -101,6 +101,8 @@
 		12E2160B2D11D3920000F44C /* AuthorityURLFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E2160A2D11D3920000F44C /* AuthorityURLFormat.swift */; };
 		12E2160C2D11D3920000F44C /* AuthorityURLFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E2160A2D11D3920000F44C /* AuthorityURLFormat.swift */; };
 		143FA5DBABB342C09531D190 /* MSALNativeAuthFlowControllerSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 915ADC93F4A3F1D7DA35F8AC /* MSALNativeAuthFlowControllerSignInTests.swift */; };
+		FE0A0B00000000000000A014 /* MSALNativeAuthFlowControllerSignUpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F014 /* MSALNativeAuthFlowControllerSignUpTests.swift */; };
+		FE0A0B00000000000000B014 /* MSALNativeAuthFlowControllerSignUpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F014 /* MSALNativeAuthFlowControllerSignUpTests.swift */; };
 		189077057FE38C5C260A2E04 /* MSALNativeAuthV2RequestProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BC76AE7D25569C4CF9C167 /* MSALNativeAuthV2RequestProvider.swift */; };
 		192F74D7E3825C5CDCF50CEB /* MSALNativeAuthV2HrefURLResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CF356DB03BC6B9F96B91E9 /* MSALNativeAuthV2HrefURLResolverTests.swift */; };
 		1D2AE62369F492086D3C3924 /* MSALNativeAuthRetryExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AAD919E560052DA700D2DA /* MSALNativeAuthRetryExecutor.swift */; };
@@ -430,6 +432,8 @@
 		3F2E65884A64B912E42B512D /* MSALNativeAuthV2RequestTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF017CDD211895E02588AA7E /* MSALNativeAuthV2RequestTarget.swift */; };
 		4076304A09CC32719F50ED6A /* MSALNativeAuthHALReadyToCompleteResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEC43FA4B89AAF40D902A54 /* MSALNativeAuthHALReadyToCompleteResponse.swift */; };
 		419729F367DAFCB911C52995 /* MSALNativeAuthHALUpdateResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EBAE8F887C06123BECF7F20 /* MSALNativeAuthHALUpdateResponse.swift */; };
+		FE0A0B00000000000000A012 /* MSALNativeAuthHALCollectAttributesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F012 /* MSALNativeAuthHALCollectAttributesResponse.swift */; };
+		FE0A0B00000000000000B012 /* MSALNativeAuthHALCollectAttributesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F012 /* MSALNativeAuthHALCollectAttributesResponse.swift */; };
 		42E1FE910A9592561A2F44DC /* MSALNativeAuthStrongAuthVerificationRequiredState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEA06244B0DACD04D94193D /* MSALNativeAuthStrongAuthVerificationRequiredState.swift */; };
 		4650C74D5FAF055CFBBD879E /* MSALNativeAuthV2TokenParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB6C9AE5AF1A99BF232126 /* MSALNativeAuthV2TokenParameters.swift */; };
 		47831ABA3193D0AB4A633F6C /* MSALNativeAuthV2SubmitPasswordRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2A98EEFC339DB826603D0 /* MSALNativeAuthV2SubmitPasswordRequestBody.swift */; };
@@ -1090,6 +1094,8 @@
 		C5CCEC94B70DFFBB39C94BBF /* MSALNativeAuthFlowContinuationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A05A2777A8FD6E91679121 /* MSALNativeAuthFlowContinuationState.swift */; };
 		C855BF96722554744C1E035E /* MSALNativeAuthV2EntryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279AB45E50C40865E60DCD30 /* MSALNativeAuthV2EntryParameters.swift */; };
 		C8C7202B3FCA487AA2E68705 /* MSALNativeAuthV2VerifyRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = D862978DEC304DD299125F27 /* MSALNativeAuthV2VerifyRequestBody.swift */; };
+		FE0A0B00000000000000A011 /* MSALNativeAuthV2SubmitAttributesRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F011 /* MSALNativeAuthV2SubmitAttributesRequestBody.swift */; };
+		FE0A0B00000000000000B011 /* MSALNativeAuthV2SubmitAttributesRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F011 /* MSALNativeAuthV2SubmitAttributesRequestBody.swift */; };
 		CADE2AB39CE543C3F26FD20E /* MSALNativeAuthHALResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963C975607D3D8411DB7C13B /* MSALNativeAuthHALResponse.swift */; };
 		CBD42DC826C8BC3C01077889 /* MSALNativeAuthFlowResponseDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFD2116FBA7674AD0CE9E36 /* MSALNativeAuthFlowResponseDispatcher.swift */; };
 		CD40769A3ADA4D4A887055D3 /* MSALNativeAuthV2ChallengeRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02F30CED3374A7C81A93A4F /* MSALNativeAuthV2ChallengeRequestBody.swift */; };
@@ -1830,6 +1836,8 @@
 		FADE0000000000000000AA02 /* HALResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADE0000000000000000AA01 /* HALResource.swift */; };
 		FADE0000000000000000AA03 /* HALResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADE0000000000000000AA01 /* HALResource.swift */; };
 		FE0A0B00000000000000A001 /* MSALNativeAuthSignInAfterResetPasswordState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F001 /* MSALNativeAuthSignInAfterResetPasswordState.swift */; };
+		FE0A0B00000000000000A013 /* MSALNativeAuthSignInAfterSignUpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F013 /* MSALNativeAuthSignInAfterSignUpState.swift */; };
+		FE0A0B00000000000000B013 /* MSALNativeAuthSignInAfterSignUpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F013 /* MSALNativeAuthSignInAfterSignUpState.swift */; };
 		FE0A0B00000000000000A002 /* MSALNativeAuthSignUpParametersV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F002 /* MSALNativeAuthSignUpParametersV2.swift */; };
 		FE0A0B00000000000000B001 /* MSALNativeAuthSignInAfterResetPasswordState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F001 /* MSALNativeAuthSignInAfterResetPasswordState.swift */; };
 		FE0A0B00000000000000B002 /* MSALNativeAuthSignUpParametersV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0A0B00000000000000F002 /* MSALNativeAuthSignUpParametersV2.swift */; };
@@ -2393,6 +2401,7 @@
 		475F1413DA1D76D5EF31F4EC /* MailTMHTTPClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MailTMHTTPClient.swift; sourceTree = "<group>"; };
 		49AAD919E560052DA700D2DA /* MSALNativeAuthRetryExecutor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthRetryExecutor.swift; sourceTree = "<group>"; };
 		4EBAE8F887C06123BECF7F20 /* MSALNativeAuthHALUpdateResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthHALUpdateResponse.swift; sourceTree = "<group>"; };
+		FE0A0B00000000000000F012 /* MSALNativeAuthHALCollectAttributesResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthHALCollectAttributesResponse.swift; sourceTree = "<group>"; };
 		4F81BEE5A1780C77F88EFC54 /* MSALNativeAuthV2RequestProviderMock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthV2RequestProviderMock.swift; sourceTree = "<group>"; };
 		509588E9A2AE1A919D2AF029 /* MSALNativeAuthStrongAuthRegistrationRequiredState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthStrongAuthRegistrationRequiredState.swift; sourceTree = "<group>"; };
 		547DFB0174DCC5EAB169C72A /* MSALNativeAuthFlowControllerResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthFlowControllerResponse.swift; sourceTree = "<group>"; };
@@ -2438,6 +2447,7 @@
 		8FB0FFEFC459978DDDDE9212 /* MSALNativeAuthCodeRequiredState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthCodeRequiredState.swift; sourceTree = "<group>"; };
 		8FE5D3DE054DBA691A401E3D /* MSALNativeAuthMFARequiredState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthMFARequiredState.swift; sourceTree = "<group>"; };
 		915ADC93F4A3F1D7DA35F8AC /* MSALNativeAuthFlowControllerSignInTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthFlowControllerSignInTests.swift; sourceTree = "<group>"; };
+		FE0A0B00000000000000F014 /* MSALNativeAuthFlowControllerSignUpTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthFlowControllerSignUpTests.swift; sourceTree = "<group>"; };
 		91AA24522BDF6439005037EA /* MSAL Test App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MSAL Test App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		91AA24582BDF643A005037EA /* MSAL_Test_App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSAL_Test_App.swift; sourceTree = "<group>"; };
 		91AA245A2BDF643A005037EA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -2803,6 +2813,7 @@
 		D6A2063B1FC510FB00755A51 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		D6B58A531EB2C4A8000B3A5F /* MSALAcquireTokenTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSALAcquireTokenTests.m; sourceTree = "<group>"; };
 		D862978DEC304DD299125F27 /* MSALNativeAuthV2VerifyRequestBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthV2VerifyRequestBody.swift; sourceTree = "<group>"; };
+		FE0A0B00000000000000F011 /* MSALNativeAuthV2SubmitAttributesRequestBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthV2SubmitAttributesRequestBody.swift; sourceTree = "<group>"; };
 		DA3D00FD456DC3F9BF81C82E /* MSALNativeAuthResetPasswordV2EndToEndTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthResetPasswordV2EndToEndTests.swift; sourceTree = "<group>"; };
 		DB4ABFF4EA9741E8B24C0066 /* MSALNativeAuthEmailOTPUserPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthEmailOTPUserPool.swift; sourceTree = "<group>"; };
 		DE0347A72A41AD08003CB3B6 /* MSALNativeAuthUserAccountResultStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthUserAccountResultStub.swift; sourceTree = "<group>"; };
@@ -3103,6 +3114,7 @@
 		FADE0000000000000000AA01 /* HALResource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HALResource.swift; sourceTree = "<group>"; };
 		FAEA06244B0DACD04D94193D /* MSALNativeAuthStrongAuthVerificationRequiredState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthStrongAuthVerificationRequiredState.swift; sourceTree = "<group>"; };
 		FE0A0B00000000000000F001 /* MSALNativeAuthSignInAfterResetPasswordState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInAfterResetPasswordState.swift; sourceTree = "<group>"; };
+		FE0A0B00000000000000F013 /* MSALNativeAuthSignInAfterSignUpState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignInAfterSignUpState.swift; sourceTree = "<group>"; };
 		FE0A0B00000000000000F002 /* MSALNativeAuthSignUpParametersV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthSignUpParametersV2.swift; sourceTree = "<group>"; };
 		FF41A7FB39DDF09BF8D97B35 /* MSALNativeAuthState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MSALNativeAuthState.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -3305,6 +3317,7 @@
 				A02F30CED3374A7C81A93A4F /* MSALNativeAuthV2ChallengeRequestBody.swift */,
 				729C79DAE4CA439EA155E210 /* MSALNativeAuthV2PollRequestBody.swift */,
 				D862978DEC304DD299125F27 /* MSALNativeAuthV2VerifyRequestBody.swift */,
+				FE0A0B00000000000000F011 /* MSALNativeAuthV2SubmitAttributesRequestBody.swift */,
 				1DC8B004B3BB485B8FA4CB5D /* MSALNativeAuthV2UpdatePasswordRequestBody.swift */,
 				F18852980FF1EB62CED58B88 /* MSALNativeAuthV2HrefURLResolver.swift */,
 				B0BC76AE7D25569C4CF9C167 /* MSALNativeAuthV2RequestProvider.swift */,
@@ -3743,6 +3756,7 @@
 				0D992A9000DC4DCE7068F4E9 /* MSALNativeAuthHALAuthorizationCodeResponse.swift */,
 				078016E3214C182662DA4C46 /* MSALNativeAuthHALPollResponse.swift */,
 				4EBAE8F887C06123BECF7F20 /* MSALNativeAuthHALUpdateResponse.swift */,
+				FE0A0B00000000000000F012 /* MSALNativeAuthHALCollectAttributesResponse.swift */,
 				F3F98BF51358D728874C29F1 /* MSALNativeAuthHALCodeSentResponse.swift */,
 				EFF0849BF9C6E8094353D212 /* MSALNativeAuthHALChallengeResponse.swift */,
 				6B0FB1D8F96E014C18B59C51 /* MSALNativeAuthV2HALAction.swift */,
@@ -3790,6 +3804,7 @@
 				B4EA08303731BCACB308104F /* MSALNativeAuthPasswordRequiredState.swift */,
 				8273A2EAA82AE303691B976F /* MSALNativeAuthNewPasswordRequiredState.swift */,
 				FE0A0B00000000000000F001 /* MSALNativeAuthSignInAfterResetPasswordState.swift */,
+				FE0A0B00000000000000F013 /* MSALNativeAuthSignInAfterSignUpState.swift */,
 				A315CA10DE2299B7370E11BE /* MSALNativeAuthAttributesRequiredState.swift */,
 				BFEF89FFAE159B6EE80EDFC7 /* MSALNativeAuthAttributesInvalidState.swift */,
 				8FE5D3DE054DBA691A401E3D /* MSALNativeAuthMFARequiredState.swift */,
@@ -5687,6 +5702,7 @@
 				76FDC0929F7E8268E1076A6F /* MSALNativeAuthFlowControllerTests.swift */,
 				0EA741A0AB71BF04C23FD120 /* MSALNativeAuthFlowResponseDispatcherTests.swift */,
 				915ADC93F4A3F1D7DA35F8AC /* MSALNativeAuthFlowControllerSignInTests.swift */,
+				FE0A0B00000000000000F014 /* MSALNativeAuthFlowControllerSignUpTests.swift */,
 			);
 			path = v2;
 			sourceTree = "<group>";
@@ -7588,6 +7604,7 @@
 				DE43150D2D3E551F009A7FA2 /* MSALNativeAuthSignInAfterSignUpParameters.swift in Sources */,
 				DE43150E2D3E551F009A7FA2 /* MSALNativeAuthResetPasswordParameters.swift in Sources */,
 				FE0A0B00000000000000A001 /* MSALNativeAuthSignInAfterResetPasswordState.swift in Sources */,
+				FE0A0B00000000000000A013 /* MSALNativeAuthSignInAfterSignUpState.swift in Sources */,
 				DE43150F2D3E551F009A7FA2 /* MSALNativeAuthSignInAfterResetPasswordParameters .swift in Sources */,
 				232D68D8223DB8C200594BBD /* MSALSilentTokenParameters.m in Sources */,
 				DE729ECD2A1793A100A761D9 /* MSALNativeAuthChannelType.swift in Sources */,
@@ -7607,6 +7624,7 @@
 				DF813C5ACBE0DC7BC2410819 /* MSALNativeAuthHALAuthorizationCodeResponse.swift in Sources */,
 				10B85348A2C10AC18982316D /* MSALNativeAuthHALPollResponse.swift in Sources */,
 				419729F367DAFCB911C52995 /* MSALNativeAuthHALUpdateResponse.swift in Sources */,
+				FE0A0B00000000000000A012 /* MSALNativeAuthHALCollectAttributesResponse.swift in Sources */,
 				268A97A2DFD4033E912F07E5 /* MSALNativeAuthHALCodeSentResponse.swift in Sources */,
 				A07004AB82351768F5BE2B15 /* MSALNativeAuthHALChallengeResponse.swift in Sources */,
 				4B40B01DE4265B175930AC63 /* MSALNativeAuthV2HALAction.swift in Sources */,
@@ -7621,6 +7639,7 @@
 				CD40769A3ADA4D4A887055D3 /* MSALNativeAuthV2ChallengeRequestBody.swift in Sources */,
 				97E553EE2AA241AE902BC091 /* MSALNativeAuthV2PollRequestBody.swift in Sources */,
 				EF61121B295842DC8C240C1E /* MSALNativeAuthV2VerifyRequestBody.swift in Sources */,
+				FE0A0B00000000000000A011 /* MSALNativeAuthV2SubmitAttributesRequestBody.swift in Sources */,
 				92C040B9010549CB8F7149FF /* MSALNativeAuthV2UpdatePasswordRequestBody.swift in Sources */,
 				564AB0A43B9671347F1E83A1 /* MSALNativeAuthV2HrefURLResolver.swift in Sources */,
 				189077057FE38C5C260A2E04 /* MSALNativeAuthV2RequestProvider.swift in Sources */,
@@ -7921,6 +7940,7 @@
 				DE4315132D3E551F009A7FA2 /* MSALNativeAuthSignInAfterSignUpParameters.swift in Sources */,
 				DE4315142D3E551F009A7FA2 /* MSALNativeAuthResetPasswordParameters.swift in Sources */,
 				FE0A0B00000000000000B001 /* MSALNativeAuthSignInAfterResetPasswordState.swift in Sources */,
+				FE0A0B00000000000000B013 /* MSALNativeAuthSignInAfterSignUpState.swift in Sources */,
 				DE4315152D3E551F009A7FA2 /* MSALNativeAuthSignInAfterResetPasswordParameters .swift in Sources */,
 				DE8DC4852C6621A300534E8F /* SignInAfterPreviousFlowBaseState+Internal.swift in Sources */,
 				DE8DC49E2C6621AE00534E8F /* MSALNativeAuthResetPasswordRequestProvider.swift in Sources */,
@@ -7951,6 +7971,7 @@
 				64F5C9EE20EBA08795D0DB56 /* MSALNativeAuthHALAuthorizationCodeResponse.swift in Sources */,
 				8152D13781903C8D0872832B /* MSALNativeAuthHALPollResponse.swift in Sources */,
 				6E254989A399FF946702D1AF /* MSALNativeAuthHALUpdateResponse.swift in Sources */,
+				FE0A0B00000000000000B012 /* MSALNativeAuthHALCollectAttributesResponse.swift in Sources */,
 				3276108D1E5D204DF5582BB7 /* MSALNativeAuthHALCodeSentResponse.swift in Sources */,
 				AD8F9352860B8BB8784A55A3 /* MSALNativeAuthHALChallengeResponse.swift in Sources */,
 				2161D7C3F3059052DD18D048 /* MSALNativeAuthV2HALAction.swift in Sources */,
@@ -7965,6 +7986,7 @@
 				584F147D25DE469499C2B538 /* MSALNativeAuthV2ChallengeRequestBody.swift in Sources */,
 				59B764D2DDE4420295E78F3C /* MSALNativeAuthV2PollRequestBody.swift in Sources */,
 				C8C7202B3FCA487AA2E68705 /* MSALNativeAuthV2VerifyRequestBody.swift in Sources */,
+				FE0A0B00000000000000B011 /* MSALNativeAuthV2SubmitAttributesRequestBody.swift in Sources */,
 				88C90FA7417644029A718568 /* MSALNativeAuthV2UpdatePasswordRequestBody.swift in Sources */,
 				7E475EF1BD0DBD5E66BED4C1 /* MSALNativeAuthV2HrefURLResolver.swift in Sources */,
 				7D1ED8DBB108BB3F25619C96 /* MSALNativeAuthV2RequestProvider.swift in Sources */,
@@ -8186,6 +8208,7 @@
 				C3B881EFA8EC0E8B506F576D /* MSALNativeAuthV2HALResponseSerializerTests.swift in Sources */,
 				3910135713EE25264B751FF5 /* MSALNativeAuthV2ResponseErrorHandlerTests.swift in Sources */,
 				143FA5DBABB342C09531D190 /* MSALNativeAuthFlowControllerSignInTests.swift in Sources */,
+				FE0A0B00000000000000A014 /* MSALNativeAuthFlowControllerSignUpTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8381,6 +8404,7 @@
 				C277EAF06922901997D9D450 /* MSALNativeAuthV2HALResponseSerializerTests.swift in Sources */,
 				B241DD9BDD1D50BFBAC9BEFF /* MSALNativeAuthV2ResponseErrorHandlerTests.swift in Sources */,
 				4B10EE83FDFA69F5A75129F3 /* MSALNativeAuthFlowControllerSignInTests.swift in Sources */,
+				FE0A0B00000000000000B014 /* MSALNativeAuthFlowControllerSignUpTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowContinuationState.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowContinuationState.swift
@@ -42,6 +42,10 @@ class MSALNativeAuthFlowContinuationState {
     let links: [MSALNativeAuthV2LinkKey: URL]
     let scopes: [String]
     let claimsRequestJson: String?
+    /// Names of the attributes the SDK has already submitted to the server during sign up (including
+    /// `email` and, when supplied, `password`). Used to detect when the server re-requests
+    /// an attribute that was already submitted, which is treated as an unrecoverable error.
+    let submittedAttributes: [String]
 
     init(
         flowScenario: MSALNativeAuthFlowScenario,
@@ -49,7 +53,8 @@ class MSALNativeAuthFlowContinuationState {
         continuationToken: String?,
         links: [MSALNativeAuthV2LinkKey: URL],
         scopes: [String] = [],
-        claimsRequestJson: String? = nil
+        claimsRequestJson: String? = nil,
+        submittedAttributes: [String] = []
     ) {
         self.flowScenario = flowScenario
         self.correlationId = correlationId
@@ -57,6 +62,23 @@ class MSALNativeAuthFlowContinuationState {
         self.links = links
         self.scopes = scopes
         self.claimsRequestJson = claimsRequestJson
+        self.submittedAttributes = submittedAttributes
+    }
+
+    func addingSubmittedAttributes(_ names: [String]) -> MSALNativeAuthFlowContinuationState {
+        var merged = submittedAttributes
+        for name in names where !merged.contains(where: { $0.caseInsensitiveCompare(name) == .orderedSame }) {
+            merged.append(name)
+        }
+        return MSALNativeAuthFlowContinuationState(
+            flowScenario: flowScenario,
+            correlationId: correlationId,
+            continuationToken: continuationToken,
+            links: links,
+            scopes: scopes,
+            claimsRequestJson: claimsRequestJson,
+            submittedAttributes: merged
+        )
     }
 
     func link(_ relation: MSALNativeAuthV2LinkRelation) -> URL? {

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowContinuationState.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowContinuationState.swift
@@ -81,6 +81,11 @@ class MSALNativeAuthFlowContinuationState {
         )
     }
 
+    /// Whether an attribute with the given name has already been submitted to the server.
+    func hasSubmittedAttribute(_ name: String) -> Bool {
+        return submittedAttributes.contains { $0.caseInsensitiveCompare(name) == .orderedSame }
+    }
+
     func link(_ relation: MSALNativeAuthV2LinkRelation) -> URL? {
         return links[.relation(relation)]
     }

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -750,7 +750,12 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         )
 
         if let signUpParameters = signUpParameters {
-            return await performSubmitAttributes(upfrontAttributeValues(signUpParameters), flowContinuationState: next, step: step)
+            let submitStep = MSALNativeAuthFlowStepContext(
+                apiId: .telemetryApiIdV2SignUpSubmitAttributes,
+                event: step.event,
+                context: step.context
+            )
+            return await performSubmitAttributes(upfrontAttributeValues(signUpParameters), flowContinuationState: next, step: submitStep)
         }
 
         // The server is requesting more information, and it may re-ask for something already submitted. A

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -750,12 +750,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         )
 
         if let signUpParameters = signUpParameters {
-            let submitStep = MSALNativeAuthFlowStepContext(
-                apiId: .telemetryApiIdV2SignUpSubmitAttributes,
-                event: step.event,
-                context: step.context
-            )
-            return await performSubmitAttributes(upfrontAttributeValues(signUpParameters), flowContinuationState: next, step: submitStep)
+            return await performSubmitAttributes(upfrontAttributeValues(signUpParameters), flowContinuationState: next, step: step)
         }
 
         // The server is requesting more information, and it may re-ask for something already submitted. A

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -107,6 +107,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         return await handleSignUpInteractionResult(startResult, flowContinuationState: continuation, step: step, upfront: parameters)
     }
 
+    // swiftlint:disable:next function_body_length
     func signIn(parameters: MSALNativeAuthSignInParameters) async -> MSALNativeAuthFlowControllerResponse {
         let flowScenario: MSALNativeAuthFlowScenario = .signIn
         let context = MSALNativeAuthRequestContext(correlationId: parameters.correlationId)

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -88,6 +88,9 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         }
 
         let startResult = await performInteraction(context: context) {
+            // We do not pass the username to the server so that the server requests it as an attribute
+            // If we do pass it, we would get `verify` and we would need to persist `password` and any other `attributes`
+            // in `MSALNativeAuthSignUpParametersV2`
             try self.requestProvider.signUpStart(
                 continuationToken: continuationToken,
                 href: signUpLink,

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -457,7 +457,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignUpSubmitAttributes, context: context)
         let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignUpSubmitAttributes, event: event, context: context)
-        return await performSubmitSignUpAttributes(attributes, flowContinuationState: flowContinuationState, step: step)
+        return await performSubmitAttributes(attributes, flowContinuationState: flowContinuationState, step: step)
     }
 
     func signInAfterResetPassword(
@@ -576,7 +576,6 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
     func resendCode(state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse {
         let flowContinuationState = state.continuation
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
-
         let apiId: MSALNativeAuthTelemetryApiId
         switch flowContinuationState.flowScenario {
         case .signUp:
@@ -661,7 +660,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignUpSubmitAttributes, context: context)
         let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignUpSubmitAttributes, event: event, context: context)
-        return await performSubmitSignUpAttributes(["password": password], flowContinuationState: flowContinuationState, step: step)
+        return await performSubmitAttributes(["password": password], flowContinuationState: flowContinuationState, step: step)
     }
 
     /// Requests the server to resend the sign-up one-time code.
@@ -721,7 +720,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 attributes: attributes,
                 flowContinuationState: flowContinuationState,
                 step: step,
-                upfront: upfront
+                signUpParameters: upfront
             )
         case .verificationRequired(let token, let verifyHref, let resendHref, let sentTo, let channelType, let codeLength):
             // Sign up currently supports email one-time-code verification only.
@@ -751,12 +750,12 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
 
     /// Handles a `collectAttributes` step.
     ///
-    /// On the first step (`upfront` is non-nil, right after sign-up start) every value supplied up front —
-    /// `email` (the username), `password` if provided, and any user attributes — is submitted in a single
+    /// On the first step (`signUpParameters` is non-nil, right after sign-up start) every value supplied up front -
+    /// `email` (the username), `password` if provided, and any user attributes - is submitted in a single
     /// request, regardless of which attributes the server actually asked for. The names of the submitted
     /// attributes are then recorded on the continuation state.
     ///
-    /// On any later step (`upfront` is nil) the server is asking for something the app did not provide up
+    /// On any later step (`signUpParameters` is nil) the server is asking for something the app did not provide up
     /// front. If it re-requests `email`, `password`, or an attribute already submitted, that is treated as
     /// an error; otherwise the requested attributes are surfaced via ``MSALNativeAuthAttributesRequiredState``.
     private func handleSignUpAttributesRequired(
@@ -765,7 +764,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         attributes: [MSALNativeAuthRequiredAttributeInternal],
         flowContinuationState: MSALNativeAuthFlowContinuationState,
         step: MSALNativeAuthFlowStepContext,
-        upfront: MSALNativeAuthSignUpParametersV2? = nil
+        signUpParameters: MSALNativeAuthSignUpParametersV2? = nil
     ) async -> MSALNativeAuthFlowControllerResponse {
         let next = makeSignUpContinuation(
             from: flowContinuationState,
@@ -773,8 +772,8 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             links: [.submitAttributes: submitHref]
         )
 
-        if let upfront = upfront {
-            return await performSubmitSignUpAttributes(upfrontAttributeValues(upfront), flowContinuationState: next, step: step)
+        if let signUpParameters = signUpParameters {
+            return await performSubmitAttributes(upfrontAttributeValues(signUpParameters), flowContinuationState: next, step: step)
         }
 
         if let invalid = attributes.first(where: { isReservedOrAlreadySubmitted($0, flowContinuationState: flowContinuationState) }) {
@@ -791,7 +790,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
 
     /// Posts collected attributes to the `submitAttributes` href, records their names on the continuation
     /// state, and continues the flow.
-    private func performSubmitSignUpAttributes(
+    private func performSubmitAttributes(
         _ attributes: [String: Any],
         flowContinuationState: MSALNativeAuthFlowContinuationState,
         step: MSALNativeAuthFlowStepContext

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -567,9 +567,15 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         state: MSALNativeAuthFlowInternalState
     ) async -> MSALNativeAuthFlowControllerResponse {
         let flowContinuationState = state.continuation
+        guard flowContinuationState.flowScenario == .signUp else {
+            return invalidFlowMethodCalled(
+                stateName: "MSALNativeAuthSignInAfterSignUpState",
+                scenario: flowContinuationState.flowScenario,
+                correlationId: flowContinuationState.correlationId
+            )
+        }
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignInAfterSignUp, context: context)
-
         guard let continuationToken = flowContinuationState.continuationToken else {
             return failure(
                 .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing continuation token")),

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -811,14 +811,24 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
     }
 
     /// Builds the attribute dictionary submitted up front: `email` (the username) plus any password and
-    /// user attributes supplied to `signUp`.
+    /// user attributes supplied to `signUp`. The SDK-owned `email` and `password` keys cannot be overridden
+    /// by app-supplied attributes; any such attribute (matched case-insensitively) is ignored.
     private func upfrontAttributeValues(_ parameters: MSALNativeAuthSignUpParametersV2) -> [String: Any] {
         var values: [String: Any] = ["email": parameters.username]
         if let password = parameters.password, !password.isEmpty {
             values["password"] = password
         }
+        let reservedAttributeNames: Set<String> = ["email", "password"]
         if let attributes = parameters.attributes {
             for (name, value) in attributes {
+                if reservedAttributeNames.contains(name.lowercased()) {
+                    MSALNativeAuthLogger.log(
+                        level: .warning,
+                        context: nil,
+                        format: "Ignoring app-supplied sign-up attribute because it uses a reserved SDK attribute name."
+                    )
+                    continue
+                }
                 values[name] = value
             }
         }

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -802,7 +802,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 href: submitHref,
                 attributes: attributes,
                 continuationToken: continuationToken,
-                apiId: .telemetryApiIdV2SignUpSubmitAttributes,
+                apiId: step.apiId,
                 context: step.context
             )
         }

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -240,7 +240,11 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         case .passwordReset:
             apiId = .telemetryApiIdV2ResetPasswordSubmitCode
         default:
-            return notImplementedResponse(scenario: flowContinuationState.flowScenario)
+            return invalidFlowMethodCalled(
+                stateName: "MSALNativeAuthCodeRequiredState",
+                scenario: flowContinuationState.flowScenario,
+                correlationId: flowContinuationState.correlationId
+            )
         }
         let event = makeAndStartTelemetryEvent(id: apiId, context: context)
 
@@ -289,7 +293,11 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         case .signIn:
             return await submitSignInPassword(password, flowContinuationState: flowContinuationState)
         default:
-            return notImplementedResponse(scenario: flowContinuationState.flowScenario)
+            return invalidFlowMethodCalled(
+                stateName: "MSALNativeAuthPasswordRequiredState",
+                scenario: flowContinuationState.flowScenario,
+                correlationId: flowContinuationState.correlationId
+            )
         }
     }
 
@@ -440,7 +448,11 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
     func submitAttributes(_ attributes: [String: Any], state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse {
         let flowContinuationState = state.continuation
         guard flowContinuationState.flowScenario == .signUp else {
-            return notImplementedResponse(scenario: flowContinuationState.flowScenario)
+            return invalidFlowMethodCalled(
+                stateName: "MSALNativeAuthAttributesRequiredState",
+                scenario: flowContinuationState.flowScenario,
+                correlationId: flowContinuationState.correlationId
+            )
         }
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignUpSubmitAttributes, context: context)
@@ -483,7 +495,11 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
     ) async -> MSALNativeAuthFlowControllerResponse {
         let flowContinuationState = state.continuation
         guard flowContinuationState.flowScenario == .signIn else {
-            return notImplementedResponse(scenario: flowContinuationState.flowScenario)
+            return invalidFlowMethodCalled(
+                stateName: "MSALNativeAuthMFARequiredState",
+                scenario: flowContinuationState.flowScenario,
+                correlationId: flowContinuationState.correlationId
+            )
         }
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2MFAGetAuthMethods, context: context)
@@ -519,7 +535,11 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
     func submitChallenge(_ challenge: String, state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse {
         let flowContinuationState = state.continuation
         guard flowContinuationState.flowScenario == .signIn else {
-            return notImplementedResponse(scenario: flowContinuationState.flowScenario)
+            return invalidFlowMethodCalled(
+                stateName: "MSALNativeAuthMFAVerificationRequiredState",
+                scenario: flowContinuationState.flowScenario,
+                correlationId: flowContinuationState.correlationId
+            )
         }
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2MFASubmitChallenge, context: context)
@@ -566,7 +586,11 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         case .passwordReset:
             apiId = .telemetryApiIdV2ResetPasswordResendCode
         default:
-            return notImplementedResponse(scenario: flowContinuationState.flowScenario)
+            return invalidFlowMethodCalled(
+                stateName: "MSALNativeAuthCodeRequiredState",
+                scenario: flowContinuationState.flowScenario,
+                correlationId: flowContinuationState.correlationId
+            )
         }
         let event = makeAndStartTelemetryEvent(id: apiId, context: context)
 
@@ -1492,11 +1516,26 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         )
     }
 
-    /// Response for flows that are not implemented currently
+    /// Response for the case where, after performing a step, no handler is available to process the
+    /// result for the current flow scenario (a handler that should exist is missing).
     private func notImplementedResponse(scenario: MSALNativeAuthFlowScenario) -> MSALNativeAuthFlowControllerResponse {
         return MSALNativeAuthFlowControllerResponse(
             .error(error: MSALNativeAuthFlowError(type: .notImplemented)),
             correlationId: UUID(),
+            scenario: scenario
+        )
+    }
+
+    /// Response for when a continuation method is invoked on a flow scenario that does not support it.
+    private func invalidFlowMethodCalled(
+        stateName: String,
+        scenario: MSALNativeAuthFlowScenario,
+        correlationId: UUID
+    ) -> MSALNativeAuthFlowControllerResponse {
+        let message = String(format: MSALNativeAuthErrorMessage.methodNotAllowedForFlow, stateName, scenario.name)
+        return MSALNativeAuthFlowControllerResponse(
+            .error(error: MSALNativeAuthFlowError(type: .generalError, errorDescription: message, correlationId: correlationId)),
+            correlationId: correlationId,
             scenario: scenario
         )
     }

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -579,7 +579,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         let apiId: MSALNativeAuthTelemetryApiId
         switch flowContinuationState.flowScenario {
         case .signUp:
-            return await resendSignUpCode(flowContinuationState: flowContinuationState)
+            apiId = .telemetryApiIdV2SignUpStart
         case .signIn:
             apiId = .telemetryApiIdV2SignInResendCode
         case .passwordReset:
@@ -619,7 +619,14 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         }
 
         let step = MSALNativeAuthFlowStepContext(apiId: apiId, event: event, context: context)
-        return handleResendCodeResult(result, flowContinuationState: flowContinuationState, step: step)
+        switch flowContinuationState.flowScenario {
+        case .signUp:
+            return await handleSignUpInteractionResult(result, flowContinuationState: flowContinuationState, step: step)
+        case .signIn, .passwordReset:
+            return handleResendCodeResult(result, flowContinuationState: flowContinuationState, step: step)
+        default:
+            return notImplementedResponse(scenario: flowContinuationState.flowScenario)
+        }
     }
 
     // MARK: - Sign-up
@@ -661,41 +668,6 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignUpSubmitAttributes, context: context)
         let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignUpSubmitAttributes, event: event, context: context)
         return await performSubmitAttributes(["password": password], flowContinuationState: flowContinuationState, step: step)
-    }
-
-    /// Requests the server to resend the sign-up one-time code.
-    private func resendSignUpCode(
-        flowContinuationState: MSALNativeAuthFlowContinuationState
-    ) async -> MSALNativeAuthFlowControllerResponse {
-        let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
-        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignUpStart, context: context)
-
-        guard let resendHref = flowContinuationState.link(.resend)?.absoluteString else {
-            return failure(
-                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing resend link")),
-                event: event,
-                context: context, scenario: flowContinuationState.flowScenario
-            )
-        }
-
-        guard let continuationToken = flowContinuationState.continuationToken else {
-            return failure(
-                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing continuation token")),
-                event: event,
-                context: context, scenario: flowContinuationState.flowScenario
-            )
-        }
-
-        let result = await performInteraction(context: context) {
-            try self.requestProvider.challenge(
-                href: resendHref,
-                continuationToken: continuationToken,
-                apiId: .telemetryApiIdV2SignUpStart,
-                context: context
-            )
-        }
-        let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignUpStart, event: event, context: context)
-        return await handleSignUpInteractionResult(result, flowContinuationState: flowContinuationState, step: step)
     }
 
     // MARK: - Sign-up result mapping

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -73,7 +73,39 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
     // MARK: - Entry points
 
     func signUp(parameters: MSALNativeAuthSignUpParametersV2) async -> MSALNativeAuthFlowControllerResponse {
-        return notImplementedResponse(scenario: .signUp)
+        let flowScenario: MSALNativeAuthFlowScenario = .signUp
+        let context = MSALNativeAuthRequestContext(correlationId: parameters.correlationId)
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignUpStart, context: context)
+
+        // Authorization challenge (expects 401 + continuation token + sign_up link).
+        let authorizationChallenge = await performAuthorizeChallengeStart(
+            flowScenario: flowScenario,
+            apiId: .telemetryApiIdV2SignUpStart,
+            context: context
+        )
+        guard case .continuationToken(let continuationToken, let signUpLink) = authorizationChallenge else {
+            return failure(authorizationChallenge, event: event, context: context, scenario: flowScenario)
+        }
+
+        let startResult = await performInteraction(context: context) {
+            try self.requestProvider.signUpStart(
+                username: parameters.username,
+                continuationToken: continuationToken,
+                href: signUpLink,
+                apiId: .telemetryApiIdV2SignUpStart,
+                context: context
+            )
+        }
+
+        let continuation = MSALNativeAuthFlowContinuationState(
+            flowScenario: flowScenario,
+            correlationId: context.correlationId(),
+            continuationToken: nil,
+            links: [:],
+            scopes: joinScopes(parameters.scopes)
+        )
+        let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignUpStart, event: event, context: context)
+        return await handleSignUpInteractionResult(startResult, flowContinuationState: continuation, step: step, upfront: parameters)
     }
 
     func signIn(parameters: MSALNativeAuthSignInParameters) async -> MSALNativeAuthFlowControllerResponse {
@@ -190,8 +222,11 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
 
     func submitCode(_ code: String, state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse {
         let flowContinuationState = state.continuation
+        let isSignUp = flowContinuationState.flowScenario == .signUp
+        let apiId: MSALNativeAuthTelemetryApiId = isSignUp ? .telemetryApiIdV2SignUpSubmitCode : .telemetryApiIdV2ResetPasswordSubmitCode
+
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
-        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2ResetPasswordSubmitCode, context: context)
+        let event = makeAndStartTelemetryEvent(id: apiId, context: context)
 
         guard let verifyHref = flowContinuationState.link(.verify)?.absoluteString else {
             return failure(
@@ -214,16 +249,24 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
                 href: verifyHref,
                 otp: code,
                 continuationToken: continuationToken,
-                apiId: .telemetryApiIdV2ResetPasswordSubmitCode,
+                apiId: apiId,
                 context: context
             )
         }
-        let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2ResetPasswordSubmitCode, event: event, context: context)
+        let step = MSALNativeAuthFlowStepContext(apiId: apiId, event: event, context: context)
+        if isSignUp {
+            return await handleSignUpInteractionResult(result, flowContinuationState: flowContinuationState, step: step)
+        }
         return await handleSubmitCodeResult(result, flowContinuationState: flowContinuationState, step: step)
     }
 
     func submitPassword(_ password: String, state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse {
         let flowContinuationState = state.continuation
+
+        if flowContinuationState.flowScenario == .signUp {
+            return await submitSignUpPassword(password, flowContinuationState: flowContinuationState)
+        }
+
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignInSubmitPassword, context: context)
         let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignInSubmitPassword, event: event, context: context)
@@ -365,7 +408,14 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
     }
 
     func submitAttributes(_ attributes: [String: Any], state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse {
-        return notImplementedResponse(scenario: state.continuation.flowScenario)
+        let flowContinuationState = state.continuation
+        guard flowContinuationState.flowScenario == .signUp else {
+            return notImplementedResponse(scenario: flowContinuationState.flowScenario)
+        }
+        let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignUpSubmitAttributes, context: context)
+        let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignUpSubmitAttributes, event: event, context: context)
+        return await performSubmitSignUpAttributes(attributes, flowContinuationState: flowContinuationState, step: step)
     }
 
     func signInAfterResetPassword(
@@ -475,6 +525,11 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
 
     func resendCode(state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse {
         let flowContinuationState = state.continuation
+
+        if flowContinuationState.flowScenario == .signUp {
+            return await resendSignUpCode(flowContinuationState: flowContinuationState)
+        }
+
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2ResetPasswordResendCode, context: context)
 
@@ -505,6 +560,282 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
 
         let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2ResetPasswordResendCode, event: event, context: context)
         return handleResendCodeResult(result, flowContinuationState: flowContinuationState, step: step)
+    }
+
+    // MARK: - Sign-up
+
+    func signInAfterSignUp(
+        scopes: [String]?,
+        claimsRequestJson: String?,
+        state: MSALNativeAuthFlowInternalState
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        let flowContinuationState = state.continuation
+        let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignInAfterSignUp, context: context)
+
+        guard let continuationToken = flowContinuationState.continuationToken else {
+            return failure(
+                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing continuation token")),
+                event: event,
+                context: context,
+                scenario: flowContinuationState.flowScenario
+            )
+        }
+
+        let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdSignInAfterSignUp, event: event, context: context)
+        return await completeWithToken(
+            flowContinuationState: flowContinuationState,
+            continuationToken: continuationToken,
+            scopes: joinScopes(scopes),
+            claimsRequestJson: claimsRequestJson,
+            step: step
+        )
+    }
+
+    /// Submits the password supplied for the password `collectAttributes` step during sign up.
+    private func submitSignUpPassword(
+        _ password: String,
+        flowContinuationState: MSALNativeAuthFlowContinuationState
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignUpSubmitAttributes, context: context)
+        let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignUpSubmitAttributes, event: event, context: context)
+        return await performSubmitSignUpAttributes(["password": password], flowContinuationState: flowContinuationState, step: step)
+    }
+
+    /// Requests the server to resend the sign-up one-time code.
+    private func resendSignUpCode(
+        flowContinuationState: MSALNativeAuthFlowContinuationState
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignUpStart, context: context)
+
+        guard let resendHref = flowContinuationState.link(.resend)?.absoluteString else {
+            return failure(
+                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing resend link")),
+                event: event,
+                context: context, scenario: flowContinuationState.flowScenario
+            )
+        }
+
+        guard let continuationToken = flowContinuationState.continuationToken else {
+            return failure(
+                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing continuation token")),
+                event: event,
+                context: context, scenario: flowContinuationState.flowScenario
+            )
+        }
+
+        let result = await performInteraction(context: context) {
+            try self.requestProvider.challenge(
+                href: resendHref,
+                continuationToken: continuationToken,
+                apiId: .telemetryApiIdV2SignUpStart,
+                context: context
+            )
+        }
+        let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignUpStart, event: event, context: context)
+        return await handleSignUpInteractionResult(result, flowContinuationState: flowContinuationState, step: step)
+    }
+
+    // MARK: - Sign-up result mapping
+
+    /// Drives the server-directed sign-up sequence forward.
+    ///
+    /// Sign up is a chain of `collectAttributes` steps interleaved with a `verify` (one-time code) step.
+    /// On the first `collectAttributes` step every value supplied up front is submitted at once; any
+    /// attribute the server later requests that the app did not supply is surfaced via
+    /// ``MSALNativeAuthAttributesRequiredState`` so the app can collect it.
+    private func handleSignUpInteractionResult(
+        _ result: MSALNativeAuthV2InteractionParsedResponse,
+        flowContinuationState: MSALNativeAuthFlowContinuationState,
+        step: MSALNativeAuthFlowStepContext,
+        upfront: MSALNativeAuthSignUpParametersV2? = nil
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        switch result {
+        case .attributesRequired(let token, let submitHref, let attributes):
+            return await handleSignUpAttributesRequired(
+                continuationToken: token,
+                submitHref: submitHref,
+                attributes: attributes,
+                flowContinuationState: flowContinuationState,
+                step: step,
+                upfront: upfront
+            )
+        case .verificationRequired(let token, let verifyHref, let resendHref, let sentTo, let channelType, let codeLength):
+            // Sign up currently supports email one-time-code verification only.
+            guard channelType.isEmailType else {
+                let error = MSALNativeAuthFlowError(type: .generalError, errorDescription: MSALNativeAuthErrorMessage.generalError)
+                stopTelemetryEvent(step.event, context: step.context, error: error)
+                return response(.error(error: error), context: step.context, scenario: flowContinuationState.flowScenario)
+            }
+            let next = makeSignUpContinuation(
+                from: flowContinuationState,
+                continuationToken: token,
+                links: [.verify: verifyHref, .resend: resendHref]
+            )
+            return codeRequiredResponse(flowContinuationState: next, sentTo: sentTo, channelType: channelType, codeLength: codeLength, step: step)
+        case .readyToComplete(let token):
+            return signInAfterSignUpResponse(flowContinuationState: flowContinuationState, continuationToken: token, step: step)
+        case .browserRequired:
+            stopTelemetryEvent(step.event, context: step.context)
+            return response(.browserRequired, context: step.context, scenario: flowContinuationState.flowScenario)
+        case .error(let error):
+            stopTelemetryEvent(step.event, context: step.context, error: error)
+            return response(.error(error: error), context: step.context, scenario: flowContinuationState.flowScenario)
+        default:
+            return interactionFailure(result, event: step.event, context: step.context, scenario: flowContinuationState.flowScenario, newState: nil)
+        }
+    }
+
+    /// Handles a `collectAttributes` step.
+    ///
+    /// On the first step (`upfront` is non-nil, right after sign-up start) every value supplied up front —
+    /// `email` (the username), `password` if provided, and any user attributes — is submitted in a single
+    /// request, regardless of which attributes the server actually asked for. The names of the submitted
+    /// attributes are then recorded on the continuation state.
+    ///
+    /// On any later step (`upfront` is nil) the server is asking for something the app did not provide up
+    /// front. If it re-requests `email`, `password`, or an attribute already submitted, that is treated as
+    /// an error; otherwise the requested attributes are surfaced via ``MSALNativeAuthAttributesRequiredState``.
+    private func handleSignUpAttributesRequired(
+        continuationToken: String,
+        submitHref: String,
+        attributes: [MSALNativeAuthRequiredAttributeInternal],
+        flowContinuationState: MSALNativeAuthFlowContinuationState,
+        step: MSALNativeAuthFlowStepContext,
+        upfront: MSALNativeAuthSignUpParametersV2? = nil
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        let next = makeSignUpContinuation(
+            from: flowContinuationState,
+            continuationToken: continuationToken,
+            links: [.submitAttributes: submitHref]
+        )
+
+        if let upfront = upfront {
+            return await performSubmitSignUpAttributes(upfrontAttributeValues(upfront), flowContinuationState: next, step: step)
+        }
+
+        if let invalid = attributes.first(where: { isReservedOrAlreadySubmitted($0, flowContinuationState: flowContinuationState) }) {
+            let error = MSALNativeAuthFlowError(
+                type: .generalError,
+                errorDescription: "The server requested attribute '\(invalid.name)' that was already submitted or cannot be collected."
+            )
+            stopTelemetryEvent(step.event, context: step.context, error: error)
+            return response(.error(error: error), context: step.context, scenario: flowContinuationState.flowScenario)
+        }
+
+        return attributesRequiredResponse(flowContinuationState: next, attributes: attributes, step: step)
+    }
+
+    /// Posts collected attributes to the `submitAttributes` href, records their names on the continuation
+    /// state, and continues the flow.
+    private func performSubmitSignUpAttributes(
+        _ attributes: [String: Any],
+        flowContinuationState: MSALNativeAuthFlowContinuationState,
+        step: MSALNativeAuthFlowStepContext
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        guard let submitHref = flowContinuationState.link(.submitAttributes)?.absoluteString else {
+            return failure(
+                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing submit attributes link")),
+                event: step.event,
+                context: step.context, scenario: flowContinuationState.flowScenario
+            )
+        }
+
+        guard let continuationToken = flowContinuationState.continuationToken else {
+            return failure(
+                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing continuation token")),
+                event: step.event,
+                context: step.context, scenario: flowContinuationState.flowScenario
+            )
+        }
+
+        let result = await performInteraction(context: step.context) {
+            try self.requestProvider.submitAttributes(
+                href: submitHref,
+                attributes: attributes,
+                continuationToken: continuationToken,
+                apiId: .telemetryApiIdV2SignUpSubmitAttributes,
+                context: step.context
+            )
+        }
+        let submitted = flowContinuationState.addingSubmittedAttributes(Array(attributes.keys))
+        return await handleSignUpInteractionResult(result, flowContinuationState: submitted, step: step)
+    }
+
+    /// Builds the attribute dictionary submitted up front: `email` (the username) plus any password and
+    /// user attributes supplied to `signUp`.
+    private func upfrontAttributeValues(_ parameters: MSALNativeAuthSignUpParametersV2) -> [String: Any] {
+        var values: [String: Any] = ["email": parameters.username]
+        if let password = parameters.password, !password.isEmpty {
+            values["password"] = password
+        }
+        if let attributes = parameters.attributes {
+            for (name, value) in attributes {
+                values[name] = value
+            }
+        }
+        return values
+    }
+
+    /// A requested attribute is invalid when it is `email`, `password`, or one the SDK has already submitted.
+    private func isReservedOrAlreadySubmitted(
+        _ attribute: MSALNativeAuthRequiredAttributeInternal,
+        flowContinuationState: MSALNativeAuthFlowContinuationState
+    ) -> Bool {
+        if isPasswordAttribute(attribute) || attribute.name.caseInsensitiveCompare("email") == .orderedSame {
+            return true
+        }
+        return flowContinuationState.submittedAttributes.contains { $0.caseInsensitiveCompare(attribute.name) == .orderedSame }
+    }
+
+    private func isPasswordAttribute(_ attribute: MSALNativeAuthRequiredAttributeInternal) -> Bool {
+        return attribute.type.caseInsensitiveCompare("password") == .orderedSame
+            || attribute.name.caseInsensitiveCompare("password") == .orderedSame
+    }
+
+    /// Derives the next sign-up continuation, preserving the names of the attributes already submitted.
+    private func makeSignUpContinuation(
+        from flowContinuationState: MSALNativeAuthFlowContinuationState,
+        continuationToken: String,
+        links: [MSALNativeAuthV2LinkRelation: String?]
+    ) -> MSALNativeAuthFlowContinuationState {
+        return MSALNativeAuthFlowContinuationState(
+            flowScenario: flowContinuationState.flowScenario,
+            correlationId: flowContinuationState.correlationId,
+            continuationToken: continuationToken,
+            links: resolveLinks(links),
+            scopes: flowContinuationState.scopes,
+            claimsRequestJson: flowContinuationState.claimsRequestJson,
+            submittedAttributes: flowContinuationState.submittedAttributes
+        )
+    }
+
+    private func attributesRequiredResponse(
+        flowContinuationState: MSALNativeAuthFlowContinuationState,
+        attributes: [MSALNativeAuthRequiredAttributeInternal],
+        step: MSALNativeAuthFlowStepContext
+    ) -> MSALNativeAuthFlowControllerResponse {
+        let internalState = MSALNativeAuthFlowInternalState(continuation: flowContinuationState, controller: self)
+        let publicAttributes = attributes.map { $0.toRequiredAttributePublic() }
+        let state = MSALNativeAuthAttributesRequiredState(internalState: internalState, attributes: publicAttributes)
+        stopTelemetryEvent(step.event, context: step.context)
+        return response(.actionRequired(state: state), context: step.context)
+    }
+
+    private func signInAfterSignUpResponse(
+        flowContinuationState: MSALNativeAuthFlowContinuationState,
+        continuationToken: String,
+        step: MSALNativeAuthFlowStepContext
+    ) -> MSALNativeAuthFlowControllerResponse {
+        let continuation = makeSignUpContinuation(from: flowContinuationState, continuationToken: continuationToken, links: [:])
+        let internalState = MSALNativeAuthFlowInternalState(continuation: continuation, controller: self)
+        stopTelemetryEvent(step.event, context: step.context)
+        return response(
+            .actionRequired(state: MSALNativeAuthSignInAfterSignUpState(internalState: internalState)),
+            context: step.context
+        )
     }
 
     // MARK: - Sign-in result mapping

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -301,49 +301,6 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         }
     }
 
-    private func submitSignInPassword(
-        _ password: String,
-        flowContinuationState: MSALNativeAuthFlowContinuationState
-    ) async -> MSALNativeAuthFlowControllerResponse {
-        let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
-        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignInSubmitPassword, context: context)
-        let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignInSubmitPassword, event: event, context: context)
-        return await submitPassword(password, flowContinuationState: flowContinuationState, step: step)
-    }
-
-    private func submitPassword(
-        _ password: String,
-        flowContinuationState: MSALNativeAuthFlowContinuationState,
-        step: MSALNativeAuthFlowStepContext
-    ) async -> MSALNativeAuthFlowControllerResponse {
-        guard let verifyHref = flowContinuationState.link(.verify)?.absoluteString else {
-            return failure(
-                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing verify link")),
-                event: step.event,
-                context: step.context, scenario: flowContinuationState.flowScenario
-            )
-        }
-
-        guard let continuationToken = flowContinuationState.continuationToken else {
-            return failure(
-                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing continuation token")),
-                event: step.event,
-                context: step.context, scenario: flowContinuationState.flowScenario
-            )
-        }
-
-        let result = await performInteraction(context: step.context) {
-            try self.requestProvider.submitPassword(
-                href: verifyHref,
-                password: password,
-                continuationToken: continuationToken,
-                apiId: step.apiId,
-                context: step.context
-            )
-        }
-        return await handleSignInSubmitPasswordResult(result, flowContinuationState: flowContinuationState, step: step)
-    }
-
     // swiftlint:disable:next function_body_length
     func submitNewPassword(_ password: String, state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse {
         let flowContinuationState = state.continuation
@@ -460,34 +417,6 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         return await performSubmitAttributes(attributes, flowContinuationState: flowContinuationState, step: step)
     }
 
-    func signInAfterResetPassword(
-        scopes: [String]?,
-        claimsRequestJson: String?,
-        state: MSALNativeAuthFlowInternalState
-    ) async -> MSALNativeAuthFlowControllerResponse {
-        let flowContinuationState = state.continuation
-        let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
-        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignInAfterPasswordReset, context: context)
-
-        guard let continuationToken = flowContinuationState.continuationToken else {
-            return failure(
-                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing continuation token")),
-                event: event,
-                context: context,
-                scenario: flowContinuationState.flowScenario
-            )
-        }
-
-        let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdSignInAfterPasswordReset, event: event, context: context)
-        return await completeWithToken(
-            flowContinuationState: flowContinuationState,
-            continuationToken: continuationToken,
-            scopes: joinScopes(scopes),
-            claimsRequestJson: claimsRequestJson,
-            step: step
-        )
-    }
-
     func selectAuthMethod(
         _ method: MSALAuthMethod,
         verificationContact: String?,
@@ -579,7 +508,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         let apiId: MSALNativeAuthTelemetryApiId
         switch flowContinuationState.flowScenario {
         case .signUp:
-            apiId = .telemetryApiIdV2SignUpStart
+            apiId = .telemetryApiIdV2SignUpResendCode
         case .signIn:
             apiId = .telemetryApiIdV2SignInResendCode
         case .passwordReset:
@@ -629,8 +558,6 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         }
     }
 
-    // MARK: - Sign-up
-
     func signInAfterSignUp(
         scopes: [String]?,
         claimsRequestJson: String?,
@@ -659,7 +586,46 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         )
     }
 
-    /// Submits the password supplied for the password `collectAttributes` step during sign up.
+    func signInAfterResetPassword(
+        scopes: [String]?,
+        claimsRequestJson: String?,
+        state: MSALNativeAuthFlowInternalState
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        let flowContinuationState = state.continuation
+        let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdSignInAfterPasswordReset, context: context)
+
+        guard let continuationToken = flowContinuationState.continuationToken else {
+            return failure(
+                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing continuation token")),
+                event: event,
+                context: context,
+                scenario: flowContinuationState.flowScenario
+            )
+        }
+
+        let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdSignInAfterPasswordReset, event: event, context: context)
+        return await completeWithToken(
+            flowContinuationState: flowContinuationState,
+            continuationToken: continuationToken,
+            scopes: joinScopes(scopes),
+            claimsRequestJson: claimsRequestJson,
+            step: step
+        )
+    }
+
+    // MARK: - Private
+
+    private func submitSignInPassword(
+        _ password: String,
+        flowContinuationState: MSALNativeAuthFlowContinuationState
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
+        let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignInSubmitPassword, context: context)
+        let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignInSubmitPassword, event: event, context: context)
+        return await submitPassword(password, flowContinuationState: flowContinuationState, step: step)
+    }
+
     private func submitSignUpPassword(
         _ password: String,
         flowContinuationState: MSALNativeAuthFlowContinuationState
@@ -670,14 +636,42 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         return await performSubmitAttributes(["password": password], flowContinuationState: flowContinuationState, step: step)
     }
 
+    private func submitPassword(
+        _ password: String,
+        flowContinuationState: MSALNativeAuthFlowContinuationState,
+        step: MSALNativeAuthFlowStepContext
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        guard let verifyHref = flowContinuationState.link(.verify)?.absoluteString else {
+            return failure(
+                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing verify link")),
+                event: step.event,
+                context: step.context, scenario: flowContinuationState.flowScenario
+            )
+        }
+
+        guard let continuationToken = flowContinuationState.continuationToken else {
+            return failure(
+                .error(MSALNativeAuthFlowError(type: .generalError, errorDescription: "Missing continuation token")),
+                event: step.event,
+                context: step.context, scenario: flowContinuationState.flowScenario
+            )
+        }
+
+        let result = await performInteraction(context: step.context) {
+            try self.requestProvider.submitPassword(
+                href: verifyHref,
+                password: password,
+                continuationToken: continuationToken,
+                apiId: step.apiId,
+                context: step.context
+            )
+        }
+        return await handleSignInSubmitPasswordResult(result, flowContinuationState: flowContinuationState, step: step)
+    }
+
     // MARK: - Sign-up result mapping
 
     /// Drives the server-directed sign-up sequence forward.
-    ///
-    /// Sign up is a chain of `collectAttributes` steps interleaved with a `verify` (one-time code) step.
-    /// On the first `collectAttributes` step every value supplied up front is submitted at once; any
-    /// attribute the server later requests that the app did not supply is surfaced via
-    /// ``MSALNativeAuthAttributesRequiredState`` so the app can collect it.
     private func handleSignUpInteractionResult(
         _ result: MSALNativeAuthV2InteractionParsedResponse,
         flowContinuationState: MSALNativeAuthFlowContinuationState,
@@ -816,15 +810,10 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
         _ attribute: MSALNativeAuthRequiredAttributeInternal,
         flowContinuationState: MSALNativeAuthFlowContinuationState
     ) -> Bool {
-        if isPasswordAttribute(attribute) || attribute.name.caseInsensitiveCompare("email") == .orderedSame {
+        if attribute.name.caseInsensitiveCompare("password") == .orderedSame || attribute.name.caseInsensitiveCompare("email") == .orderedSame {
             return true
         }
         return flowContinuationState.submittedAttributes.contains { $0.caseInsensitiveCompare(attribute.name) == .orderedSame }
-    }
-
-    private func isPasswordAttribute(_ attribute: MSALNativeAuthRequiredAttributeInternal) -> Bool {
-        return attribute.type.caseInsensitiveCompare("password") == .orderedSame
-            || attribute.name.caseInsensitiveCompare("password") == .orderedSame
     }
 
     /// Derives the next sign-up continuation, preserving the names of the attributes already submitted.

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -724,9 +724,11 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
     /// request, regardless of which attributes the server actually asked for. The names of the submitted
     /// attributes are then recorded on the continuation state.
     ///
-    /// On any later step (`signUpParameters` is nil) the server is asking for something the app did not provide up
-    /// front. If it re-requests `email`, `password`, or an attribute already submitted, that is treated as
-    /// an error; otherwise the requested attributes are surfaced via ``MSALNativeAuthAttributesRequiredState``.
+    /// On any later step (`signUpParameters` is nil) the server is requesting more information. It may ask again
+    /// for something already submitted, and the SDK detects that and fails. If it requests `password` that was not
+    /// supplied up front, the password-required state is surfaced so the app can collect it. If it requests any
+    /// other attribute not yet submitted, the attributes-required state is surfaced. If it re-requests `email`
+    /// (always sent up front) or any attribute already submitted, that is treated as an error
     private func handleSignUpAttributesRequired(
         continuationToken: String,
         submitHref: String,
@@ -745,7 +747,16 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             return await performSubmitAttributes(upfrontAttributeValues(signUpParameters), flowContinuationState: next, step: step)
         }
 
-        if let invalid = attributes.first(where: { isReservedOrAlreadySubmitted($0, flowContinuationState: flowContinuationState) }) {
+        // The server is requesting more information, and it may re-ask for something already submitted. A
+        // password not yet submitted is collected through the dedicated password-required state; any other
+        // attribute already submitted (including `email`, which is always sent up front) must not be
+        // requested again and is treated as an error.
+        if attributes.contains(where: { $0.name.caseInsensitiveCompare("password") == .orderedSame }),
+           !flowContinuationState.hasSubmittedAttribute("password") {
+            return passwordRequiredResponse(flowContinuationState: next, step: step)
+        }
+
+        if let invalid = attributes.first(where: { flowContinuationState.hasSubmittedAttribute($0.name) }) {
             let error = MSALNativeAuthFlowError(
                 type: .generalError,
                 errorDescription: "The server requested attribute '\(invalid.name)' that was already submitted or cannot be collected."
@@ -806,17 +817,6 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             }
         }
         return values
-    }
-
-    /// A requested attribute is invalid when it is `email`, `password`, or one the SDK has already submitted.
-    private func isReservedOrAlreadySubmitted(
-        _ attribute: MSALNativeAuthRequiredAttributeInternal,
-        flowContinuationState: MSALNativeAuthFlowContinuationState
-    ) -> Bool {
-        if attribute.name.caseInsensitiveCompare("password") == .orderedSame || attribute.name.caseInsensitiveCompare("email") == .orderedSame {
-            return true
-        }
-        return flowContinuationState.submittedAttributes.contains { $0.caseInsensitiveCompare(attribute.name) == .orderedSame }
     }
 
     /// Derives the next sign-up continuation, preserving the names of the attributes already submitted.

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -1477,7 +1477,7 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
     }
 
     /// Response for the case where, after performing a step, no handler is available to process the
-    /// result for the current flow scenario (a handler that should exist is missing).
+    /// result for the current flow scenario.
     private func notImplementedResponse(scenario: MSALNativeAuthFlowScenario) -> MSALNativeAuthFlowControllerResponse {
         return MSALNativeAuthFlowControllerResponse(
             .error(error: MSALNativeAuthFlowError(type: .notImplemented)),

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -270,19 +270,33 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
             )
         }
         let step = MSALNativeAuthFlowStepContext(apiId: apiId, event: event, context: context)
-        if flowContinuationState.flowScenario == .signUp {
+        switch flowContinuationState.flowScenario {
+        case .signUp:
             return await handleSignUpInteractionResult(result, flowContinuationState: flowContinuationState, step: step)
+        case .signIn, .passwordReset:
+            return await handleSubmitCodeResult(result, flowContinuationState: flowContinuationState, step: step)
+        default:
+            return notImplementedResponse(scenario: flowContinuationState.flowScenario)
         }
-        return await handleSubmitCodeResult(result, flowContinuationState: flowContinuationState, step: step)
     }
 
     func submitPassword(_ password: String, state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse {
         let flowContinuationState = state.continuation
 
-        if flowContinuationState.flowScenario == .signUp {
+        switch flowContinuationState.flowScenario {
+        case .signUp:
             return await submitSignUpPassword(password, flowContinuationState: flowContinuationState)
+        case .signIn:
+            return await submitSignInPassword(password, flowContinuationState: flowContinuationState)
+        default:
+            return notImplementedResponse(scenario: flowContinuationState.flowScenario)
         }
+    }
 
+    private func submitSignInPassword(
+        _ password: String,
+        flowContinuationState: MSALNativeAuthFlowContinuationState
+    ) async -> MSALNativeAuthFlowControllerResponse {
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
         let event = makeAndStartTelemetryEvent(id: .telemetryApiIdV2SignInSubmitPassword, context: context)
         let step = MSALNativeAuthFlowStepContext(apiId: .telemetryApiIdV2SignInSubmitPassword, event: event, context: context)
@@ -541,14 +555,12 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
 
     func resendCode(state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse {
         let flowContinuationState = state.continuation
-
-        if flowContinuationState.flowScenario == .signUp {
-            return await resendSignUpCode(flowContinuationState: flowContinuationState)
-        }
-
         let context = MSALNativeAuthRequestContext(correlationId: flowContinuationState.correlationId)
+
         let apiId: MSALNativeAuthTelemetryApiId
         switch flowContinuationState.flowScenario {
+        case .signUp:
+            return await resendSignUpCode(flowContinuationState: flowContinuationState)
         case .signIn:
             apiId = .telemetryApiIdV2SignInResendCode
         case .passwordReset:

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowController.swift
@@ -89,7 +89,6 @@ final class MSALNativeAuthFlowController: MSALNativeAuthBaseController, MSALNati
 
         let startResult = await performInteraction(context: context) {
             try self.requestProvider.signUpStart(
-                username: parameters.username,
                 continuationToken: continuationToken,
                 href: signUpLink,
                 apiId: .telemetryApiIdV2SignUpStart,

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowControlling.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowControlling.swift
@@ -53,6 +53,12 @@ protocol MSALNativeAuthFlowControlling {
         state: MSALNativeAuthFlowInternalState
     ) async -> MSALNativeAuthFlowControllerResponse
 
+    func signInAfterSignUp(
+        scopes: [String]?,
+        claimsRequestJson: String?,
+        state: MSALNativeAuthFlowInternalState
+    ) async -> MSALNativeAuthFlowControllerResponse
+
     func submitAttributes(_ attributes: [String: Any], state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse
 
     func selectAuthMethod(

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowResponseDispatcher.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowResponseDispatcher.swift
@@ -109,6 +109,30 @@ struct MSALNativeAuthFlowResponseDispatcher {
                           scenario: scenario) {
                 await $0.onSignInAfterResetPasswordRequired(state: state, scenario: scenario)
             }
+        case let state as MSALNativeAuthSignInAfterSignUpState:
+            await deliver(to: delegate,
+                          delegateName: "MSALNativeAuthSignInAfterSignUpRequiredDelegate",
+                          response: response,
+                          as: MSALNativeAuthSignInAfterSignUpRequiredDelegate.self,
+                          scenario: scenario) {
+                await $0.onSignInAfterSignUpRequired(state: state, scenario: scenario)
+            }
+        case let state as MSALNativeAuthAttributesRequiredState:
+            await deliver(to: delegate,
+                          delegateName: "MSALNativeAuthAttributesRequiredDelegate",
+                          response: response,
+                          as: MSALNativeAuthAttributesRequiredDelegate.self,
+                          scenario: scenario) {
+                await $0.onAttributesRequired(state: state, scenario: scenario)
+            }
+        case let state as MSALNativeAuthAttributesInvalidState:
+            await deliver(to: delegate,
+                          delegateName: "MSALNativeAuthAttributesInvalidDelegate",
+                          response: response,
+                          as: MSALNativeAuthAttributesInvalidDelegate.self,
+                          scenario: scenario) {
+                await $0.onAttributesInvalid(state: state, scenario: scenario)
+            }
         default:
             await notImplemented(delegate: delegate, delegateName: "unknown", scenario: scenario, correlationId: response.correlationId)
         }

--- a/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowResponseDispatcher.swift
+++ b/MSAL/src/native_auth/controllers/v2/MSALNativeAuthFlowResponseDispatcher.swift
@@ -77,6 +77,22 @@ struct MSALNativeAuthFlowResponseDispatcher {
                           scenario: scenario) {
                 await $0.onPasswordRequired(state: state, scenario: scenario)
             }
+        case let state as MSALNativeAuthAttributesRequiredState:
+            await deliver(to: delegate,
+                          delegateName: "MSALNativeAuthAttributesRequiredDelegate",
+                          response: response,
+                          as: MSALNativeAuthAttributesRequiredDelegate.self,
+                          scenario: scenario) {
+                await $0.onAttributesRequired(state: state, scenario: scenario)
+            }
+        case let state as MSALNativeAuthAttributesInvalidState:
+            await deliver(to: delegate,
+                          delegateName: "MSALNativeAuthAttributesInvalidDelegate",
+                          response: response,
+                          as: MSALNativeAuthAttributesInvalidDelegate.self,
+                          scenario: scenario) {
+                await $0.onAttributesInvalid(state: state, scenario: scenario)
+            }
         case let state as MSALNativeAuthMFARequiredState:
             await deliver(to: delegate,
                           delegateName: "MSALNativeAuthMFARequiredDelegate",
@@ -101,14 +117,6 @@ struct MSALNativeAuthFlowResponseDispatcher {
                           scenario: scenario) {
                 await $0.onNewPasswordRequired(state: state, scenario: scenario)
             }
-        case let state as MSALNativeAuthSignInAfterResetPasswordState:
-            await deliver(to: delegate,
-                          delegateName: "MSALNativeAuthSignInAfterResetPasswordRequiredDelegate",
-                          response: response,
-                          as: MSALNativeAuthSignInAfterResetPasswordRequiredDelegate.self,
-                          scenario: scenario) {
-                await $0.onSignInAfterResetPasswordRequired(state: state, scenario: scenario)
-            }
         case let state as MSALNativeAuthSignInAfterSignUpState:
             await deliver(to: delegate,
                           delegateName: "MSALNativeAuthSignInAfterSignUpRequiredDelegate",
@@ -117,21 +125,13 @@ struct MSALNativeAuthFlowResponseDispatcher {
                           scenario: scenario) {
                 await $0.onSignInAfterSignUpRequired(state: state, scenario: scenario)
             }
-        case let state as MSALNativeAuthAttributesRequiredState:
+        case let state as MSALNativeAuthSignInAfterResetPasswordState:
             await deliver(to: delegate,
-                          delegateName: "MSALNativeAuthAttributesRequiredDelegate",
+                          delegateName: "MSALNativeAuthSignInAfterResetPasswordRequiredDelegate",
                           response: response,
-                          as: MSALNativeAuthAttributesRequiredDelegate.self,
+                          as: MSALNativeAuthSignInAfterResetPasswordRequiredDelegate.self,
                           scenario: scenario) {
-                await $0.onAttributesRequired(state: state, scenario: scenario)
-            }
-        case let state as MSALNativeAuthAttributesInvalidState:
-            await deliver(to: delegate,
-                          delegateName: "MSALNativeAuthAttributesInvalidDelegate",
-                          response: response,
-                          as: MSALNativeAuthAttributesInvalidDelegate.self,
-                          scenario: scenario) {
-                await $0.onAttributesInvalid(state: state, scenario: scenario)
+                await $0.onSignInAfterResetPasswordRequired(state: state, scenario: scenario)
             }
         default:
             await notImplemented(delegate: delegate, delegateName: "unknown", scenario: scenario, correlationId: response.correlationId)

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
@@ -40,6 +40,7 @@ enum MSALNativeAuthErrorMessage {
     static let generalError = "General error"
     static let invalidCode = "Invalid code"
     static let delegateNotImplementedV2 = "Delegate %@ is not implemented"
+    static let methodNotAllowedForFlow = "This method cannot be called for state %@ flow %@"
     static let invalidChallenge = "Invalid challenge"
     static let invalidInput = "Invalid input"
     static let refreshTokenExpired = "Refresh token is expired"

--- a/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
+++ b/MSAL/src/native_auth/network/errors/MSALNativeAuthErrorMessage.swift
@@ -40,7 +40,7 @@ enum MSALNativeAuthErrorMessage {
     static let generalError = "General error"
     static let invalidCode = "Invalid code"
     static let delegateNotImplementedV2 = "Delegate %@ is not implemented"
-    static let methodNotAllowedForFlow = "This method cannot be called for state %@ flow %@"
+    static let methodNotAllowedForFlow = "This method cannot be called for state %@ in %@ flow"
     static let invalidChallenge = "Invalid challenge"
     static let invalidInput = "Invalid input"
     static let refreshTokenExpired = "Refresh token is expired"

--- a/MSAL/src/native_auth/network/responses/v2/MSALNativeAuthHALCollectAttributesResponse.swift
+++ b/MSAL/src/native_auth/network/responses/v2/MSALNativeAuthHALCollectAttributesResponse.swift
@@ -24,17 +24,36 @@
 
 import Foundation
 
-/// JSON body keys used by the Native Auth V2 (server-driven, HAL) requests.
-///
-/// V2 HAL bodies are camelCase JSON (unlike the snake_case, form-encoded keys in
-/// ``MSALNativeAuthRequestParametersKey`` used by the OAuth `/token` and `/authorize-challenge`
-/// endpoints)
-enum MSALNativeAuthV2RequestBodyKey: String {
-    case username
-    case continuationToken
-    case code
-    case otp
-    case password
-    case newPassword
-    case attributes
+/// `action == collectAttributes`: the server asks the SDK to collect one or more user attributes
+/// (e.g. `email`, `password`) and post them back to the `submitAttributes` href.
+final class MSALNativeAuthHALCollectAttributesResponse: MSALNativeAuthHALResponse {
+
+    /// A single attribute the server asked the SDK to collect.
+    struct Attribute: Equatable {
+        let attributeId: String
+        let inputType: String?
+        let required: Bool
+    }
+
+    let attributes: [Attribute]
+
+    init(
+        statusCode: Int,
+        correlationId: UUID?,
+        continuationToken: String?,
+        links: [String: String],
+        error: ServerError?,
+        isWebFallbackRequired: Bool,
+        attributes: [Attribute]
+    ) {
+        self.attributes = attributes
+        super.init(
+            statusCode: statusCode,
+            correlationId: correlationId,
+            continuationToken: continuationToken,
+            links: links,
+            error: error,
+            isWebFallbackRequired: isWebFallbackRequired
+        )
+    }
 }

--- a/MSAL/src/native_auth/network/responses/v2/MSALNativeAuthHALCollectAttributesResponse.swift
+++ b/MSAL/src/native_auth/network/responses/v2/MSALNativeAuthHALCollectAttributesResponse.swift
@@ -24,11 +24,9 @@
 
 import Foundation
 
-/// `action == collectAttributes`: the server asks the SDK to collect one or more user attributes
-/// (e.g. `email`, `password`) and post them back to the `submitAttributes` href.
 final class MSALNativeAuthHALCollectAttributesResponse: MSALNativeAuthHALResponse {
 
-    /// A single attribute the server asked the SDK to collect.
+    /// A single attribute the server asked the client to collect.
     struct Attribute: Equatable {
         let attributeId: String
         let inputType: String?

--- a/MSAL/src/native_auth/network/responses/v2/MSALNativeAuthV2HALResponseSerializer.swift
+++ b/MSAL/src/native_auth/network/responses/v2/MSALNativeAuthV2HALResponseSerializer.swift
@@ -95,6 +95,8 @@ final class MSALNativeAuthV2HALResponseSerializer: NSObject, MSIDResponseSeriali
                     methodType: resource.string(forKey: "type"),
                     hint: resource.string(forKey: "hint")
                 )
+            case .collectAttributes:
+                return makeCollectAttributesResponse(base, attributes: parseAttributes(from: json))
             case .update:
                 return makeUpdateResponse(base)
             case .poll:
@@ -167,6 +169,21 @@ final class MSALNativeAuthV2HALResponseSerializer: NSObject, MSIDResponseSeriali
             codeLength: codeLength,
             methodType: methodType,
             hint: hint
+        )
+    }
+
+    private func makeCollectAttributesResponse(
+        _ base: BaseFields,
+        attributes: [MSALNativeAuthHALCollectAttributesResponse.Attribute]
+    ) -> MSALNativeAuthHALCollectAttributesResponse {
+        return MSALNativeAuthHALCollectAttributesResponse(
+            statusCode: base.statusCode,
+            correlationId: base.correlationId,
+            continuationToken: base.continuationToken,
+            links: base.links,
+            error: base.error,
+            isWebFallbackRequired: base.isWebFallbackRequired,
+            attributes: attributes
         )
     }
 
@@ -258,8 +275,24 @@ final class MSALNativeAuthV2HALResponseSerializer: NSObject, MSIDResponseSeriali
         }
     }
 
-    private func parseError(from json: [String: Any], fallbackCorrelationId: UUID?) -> MSALNativeAuthHALResponse.ServerError? {
-        guard let errorDict = json["error"] as? [String: Any] else {
+    /// Parses the top-level `attributes` array of a `collectAttributes` response.
+    private func parseAttributes(from json: [String: Any]) -> [MSALNativeAuthHALCollectAttributesResponse.Attribute] {
+        guard let attributes = json["attributes"] as? [[String: Any]] else {
+            return []
+        }
+        return attributes.compactMap { attribute in
+            guard let attributeId = attribute["attributeId"] as? String else {
+                return nil
+            }
+            return MSALNativeAuthHALCollectAttributesResponse.Attribute(
+                attributeId: attributeId,
+                inputType: attribute["inputType"] as? String,
+                required: attribute["required"] as? Bool ?? false
+            )
+        }
+    }
+
+    private func parseError(from json: [String: Any], fallbackCorrelationId: UUID?) -> MSALNativeAuthHALResponse.ServerError? {        guard let errorDict = json["error"] as? [String: Any] else {
             return nil
         }
 

--- a/MSAL/src/native_auth/network/responses/v2/MSALNativeAuthV2HALResponseSerializer.swift
+++ b/MSAL/src/native_auth/network/responses/v2/MSALNativeAuthV2HALResponseSerializer.swift
@@ -275,7 +275,6 @@ final class MSALNativeAuthV2HALResponseSerializer: NSObject, MSIDResponseSeriali
         }
     }
 
-    /// Parses the top-level `attributes` array of a `collectAttributes` response.
     private func parseAttributes(from json: [String: Any]) -> [MSALNativeAuthHALCollectAttributesResponse.Attribute] {
         guard let attributes = json["attributes"] as? [[String: Any]] else {
             return []
@@ -292,7 +291,8 @@ final class MSALNativeAuthV2HALResponseSerializer: NSObject, MSIDResponseSeriali
         }
     }
 
-    private func parseError(from json: [String: Any], fallbackCorrelationId: UUID?) -> MSALNativeAuthHALResponse.ServerError? {        guard let errorDict = json["error"] as? [String: Any] else {
+    private func parseError(from json: [String: Any], fallbackCorrelationId: UUID?) -> MSALNativeAuthHALResponse.ServerError? {
+        guard let errorDict = json["error"] as? [String: Any] else {
             return nil
         }
 

--- a/MSAL/src/native_auth/network/responses/v2/parser/MSALNativeAuthV2ParsedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/v2/parser/MSALNativeAuthV2ParsedResponses.swift
@@ -92,8 +92,7 @@ enum MSALNativeAuthV2InteractionParsedResponse: Equatable {
     )
     /// `action == update`: a new password is required from the user.
     case updateRequired(continuationToken: String, updateHref: String)
-    /// `action == collectAttributes`: the server asks the SDK to collect one or more user attributes
-    /// (e.g. `email`, `password`) and post them back to the `submitAttributes` href.
+    /// `action == collectAttributes`: the server asks for one or more user attributes to be sent.
     case attributesRequired(continuationToken: String, submitHref: String, attributes: [MSALNativeAuthRequiredAttributeInternal])
     /// `action == poll`: the operation is still running; keep polling.
     case pollInProgress(continuationToken: String, pollHref: String)

--- a/MSAL/src/native_auth/network/responses/v2/parser/MSALNativeAuthV2ParsedResponses.swift
+++ b/MSAL/src/native_auth/network/responses/v2/parser/MSALNativeAuthV2ParsedResponses.swift
@@ -92,6 +92,9 @@ enum MSALNativeAuthV2InteractionParsedResponse: Equatable {
     )
     /// `action == update`: a new password is required from the user.
     case updateRequired(continuationToken: String, updateHref: String)
+    /// `action == collectAttributes`: the server asks the SDK to collect one or more user attributes
+    /// (e.g. `email`, `password`) and post them back to the `submitAttributes` href.
+    case attributesRequired(continuationToken: String, submitHref: String, attributes: [MSALNativeAuthRequiredAttributeInternal])
     /// `action == poll`: the operation is still running; keep polling.
     case pollInProgress(continuationToken: String, pollHref: String)
     /// `state == continue`: the flow is ready to complete (call `authorize-challenge`).
@@ -113,6 +116,8 @@ enum MSALNativeAuthV2InteractionParsedResponse: Equatable {
             return lToken == rToken && lVerify == rVerify && lResend == rResend && lSent == rSent && lChannel.value == rChannel.value && lLen == rLen
         case let (.updateRequired(lToken, lHref), .updateRequired(rToken, rHref)):
             return lToken == rToken && lHref == rHref
+        case let (.attributesRequired(lToken, lHref, lAttrs), .attributesRequired(rToken, rHref, rAttrs)):
+            return lToken == rToken && lHref == rHref && lAttrs.map { $0.name } == rAttrs.map { $0.name }
         case let (.pollInProgress(lToken, lHref), .pollInProgress(rToken, rHref)):
             return lToken == rToken && lHref == rHref
         case let (.readyToComplete(lToken), .readyToComplete(rToken)):

--- a/MSAL/src/native_auth/network/responses/v2/parser/MSALNativeAuthV2ResponseParser.swift
+++ b/MSAL/src/native_auth/network/responses/v2/parser/MSALNativeAuthV2ResponseParser.swift
@@ -160,6 +160,18 @@ final class MSALNativeAuthV2ResponseParser: MSALNativeAuthV2ResponseParsing {
                 continuationToken: continuationToken,
                 updateHref: updateHref
             )
+        case let collectAttributesResponse as MSALNativeAuthHALCollectAttributesResponse:
+            guard let submitHref = collectAttributesResponse.href(for: .submitAttributes) ?? collectAttributesResponse.href(for: .self) else {
+                return missingLink(.submitAttributes, context: context)
+            }
+            let attributes = collectAttributesResponse.attributes.map {
+                MSALNativeAuthRequiredAttributeInternal(name: $0.attributeId, type: $0.inputType ?? "", required: $0.required)
+            }
+            return .attributesRequired(
+                continuationToken: continuationToken,
+                submitHref: submitHref,
+                attributes: attributes
+            )
         case let pollResponse as MSALNativeAuthHALPollResponse:
             guard let pollHref = pollResponse.href(for: .poll) else {
                 return missingLink(.poll, context: context)
@@ -271,6 +283,9 @@ extension MSALNativeAuthV2ResponseParser {
         } else if code == "invalidRequest", let message = message, message.contains("AADSTS50034") {
             // Account does not exist in the directory. This response carries no inner code.
             type = .userNotFound
+        } else if code == "userAlreadyExists" {
+            // An account already exists for the supplied username during sign up.
+            type = .userAlreadyExists
         } else {
             type = .generalError
         }

--- a/MSAL/src/native_auth/network/v2/MSALNativeAuthV2LinkRelation.swift
+++ b/MSAL/src/native_auth/network/v2/MSALNativeAuthV2LinkRelation.swift
@@ -60,3 +60,7 @@ extension MSALNativeAuthV2LinkRelation {
 extension MSALNativeAuthV2LinkRelation {
     static let `self` = Self(rawValue: "self")
 }
+
+extension MSALNativeAuthV2LinkRelation {
+    static let submitAttributes = Self(rawValue: "submitAttributes")
+}

--- a/MSAL/src/native_auth/network/v2/MSALNativeAuthV2RequestProvider.swift
+++ b/MSAL/src/native_auth/network/v2/MSALNativeAuthV2RequestProvider.swift
@@ -178,6 +178,9 @@ final class MSALNativeAuthV2RequestProvider: MSALNativeAuthV2RequestProviding {
                           apiId: MSALNativeAuthTelemetryApiId,
                           context: MSALNativeAuthRequestContext
     ) throws -> MSIDHttpRequest {
+        guard JSONSerialization.isValidJSONObject(attributes) else {
+            throw MSALNativeAuthInternalError.invalidAttributes
+        }
         return try configurator.configure(parameters: MSALNativeAuthV2HrefParameters(
             context: context,
             href: href,

--- a/MSAL/src/native_auth/network/v2/MSALNativeAuthV2RequestProvider.swift
+++ b/MSAL/src/native_auth/network/v2/MSALNativeAuthV2RequestProvider.swift
@@ -43,8 +43,7 @@ protocol MSALNativeAuthV2RequestProviding {
     ) throws -> MSIDHttpRequest
 
     /// Sign-up entry, posted to the authorize-challenge `sign_up` href.
-    func signUpStart(username: String,
-                     continuationToken: String,
+    func signUpStart(continuationToken: String,
                      href: String,
                      apiId: MSALNativeAuthTelemetryApiId,
                      context: MSALNativeAuthRequestContext
@@ -158,8 +157,7 @@ final class MSALNativeAuthV2RequestProvider: MSALNativeAuthV2RequestProviding {
         ))
     }
 
-    func signUpStart(username: String,
-                     continuationToken: String,
+    func signUpStart(continuationToken: String,
                      href: String,
                      apiId: MSALNativeAuthTelemetryApiId,
                      context: MSALNativeAuthRequestContext
@@ -169,7 +167,7 @@ final class MSALNativeAuthV2RequestProvider: MSALNativeAuthV2RequestProviding {
             target: .href(href),
             apiId: apiId,
             operationType: MSALNativeAuthV2OperationType.signUpStart.rawValue,
-            username: username,
+            username: nil,
             continuationToken: continuationToken
         ))
     }

--- a/MSAL/src/native_auth/network/v2/MSALNativeAuthV2RequestProvider.swift
+++ b/MSAL/src/native_auth/network/v2/MSALNativeAuthV2RequestProvider.swift
@@ -42,6 +42,22 @@ protocol MSALNativeAuthV2RequestProviding {
                      context: MSALNativeAuthRequestContext
     ) throws -> MSIDHttpRequest
 
+    /// Sign-up entry, posted to the authorize-challenge `sign_up` href.
+    func signUpStart(username: String,
+                     continuationToken: String,
+                     href: String,
+                     apiId: MSALNativeAuthTelemetryApiId,
+                     context: MSALNativeAuthRequestContext
+    ) throws -> MSIDHttpRequest
+
+    /// Submit collected user attributes during sign up (server `submitAttributes` href).
+    func submitAttributes(href: String,
+                          attributes: [String: Any],
+                          continuationToken: String,
+                          apiId: MSALNativeAuthTelemetryApiId,
+                          context: MSALNativeAuthRequestContext
+    ) throws -> MSIDHttpRequest
+
     /// Send EOTP (server `challenge` / `resend` href).
     func challenge(href: String,
                    continuationToken: String,
@@ -139,6 +155,38 @@ final class MSALNativeAuthV2RequestProvider: MSALNativeAuthV2RequestProviding {
             operationType: MSALNativeAuthV2OperationType.signInStart.rawValue,
             username: username,
             continuationToken: continuationToken
+        ))
+    }
+
+    func signUpStart(username: String,
+                     continuationToken: String,
+                     href: String,
+                     apiId: MSALNativeAuthTelemetryApiId,
+                     context: MSALNativeAuthRequestContext
+    ) throws -> MSIDHttpRequest {
+        return try configurator.configure(parameters: MSALNativeAuthV2EntryParameters(
+            context: context,
+            target: .href(href),
+            apiId: apiId,
+            operationType: MSALNativeAuthV2OperationType.signUpStart.rawValue,
+            username: username,
+            continuationToken: continuationToken
+        ))
+    }
+
+    func submitAttributes(href: String,
+                          attributes: [String: Any],
+                          continuationToken: String,
+                          apiId: MSALNativeAuthTelemetryApiId,
+                          context: MSALNativeAuthRequestContext
+    ) throws -> MSIDHttpRequest {
+        return try configurator.configure(parameters: MSALNativeAuthV2HrefParameters(
+            context: context,
+            href: href,
+            httpMethod: "POST",
+            apiId: apiId,
+            operationType: MSALNativeAuthV2OperationType.submitAttributes.rawValue,
+            requestBody: MSALNativeAuthV2SubmitAttributesRequestBody(continuationToken: continuationToken, attributes: attributes)
         ))
     }
 

--- a/MSAL/src/native_auth/network/v2/MSALNativeAuthV2SubmitAttributesRequestBody.swift
+++ b/MSAL/src/native_auth/network/v2/MSALNativeAuthV2SubmitAttributesRequestBody.swift
@@ -24,17 +24,19 @@
 
 import Foundation
 
-/// JSON body keys used by the Native Auth V2 (server-driven, HAL) requests.
-///
-/// V2 HAL bodies are camelCase JSON (unlike the snake_case, form-encoded keys in
-/// ``MSALNativeAuthRequestParametersKey`` used by the OAuth `/token` and `/authorize-challenge`
-/// endpoints)
-enum MSALNativeAuthV2RequestBodyKey: String {
-    case username
-    case continuationToken
-    case code
-    case otp
-    case password
-    case newPassword
-    case attributes
+/// Body of the sign-up `submitattributes` request. JSON encoded `{continuationToken, attributes: { ... }}`,
+/// where `attributes` is the nested map of attribute id to value the server asked the SDK to collect.
+final class MSALNativeAuthV2SubmitAttributesRequestBody: MSALNativeAuthV2RequestBody {
+    let attributes: [String: Any]
+
+    init(continuationToken: String?, attributes: [String: Any]) {
+        self.attributes = attributes
+        super.init(continuationToken: continuationToken)
+    }
+
+    override var dictionary: [String: Any] {
+        var body = super.dictionary
+        body[MSALNativeAuthV2RequestBodyKey.attributes.rawValue] = attributes
+        return body
+    }
 }

--- a/MSAL/src/native_auth/network/v2/MSALNativeAuthV2SubmitAttributesRequestBody.swift
+++ b/MSAL/src/native_auth/network/v2/MSALNativeAuthV2SubmitAttributesRequestBody.swift
@@ -24,8 +24,6 @@
 
 import Foundation
 
-/// Body of the sign-up `submitattributes` request. JSON encoded `{continuationToken, attributes: { ... }}`,
-/// where `attributes` is the nested map of attribute id to value the server asked the SDK to collect.
 final class MSALNativeAuthV2SubmitAttributesRequestBody: MSALNativeAuthV2RequestBody {
     let attributes: [String: Any]
 

--- a/MSAL/src/native_auth/network/v2/parameters/MSALNativeAuthV2EntryParameters.swift
+++ b/MSAL/src/native_auth/network/v2/parameters/MSALNativeAuthV2EntryParameters.swift
@@ -24,22 +24,25 @@
 
 import Foundation
 
-/// The signup/signin/resetpassword `start` entry requests. JSON encoded `{username, continuationToken}`,
-/// targeting either the well-known start endpoint or a server-provided `href`.
+/// The signup/signin/resetpassword `start` entry requests. JSON encoded `{continuationToken}` plus an
+/// optional `username`, targeting either the well-known start endpoint or a server-provided `href`.
 struct MSALNativeAuthV2EntryParameters: MSALNativeAuthV2Requestable {
     let context: MSALNativeAuthRequestContext
     let target: MSALNativeAuthV2RequestTarget
     let apiId: MSALNativeAuthTelemetryApiId
     let operationType: MSALNativeAuthOperationType
-    let username: String
+    let username: String?
     let continuationToken: String
     let encoding: MSALNativeAuthUrlRequestEncoding = .json
 
     var body: [AnyHashable: Any] {
-        return [
-            MSALNativeAuthV2RequestBodyKey.username.rawValue: username,
+        var body: [AnyHashable: Any] = [
             MSALNativeAuthV2RequestBodyKey.continuationToken.rawValue: continuationToken
         ]
+        if let username = username {
+            body[MSALNativeAuthV2RequestBodyKey.username.rawValue] = username
+        }
+        return body
     }
 
     func url(resolver: MSALNativeAuthV2HrefURLResolver) throws -> URL {

--- a/MSAL/src/native_auth/network/v2/parameters/MSALNativeAuthV2EntryParameters.swift
+++ b/MSAL/src/native_auth/network/v2/parameters/MSALNativeAuthV2EntryParameters.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-/// The signup/signin/resetpassword `start` entry requests. JSON encoded `{continuationToken}` plus an
+/// The signup/signin/resetpassword `start` entry requests. JSON encoded `{continuationToken}` and
 /// optional `username`, targeting either the well-known start endpoint or a server-provided `href`.
 struct MSALNativeAuthV2EntryParameters: MSALNativeAuthV2Requestable {
     let context: MSALNativeAuthRequestContext

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication+Internal.swift
@@ -104,4 +104,58 @@ extension MSALNativeAuthPublicClientApplication {
             )
         )
     }
+
+    func signUpV2Internal(
+        parameters: MSALNativeAuthSignUpParametersV2
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: parameters.correlationId)
+        let correlationId = context.correlationId()
+
+        guard inputValidator.isInputValid(parameters.username) else {
+            return .init(
+                .error(error: MSALNativeAuthFlowError(type: .invalidUsername, correlationId: correlationId)),
+                correlationId: correlationId,
+                scenario: .signUp
+            )
+        }
+
+        let controller = controllerFactory.makeFlowController(cacheAccessor: cacheAccessor)
+        return await controller.signUp(parameters: parameters)
+    }
+
+    func signInV2Internal(
+        parameters: MSALNativeAuthSignInParameters
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: parameters.correlationId)
+        let correlationId = context.correlationId()
+
+        guard inputValidator.isInputValid(parameters.username) else {
+            return .init(
+                .error(error: MSALNativeAuthFlowError(type: .invalidUsername, correlationId: correlationId)),
+                correlationId: correlationId,
+                scenario: .signIn
+            )
+        }
+
+        let controller = controllerFactory.makeFlowController(cacheAccessor: cacheAccessor)
+        return await controller.signIn(parameters: parameters)
+    }
+
+    func resetPasswordV2Internal(
+        parameters: MSALNativeAuthResetPasswordParameters
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        let context = MSALNativeAuthRequestContext(correlationId: parameters.correlationId)
+        let correlationId = context.correlationId()
+
+        guard inputValidator.isInputValid(parameters.username) else {
+            return .init(
+                .error(error: MSALNativeAuthFlowError(type: .invalidUsername, correlationId: correlationId)),
+                correlationId: correlationId,
+                scenario: .passwordReset
+            )
+        }
+
+        let controller = controllerFactory.makeFlowController(cacheAccessor: cacheAccessor)
+        return await controller.resetPassword(parameters: parameters)
+    }
 }

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -272,10 +272,8 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: MSALNativeAuthFlowDelegate
     ) {
         Task {
-            let controller = controllerFactory.makeFlowController(cacheAccessor: cacheAccessor)
+            let response = await signUpV2Internal(parameters: parameters)
             let dispatcher = MSALNativeAuthFlowResponseDispatcher()
-
-            let response = await controller.signUp(parameters: parameters)
             await dispatcher.dispatch(response, delegate: delegate)
         }
     }
@@ -291,10 +289,8 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: MSALNativeAuthFlowDelegate
     ) {
         Task {
-            let controller = controllerFactory.makeFlowController(cacheAccessor: cacheAccessor)
+            let response = await signInV2Internal(parameters: parameters)
             let dispatcher = MSALNativeAuthFlowResponseDispatcher()
-
-            let response = await controller.signIn(parameters: parameters)
             await dispatcher.dispatch(response, delegate: delegate)
         }
     }
@@ -310,10 +306,8 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
         delegate: MSALNativeAuthFlowDelegate
     ) {
         Task {
-            let controller = controllerFactory.makeFlowController(cacheAccessor: cacheAccessor)
+            let response = await resetPasswordV2Internal(parameters: parameters)
             let dispatcher = MSALNativeAuthFlowResponseDispatcher()
-
-            let response = await controller.resetPassword(parameters: parameters)
             await dispatcher.dispatch(response, delegate: delegate)
         }
     }

--- a/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
+++ b/MSAL/src/native_auth/public/MSALNativeAuthPublicClientApplication.swift
@@ -261,7 +261,13 @@ public final class MSALNativeAuthPublicClientApplication: MSALPublicClientApplic
 
     // MARK: - Native Auth V2 (server-driven)
 
-    private func signUpV2(
+    /// Sign up a user using the server-driven (V2) flow.
+    ///
+    /// - Warning: This API is experimental. It may be changed in the future without notice. Do not use in production applications.
+    /// - Parameters:
+    ///   - parameters: Parameters used for the Sign Up flow.
+    ///   - delegate: Unified delegate that receives callbacks for the flow.
+    public func signUpV2(
         parameters: MSALNativeAuthSignUpParametersV2,
         delegate: MSALNativeAuthFlowDelegate
     ) {

--- a/MSAL/src/native_auth/public/state_machine/v2/MSALNativeAuthFlowScenario.swift
+++ b/MSAL/src/native_auth/public/state_machine/v2/MSALNativeAuthFlowScenario.swift
@@ -48,3 +48,19 @@ public enum MSALNativeAuthFlowScenario: Int, CaseIterable {
     /// The callback originated from a password reset flow.
     case passwordReset
 }
+
+extension MSALNativeAuthFlowScenario {
+
+    var name: String {
+        switch self {
+        case .unknown:
+            return "unknown"
+        case .signUp:
+            return "signUp"
+        case .signIn:
+            return "signIn"
+        case .passwordReset:
+            return "passwordReset"
+        }
+    }
+}

--- a/MSAL/src/native_auth/public/state_machine/v2/state/MSALNativeAuthSignInAfterSignUpState.swift
+++ b/MSAL/src/native_auth/public/state_machine/v2/state/MSALNativeAuthSignInAfterSignUpState.swift
@@ -1,0 +1,68 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/// The sign-up completed. Sign the new account in by calling
+/// ``signIn(parameters:delegate:)`` with the scopes to request on the access token.
+///
+/// - Warning: This API is experimental. It may be changed in the future without notice. Do not use in production applications.
+@objcMembers
+public class MSALNativeAuthSignInAfterSignUpState: MSALNativeAuthState {
+
+    /// Sign in after a successful sign up.
+    public func signIn(parameters: MSALNativeAuthSignInAfterSignUpParameters, delegate: MSALNativeAuthFlowDelegate) {
+        run(delegate: delegate) { controller, state in
+            await controller.signInAfterSignUp(
+                scopes: parameters.scopes,
+                claimsRequestJson: parameters.claimsRequest?.jsonString(),
+                state: state
+            )
+        }
+    }
+
+    public override var description: String {
+        return "signInAfterSignUp"
+    }
+}
+
+/// Per-state delegate for the ``MSALNativeAuthSignInAfterSignUpState`` step of a Native Auth V2 flow.
+///
+/// Conform to this protocol (in addition to the terminal callbacks inherited from
+/// ``MSALNativeAuthFlowDelegate``) to handle this state. Conforming is opt-in per state, but the
+/// callback is required once you conform.
+///
+/// - Warning: This API is experimental. It may be changed in the future without notice. Do not use in production applications.
+@objc
+public protocol MSALNativeAuthSignInAfterSignUpRequiredDelegate: MSALNativeAuthFlowDelegate {
+
+    /// The sign up completed and the new account can now be signed in.
+    /// Continue with ``MSALNativeAuthSignInAfterSignUpState/signIn(parameters:delegate:)``.
+    /// - Parameters:
+    ///   - state: The sign-in-after-sign-up state.
+    ///   - scenario: The flow that produced this callback.
+    /// - Note: If the app's delegate does not conform to this protocol, then
+    ///   ``MSALNativeAuthFlowDelegate/onFlowError(error:scenario:)`` is called with error type `notImplemented`.
+    @MainActor func onSignInAfterSignUpRequired(state: MSALNativeAuthSignInAfterSignUpState, scenario: MSALNativeAuthFlowScenario)
+}

--- a/MSAL/src/native_auth/telemetry/MSALNativeAuthTelemetryApiId.swift
+++ b/MSAL/src/native_auth/telemetry/MSALNativeAuthTelemetryApiId.swift
@@ -77,4 +77,5 @@ enum MSALNativeAuthTelemetryApiId: Int {
     case telemetryApiIdV2MFASubmitChallenge = 76019
     case telemetryApiIdV2ResetPasswordResendCode = 76020
     case telemetryApiIdV2SignInResendCode = 76021
+    case telemetryApiIdV2SignUpResendCode = 76022
 }

--- a/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
@@ -129,9 +129,9 @@ final class MSALNativeAuthFlowControllerSignUpTests: MSALNativeAuthTestCase {
         XCTAssertTrue(state is MSALNativeAuthCodeRequiredState)
         XCTAssertTrue(requestProviderMock.authorizeChallengeStartCalled)
         XCTAssertTrue(requestProviderMock.signUpStartCalled)
-        XCTAssertEqual(requestProviderMock.signUpStartUsername, username)
         XCTAssertTrue(requestProviderMock.submitAttributesCalled)
         // Everything supplied up front is submitted at once, regardless of what the server asked for.
+        // The username is sent as the `email` attribute here, not on the start request.
         XCTAssertEqual(requestProviderMock.submitAttributesReceived?["email"] as? String, username)
         XCTAssertEqual(requestProviderMock.submitAttributesReceived?["password"] as? String, "password")
         XCTAssertEqual(requestProviderMock.submitAttributesReceived?["city"] as? String, "Seattle")

--- a/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
@@ -137,7 +137,7 @@ final class MSALNativeAuthFlowControllerSignUpTests: MSALNativeAuthTestCase {
         XCTAssertEqual(requestProviderMock.submitAttributesReceived?["city"] as? String, "Seattle")
     }
 
-    func test_signUp_upfrontAttributesSubmit_isAttributedToSubmitAttributesApiId() async {
+    func test_signUp_upfrontAttributesSubmit_isAttributedToSignUpStartApiId() async {
         requestProviderMock.mockRequest()
         parserMock.authorizeChallengeResponses = [
             .continuationToken(continuationToken: "ct-authorization-challenge", href: "https://contoso.com/signup")
@@ -160,10 +160,10 @@ final class MSALNativeAuthFlowControllerSignUpTests: MSALNativeAuthTestCase {
 
         _ = await sut.signUp(parameters: signUpParameters(password: "password", attributes: ["city": "Seattle"]))
 
-        // The upfront submitAttributes network call must be reported under its dedicated API id, not the
-        // sign-up start API id, so per-API telemetry counts stay accurate.
+        // One public call = one API id: every network request made while servicing signUp() start - including
+        // the upfront submitAttributes - is reported under the sign-up start API id.
         XCTAssertTrue(requestProviderMock.submitAttributesCalled)
-        XCTAssertEqual(requestProviderMock.submitAttributesApiIdReceived, .telemetryApiIdV2SignUpSubmitAttributes)
+        XCTAssertEqual(requestProviderMock.submitAttributesApiIdReceived, .telemetryApiIdV2SignUpStart)
     }
 
     func test_signUp_appSuppliedReservedAttributes_areIgnored_soSDKValuesWin() async {

--- a/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
@@ -1,0 +1,355 @@
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import XCTest
+@testable import MSAL
+@_implementationOnly import MSAL_Private
+
+// swiftlint:disable type_body_length file_length
+final class MSALNativeAuthFlowControllerSignUpTests: MSALNativeAuthTestCase {
+
+    private var sut: MSALNativeAuthFlowController!
+    private var requestProviderMock: MSALNativeAuthV2RequestProviderMock!
+    private var parserMock: MSALNativeAuthV2ResponseParserMock!
+    private var cacheAccessorMock: MSALNativeAuthCacheAccessorMock!
+    private var resultFactoryMock: MSALNativeAuthResultFactoryMock!
+
+    private let username = "user@contoso.com"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        requestProviderMock = .init()
+        parserMock = .init()
+        cacheAccessorMock = .init()
+        resultFactoryMock = .init()
+
+        sut = .init(
+            config: MSALNativeAuthConfigStubs.configuration,
+            requestProvider: requestProviderMock,
+            responseParser: parserMock,
+            cacheAccessor: cacheAccessorMock,
+            resultFactory: resultFactoryMock
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func signUpParameters(
+        password: String? = nil,
+        attributes: [String: Any]? = nil,
+        scopes: [String]? = ["scope1"]
+    ) -> MSALNativeAuthSignUpParametersV2 {
+        let params = MSALNativeAuthSignUpParametersV2(username: username)
+        params.password = password
+        params.attributes = attributes
+        params.scopes = scopes
+        return params
+    }
+
+    private func makeSignUpState(
+        links: [MSALNativeAuthV2LinkRelation: URL] = [:],
+        continuationToken: String = "ct",
+        scopes: [String] = ["scope1"],
+        submittedAttributes: [String] = [],
+        correlationId: UUID = UUID()
+    ) -> MSALNativeAuthFlowInternalState {
+        let resolved = links.reduce(into: [MSALNativeAuthV2LinkKey: URL]()) { result, entry in
+            result[.relation(entry.key)] = entry.value
+        }
+        let continuation = MSALNativeAuthFlowContinuationState(
+            flowScenario: .signUp,
+            correlationId: correlationId,
+            continuationToken: continuationToken,
+            links: resolved,
+            scopes: scopes,
+            claimsRequestJson: nil,
+            submittedAttributes: submittedAttributes
+        )
+        return MSALNativeAuthFlowInternalState(continuation: continuation, controller: sut)
+    }
+
+    private func emailAttribute() -> MSALNativeAuthRequiredAttributeInternal {
+        MSALNativeAuthRequiredAttributeInternal(name: "email", type: "text", required: true)
+    }
+
+    private func passwordAttribute() -> MSALNativeAuthRequiredAttributeInternal {
+        MSALNativeAuthRequiredAttributeInternal(name: "password", type: "password", required: true)
+    }
+
+    // MARK: - signUp start
+
+    func test_signUp_upfrontValuesSubmitted_returnsCodeRequired() async {
+        requestProviderMock.mockRequest()
+        parserMock.authorizeChallengeResponses = [
+            .continuationToken(continuationToken: "ct-authorization-challenge", href: "https://contoso.com/signup")
+        ]
+        parserMock.interactionResponses = [
+            .attributesRequired(
+                continuationToken: "ct-2",
+                submitHref: "https://contoso.com/signup/attributes",
+                attributes: [emailAttribute()]
+            ),
+            .verificationRequired(
+                continuationToken: "ct-3",
+                verifyHref: "https://contoso.com/signup/verify",
+                resendHref: "https://contoso.com/signup/resend",
+                sentTo: "user@contoso.com",
+                channelType: MSALNativeAuthChannelType(value: "email"),
+                codeLength: 8
+            )
+        ]
+
+        let response = await sut.signUp(parameters: signUpParameters(password: "password", attributes: ["city": "Seattle"]))
+
+        guard case .actionRequired(let state) = response.result else {
+            return XCTFail("Expected actionRequired, got \(response.result)")
+        }
+        XCTAssertTrue(state is MSALNativeAuthCodeRequiredState)
+        XCTAssertTrue(requestProviderMock.authorizeChallengeStartCalled)
+        XCTAssertTrue(requestProviderMock.signUpStartCalled)
+        XCTAssertEqual(requestProviderMock.signUpStartUsername, username)
+        XCTAssertTrue(requestProviderMock.submitAttributesCalled)
+        // Everything supplied up front is submitted at once, regardless of what the server asked for.
+        XCTAssertEqual(requestProviderMock.submitAttributesReceived?["email"] as? String, username)
+        XCTAssertEqual(requestProviderMock.submitAttributesReceived?["password"] as? String, "password")
+        XCTAssertEqual(requestProviderMock.submitAttributesReceived?["city"] as? String, "Seattle")
+    }
+
+    func test_signUp_serverRequestsNewAttributeAfterUpfront_returnsAttributesRequired() async {
+        requestProviderMock.mockRequest()
+        parserMock.authorizeChallengeResponses = [
+            .continuationToken(continuationToken: "ct-authorization-challenge", href: "https://contoso.com/signup")
+        ]
+        parserMock.interactionResponses = [
+            .attributesRequired(
+                continuationToken: "ct-2",
+                submitHref: "https://contoso.com/signup/attributes",
+                attributes: [emailAttribute()]
+            ),
+            .attributesRequired(
+                continuationToken: "ct-3",
+                submitHref: "https://contoso.com/signup/attributes",
+                attributes: [MSALNativeAuthRequiredAttributeInternal(name: "city", type: "text", required: true)]
+            )
+        ]
+
+        let response = await sut.signUp(parameters: signUpParameters(password: "password"))
+
+        guard case .actionRequired(let state) = response.result else {
+            return XCTFail("Expected actionRequired, got \(response.result)")
+        }
+        XCTAssertTrue(state is MSALNativeAuthAttributesRequiredState)
+        // The up-front dump was submitted; the newly requested attribute is surfaced to the app.
+        XCTAssertTrue(requestProviderMock.submitAttributesCalled)
+    }
+
+    func test_signUp_serverReRequestsAlreadySubmittedAttribute_returnsError() async {
+        requestProviderMock.mockRequest()
+        parserMock.authorizeChallengeResponses = [
+            .continuationToken(continuationToken: "ct-authorization-challenge", href: "https://contoso.com/signup")
+        ]
+        parserMock.interactionResponses = [
+            .attributesRequired(
+                continuationToken: "ct-2",
+                submitHref: "https://contoso.com/signup/attributes",
+                attributes: [MSALNativeAuthRequiredAttributeInternal(name: "city", type: "text", required: true)]
+            ),
+            .attributesRequired(
+                continuationToken: "ct-3",
+                submitHref: "https://contoso.com/signup/attributes",
+                attributes: [MSALNativeAuthRequiredAttributeInternal(name: "city", type: "text", required: true)]
+            )
+        ]
+
+        let response = await sut.signUp(parameters: signUpParameters(attributes: ["city": "Seattle"]))
+
+        guard case .error = response.result else {
+            return XCTFail("Expected error, got \(response.result)")
+        }
+    }
+
+    func test_signUp_whenUserAlreadyExists_returnsError() async {
+        requestProviderMock.mockRequest()
+        parserMock.authorizeChallengeResponses = [
+            .continuationToken(continuationToken: "ct-authorization-challenge", href: "https://contoso.com/signup")
+        ]
+        parserMock.interactionResponses = [
+            .error(MSALNativeAuthFlowError(type: .userAlreadyExists))
+        ]
+
+        let response = await sut.signUp(parameters: signUpParameters(password: "password"))
+
+        guard case .error = response.result else {
+            return XCTFail("Expected error, got \(response.result)")
+        }
+    }
+
+    // MARK: - submitCode
+
+    func test_submitCode_returnsSignInAfterSignUp() async {
+        requestProviderMock.mockRequest()
+        parserMock.interactionResponses = [
+            .readyToComplete(continuationToken: "ct-continue")
+        ]
+
+        let state = makeSignUpState(
+            links: [.verify: URL(string: "https://contoso.com/signup/verify")!]
+        )
+        let response = await sut.submitCode("12345678", state: state)
+
+        guard case .actionRequired(let resultState) = response.result else {
+            return XCTFail("Expected actionRequired, got \(response.result)")
+        }
+        XCTAssertTrue(resultState is MSALNativeAuthSignInAfterSignUpState)
+        XCTAssertTrue(requestProviderMock.verifyCalled)
+    }
+
+    func test_submitCode_whenServerReRequestsPassword_returnsError() async {
+        requestProviderMock.mockRequest()
+        parserMock.interactionResponses = [
+            .attributesRequired(
+                continuationToken: "ct-pwd",
+                submitHref: "https://contoso.com/signup/attributes",
+                attributes: [passwordAttribute()]
+            )
+        ]
+
+        let state = makeSignUpState(
+            links: [.verify: URL(string: "https://contoso.com/signup/verify")!]
+        )
+        let response = await sut.submitCode("12345678", state: state)
+
+        guard case .error = response.result else {
+            return XCTFail("Expected error, got \(response.result)")
+        }
+        XCTAssertFalse(requestProviderMock.submitAttributesCalled)
+    }
+
+    // MARK: - submitPassword
+
+    func test_submitPassword_signUp_submitsAttributesAndReturnsSignInAfterSignUp() async {
+        requestProviderMock.mockRequest()
+        parserMock.interactionResponses = [
+            .readyToComplete(continuationToken: "ct-continue")
+        ]
+
+        let state = makeSignUpState(
+            links: [.submitAttributes: URL(string: "https://contoso.com/signup/attributes")!]
+        )
+        let response = await sut.submitPassword("password", state: state)
+
+        guard case .actionRequired(let resultState) = response.result else {
+            return XCTFail("Expected actionRequired, got \(response.result)")
+        }
+        XCTAssertTrue(resultState is MSALNativeAuthSignInAfterSignUpState)
+        XCTAssertTrue(requestProviderMock.submitAttributesCalled)
+        XCTAssertEqual(requestProviderMock.submitAttributesReceived?["password"] as? String, "password")
+    }
+
+    // MARK: - submitAttributes
+
+    func test_submitAttributes_signUp_returnsSignInAfterSignUp() async {
+        requestProviderMock.mockRequest()
+        parserMock.interactionResponses = [
+            .readyToComplete(continuationToken: "ct-continue")
+        ]
+
+        let state = makeSignUpState(
+            links: [.submitAttributes: URL(string: "https://contoso.com/signup/attributes")!]
+        )
+        let response = await sut.submitAttributes(["city": "Seattle"], state: state)
+
+        guard case .actionRequired(let resultState) = response.result else {
+            return XCTFail("Expected actionRequired, got \(response.result)")
+        }
+        XCTAssertTrue(resultState is MSALNativeAuthSignInAfterSignUpState)
+        XCTAssertEqual(requestProviderMock.submitAttributesReceived?["city"] as? String, "Seattle")
+    }
+
+    // MARK: - resendCode
+
+    func test_resendCode_signUp_returnsCodeRequired() async {
+        requestProviderMock.mockRequest()
+        parserMock.interactionResponses = [
+            .verificationRequired(
+                continuationToken: "ct-3",
+                verifyHref: "https://contoso.com/signup/verify",
+                resendHref: "https://contoso.com/signup/resend",
+                sentTo: "user@contoso.com",
+                channelType: MSALNativeAuthChannelType(value: "email"),
+                codeLength: 8
+            )
+        ]
+
+        let state = makeSignUpState(
+            links: [.resend: URL(string: "https://contoso.com/signup/resend")!]
+        )
+        let response = await sut.resendCode(state: state)
+
+        guard case .actionRequired(let resultState) = response.result else {
+            return XCTFail("Expected actionRequired, got \(response.result)")
+        }
+        XCTAssertTrue(resultState is MSALNativeAuthCodeRequiredState)
+        XCTAssertTrue(requestProviderMock.challengeCalled)
+    }
+
+    // MARK: - signInAfterSignUp
+
+    func test_signInAfterSignUp_completesWithToken() async {
+        requestProviderMock.mockRequest()
+        parserMock.authorizeChallengeResponses = [
+            .authorizationCode(code: "auth-code")
+        ]
+        cacheAccessorMock.expectedMSIDTokenResult = MSIDTokenResult()
+
+        let state = makeSignUpState(continuationToken: "ct-continue")
+        let response = await sut.signInAfterSignUp(scopes: ["scope1"], claimsRequestJson: nil, state: state)
+
+        guard case .completed = response.result else {
+            return XCTFail("Expected completed, got \(response.result)")
+        }
+        XCTAssertTrue(requestProviderMock.tokenCalled)
+    }
+
+    func test_signInAfterSignUp_whenMissingContinuationToken_returnsError() async {
+        requestProviderMock.mockRequest()
+        let state = makeSignUpState(continuationToken: "")
+        // Build a continuation with a nil continuation token explicitly.
+        let continuation = MSALNativeAuthFlowContinuationState(
+            flowScenario: .signUp,
+            correlationId: UUID(),
+            continuationToken: nil,
+            links: [:]
+        )
+        let nilState = MSALNativeAuthFlowInternalState(continuation: continuation, controller: sut)
+        _ = state
+        let response = await sut.signInAfterSignUp(scopes: ["scope1"], claimsRequestJson: nil, state: nilState)
+
+        guard case .error = response.result else {
+            return XCTFail("Expected error, got \(response.result)")
+        }
+    }
+}
+// swiftlint:enable type_body_length file_length

--- a/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
@@ -137,6 +137,46 @@ final class MSALNativeAuthFlowControllerSignUpTests: MSALNativeAuthTestCase {
         XCTAssertEqual(requestProviderMock.submitAttributesReceived?["city"] as? String, "Seattle")
     }
 
+    func test_signUp_appSuppliedReservedAttributes_areIgnored_soSDKValuesWin() async {
+        requestProviderMock.mockRequest()
+        parserMock.authorizeChallengeResponses = [
+            .continuationToken(continuationToken: "ct-authorization-challenge", href: "https://contoso.com/signup")
+        ]
+        parserMock.interactionResponses = [
+            .attributesRequired(
+                continuationToken: "ct-2",
+                submitHref: "https://contoso.com/signup/attributes",
+                attributes: [emailAttribute()]
+            ),
+            .verificationRequired(
+                continuationToken: "ct-3",
+                verifyHref: "https://contoso.com/signup/verify",
+                resendHref: "https://contoso.com/signup/resend",
+                sentTo: "user@contoso.com",
+                channelType: MSALNativeAuthChannelType(value: "email"),
+                codeLength: 8
+            )
+        ]
+
+        // App tries to override the SDK-owned username/password via attributes, using different casing.
+        let response = await sut.signUp(parameters: signUpParameters(
+            password: "password",
+            attributes: ["Email": "attacker@contoso.com", "PASSWORD": "attackerPassword", "city": "Seattle"]
+        ))
+
+        guard case .actionRequired = response.result else {
+            return XCTFail("Expected actionRequired, got \(response.result)")
+        }
+        XCTAssertTrue(requestProviderMock.submitAttributesCalled)
+        // Reserved keys are not overridden: the SDK's username/password are submitted, not the app-supplied ones.
+        XCTAssertEqual(requestProviderMock.submitAttributesReceived?["email"] as? String, username)
+        XCTAssertEqual(requestProviderMock.submitAttributesReceived?["password"] as? String, "password")
+        XCTAssertNil(requestProviderMock.submitAttributesReceived?["Email"])
+        XCTAssertNil(requestProviderMock.submitAttributesReceived?["PASSWORD"])
+        // Non-reserved attributes are still submitted.
+        XCTAssertEqual(requestProviderMock.submitAttributesReceived?["city"] as? String, "Seattle")
+    }
+
     func test_signUp_serverRequestsNewAttributeAfterUpfront_returnsAttributesRequired() async {
         requestProviderMock.mockRequest()
         parserMock.authorizeChallengeResponses = [

--- a/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
@@ -226,7 +226,29 @@ final class MSALNativeAuthFlowControllerSignUpTests: MSALNativeAuthTestCase {
         XCTAssertTrue(requestProviderMock.verifyCalled)
     }
 
-    func test_submitCode_whenServerReRequestsPassword_returnsError() async {
+    func test_submitCode_whenServerReRequestsAlreadySubmittedPassword_returnsError() async {
+        requestProviderMock.mockRequest()
+        parserMock.interactionResponses = [
+            .attributesRequired(
+                continuationToken: "ct-pwd",
+                submitHref: "https://contoso.com/signup/attributes",
+                attributes: [passwordAttribute()]
+            )
+        ]
+
+        let state = makeSignUpState(
+            links: [.verify: URL(string: "https://contoso.com/signup/verify")!],
+            submittedAttributes: ["password"]
+        )
+        let response = await sut.submitCode("12345678", state: state)
+
+        guard case .error = response.result else {
+            return XCTFail("Expected error, got \(response.result)")
+        }
+        XCTAssertFalse(requestProviderMock.submitAttributesCalled)
+    }
+
+    func test_submitCode_whenServerRequestsUnsubmittedPassword_returnsPasswordRequired() async {
         requestProviderMock.mockRequest()
         parserMock.interactionResponses = [
             .attributesRequired(
@@ -241,9 +263,10 @@ final class MSALNativeAuthFlowControllerSignUpTests: MSALNativeAuthTestCase {
         )
         let response = await sut.submitCode("12345678", state: state)
 
-        guard case .error = response.result else {
-            return XCTFail("Expected error, got \(response.result)")
+        guard case .actionRequired(let resultState) = response.result else {
+            return XCTFail("Expected actionRequired, got \(response.result)")
         }
+        XCTAssertTrue(resultState is MSALNativeAuthPasswordRequiredState)
         XCTAssertFalse(requestProviderMock.submitAttributesCalled)
     }
 

--- a/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
+++ b/MSAL/test/unit/native_auth/controllers/v2/MSALNativeAuthFlowControllerSignUpTests.swift
@@ -137,6 +137,35 @@ final class MSALNativeAuthFlowControllerSignUpTests: MSALNativeAuthTestCase {
         XCTAssertEqual(requestProviderMock.submitAttributesReceived?["city"] as? String, "Seattle")
     }
 
+    func test_signUp_upfrontAttributesSubmit_isAttributedToSubmitAttributesApiId() async {
+        requestProviderMock.mockRequest()
+        parserMock.authorizeChallengeResponses = [
+            .continuationToken(continuationToken: "ct-authorization-challenge", href: "https://contoso.com/signup")
+        ]
+        parserMock.interactionResponses = [
+            .attributesRequired(
+                continuationToken: "ct-2",
+                submitHref: "https://contoso.com/signup/attributes",
+                attributes: [emailAttribute()]
+            ),
+            .verificationRequired(
+                continuationToken: "ct-3",
+                verifyHref: "https://contoso.com/signup/verify",
+                resendHref: "https://contoso.com/signup/resend",
+                sentTo: "user@contoso.com",
+                channelType: MSALNativeAuthChannelType(value: "email"),
+                codeLength: 8
+            )
+        ]
+
+        _ = await sut.signUp(parameters: signUpParameters(password: "password", attributes: ["city": "Seattle"]))
+
+        // The upfront submitAttributes network call must be reported under its dedicated API id, not the
+        // sign-up start API id, so per-API telemetry counts stay accurate.
+        XCTAssertTrue(requestProviderMock.submitAttributesCalled)
+        XCTAssertEqual(requestProviderMock.submitAttributesApiIdReceived, .telemetryApiIdV2SignUpSubmitAttributes)
+    }
+
     func test_signUp_appSuppliedReservedAttributes_areIgnored_soSDKValuesWin() async {
         requestProviderMock.mockRequest()
         parserMock.authorizeChallengeResponses = [

--- a/MSAL/test/unit/native_auth/mock/v2/MSALNativeAuthFlowControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/v2/MSALNativeAuthFlowControllerMock.swift
@@ -35,6 +35,7 @@ class MSALNativeAuthFlowControllerMock: MSALNativeAuthFlowControlling {
     var submitPasswordResponse: MSALNativeAuthFlowControllerResponse?
     var submitNewPasswordResponse: MSALNativeAuthFlowControllerResponse?
     var signInAfterResetPasswordResponse: MSALNativeAuthFlowControllerResponse?
+    var signInAfterSignUpResponse: MSALNativeAuthFlowControllerResponse?
     var submitAttributesResponse: MSALNativeAuthFlowControllerResponse?
     var selectAuthMethodResponse: MSALNativeAuthFlowControllerResponse?
     var submitChallengeResponse: MSALNativeAuthFlowControllerResponse?
@@ -77,6 +78,14 @@ class MSALNativeAuthFlowControllerMock: MSALNativeAuthFlowControlling {
         state: MSALNativeAuthFlowInternalState
     ) async -> MSALNativeAuthFlowControllerResponse {
         return signInAfterResetPasswordResponse ?? notImplementedResponse()
+    }
+
+    func signInAfterSignUp(
+        scopes: [String]?,
+        claimsRequestJson: String?,
+        state: MSALNativeAuthFlowInternalState
+    ) async -> MSALNativeAuthFlowControllerResponse {
+        return signInAfterSignUpResponse ?? notImplementedResponse()
     }
 
     func submitAttributes(_ attributes: [String: Any], state: MSALNativeAuthFlowInternalState) async -> MSALNativeAuthFlowControllerResponse {

--- a/MSAL/test/unit/native_auth/mock/v2/MSALNativeAuthFlowControllerMock.swift
+++ b/MSAL/test/unit/native_auth/mock/v2/MSALNativeAuthFlowControllerMock.swift
@@ -41,6 +41,10 @@ class MSALNativeAuthFlowControllerMock: MSALNativeAuthFlowControlling {
     var submitChallengeResponse: MSALNativeAuthFlowControllerResponse?
     var resendCodeResponse: MSALNativeAuthFlowControllerResponse?
 
+    private(set) var signUpCalled = false
+    private(set) var signInCalled = false
+    private(set) var resetPasswordCalled = false
+
     private func notImplementedResponse() -> MSALNativeAuthFlowControllerResponse {
         return MSALNativeAuthFlowControllerResponse(
             .error(error: MSALNativeAuthFlowError(type: .notImplemented)),
@@ -49,14 +53,17 @@ class MSALNativeAuthFlowControllerMock: MSALNativeAuthFlowControlling {
     }
 
     func resetPassword(parameters: MSALNativeAuthResetPasswordParameters) async -> MSALNativeAuthFlowControllerResponse {
+        resetPasswordCalled = true
         return resetPasswordResponse ?? notImplementedResponse()
     }
 
     func signUp(parameters: MSALNativeAuthSignUpParametersV2) async -> MSALNativeAuthFlowControllerResponse {
+        signUpCalled = true
         return signUpResponse ?? notImplementedResponse()
     }
 
     func signIn(parameters: MSALNativeAuthSignInParameters) async -> MSALNativeAuthFlowControllerResponse {
+        signInCalled = true
         return signInResponse ?? notImplementedResponse()
     }
 

--- a/MSAL/test/unit/native_auth/mock/v2/MSALNativeAuthV2RequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/v2/MSALNativeAuthV2RequestProviderMock.swift
@@ -44,6 +44,7 @@ class MSALNativeAuthV2RequestProviderMock: MSALNativeAuthV2RequestProviding {
     private(set) var submitAttributesCalled = false
     private(set) var submitAttributesHrefReceived: String?
     private(set) var submitAttributesReceived: [String: Any]?
+    private(set) var submitAttributesApiIdReceived: MSALNativeAuthTelemetryApiId?
     private(set) var challengeCalled = false
     private(set) var challengeApiIdReceived: MSALNativeAuthTelemetryApiId?
     private(set) var verifyCalled = false
@@ -163,6 +164,7 @@ class MSALNativeAuthV2RequestProviderMock: MSALNativeAuthV2RequestProviding {
         submitAttributesCalled = true
         submitAttributesHrefReceived = href
         submitAttributesReceived = attributes
+        submitAttributesApiIdReceived = apiId
         return try resolveRequest()
     }
 

--- a/MSAL/test/unit/native_auth/mock/v2/MSALNativeAuthV2RequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/v2/MSALNativeAuthV2RequestProviderMock.swift
@@ -41,7 +41,6 @@ class MSALNativeAuthV2RequestProviderMock: MSALNativeAuthV2RequestProviding {
     private(set) var signInStartCalled = false
     private(set) var signInStartUsername: String?
     private(set) var signUpStartCalled = false
-    private(set) var signUpStartUsername: String?
     private(set) var submitAttributesCalled = false
     private(set) var submitAttributesHrefReceived: String?
     private(set) var submitAttributesReceived: [String: Any]?
@@ -145,14 +144,12 @@ class MSALNativeAuthV2RequestProviderMock: MSALNativeAuthV2RequestProviding {
     }
 
     func signUpStart(
-        username: String,
         continuationToken: String,
         href: String,
         apiId: MSALNativeAuthTelemetryApiId,
         context: MSALNativeAuthRequestContext
     ) throws -> MSIDHttpRequest {
         signUpStartCalled = true
-        signUpStartUsername = username
         return try resolveRequest()
     }
 

--- a/MSAL/test/unit/native_auth/mock/v2/MSALNativeAuthV2RequestProviderMock.swift
+++ b/MSAL/test/unit/native_auth/mock/v2/MSALNativeAuthV2RequestProviderMock.swift
@@ -40,6 +40,11 @@ class MSALNativeAuthV2RequestProviderMock: MSALNativeAuthV2RequestProviding {
     private(set) var resetPasswordStartCalled = false
     private(set) var signInStartCalled = false
     private(set) var signInStartUsername: String?
+    private(set) var signUpStartCalled = false
+    private(set) var signUpStartUsername: String?
+    private(set) var submitAttributesCalled = false
+    private(set) var submitAttributesHrefReceived: String?
+    private(set) var submitAttributesReceived: [String: Any]?
     private(set) var challengeCalled = false
     private(set) var verifyCalled = false
     private(set) var submitPasswordCalled = false
@@ -135,6 +140,31 @@ class MSALNativeAuthV2RequestProviderMock: MSALNativeAuthV2RequestProviding {
     ) throws -> MSIDHttpRequest {
         signInStartCalled = true
         signInStartUsername = username
+        return try resolveRequest()
+    }
+
+    func signUpStart(
+        username: String,
+        continuationToken: String,
+        href: String,
+        apiId: MSALNativeAuthTelemetryApiId,
+        context: MSALNativeAuthRequestContext
+    ) throws -> MSIDHttpRequest {
+        signUpStartCalled = true
+        signUpStartUsername = username
+        return try resolveRequest()
+    }
+
+    func submitAttributes(
+        href: String,
+        attributes: [String: Any],
+        continuationToken: String,
+        apiId: MSALNativeAuthTelemetryApiId,
+        context: MSALNativeAuthRequestContext
+    ) throws -> MSIDHttpRequest {
+        submitAttributesCalled = true
+        submitAttributesHrefReceived = href
+        submitAttributesReceived = attributes
         return try resolveRequest()
     }
 

--- a/MSAL/test/unit/native_auth/network/v2/MSALNativeAuthV2RequestProviderTests.swift
+++ b/MSAL/test/unit/native_auth/network/v2/MSALNativeAuthV2RequestProviderTests.swift
@@ -155,4 +155,43 @@ final class MSALNativeAuthV2RequestProviderTests: XCTestCase {
         XCTAssertEqual(apiId(of: request), .telemetryApiIdV2ResetPasswordSubmit)
         XCTAssertFalse(request.responseSerializer is MSALNativeAuthV2HALResponseSerializer)
     }
+
+    // MARK: - submitAttributes
+
+    func test_submitAttributes_withValidAttributes_serializesBodyWithContinuationToken() throws {
+        let request = try sut.submitAttributes(
+            href: href,
+            attributes: ["city": "Redmond"],
+            continuationToken: "CT",
+            apiId: .telemetryApiIdV2SignUpSubmitAttributes,
+            context: context
+        )
+
+        XCTAssertEqual(request.urlRequest?.httpMethod, "POST")
+        XCTAssertEqual(request.urlRequest?.url, try resolver.url(forHref: href))
+        XCTAssertEqual(apiId(of: request), .telemetryApiIdV2SignUpSubmitAttributes)
+
+        let serializer = try XCTUnwrap(request.requestSerializer as? MSALNativeAuthUrlRequestSerializer)
+        let urlRequest = try XCTUnwrap(request.urlRequest)
+        let serialized = serializer.serialize(with: urlRequest, parameters: [:], headers: [:])
+        let body = try XCTUnwrap(serialized.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["continuationToken"] as? String, "CT")
+        let attributes = try XCTUnwrap(json["attributes"] as? [String: Any])
+        XCTAssertEqual(attributes["city"] as? String, "Redmond")
+    }
+
+    func test_submitAttributes_withNonJSONValue_throwsInvalidAttributes() {
+        XCTAssertThrowsError(
+            try sut.submitAttributes(
+                href: href,
+                attributes: ["birthdate": Date()],
+                continuationToken: "CT",
+                apiId: .telemetryApiIdV2SignUpSubmitAttributes,
+                context: context
+            )
+        ) { error in
+            XCTAssertEqual(error as? MSALNativeAuthInternalError, .invalidAttributes)
+        }
+    }
 }

--- a/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
+++ b/MSAL/test/unit/native_auth/public/MSALNativeAuthPublicClientApplicationTest.swift
@@ -2258,4 +2258,77 @@ final class MSALNativeAuthPublicClientApplicationTest: XCTestCase {
             context: contextMock,
             continuationToken: token)
     }
+
+    // MARK: - Native Auth V2 - username validation
+
+    func testSignUpV2_whenInvalidUsernameUsed_shouldReturnInvalidUsernameErrorAndNotCallController() {
+        let exp = expectation(description: "sign-up V2 public interface")
+        let delegate = NativeAuthFlowDelegateSpy(expectation: exp)
+
+        let parameters = MSALNativeAuthSignUpParametersV2(username: "")
+        parameters.correlationId = correlationId
+
+        sut.signUpV2(parameters: parameters, delegate: delegate)
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertEqual(delegate.error?.isInvalidUsername, true)
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
+        XCTAssertEqual(delegate.errorScenario, .signUp)
+        XCTAssertFalse(controllerFactoryMock.v2FlowController.signUpCalled)
+    }
+
+    func testSignInV2_whenInvalidUsernameUsed_shouldReturnInvalidUsernameErrorAndNotCallController() {
+        let exp = expectation(description: "sign-in V2 public interface")
+        let delegate = NativeAuthFlowDelegateSpy(expectation: exp)
+
+        let parameters = MSALNativeAuthSignInParameters(username: "")
+        parameters.correlationId = correlationId
+
+        sut.signInV2(parameters: parameters, delegate: delegate)
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertEqual(delegate.error?.isInvalidUsername, true)
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
+        XCTAssertEqual(delegate.errorScenario, .signIn)
+        XCTAssertFalse(controllerFactoryMock.v2FlowController.signInCalled)
+    }
+
+    func testResetPasswordV2_whenInvalidUsernameUsed_shouldReturnInvalidUsernameErrorAndNotCallController() {
+        let exp = expectation(description: "reset-password V2 public interface")
+        let delegate = NativeAuthFlowDelegateSpy(expectation: exp)
+
+        let parameters = MSALNativeAuthResetPasswordParameters(username: "")
+        parameters.correlationId = correlationId
+
+        sut.resetPasswordV2(parameters: parameters, delegate: delegate)
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertEqual(delegate.error?.isInvalidUsername, true)
+        XCTAssertEqual(delegate.error?.correlationId, correlationId)
+        XCTAssertEqual(delegate.errorScenario, .passwordReset)
+        XCTAssertFalse(controllerFactoryMock.v2FlowController.resetPasswordCalled)
+    }
+}
+
+private final class NativeAuthFlowDelegateSpy: NSObject, MSALNativeAuthFlowDelegate {
+
+    private let expectation: XCTestExpectation
+    private(set) var error: MSALNativeAuthFlowError?
+    private(set) var errorScenario: MSALNativeAuthFlowScenario?
+    private(set) var completedScenario: MSALNativeAuthFlowScenario?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func onFlowError(error: MSALNativeAuthFlowError, scenario: MSALNativeAuthFlowScenario) {
+        self.error = error
+        self.errorScenario = scenario
+        expectation.fulfill()
+    }
+
+    func onFlowCompleted(result: MSALNativeAuthUserAccountResult, scenario: MSALNativeAuthFlowScenario) {
+        self.completedScenario = scenario
+        expectation.fulfill()
+    }
 }


### PR DESCRIPTION
## Summary

Adds the **server-driven (V2) native-auth sign-up flow** (HAL/`href`-driven) to the MSAL native-auth stack, wiring it through the unified flow controller, dispatcher, and public client application. This builds on the existing V2 sign-in / reset-password server-driven plumbing and extends it to sign-up, including an upfront-attribute submission model and a post-sign-up sign-in handoff.

> **Note:** The new public surface is explicitly experimental (`- Warning: This API is experimental…`) and is not intended for production use yet.

## What's included

### Public API
- `MSALNativeAuthPublicClientApplication.signUpV2(parameters:delegate:)` is now **public** (was private), gated as experimental. Drives sign-up through the unified `MSALNativeAuthFlowDelegate`.
- New experimental state `MSALNativeAuthSignInAfterSignUpState` with `signIn(...)` to sign the new account in after a successful sign-up, plus `signInAfterSignUp(scopes:claimsRequestJson:state:)` on `MSALNativeAuthFlowControlling`.

### Flow orchestration (`MSALNativeAuthFlowController`)
- Full V2 sign-up: authorize-challenge start → `signUpStart` → interleaved `collectAttributes` / `verify` (one-time code) steps → continuation.
- **Upfront attribute submission:** on the first `collectAttributes` step the SDK submits everything supplied up front at once (`email` = username, `password` when provided, and any app-supplied attributes). Attributes the server later requests that weren't supplied are surfaced via the attributes-required state so the app can collect them. A server re-request of an already-submitted attribute (e.g. `email`/`password`) is treated as an unrecoverable error.
- `submitCode` and `resendCode` now handle the sign-up scenario **inline** (mirroring the existing sign-in/reset pattern); the standalone `resendSignUpCode` helper was removed.

### Request/response plumbing
- `signUpStart` **no longer sends `username`/`email`** on the start request — the server ignores it and asks for `email` via `collectAttributes`; the SDK already submits it in the upfront attribute dump. `MSALNativeAuthV2EntryParameters.username` is now optional and omitted from the body when `nil`. Sign-in / reset-password start requests are unchanged and still send `username`.
- New `MSALNativeAuthHALCollectAttributesResponse` (+ parser support), `MSALNativeAuthV2SubmitAttributesRequestBody`, `submitAttributes` link relation, and `attributes` body key.
- `MSALNativeAuthFlowContinuationState` now tracks `submittedAttributes` (case-insensitive) to detect duplicate server re-requests.

### Errors & telemetry
- New wrong-flow error `generalError` (`description` = "This method cannot be called for state %@ flow %@") for continuation methods invoked on a flow that doesn't support them — distinct from the existing `notImplementedResponse` used when a result-routing handler is genuinely missing.
- New telemetry api id `telemetryApiIdV2SignUpResendCode = 76022`, so `telemetryApiIdV2SignUpStart` is confined to the actual start call.

## Testing
- New `MSALNativeAuthFlowControllerSignUpTests` covering the V2 sign-up paths, plus V2 request-provider / flow-controller mock updates.

## Notes
- `MSAL/IdentityCore` submodule pointer is aligned with `dev` (no submodule change in this PR).

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
