### PR TITLE
[patch] [bugfix]: Restore AI issue auto-reply by moving from GitHub Models to Copilot CLI

### DIFF
--- a/.github/ai-prompts/reference-files.txt
+++ b/.github/ai-prompts/reference-files.txt
@@ -2,15 +2,15 @@
 # One path per line, relative to the repo root. Blank lines and lines
 # starting with # are ignored. Missing files are skipped with a warning.
 #
-# BUDGET: GitHub Models caps some free-tier models (gpt-4o-mini) at
-# 8000 tokens per request. With system prompt + question + completion
-# overhead, reference content must fit in ~8 KB (~2000 tokens).
+# BUDGET: the workflow runs Copilot CLI, which has no small per-request
+# input cap, so ai-issues-auto-reply.yml raises the caps via the
+# *_OVERRIDE env vars and this manifest (~107 KB) is sent whole.
 #
 # Each .h file is stripped of its MIT license block and #import lines
 # before inlining. A per-file cap (MAX_PER_FILE_BYTES, default 3000)
-# and a total cap (MAX_REFERENCE_BYTES, default 8000) apply. Both can be
-# raised on plans with higher per-request limits via the corresponding
-# *_OVERRIDE env vars in the workflow.
+# and a total cap (MAX_REFERENCE_BYTES, default 8000) still apply as a
+# runaway guard. Both are raised via the corresponding *_OVERRIDE env
+# vars in the workflow.
 #
 # Files are included in the order listed below. Anything that doesn't
 # fit under the total cap is truncated from the tail, so the most

--- a/.github/workflows/ai-issues-auto-reply.yml
+++ b/.github/workflows/ai-issues-auto-reply.yml
@@ -25,7 +25,9 @@ on:
 permissions:
   issues: write
   contents: read
-  models: read
+  # Lets Copilot CLI authenticate with the built-in GITHUB_TOKEN instead of a
+  # PAT. Replaces the retired `models: read` scope.
+  copilot-requests: write
 
 env:
   # ---- Behavior toggles ----
@@ -36,14 +38,11 @@ env:
   STOP_COPILOT_PHRASE: "STOP-COPILOT"        # canonical opt-out phrase shown in docs/acks; natural variants are also matched
   OPT_OUT_LABEL: "no-ai"                      # label added when opt-out is triggered (must be present in BLOCK_LABELS to suppress future replies)
   DRY_RUN: "false"
-  # Comma-separated preference list of GitHub Models to try, most powerful
-  # first. The workflow iterates through the list and uses the first model
-  # that returns 2xx. Transient failures (429 / 5xx / transport error) retry
-  # on the SAME model; terminal failures (4xx except 429, e.g. 403 "not
-  # entitled" or 404 "unknown model") move on to the next entry. This lets
-  # a well-entitled repo land on gpt-5 while a fork on the free tier
-  # automatically slides down to gpt-4o-mini without any config change.
-  MODELS_MODEL: "openai/gpt-5,openai/gpt-4.1,openai/gpt-4o,openai/gpt-4o-mini"
+  # Model for Copilot CLI to use. "auto" lets Copilot pick, which keeps this
+  # working as models are added and retired — the failure mode that took the
+  # whole workflow down when GitHub Models was retired. Pin a specific model
+  # here only if a run needs to be reproducible.
+  COPILOT_MODEL: "auto"
 
 jobs:
   ai_autoreply:
@@ -304,17 +303,30 @@ jobs:
               body: labelApplied ? successAck : failureAck
             });
 
-      - name: Generate AI reply (GitHub Models)
+      - name: Install Copilot CLI
+        if: steps.gate.outputs.should == 'true'
+        run: npm install -g @github/copilot
+
+      - name: Generate AI reply (Copilot CLI)
         id: ai
         if: steps.gate.outputs.should == 'true'
+        timeout-minutes: 15
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Comma-separated preference list. Workflow iterates and uses the
-          # first model that returns 2xx; see the loop below for details.
-          GH_MODELS_MODEL: ${{ env.MODELS_MODEL }}
+          # Copilot CLI picks this up automatically; the job grants
+          # `copilot-requests: write` so no PAT or extra secret is needed.
+          GITHUB_TOKEN: ${{ github.token }}
+          COPILOT_MODEL: ${{ env.COPILOT_MODEL }}
           MODE: ${{ steps.gate.outputs.mode }}
           ISSUE_TITLE_JSON: ${{ toJSON(github.event.issue.title) }}
           ISSUE_BODY_JSON: ${{ toJSON(github.event.issue.body || '') }}
