### PR TITLE
[WIP] Fix MFA continuation after password reset in V1 api for SMS MFA user

### DIFF
--- a/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
+++ b/MSAL/src/native_auth/controllers/sign_in/MSALNativeAuthSignInController.swift
@@ -158,11 +158,13 @@ final class MSALNativeAuthSignInController: MSALNativeAuthTokenController, MSALN
             return .init(.completed(accountResult), correlationId: context.correlationId(), telemetryUpdate: { [weak self] result in
                             self?.stopTelemetryEvent(telemetryInfo.event, context: context, delegateDispatcherResult: result)
                         })
-        case .awaitingMFA(_, _):
-            let error = SignInAfterSignUpError(type: .generalError, correlationId: context.correlationId())
-            MSALNativeAuthLogger.log(level: .error, context: context, format: "SignIn: received unexpected MFA required API result")
-            self.stopTelemetryEvent(telemetryInfo.event, context: context, error: error)
-            return .init(.error(error: error), correlationId: context.correlationId())
+        case .awaitingMFA(let authMethods, let mfaRequiredState):
+            return .init(
+                .awaitingMFA(authMethods: authMethods, newState: mfaRequiredState),
+                correlationId: context.correlationId(),
+                telemetryUpdate: { [weak self] result in
+                    self?.stopTelemetryEvent(telemetryInfo.event, context: context, delegateDispatcherResult: result)
+                })
         case .jitAuthMethodsSelectionRequired(let authMethods, let jitRequiredState):
             MSALNativeAuthLogger.log(level: .info, context: context, format: "RegisterStrongAuth required after sign in after previous flow")
             return .init(


### PR DESCRIPTION
## Summary
- Forward MFA-required results from continuation-token sign-in through the existing `.awaitingMFA` delegate flow.
- Preserve authentication methods, state, correlation ID, and deferred telemetry completion.

## Validation
Manually verified with a V1 self-service password reset flow requiring MFA. Automated builds and tests were not run at the requester's direction.