+          # GitHub Models capped input at 8000 tokens per request, which forced
+          # the reference block down to 8 KB and truncated away most of the
+          # curated grounding set (it assembles to ~107 KB). Copilot CLI has no
+          # comparable per-request cap, so send the whole manifest — every
+          # public header the reply might need to cite, untruncated.
+          MAX_REFERENCE_BYTES_OVERRIDE: "200000"
+          MAX_PER_FILE_BYTES_OVERRIDE: "25000"
+          MAX_DYNAMIC_BYTES_OVERRIDE: "40000"
         run: |
           set -euo pipefail
           # set -x   # use for debugging, it prints each command before executing it
@@ -334,17 +346,14 @@ jobs:
           # touching this workflow. Files not present on disk log a warning
           # and are skipped.
           #
-          # Budget: GitHub Models free tier caps some models (e.g.,
-          # gpt-4o-mini) at 8000 tokens PER REQUEST. Tokens ≈ bytes/4 for
-          # English/code. We budget roughly:
-          #   system prompt: ~1500 tokens (~6000 bytes)
-          #   reference:     up to MAX_REFERENCE_BYTES (default 8000 = ~2000 tokens)
-          #   question:      up to ~2500 tokens (thread-heavy PING-COPILOT)
-          #   completion:    separate from the 8000 input cap
+          # Budget: Copilot CLI has no small per-request input cap, so the
+          # defaults below are raised by the step env and the curated manifest
+          # is sent whole. The caps remain as a runaway guard, and so a fork
+          # that overrides them downward still gets a coherent prompt.
           # Per-file boilerplate stripping saves ~1 KB/header (license +
           # #import lines). Each file is also capped individually at
-          # MAX_PER_FILE_BYTES (default 3000) so one large header (e.g.
-          # MSALError.h at ~19 KB) cannot squeeze out everything else.
+          # MAX_PER_FILE_BYTES so one large header cannot squeeze out
+          # everything else.
           REFERENCE_MANIFEST=".github/ai-prompts/reference-files.txt"
           REFERENCE_FILE="$(mktemp)"
           MAX_REFERENCE_BYTES="${MAX_REFERENCE_BYTES_OVERRIDE:-8000}"
@@ -639,158 +648,89 @@ jobs:
             USER_PROMPT="$(printf '=== REFERENCE MATERIAL (for grounding) ===\n%s\n\n=== NEW ISSUE ===\n%s' "$REFERENCE_CONTENT" "$QUESTION_BLOCK")"
           fi
 
-          # Build the request body. Factored into a function so we can rebuild
-          # with a different model for the fallback retry below.
-          build_req () { jq -n --arg m "$1" \
-                      --arg sys "$SYSTEM_PROMPT" \
-                      --arg user "$USER_PROMPT" \
-                '{model:$m, messages:[{role:"system",content:$sys},{role:"user",content:$user}]}'; }
-
-          REQ=$(build_req "$GH_MODELS_MODEL")
-
-          # Helper: invoke the Models API and set HTTP_CODE, tolerating
-          # transport-level failures (DNS, TLS, timeout, reset, …). Previously
-          # a non-zero curl exit would propagate through `HTTP_CODE=$(curl …)`
-          # and `set -e` would abort the whole script silently — no echo, no
-          # retry, no fallback, just exit 1 after some seconds of nothing.
-          # Now:
-          #   - `set +e` around the curl so failures don't kill the shell.
-          #   - stderr captured to a temp file and surfaced.
-          #   - --max-time bounds the request.
-          #   - HTTP_CODE set to "000" on transport failure, which is treated
-          #     as retryable below.
-          call_models_api () {
-            local body="$1"
-            local label="$2"
-            local stderr_file
-            stderr_file="$(mktemp)"
-            echo "→ Calling Models API (${label})..."
-            local curl_exit=0
-            set +e
-            HTTP_CODE=$(curl -sSL -X POST --max-time 120 -w "%{http_code}" \
-              -o response.json -D headers.txt \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              -H "Content-Type: application/json" \
-              https://models.github.ai/inference/chat/completions \
-              -d "$body" 2>"$stderr_file")
-            curl_exit=$?
-            set -e
-            if [[ $curl_exit -ne 0 ]]; then
-              echo "← curl failed (exit ${curl_exit}) for ${label}. stderr:"
-              sed 's/^/    /' "$stderr_file" || true
-              HTTP_CODE="000"
-            else
-              echo "← Models API responded HTTP ${HTTP_CODE} (${label})"
-            fi
-            rm -f "$stderr_file"
-          }
-
-          # Walk the comma-separated MODELS_MODEL preference list, most
-          # powerful first. For each model:
-          #   - Retry on 429 / 5xx / transport failure (000) on the SAME
-          #     model with exponential backoff (10s, 20s, 40s, capped 5-60s).
-          #   - Terminal failures (4xx except 429 — e.g., 403 "not entitled",
-          #     404 "unknown model", 422 "token limit") move on to the NEXT
-          #     model in the list without retrying.
-          #   - First 2xx wins; subsequent models are not tried.
+          # ---- Invoke Copilot CLI ----
+          # GitHub Models (models.github.ai) was retired on 2026-07-30. Every
+          # model in the old preference list now answers HTTP 410
+          # github_models_retirement_brownout, so the step emitted empty text
+          # and "Post reply" skipped on its non-empty guard — the workflow went
+          # green while silently answering nobody.
           #
-          # This gives a repo with strong entitlements (e.g. AzureAD) gpt-5,
-          # while a fork on the free tier automatically slides down to
-          # gpt-4o-mini with no config change.
-          MAX_ATTEMPTS=3
-          IFS=',' read -ra MODEL_LIST_RAW <<< "${GH_MODELS_MODEL}"
-          MODEL_LIST=()
-          for raw in "${MODEL_LIST_RAW[@]}"; do
-            trimmed="$(echo "$raw" | awk '{$1=$1};1')"
-            [[ -n "$trimmed" ]] && MODEL_LIST+=("$trimmed")
-          done
+          # Copilot CLI is the supported way to run AI in Actions and
+          # authenticates with the built-in GITHUB_TOKEN, so this needs no PAT
+          # and no repository secret. See
+          # https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli-in-actions
+          #
+          # The prompt is handed over on disk rather than through -p: it is
+          # ~100 KB of Objective-C, Markdown and shell metacharacters
+          # (backticks, ${...}, quotes) and passing that as an argv string is a
+          # quoting minefield. Copilot reads the file itself and writes the
+          # finished comment to REPLY_FILE, so neither the prompt nor the reply
+          # transits the shell.
+          PROMPT_FILE="$PWD/ai_prompt.md"
+          REPLY_FILE="$PWD/ai_reply.md"
+          rm -f "$PROMPT_FILE" "$REPLY_FILE"
 
-          if [[ ${#MODEL_LIST[@]} -eq 0 ]]; then
-            echo "::warning::MODELS_MODEL is empty — no models to try. Skipping AI reply."
+          {
+            printf '%s\n\n' "$SYSTEM_PROMPT"
+            printf '%s\n'   "$USER_PROMPT"
+          } > "$PROMPT_FILE"
+
+          echo "Prompt assembled: $(wc -c < "$PROMPT_FILE") bytes."
+
+          # Copilot has file and shell tools under --yolo, and the prompt it is
+          # about to read is full of imperative language aimed at a support
+          # agent. Say plainly that the only deliverable is a file, or it will
+          # try to "fix" the repository instead of answering the issue.
+          # Built-in MCP servers are disabled to keep the run hermetic: the
+          # issue text and reference material are already in the prompt.
+          set +e
+          copilot \
+            --yolo \
+            --no-color \
+            --no-ask-user \
+            --disable-builtin-mcps \
+            --log-level none \
+            --model "${COPILOT_MODEL:-auto}" \
+            -p "Read the file ${PROMPT_FILE}. It contains a system prompt followed by the GitHub issue to answer. Follow those instructions and compose the reply comment they describe. Do not modify any file in this repository, do not run git, and do not post anything to GitHub. Your only side effect must be writing the finished comment — GitHub-flavoured Markdown, no preamble, no code fence around the whole thing — to ${REPLY_FILE}."
+          COPILOT_EXIT=$?
+          set -e
+          rm -f "$PROMPT_FILE"
+
+          # Same tolerance as the old Models path: warn, emit empty text, exit
+          # 0. "Post reply" is guarded on non-empty text so it skips cleanly
+          # and the run stays green rather than paging anyone over a flaky
+          # model call.
+          if [[ $COPILOT_EXIT -ne 0 ]]; then
+            echo "::warning::Copilot CLI exited ${COPILOT_EXIT}. Skipping AI reply for this run."
             { echo "text<<EOF"; echo ""; echo "EOF"; } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Model preference list: ${MODEL_LIST[*]}"
-
-          WORKING_MODEL=""
-          for candidate in "${MODEL_LIST[@]}"; do
-            REQ=$(build_req "$candidate")
-
-            for (( attempt=1; attempt<=MAX_ATTEMPTS; attempt++ )); do
-              call_models_api "$REQ" "model=${candidate}, attempt ${attempt}/${MAX_ATTEMPTS}"
-
-              # Success
-              if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
-                WORKING_MODEL="$candidate"
-                break 2
-              fi
-
-              # Retryable on the same model
-              if { [[ "$HTTP_CODE" == "429" ]] \
-                   || [[ "$HTTP_CODE" == "000" ]] \
-                   || [[ "$HTTP_CODE" -ge 500 && "$HTTP_CODE" -lt 600 ]]; } \
-                   && (( attempt < MAX_ATTEMPTS )); then
-                RETRY_AFTER=$(grep -i '^retry-after:' headers.txt 2>/dev/null | tr -dc '0-9' || true)
-                DEFAULT_WAIT=$(( 10 * (1 << (attempt - 1)) ))
-                WAIT=${RETRY_AFTER:-$DEFAULT_WAIT}
-                (( WAIT > 60 )) && WAIT=60
-                (( WAIT < 5  )) && WAIT=5
-                echo "Retrying '${candidate}' in ${WAIT}s..."
-                sleep "$WAIT"
-                continue
-              fi
-
-              # Terminal failure for this model (4xx except 429, or retries
-              # exhausted on a transient). Break inner loop to move to the
-              # next model in the preference list.
-              break
-            done
-
-            echo "Model '${candidate}' terminal HTTP ${HTTP_CODE}; trying next in preference list (if any)."
-          done
-          rm -f headers.txt
-
-          if [[ -z "$WORKING_MODEL" ]]; then
-            # Every model in the preference list failed. Warn (don't error),
-            # emit empty text, and exit 0. Post reply step is guarded on
-            # non-empty text so it skips cleanly.
-            echo "::warning::No model in the preference list returned 2xx. Tried: ${MODEL_LIST[*]}. Last HTTP: ${HTTP_CODE}. Skipping AI reply for this run."
-            echo "Response body from last attempt (if any):"
-            cat response.json 2>/dev/null || echo "(no response body written)"
+          if [[ ! -s "$REPLY_FILE" ]]; then
+            echo "::warning::Copilot CLI wrote no reply to ${REPLY_FILE}. Skipping AI reply for this run."
             { echo "text<<EOF"; echo ""; echo "EOF"; } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Successfully used model: ${WORKING_MODEL} (HTTP ${HTTP_CODE})"
+          echo "Copilot CLI reply: $(wc -c < "$REPLY_FILE") bytes."
 
-          # Check for JSON error field. Same tolerance as above: warn,
-          # skip, stay green.
-          if jq -e '.error' response.json >/dev/null 2>&1; then
-            echo "::warning::Models API returned a JSON error payload. Skipping AI reply for this run."
-            cat response.json
-            {
-              echo "text<<EOF"
-              echo ""
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Extract text
-          AI=$(jq -r '.choices[0].message.content // ""' response.json)
-
-          # Set multi-line output for next step
-          echo "text<<EOF" >> "$GITHUB_OUTPUT"
-          printf '%s\n' "$AI" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          # Multi-line step output. The delimiter is randomised because the
+          # reply is model-generated: a literal "EOF" line in the comment would
+          # otherwise close the heredoc early and truncate the posted comment.
+          DELIM="AIREPLY_$(openssl rand -hex 12)"
+          {
+            echo "text<<${DELIM}"
+            cat "$REPLY_FILE"
+            echo ""
+            echo "${DELIM}"
+          } >> "$GITHUB_OUTPUT"
+          rm -f "$REPLY_FILE"
 
 
       - name: Post reply
-        # Skip when the AI step emitted no text (Models API was unavailable
-        # and the step chose to warn-and-skip instead of failing the job).
+        # Skip when the AI step emitted no text (Copilot CLI failed or wrote
+        # nothing, and the step chose to warn-and-skip instead of failing the
+        # job).
         if: steps.gate.outputs.should == 'true' && steps.ai.outputs.text != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:


### PR DESCRIPTION
## Problem

The AI issue auto-reply workflow has been silently dead since **2026-07-30**, when [GitHub Models was retired](https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli-in-actions).

Every model in `MODELS_MODEL` now returns `HTTP 410 github_models_retirement_brownout`. I confirmed this is still true today:

```
POST https://models.github.ai/inference/chat/completions
→ 410 {"code":"github_models_retirement_brownout"}
```

The failure is invisible: the generate step warns, emits empty text, and exits 0, so `Post reply` skips on its `steps.ai.outputs.text != ''` guard and **the run goes green while nobody gets an answer.**

Concrete example — #3082 was filed on 2026-08-20 and has never received a reply. The workflow *did* run (`32371193675`, `32371193495`); the gate passed and the model call was attempted:

```
← Models API responded HTTP 410 (model=openai/gpt-5, attempt 1/3)
← Models API responded HTTP 410 (model=openai/gpt-4.1, attempt 1/3)
← Models API responded HTTP 410 (model=openai/gpt-4o, attempt 1/3)
← Models API responded HTTP 410 (model=openai/gpt-4o-mini, attempt 1/3)
##[warning]No model in the preference list returned 2xx.
```

## Fix

Move to **Copilot CLI**, the supported way to run AI in Actions. It authenticates with the built-in `GITHUB_TOKEN` — no PAT, no API key. That mattered here: this repo has **zero** Actions secrets, so any provider requiring a key (Azure AI Foundry, direct OpenAI) would have needed an admin to provision one first.

- `permissions`: swap the retired `models: read` for `copilot-requests: write`.
- Install `@github/copilot`; invoke with `--yolo` (required for non-interactive runs), plus `--no-ask-user` and `--disable-builtin-mcps` to keep the run autonomous and hermetic.
- **Pass the prompt on disk, not through `-p`.** The assembled prompt is ~90 KB of Objective-C, Markdown and shell metacharacters (backticks, `${...}`, quotes); passing that as an argv string is a quoting minefield. Copilot reads the file and writes the finished comment to `ai_reply.md`, so neither prompt nor reply transits the shell.
- **Randomise the `GITHUB_OUTPUT` heredoc delimiter.** The reply is model-generated, so a literal `EOF` line in a comment would have closed the heredoc early and truncated the posted comment.
- Add `timeout-minutes: 15` so a runaway agent can't hang the job.

The existing failure contract is preserved exactly — warn, emit empty text, exit 0, let `Post reply` skip. A flaky model call still must not fail the run or page anyone.

## Also: reference budget

The 8 KB reference cap existed *only* because GitHub Models capped input at 8000 tokens/request. It was truncating the curated grounding set from 46 KB down to 8 KB — on the #3082 run: `Reference material truncated: was 46358B, now 8000B`.

Copilot CLI has no comparable per-request cap, so the manifest is now sent whole. The caps remain as a runaway guard for forks that override them downward.

## Validation

- `yaml.safe_load` parses; step graph is `gate → Install Copilot CLI → ai → Post reply`.
- `bash -n` clean on the extracted generate step.
- Ran the prompt-assembly path locally against the new budgets:

| | before | after |
|---|---|---|
| reference material | 8,000 B (**truncated**) | 84,932 B (**untruncated**) |
| final prompt | — | 91,190 B |

  The assembled prompt now contains `MSALCIAMAuthority` and `MSALSilentTokenParameters` — both of which the old 8 KB cap cut off, and both directly relevant to #3082.
- Confirmed no stale references to `MODELS_MODEL` / `models.github.ai` / `GH_MODELS_MODEL` remain.

## Follow-up

Once this merges, #3082 can be triaged by adding the `target-ai-triage` label.

Worth noting for whoever picks up #3082: the reporter's analysis looks correct, and it appears to be a genuine library bug rather than misconfiguration — the CIAM factory builds its cache authority from `client_info.utid` (the **home** tenant) where the AAD factory uses the id_token realm. That realm flows into the account's tenant profile, which is why the profile carries the CIAM `oid` but the home `tid`. So `needs-review` looks more appropriate than a "send us your config" reply.